### PR TITLE
Add missing features for javascript.builtins.Intl.RelativeTimeFormat.RelativeTimeFormat

### DIFF
--- a/javascript/builtins/Intl/RelativeTimeFormat.json
+++ b/javascript/builtins/Intl/RelativeTimeFormat.json
@@ -63,16 +63,9 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": [
-                  {
-                    "version_added": "13.0.0"
-                  },
-                  {
-                    "version_added": "12.0.0",
-                    "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>RelativeTimeFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available before version 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
-                  }
-                ],
+                "nodejs": {
+                  "version_added": "12.0.0"
+                },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
@@ -87,6 +80,171 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
+              }
+            },
+            "locales_parameter": {
+              "__compat": {
+                "description": "<code>locales</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "71"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "65"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": [
+                    {
+                      "version_added": "13.0.0"
+                    },
+                    {
+                      "version_added": "12.0.0",
+                      "partial_implementation": true,
+                      "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>RelativeTimeFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available before version 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
+                    }
+                  ],
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "14"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_parameter": {
+              "options_localeMatcher_parameter": {
+                "__compat": {
+                  "description": "<code>options.localeMatcher</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "71"
+                    },
+                    "chrome_android": "mirror",
+                    "deno": {
+                      "version_added": "1.8"
+                    },
+                    "edge": "mirror",
+                    "firefox": {
+                      "version_added": "65"
+                    },
+                    "firefox_android": "mirror",
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "12.0.0"
+                    },
+                    "oculus": "mirror",
+                    "opera": "mirror",
+                    "opera_android": "mirror",
+                    "safari": {
+                      "version_added": "14"
+                    },
+                    "safari_ios": "mirror",
+                    "samsunginternet_android": "mirror",
+                    "webview_android": "mirror"
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              },
+              "options_numberingSystem_parameter": {
+                "__compat": {
+                  "description": "<code>options.numberingSystem</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "71"
+                    },
+                    "chrome_android": "mirror",
+                    "deno": {
+                      "version_added": "1.8"
+                    },
+                    "edge": "mirror",
+                    "firefox": {
+                      "version_added": "76"
+                    },
+                    "firefox_android": "mirror",
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "12.0.0"
+                    },
+                    "oculus": "mirror",
+                    "opera": "mirror",
+                    "opera_android": "mirror",
+                    "safari": {
+                      "version_added": "14"
+                    },
+                    "safari_ios": "mirror",
+                    "samsunginternet_android": "mirror",
+                    "webview_android": "mirror"
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              },
+              "options_numeric_parameter": {
+                "__compat": {
+                  "description": "<code>options.numeric</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "71"
+                    },
+                    "chrome_android": "mirror",
+                    "deno": {
+                      "version_added": "1.8"
+                    },
+                    "edge": "mirror",
+                    "firefox": {
+                      "version_added": "65"
+                    },
+                    "firefox_android": "mirror",
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "12.0.0"
+                    },
+                    "oculus": "mirror",
+                    "opera": "mirror",
+                    "opera_android": "mirror",
+                    "safari": {
+                      "version_added": "14"
+                    },
+                    "safari_ios": "mirror",
+                    "samsunginternet_android": "mirror",
+                    "webview_android": "mirror"
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
This PR adds the missing features of the `RelativeTimeFormat.RelativeTimeFormat` member of the `Intl` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat
