### PR TITLE
HTML global attribute contextmenu removed

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -431,44 +431,6 @@
           }
         }
       },
-      "contextmenu": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/contextmenu",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "9",
-              "version_removed": "85"
-            },
-            "firefox_android": {
-              "version_added": "32",
-              "version_removed": "56",
-              "notes": "Support for the <code>contextmenu</code> attribute has been removed from Firefox for Android (See <a href='https://bugzil.la/1424252'>bug 1424252</a>)."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "data_attributes": {
         "__compat": {
           "description": "<code>data-*</code> attributes",


### PR DESCRIPTION
According to data the `contextmenu` attribute was removed from last browser more than two years ago, and is therefore a candidate for removal from BCD and the docs.
This removes the entry.

Confirmed by @queengooborg in https://github.com/mdn/content/issues/32448#issuecomment-1965962908

Related to https://github.com/mdn/content/issues/32448