### PR TITLE
Add BCD for the WebNN API

### DIFF
--- a/api/ML.json
+++ b/api/ML.json
@@ -1,0 +1,104 @@
+{
+  "api": {
+    "ml": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ML",
+        "spec_url": "https://www.w3.org/TR/webnn/#api-ml",
+        "tags": [
+          "web-features:webnn"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": "112",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#web-machine-learning-neural-network",
+                "value_to_set": "Enabled"
+              }
+            ],
+            "notes": "Currently supported on Windows and ChromeOS."
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "deno": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "createContext": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ML/createContext",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-ml-createcontext",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "Currently supported on Windows and ChromeOS."
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ML.json
+++ b/api/ML.json
@@ -2,7 +2,6 @@
   "api": {
     "ML": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ML",
         "spec_url": "https://www.w3.org/TR/webnn/#api-ml",
         "tags": [
           "web-features:webnn"
@@ -17,7 +16,7 @@
                 "value_to_set": "Enabled"
               }
             ],
-            "notes": "Currently supported on Windows and ChromeOS."
+            "notes": "Currently supported on ChromeOS and Windows only."
           },
           "chrome_android": {
             "version_added": false
@@ -51,7 +50,6 @@
       },
       "createContext": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ML/createContext",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-ml-createcontext",
           "tags": [
             "web-features:webnn"
@@ -66,7 +64,7 @@
                   "value_to_set": "Enabled"
                 }
               ],
-              "notes": "Currently supported on Windows and ChromeOS."
+              "notes": "Currently supported on ChromeOS and Windows only."
             },
             "chrome_android": {
               "version_added": false

--- a/api/ML.json
+++ b/api/ML.json
@@ -1,6 +1,6 @@
 {
   "api": {
-    "ml": {
+    "ML": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ML",
         "spec_url": "https://www.w3.org/TR/webnn/#api-ml",

--- a/api/MLActivation.json
+++ b/api/MLActivation.json
@@ -1,0 +1,64 @@
+{
+  "api": {
+    "MLActivation": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLActivation",
+        "spec_url": "https://www.w3.org/TR/webnn/#api-mlactivation",
+        "tags": [
+          "web-features:webnn"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": "112",
+            "notes": "Currently supported on Windows and ChromeOS.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#web-machine-learning-neural-network",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "deno": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/MLActivation.json
+++ b/api/MLActivation.json
@@ -10,7 +10,6 @@
         "support": {
           "chrome": {
             "version_added": "112",
-            "notes": "Currently supported on Windows and ChromeOS.",
             "flags": [
               {
                 "type": "preference",
@@ -29,29 +28,19 @@
           "firefox": {
             "version_added": false
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": false
           },
-          "safari_ios": {
-            "version_added": false
-          },
-          "samsunginternet_android": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          }
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": true,

--- a/api/MLActivation.json
+++ b/api/MLActivation.json
@@ -2,7 +2,6 @@
   "api": {
     "MLActivation": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLActivation",
         "spec_url": "https://www.w3.org/TR/webnn/#api-mlactivation",
         "tags": [
           "web-features:webnn"
@@ -16,7 +15,8 @@
                 "name": "#web-machine-learning-neural-network",
                 "value_to_set": "Enabled"
               }
-            ]
+            ],
+            "notes": "Currently supported on ChromeOS and Windows only."
           },
           "chrome_android": {
             "version_added": false

--- a/api/MLContext.json
+++ b/api/MLContext.json
@@ -10,7 +10,6 @@
         "support": {
           "chrome": {
             "version_added": "112",
-            "notes": "Currently supported on Windows and ChromeOS.",
             "flags": [
               {
                 "type": "preference",
@@ -29,29 +28,19 @@
           "firefox": {
             "version_added": false
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": false
           },
-          "safari_ios": {
-            "version_added": false
-          },
-          "samsunginternet_android": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          }
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": true,
@@ -69,7 +58,6 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
                   "type": "preference",
@@ -88,29 +76,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/MLContext.json
+++ b/api/MLContext.json
@@ -1,0 +1,124 @@
+{
+  "api": {
+    "MLContext": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLContext",
+        "spec_url": "https://www.w3.org/TR/webnn/#api-mlcontext",
+        "tags": [
+          "web-features:webnn"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": "112",
+            "notes": "Currently supported on Windows and ChromeOS.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#web-machine-learning-neural-network",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "deno": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "compute": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLContext/compute",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlcontext-compute",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/MLContext.json
+++ b/api/MLContext.json
@@ -2,7 +2,6 @@
   "api": {
     "MLContext": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLContext",
         "spec_url": "https://www.w3.org/TR/webnn/#api-mlcontext",
         "tags": [
           "web-features:webnn"
@@ -16,7 +15,8 @@
                 "name": "#web-machine-learning-neural-network",
                 "value_to_set": "Enabled"
               }
-            ]
+            ],
+            "notes": "Currently supported on ChromeOS and Windows only."
           },
           "chrome_android": {
             "version_added": false
@@ -50,7 +50,6 @@
       },
       "compute": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLContext/compute",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlcontext-compute",
           "tags": [
             "web-features:webnn"
@@ -64,7 +63,8 @@
                   "name": "#web-machine-learning-neural-network",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Currently supported on ChromeOS and Windows only."
             },
             "chrome_android": {
               "version_added": false

--- a/api/MLGraph.json
+++ b/api/MLGraph.json
@@ -2,7 +2,6 @@
   "api": {
     "MLGraph": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraph",
         "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraph",
         "tags": [
           "web-features:webnn"

--- a/api/MLGraph.json
+++ b/api/MLGraph.json
@@ -1,0 +1,64 @@
+{
+  "api": {
+    "MLGraph": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraph",
+        "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraph",
+        "tags": [
+          "web-features:webnn"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": "112",
+            "notes": "Currently supported on Windows and ChromeOS.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#web-machine-learning-neural-network",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "deno": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/MLGraph.json
+++ b/api/MLGraph.json
@@ -10,7 +10,6 @@
         "support": {
           "chrome": {
             "version_added": "112",
-            "notes": "Currently supported on Windows and ChromeOS.",
             "flags": [
               {
                 "type": "preference",
@@ -29,29 +28,19 @@
           "firefox": {
             "version_added": false
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": false
           },
-          "safari_ios": {
-            "version_added": false
-          },
-          "samsunginternet_android": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          }
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": true,

--- a/api/MLGraphBuilder.json
+++ b/api/MLGraphBuilder.json
@@ -10,11 +10,10 @@
         "support": {
           "chrome": {
             "version_added": "112",
-            "notes": "Currently supported on Windows and ChromeOS.",
             "flags": [
               {
-                "type": "preference",
                 "name": "#web-machine-learning-neural-network",
+                "type": "preference",
                 "value_to_set": "Enabled"
               }
             ]
@@ -29,29 +28,19 @@
           "firefox": {
             "version_added": false
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": false
           },
-          "safari_ios": {
-            "version_added": false
-          },
-          "samsunginternet_android": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          }
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": true,
@@ -70,11 +59,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -89,1469 +77,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "input": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/input",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-input",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "constant": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/constant",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-constant-value-type",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "build": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/build",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-build",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "argMin": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/argMin",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-argminmax",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "argMax": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/argMax",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-argminmax",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "batchNormalization": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/batchNormalization",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-batchnorm",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "cast": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/cast",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-cast",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "clamp": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/clamp",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-clamp",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "concat": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/concat",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-concat",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "conv2d": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/conv2d",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-conv2d",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "convTranspose2d": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/convTranspose2d",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-convtranspose2d",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "add": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/add",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-add",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "sub": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sub",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sub",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "mul": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/mul",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-mul",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "div": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/div",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-div",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "max": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/max",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-max",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "min": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/min",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-min",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "pow": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/pow",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-pow",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "119",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "equal": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/equal",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-equal",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "greater": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/greater",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-greater",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "greaterOrEqual": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/greaterOrEqual",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-greaterorequal",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "lesser": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lesser",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-lesser",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "lesserOrEqual": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lesserOrEqual",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-lesserorequal",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "not": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/not",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-not",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -1570,11 +108,10 @@
           "support": {
             "chrome": {
               "version_added": "116",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -1589,29 +126,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -1620,201 +147,20 @@
           }
         }
       },
-      "ceil": {
+      "add": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/ceil",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-ceil",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "cos": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/cos",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-cos",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "erf": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/erf",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-erf",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "exp": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/exp",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-exp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/add",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-add",
           "tags": [
             "web-features:webnn"
           ],
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -1829,29 +175,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -1860,621 +196,20 @@
           }
         }
       },
-      "floor": {
+      "argMax": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/floor",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-floor",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "116",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "identity": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/identity",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-identity",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "log": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/log",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-log",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "neg": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/neg",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-neg",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "116",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "reciprocal": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reciprocal",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reciprocal",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "sin": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sin",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sin",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "qrt": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/qrt",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sqrt",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "tan": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/tan",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-tan",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "elu": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/elu",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-elu",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "115",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "expand": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/expand",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-expand",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "gather": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gather",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gather",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/argMax",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-argminmax",
           "tags": [
             "web-features:webnn"
           ],
           "support": {
             "chrome": {
               "version_added": "122",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -2489,29 +224,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -2520,321 +245,20 @@
           }
         }
       },
-      "gemm": {
+      "argMin": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gemm",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gemm",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "gru": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gru",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gru",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "124",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "gruCell": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gruCell",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-grucell",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "124",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "hardSigmoid": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/hardSigmoid",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-sigmoid",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "123",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "hardSwish": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/hardSwish",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-swish",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "instanceNormalization": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/instanceNormalization",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-instancenorm",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/argMin",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-argminmax",
           "tags": [
             "web-features:webnn"
           ],
           "support": {
             "chrome": {
               "version_added": "122",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -2849,449 +273,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "layerNormalization": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/layerNormalization",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-layernorm",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "leakyRelu": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/leakyRelu",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-leakyrelu",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "linear": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/linear",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-linear",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "122",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "lstm": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lstm",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-lstm",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "124",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "lstmCell": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lstmCell",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-lstmcell",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "124",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "matmul": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/matmul",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-matmul",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "notes": "Currently supported on Windows.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "pad": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/pad",
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pad",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "114",
-              "notes": "Currently supported on Windows and ChromeOS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3310,11 +304,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3329,29 +322,1391 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "batchNormalization": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/batchNormalization",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-batchnorm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
               "version_added": false
             },
-            "samsunginternet_android": {
+            "deno": {
               "version_added": false
             },
-            "webview_android": {
+            "edge": "mirror",
+            "firefox": {
               "version_added": false
-            }
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "build": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/build",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-build",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cast": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/cast",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-cast",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ceil": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/ceil",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-ceil",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clamp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/clamp",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-clamp",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "concat": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/concat",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-concat",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "113",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "constant": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/constant",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-constant-value-type",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "conv2d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/conv2d",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-conv2d",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "convTranspose2d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/convTranspose2d",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-convtranspose2d",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "113",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cos": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/cos",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-cos",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "div": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/div",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-div",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "elu": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/elu",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-elu",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "115",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "equal": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/equal",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-equal",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "erf": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/erf",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-erf",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "exp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/exp",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-exp",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "expand": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/expand",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-expand",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "floor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/floor",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-floor",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "116",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gather": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gather",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gather",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gemm": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gemm",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gemm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "greater": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/greater",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-greater",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "greaterOrEqual": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/greaterOrEqual",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-greaterorequal",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gru": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gru",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gru",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gruCell": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gruCell",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-grucell",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hardSigmoid": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/hardSigmoid",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-sigmoid",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hardSwish": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/hardSwish",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-swish",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "identity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/identity",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-identity",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "input": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/input",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-input",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "instanceNormalization": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/instanceNormalization",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-instancenorm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3370,11 +1725,10 @@
           "support": {
             "chrome": {
               "version_added": "123",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3389,29 +1743,509 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "layerNormalization": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/layerNormalization",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-layernorm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
               "version_added": false
             },
-            "samsunginternet_android": {
+            "deno": {
               "version_added": false
             },
-            "webview_android": {
+            "edge": "mirror",
+            "firefox": {
               "version_added": false
-            }
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "leakyRelu": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/leakyRelu",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-leakyrelu",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "113",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lesser": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lesser",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-lesser",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lesserOrEqual": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lesserOrEqual",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-lesserorequal",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "linear": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/linear",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-linear",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "log": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/log",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-log",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lstm": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lstm",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-lstm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lstmCell": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lstmCell",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-lstmcell",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "matmul": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/matmul",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-matmul",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "max": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/max",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-max",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3430,11 +2264,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3449,29 +2282,313 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "min": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/min",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-min",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
               "version_added": false
             },
-            "samsunginternet_android": {
+            "deno": {
               "version_added": false
             },
-            "webview_android": {
+            "edge": "mirror",
+            "firefox": {
               "version_added": false
-            }
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mul": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/mul",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-mul",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "neg": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/neg",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-neg",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "116",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "not": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/not",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-not",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pad": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/pad",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pad",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "114",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/pow",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-pow",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "119",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3490,11 +2607,10 @@
           "support": {
             "chrome": {
               "version_added": "115",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3509,29 +2625,117 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "qrt": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/qrt",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sqrt",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
               "version_added": false
             },
-            "samsunginternet_android": {
+            "deno": {
               "version_added": false
             },
-            "webview_android": {
+            "edge": "mirror",
+            "firefox": {
               "version_added": false
-            }
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reciprocal": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reciprocal",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reciprocal",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3550,11 +2754,10 @@
           "support": {
             "chrome": {
               "version_added": "121",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3569,29 +2772,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3610,11 +2803,10 @@
           "support": {
             "chrome": {
               "version_added": "121",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3629,29 +2821,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3670,11 +2852,10 @@
           "support": {
             "chrome": {
               "version_added": "121",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3689,29 +2870,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3730,11 +2901,10 @@
           "support": {
             "chrome": {
               "version_added": "121",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3749,29 +2919,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3790,11 +2950,10 @@
           "support": {
             "chrome": {
               "version_added": "121",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3809,29 +2968,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3850,11 +2999,10 @@
           "support": {
             "chrome": {
               "version_added": "120",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3869,29 +3017,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3910,11 +3048,10 @@
           "support": {
             "chrome": {
               "version_added": "121",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3929,29 +3066,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -3970,11 +3097,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -3989,29 +3115,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4030,11 +3146,10 @@
           "support": {
             "chrome": {
               "version_added": "121",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4049,29 +3164,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4090,11 +3195,10 @@
           "support": {
             "chrome": {
               "version_added": "121",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4109,29 +3213,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4150,11 +3244,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4169,29 +3262,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4210,11 +3293,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4229,29 +3311,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4270,11 +3342,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4289,29 +3360,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4330,11 +3391,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4349,29 +3409,68 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sin",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sin",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
               "version_added": false
             },
-            "samsunginternet_android": {
+            "deno": {
               "version_added": false
             },
-            "webview_android": {
+            "edge": "mirror",
+            "firefox": {
               "version_added": false
-            }
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4390,11 +3489,10 @@
           "support": {
             "chrome": {
               "version_added": "116",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4409,29 +3507,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4450,11 +3538,10 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4469,29 +3556,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4510,11 +3587,10 @@
           "support": {
             "chrome": {
               "version_added": "122",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4529,29 +3605,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4570,11 +3636,10 @@
           "support": {
             "chrome": {
               "version_added": "123",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4589,29 +3654,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4630,11 +3685,10 @@
           "support": {
             "chrome": {
               "version_added": "116",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4649,29 +3703,117 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sub": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sub",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sub",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
               "version_added": false
             },
-            "samsunginternet_android": {
+            "deno": {
               "version_added": false
             },
-            "webview_android": {
+            "edge": "mirror",
+            "firefox": {
               "version_added": false
-            }
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "tan": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/tan",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-tan",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4690,11 +3832,10 @@
           "support": {
             "chrome": {
               "version_added": "116",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4709,29 +3850,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4750,11 +3881,10 @@
           "support": {
             "chrome": {
               "version_added": "113",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4769,29 +3899,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4810,11 +3930,10 @@
           "support": {
             "chrome": {
               "version_added": "124",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4829,29 +3948,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -4870,11 +3979,10 @@
           "support": {
             "chrome": {
               "version_added": "122",
-              "notes": "Currently supported on Windows.",
               "flags": [
                 {
-                  "type": "preference",
                   "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -4889,29 +3997,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/MLGraphBuilder.json
+++ b/api/MLGraphBuilder.json
@@ -2,7 +2,6 @@
   "api": {
     "MLGraphBuilder": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder",
         "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder",
         "tags": [
           "web-features:webnn"
@@ -16,7 +15,8 @@
                 "type": "preference",
                 "value_to_set": "Enabled"
               }
-            ]
+            ],
+            "notes": "Currently supported on ChromeOS and Windows only."
           },
           "chrome_android": {
             "version_added": false
@@ -51,7 +51,6 @@
       "MLGraphBuilder": {
         "__compat": {
           "description": "<code>MLGraphBuilder()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/MLGraphBuilder",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-constructor",
           "tags": [
             "web-features:webnn"
@@ -65,7 +64,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Currently supported on ChromeOS and Windows only."
             },
             "chrome_android": {
               "version_added": false
@@ -100,7 +100,6 @@
       },
       "abs": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/abs",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-abs",
           "tags": [
             "web-features:webnn"
@@ -149,7 +148,6 @@
       },
       "add": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/add",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-add",
           "tags": [
             "web-features:webnn"
@@ -198,7 +196,6 @@
       },
       "argMax": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/argMax",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-argminmax",
           "tags": [
             "web-features:webnn"
@@ -247,7 +244,6 @@
       },
       "argMin": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/argMin",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-argminmax",
           "tags": [
             "web-features:webnn"
@@ -296,7 +292,6 @@
       },
       "averagePool2d": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/averagePool2d",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d-average",
           "tags": [
             "web-features:webnn"
@@ -345,7 +340,6 @@
       },
       "batchNormalization": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/batchNormalization",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-batchnorm",
           "tags": [
             "web-features:webnn"
@@ -394,7 +388,6 @@
       },
       "build": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/build",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-build",
           "tags": [
             "web-features:webnn"
@@ -443,7 +436,6 @@
       },
       "cast": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/cast",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-cast",
           "tags": [
             "web-features:webnn"
@@ -492,7 +484,6 @@
       },
       "ceil": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/ceil",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-ceil",
           "tags": [
             "web-features:webnn"
@@ -541,7 +532,6 @@
       },
       "clamp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/clamp",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-clamp",
           "tags": [
             "web-features:webnn"
@@ -590,7 +580,6 @@
       },
       "concat": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/concat",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-concat",
           "tags": [
             "web-features:webnn"
@@ -639,7 +628,6 @@
       },
       "constant": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/constant",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-constant-value-type",
           "tags": [
             "web-features:webnn"
@@ -688,7 +676,6 @@
       },
       "conv2d": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/conv2d",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-conv2d",
           "tags": [
             "web-features:webnn"
@@ -737,7 +724,6 @@
       },
       "convTranspose2d": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/convTranspose2d",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-convtranspose2d",
           "tags": [
             "web-features:webnn"
@@ -786,7 +772,6 @@
       },
       "cos": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/cos",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-cos",
           "tags": [
             "web-features:webnn"
@@ -835,7 +820,6 @@
       },
       "div": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/div",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-div",
           "tags": [
             "web-features:webnn"
@@ -884,7 +868,6 @@
       },
       "elu": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/elu",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-elu",
           "tags": [
             "web-features:webnn"
@@ -933,7 +916,6 @@
       },
       "equal": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/equal",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-equal",
           "tags": [
             "web-features:webnn"
@@ -982,7 +964,6 @@
       },
       "erf": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/erf",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-erf",
           "tags": [
             "web-features:webnn"
@@ -1031,7 +1012,6 @@
       },
       "exp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/exp",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-exp",
           "tags": [
             "web-features:webnn"
@@ -1080,7 +1060,6 @@
       },
       "expand": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/expand",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-expand",
           "tags": [
             "web-features:webnn"
@@ -1129,7 +1108,6 @@
       },
       "floor": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/floor",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-floor",
           "tags": [
             "web-features:webnn"
@@ -1178,7 +1156,6 @@
       },
       "gather": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gather",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gather",
           "tags": [
             "web-features:webnn"
@@ -1227,7 +1204,6 @@
       },
       "gemm": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gemm",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gemm",
           "tags": [
             "web-features:webnn"
@@ -1276,7 +1252,6 @@
       },
       "greater": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/greater",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-greater",
           "tags": [
             "web-features:webnn"
@@ -1325,7 +1300,6 @@
       },
       "greaterOrEqual": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/greaterOrEqual",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-greaterorequal",
           "tags": [
             "web-features:webnn"
@@ -1374,7 +1348,6 @@
       },
       "gru": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gru",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gru",
           "tags": [
             "web-features:webnn"
@@ -1423,7 +1396,6 @@
       },
       "gruCell": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gruCell",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-grucell",
           "tags": [
             "web-features:webnn"
@@ -1472,7 +1444,6 @@
       },
       "hardSigmoid": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/hardSigmoid",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-sigmoid",
           "tags": [
             "web-features:webnn"
@@ -1521,7 +1492,6 @@
       },
       "hardSwish": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/hardSwish",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-swish",
           "tags": [
             "web-features:webnn"
@@ -1570,7 +1540,6 @@
       },
       "identity": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/identity",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-identity",
           "tags": [
             "web-features:webnn"
@@ -1619,7 +1588,6 @@
       },
       "input": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/input",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-input",
           "tags": [
             "web-features:webnn"
@@ -1668,7 +1636,6 @@
       },
       "instanceNormalization": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/instanceNormalization",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-instancenorm",
           "tags": [
             "web-features:webnn"
@@ -1717,7 +1684,6 @@
       },
       "l2Pool2d": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/l2Pool2d",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d-l2",
           "tags": [
             "web-features:webnn"
@@ -1766,7 +1732,6 @@
       },
       "layerNormalization": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/layerNormalization",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-layernorm",
           "tags": [
             "web-features:webnn"
@@ -1815,7 +1780,6 @@
       },
       "leakyRelu": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/leakyRelu",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-leakyrelu",
           "tags": [
             "web-features:webnn"
@@ -1864,7 +1828,6 @@
       },
       "lesser": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lesser",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-lesser",
           "tags": [
             "web-features:webnn"
@@ -1913,7 +1876,6 @@
       },
       "lesserOrEqual": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lesserOrEqual",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-lesserorequal",
           "tags": [
             "web-features:webnn"
@@ -1962,7 +1924,6 @@
       },
       "linear": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/linear",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-linear",
           "tags": [
             "web-features:webnn"
@@ -2011,7 +1972,6 @@
       },
       "log": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/log",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-log",
           "tags": [
             "web-features:webnn"
@@ -2060,7 +2020,6 @@
       },
       "lstm": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lstm",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-lstm",
           "tags": [
             "web-features:webnn"
@@ -2109,7 +2068,6 @@
       },
       "lstmCell": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lstmCell",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-lstmcell",
           "tags": [
             "web-features:webnn"
@@ -2158,7 +2116,6 @@
       },
       "matmul": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/matmul",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-matmul",
           "tags": [
             "web-features:webnn"
@@ -2207,7 +2164,6 @@
       },
       "max": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/max",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-max",
           "tags": [
             "web-features:webnn"
@@ -2256,7 +2212,6 @@
       },
       "maxPool2d": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/maxPool2d",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d-max",
           "tags": [
             "web-features:webnn"
@@ -2305,7 +2260,6 @@
       },
       "min": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/min",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-min",
           "tags": [
             "web-features:webnn"
@@ -2354,7 +2308,6 @@
       },
       "mul": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/mul",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-mul",
           "tags": [
             "web-features:webnn"
@@ -2403,7 +2356,6 @@
       },
       "neg": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/neg",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-neg",
           "tags": [
             "web-features:webnn"
@@ -2452,7 +2404,6 @@
       },
       "not": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/not",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-not",
           "tags": [
             "web-features:webnn"
@@ -2501,7 +2452,6 @@
       },
       "pad": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/pad",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pad",
           "tags": [
             "web-features:webnn"
@@ -2550,7 +2500,6 @@
       },
       "pow": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/pow",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-pow",
           "tags": [
             "web-features:webnn"
@@ -2599,7 +2548,6 @@
       },
       "prelu": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/prelu",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-prelu",
           "tags": [
             "web-features:webnn"
@@ -2646,58 +2594,8 @@
           }
         }
       },
-      "qrt": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/qrt",
-          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sqrt",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "reciprocal": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reciprocal",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reciprocal",
           "tags": [
             "web-features:webnn"
@@ -2746,7 +2644,6 @@
       },
       "reduceL1": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceL1",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducel1",
           "tags": [
             "web-features:webnn"
@@ -2795,7 +2692,6 @@
       },
       "reduceL2": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceL2",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducel2",
           "tags": [
             "web-features:webnn"
@@ -2844,7 +2740,6 @@
       },
       "reduceLogSum": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceLogSum",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducelogsum",
           "tags": [
             "web-features:webnn"
@@ -2893,7 +2788,6 @@
       },
       "reduceLogSumExp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceLogSumExp",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducelogsumexp",
           "tags": [
             "web-features:webnn"
@@ -2942,7 +2836,6 @@
       },
       "reduceMax": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceMax",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducemax",
           "tags": [
             "web-features:webnn"
@@ -2991,7 +2884,6 @@
       },
       "reduceMean": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceMean",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducemean",
           "tags": [
             "web-features:webnn"
@@ -3040,7 +2932,6 @@
       },
       "reduceMin": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceMin",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducemin",
           "tags": [
             "web-features:webnn"
@@ -3089,7 +2980,6 @@
       },
       "reduceProduct": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceProduct",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reduceproduct",
           "tags": [
             "web-features:webnn"
@@ -3138,7 +3028,6 @@
       },
       "reduceSum": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceSum",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducesum",
           "tags": [
             "web-features:webnn"
@@ -3187,7 +3076,6 @@
       },
       "reduceSumSquare": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceSumSquare",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducesumsquare",
           "tags": [
             "web-features:webnn"
@@ -3236,7 +3124,6 @@
       },
       "relu": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/relu",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-relu-method",
           "tags": [
             "web-features:webnn"
@@ -3285,7 +3172,6 @@
       },
       "resample2d": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/resample2d",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-resample2d-method",
           "tags": [
             "web-features:webnn"
@@ -3334,7 +3220,6 @@
       },
       "reshape": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reshape",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-reshape-method",
           "tags": [
             "web-features:webnn"
@@ -3383,7 +3268,6 @@
       },
       "sigmoid": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sigmoid",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-sigmoid-method",
           "tags": [
             "web-features:webnn"
@@ -3432,7 +3316,6 @@
       },
       "sin": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sin",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sin",
           "tags": [
             "web-features:webnn"
@@ -3481,7 +3364,6 @@
       },
       "slice": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/slice",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-slice",
           "tags": [
             "web-features:webnn"
@@ -3530,7 +3412,6 @@
       },
       "softmax": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/softmax",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-softmax-method",
           "tags": [
             "web-features:webnn"
@@ -3579,7 +3460,6 @@
       },
       "softplus": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/softplus",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-softplus-method",
           "tags": [
             "web-features:webnn"
@@ -3628,7 +3508,6 @@
       },
       "softsign": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/softsign",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-softsign-method",
           "tags": [
             "web-features:webnn"
@@ -3677,7 +3556,6 @@
       },
       "split": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/split",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-split",
           "tags": [
             "web-features:webnn"
@@ -3724,9 +3602,56 @@
           }
         }
       },
+      "sqrt": {
+        "__compat": {
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sqrt",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "flags": [
+                {
+                  "name": "#web-machine-learning-neural-network",
+                  "type": "preference",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sub": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sub",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sub",
           "tags": [
             "web-features:webnn"
@@ -3775,7 +3700,6 @@
       },
       "tan": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/tan",
           "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-tan",
           "tags": [
             "web-features:webnn"
@@ -3824,7 +3748,6 @@
       },
       "tanh": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/tanh",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-tanh-method",
           "tags": [
             "web-features:webnn"
@@ -3873,7 +3796,6 @@
       },
       "transpose": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/transpose",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-transpose",
           "tags": [
             "web-features:webnn"
@@ -3922,7 +3844,6 @@
       },
       "triangular": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/triangular",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-triangular",
           "tags": [
             "web-features:webnn"
@@ -3971,7 +3892,6 @@
       },
       "where": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/where",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-where",
           "tags": [
             "web-features:webnn"

--- a/api/MLGraphBuilder.json
+++ b/api/MLGraphBuilder.json
@@ -1,0 +1,4925 @@
+{
+  "api": {
+    "MLGraphBuilder": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder",
+        "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder",
+        "tags": [
+          "web-features:webnn"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": "112",
+            "notes": "Currently supported on Windows and ChromeOS.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#web-machine-learning-neural-network",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "deno": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "MLGraphBuilder": {
+        "__compat": {
+          "description": "<code>MLGraphBuilder()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/MLGraphBuilder",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-constructor",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "input": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/input",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-input",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "constant": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/constant",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-constant-value-type",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "build": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/build",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-build",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "argMin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/argMin",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-argminmax",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "argMax": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/argMax",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-argminmax",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "batchNormalization": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/batchNormalization",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-batchnorm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cast": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/cast",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-cast",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clamp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/clamp",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-clamp",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "concat": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/concat",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-concat",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "113",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "conv2d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/conv2d",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-conv2d",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "convTranspose2d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/convTranspose2d",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-convtranspose2d",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "113",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "add": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/add",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-add",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sub": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sub",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sub",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mul": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/mul",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-mul",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "div": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/div",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-div",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "max": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/max",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-max",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "min": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/min",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-min",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/pow",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-pow",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "119",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "equal": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/equal",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-equal",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "greater": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/greater",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-greater",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "greaterOrEqual": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/greaterOrEqual",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-greaterorequal",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lesser": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lesser",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-lesser",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lesserOrEqual": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lesserOrEqual",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-lesserorequal",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "not": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/not",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-not",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "abs": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/abs",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-abs",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "116",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ceil": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/ceil",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-ceil",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cos": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/cos",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-cos",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "erf": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/erf",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-erf",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "exp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/exp",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-exp",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "floor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/floor",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-floor",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "116",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "identity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/identity",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-identity",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "log": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/log",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-log",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "neg": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/neg",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-neg",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "116",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reciprocal": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reciprocal",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reciprocal",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sin",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sin",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "qrt": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/qrt",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-sqrt",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "tan": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/tan",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-tan",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "elu": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/elu",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-elu",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "115",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "expand": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/expand",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-expand",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gather": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gather",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gather",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gemm": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gemm",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gemm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gru": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gru",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-gru",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gruCell": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/gruCell",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-grucell",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hardSigmoid": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/hardSigmoid",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-sigmoid",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hardSwish": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/hardSwish",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-hard-swish",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "instanceNormalization": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/instanceNormalization",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-instancenorm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "layerNormalization": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/layerNormalization",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-layernorm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "leakyRelu": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/leakyRelu",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-leakyrelu",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "113",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "linear": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/linear",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-linear",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lstm": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lstm",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-lstm",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lstmCell": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/lstmCell",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-lstmcell",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "matmul": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/matmul",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-matmul",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pad": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/pad",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pad",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "114",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "averagePool2d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/averagePool2d",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d-average",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "l2Pool2d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/l2Pool2d",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d-l2",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "maxPool2d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/maxPool2d",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-pool2d-max",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "prelu": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/prelu",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-prelu",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "115",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceL1": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceL1",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducel1",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceL2": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceL2",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducel2",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceLogSum": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceLogSum",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducelogsum",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceLogSumExp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceLogSumExp",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducelogsumexp",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceMax": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceMax",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducemax",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceMean": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceMean",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducemean",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "120",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceMin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceMin",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducemin",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceProduct": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceProduct",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reduceproduct",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceSum": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceSum",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducesum",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reduceSumSquare": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reduceSumSquare",
+          "spec_url": "https://www.w3.org/TR/webnn/#dom-mlgraphbuilder-reducesumsquare",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "121",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "relu": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/relu",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-relu-method",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resample2d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/resample2d",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-resample2d-method",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reshape": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/reshape",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-reshape-method",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sigmoid": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/sigmoid",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-sigmoid-method",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "slice": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/slice",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-slice",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "116",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "softmax": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/softmax",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-softmax-method",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "softplus": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/softplus",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-softplus-method",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "softsign": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/softsign",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-softsign-method",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "split": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/split",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-split",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "116",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "tanh": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/tanh",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-tanh-method",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "116",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transpose": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/transpose",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-transpose",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "113",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "triangular": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/triangular",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-triangular",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "where": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLGraphBuilder/where",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mlgraphbuilder-where",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122",
+              "notes": "Currently supported on Windows.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/MLGraphBuilder.json
+++ b/api/MLGraphBuilder.json
@@ -105,16 +105,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "116",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -153,16 +178,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -209,7 +259,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on CPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -257,7 +308,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on CPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -297,16 +349,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -353,7 +430,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on CPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -449,7 +527,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on CPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -489,16 +568,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -537,16 +641,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "124",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -585,16 +714,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "120",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -633,16 +787,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -681,16 +860,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -729,16 +933,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -777,16 +995,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -825,16 +1057,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -873,16 +1130,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "115",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "115",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -929,7 +1211,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -977,7 +1260,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1017,16 +1301,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -1073,7 +1371,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1113,16 +1412,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "116",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -1169,7 +1493,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1209,16 +1534,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "124",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -1265,7 +1615,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1313,7 +1664,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1361,7 +1713,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1409,7 +1762,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1457,7 +1811,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1497,16 +1852,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -1553,7 +1933,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1593,16 +1974,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -1649,7 +2055,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1697,7 +2104,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1745,7 +2153,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1785,16 +2194,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -1841,7 +2275,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1889,7 +2324,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1937,7 +2373,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -1977,16 +2414,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2033,7 +2484,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2081,7 +2533,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2129,7 +2582,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2169,16 +2623,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2217,16 +2696,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2265,16 +2769,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2313,16 +2842,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2361,16 +2915,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "116",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2417,7 +2996,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2457,16 +3037,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "114",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "120",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "114",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2505,16 +3110,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "119",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2553,16 +3172,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "115",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "120",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "115",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -2609,7 +3242,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2657,7 +3291,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2705,7 +3340,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2753,7 +3389,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2801,7 +3438,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2849,7 +3487,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2890,14 +3529,15 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "120",
+              "version_added": "121",
               "flags": [
                 {
                   "name": "#web-machine-learning-neural-network",
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2945,7 +3585,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -2986,14 +3627,15 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "112",
+              "version_added": "121",
               "flags": [
                 {
                   "name": "#web-machine-learning-neural-network",
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -3041,7 +3683,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -3089,7 +3732,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -3129,16 +3773,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3177,16 +3846,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "124",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3225,16 +3919,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3273,16 +3992,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3321,16 +4065,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3369,16 +4127,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "116",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "120",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3417,16 +4189,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3473,7 +4270,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -3521,7 +4319,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -3561,16 +4360,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "116",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "120",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3609,16 +4422,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              },
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3657,16 +4495,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "119",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "112",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3713,7 +4576,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -3753,16 +4617,30 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "116",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "121",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3801,16 +4679,41 @@
             "web-features:webnn"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "flags": [
-                {
-                  "name": "#web-machine-learning-neural-network",
-                  "type": "preference",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "123",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on ChromeOS."
+              },
+              {
+                "version_added": "120",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on GPUs on Windows."
+              },
+              {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "name": "#web-machine-learning-neural-network",
+                    "type": "preference",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Supported on CPUs on Windows."
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },
@@ -3857,7 +4760,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false
@@ -3905,7 +4809,8 @@
                   "type": "preference",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Supported on GPUs on Windows."
             },
             "chrome_android": {
               "version_added": false

--- a/api/MLOperand.json
+++ b/api/MLOperand.json
@@ -10,7 +10,6 @@
         "support": {
           "chrome": {
             "version_added": "112",
-            "notes": "Currently supported on Windows and ChromeOS.",
             "flags": [
               {
                 "type": "preference",
@@ -29,29 +28,19 @@
           "firefox": {
             "version_added": false
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": false
           },
-          "safari_ios": {
-            "version_added": false
-          },
-          "samsunginternet_android": {
-            "version_added": false
-          },
-          "webview_android": {
-            "version_added": false
-          }
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": true,
@@ -69,7 +58,6 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
                   "type": "preference",
@@ -88,29 +76,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -129,7 +107,6 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
                   "type": "preference",
@@ -148,29 +125,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/MLOperand.json
+++ b/api/MLOperand.json
@@ -2,7 +2,6 @@
   "api": {
     "MLOperand": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLOperand",
         "spec_url": "https://www.w3.org/TR/webnn/#api-mloperand",
         "tags": [
           "web-features:webnn"
@@ -16,7 +15,8 @@
                 "name": "#web-machine-learning-neural-network",
                 "value_to_set": "Enabled"
               }
-            ]
+            ],
+            "notes": "Currently supported on ChromeOS and Windows only."
           },
           "chrome_android": {
             "version_added": false
@@ -50,7 +50,6 @@
       },
       "dataType": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLContext/dataType",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mloperand-datatype",
           "tags": [
             "web-features:webnn"
@@ -64,7 +63,8 @@
                   "name": "#web-machine-learning-neural-network",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Currently supported on ChromeOS and Windows only."
             },
             "chrome_android": {
               "version_added": false
@@ -99,7 +99,6 @@
       },
       "shape": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLContext/shape",
           "spec_url": "https://www.w3.org/TR/webnn/#api-mloperand-shape",
           "tags": [
             "web-features:webnn"
@@ -113,7 +112,8 @@
                   "name": "#web-machine-learning-neural-network",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Currently supported on ChromeOS and Windows only."
             },
             "chrome_android": {
               "version_added": false

--- a/api/MLOperand.json
+++ b/api/MLOperand.json
@@ -1,0 +1,184 @@
+{
+  "api": {
+    "MLOperand": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLOperand",
+        "spec_url": "https://www.w3.org/TR/webnn/#api-mloperand",
+        "tags": [
+          "web-features:webnn"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": "112",
+            "notes": "Currently supported on Windows and ChromeOS.",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#web-machine-learning-neural-network",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "deno": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "dataType": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLContext/dataType",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mloperand-datatype",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shape": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MLContext/shape",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-mloperand-shape",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2248,7 +2248,6 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
                   "type": "preference",
@@ -2267,29 +2266,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2238,6 +2238,66 @@
           }
         }
       },
+      "ml": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/ml",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-navigator-ml",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onLine": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/onLine",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2240,7 +2240,6 @@
       },
       "ml": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/ml",
           "spec_url": "https://www.w3.org/TR/webnn/#api-navigator-ml",
           "tags": [
             "web-features:webnn"
@@ -2254,7 +2253,8 @@
                   "name": "#web-machine-learning-neural-network",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Currently supported on ChromeOS and Windows only."
             },
             "chrome_android": {
               "version_added": false

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -542,6 +542,66 @@
           }
         }
       },
+      "ml": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/ml",
+          "spec_url": "https://www.w3.org/TR/webnn/#api-navigator-ml",
+          "tags": [
+            "web-features:webnn"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "112",
+              "notes": "Currently supported on Windows and ChromeOS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-machine-learning-neural-network",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onLine": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/onLine",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -552,7 +552,6 @@
           "support": {
             "chrome": {
               "version_added": "112",
-              "notes": "Currently supported on Windows and ChromeOS.",
               "flags": [
                 {
                   "type": "preference",
@@ -571,29 +570,19 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -544,7 +544,6 @@
       },
       "ml": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/ml",
           "spec_url": "https://www.w3.org/TR/webnn/#api-navigator-ml",
           "tags": [
             "web-features:webnn"
@@ -558,7 +557,8 @@
                   "name": "#web-machine-learning-neural-network",
                   "value_to_set": "Enabled"
                 }
-              ]
+              ],
+              "notes": "Currently supported on ChromeOS and Windows only."
             },
             "chrome_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds BCD for the [WebNN API](https://www.w3.org/TR/webnn/).

Currently the WebNN feature is behind the #web-machine-learning-neural-network flag.