### PR TITLE
FF119 :-moz-broken removed

### DIFF
--- a/css/selectors/-moz-broken.json
+++ b/css/selectors/-moz-broken.json
@@ -12,7 +12,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "119"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -31,7 +32,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
FF119 removes [`:-moz-broken`](https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-broken) in https://bugzilla.mozilla.org/show_bug.cgi?id=1850899 - confirmed by running the example in that doc in browserstack. Note that the issue also remove moz-loading but that doesn't have a BCD entry.

Fixes https://github.com/mdn/content/pull/32628