### PR TITLE
Update starting-style.json, STP 189 added support for `starting-style`, update Safari to `"preview"`

### DIFF
--- a/css/at-rules/starting-style.json
+++ b/css/at-rules/starting-style.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

STP 189 added support for `starting-style`. Update `starting-style` to `"preview"` for Safari. 

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Passes 14/15 [wpt.fyi tests](https://wpt.fyi/results/css/css-transitions?label=master&label=experimental&aligned&q=starting-style)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
In [WebKit STP 189 release notes](https://webkit.org/blog/15050/release-notes-for-safari-technology-preview-189/)
In [Apple STP 189 release notes](https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-189)

[Enabled](https://github.com/WebKit/WebKit/commit/1544606a8541c44e64d73ae4693c90da45ca6402)
[Implementation](https://github.com/WebKit/WebKit/commit/bfcf9bf5da23fd0e272fa6b63fd1f6830322a576)
[Computation](https://github.com/WebKit/WebKit/commit/b28edead7c0c1615e7f7f934c475245e61742fe7)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
No