### PR TITLE
Update light-dark to `"preview"` for Safari, STP 189 added support

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -785,8 +785,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/262914"
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
STP 189 adds support for the 'light-dark()' function for color values. Update `light-dark` in Safari to "preview".

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Attached is a test case using the playground:
<img width="1826" alt="light-dark-stp-mdn-playground-testcase" src="https://github.com/mdn/browser-compat-data/assets/113309999/b36e95ed-92c2-45bb-9204-2ba7bb46857c">
Passes 5/5 of the [wpt.fyi tests](https://wpt.fyi/results/css/css-color?label=master&label=experimental&aligned&q=light-dark)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
In [Webkit's STP release notes](https://webkit.org/blog/15050/release-notes-for-safari-technology-preview-189/)
In [Apple's STP release notes](https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-189)

[Enabling](https://github.com/WebKit/WebKit/commit/42f9569ae95a1bbef0a26f460bdaa7efdb637fff)
[Implementation](https://github.com/WebKit/WebKit/pull/22242/files)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
