### PR TITLE
Add missing api.HTMLTemplateElement.shadowRootDelegatesFocus feature

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -71,6 +71,39 @@
           }
         }
       },
+      "shadowRootDelegatesFocus": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootdelegatesfocus",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "123"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "shadowRootMode": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootmode",


### PR DESCRIPTION
This PR adds the missing `shadowRootDelegatesFocus` member of the `HTMLTemplateElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLTemplateElement/shadowRootDelegatesFocus
