### PR TITLE
FF124 Screen Wakelock everted to preview

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4904,7 +4904,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -651,7 +651,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "124"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -54,7 +54,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "124"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -54,7 +54,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -96,7 +96,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -137,7 +137,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -178,7 +178,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This reverts #22255 - FF124 has reverted shipping Screen Wakelock API in https://bugzilla.mozilla.org/show_bug.cgi?id=1883724

Updating docs and stuff in https://github.com/mdn/content/issues/32338