### PR TITLE
Add missing api.HTMLIFrameElement.adAuctionHeaders feature

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -43,6 +43,39 @@
           "deprecated": false
         }
       },
+      "adAuctionHeaders": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/turtledove/#dom-htmliframeelement-adauctionheaders",
+          "support": {
+            "chrome": {
+              "version_added": "122"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "align": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/align",


### PR DESCRIPTION
This PR adds the missing `adAuctionHeaders` member of the `HTMLIFrameElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLIFrameElement/adAuctionHeaders
