### PR TITLE
Bluetooth.requestDevice() options.filters.[manufacturerData/exclusionFilters]

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -70,44 +70,6 @@
           "deprecated": false
         }
       },
-      "availabilitychanged_event": {
-        "__compat": {
-          "description": "<code>availabilitychanged</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth#availabilitychanged",
-          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-onavailabilitychanged",
-          "support": {
-            "chrome": {
-              "version_added": "78"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/1100993"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "getAvailability": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/getAvailability",

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -181,6 +181,80 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_exclusionFilters_parameter": {
+          "__compat": {
+            "description": "<code>options.exclusionFilters</code> parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/requestDevice",
+            "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-requestdeviceoptions-exclusionfilters",
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_filter_manufacturerData_parameter": {
+          "__compat": {
+            "description": "<code>options.filter.manufacturerData</code> parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/requestDevice",
+            "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-manufacturerdata",
+            "support": {
+              "chrome": {
+                "version_added": "92"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -70,6 +70,41 @@
           "deprecated": false
         }
       },
+      "availabilitychanged_event": {
+        "__compat": {
+          "description": "<code>availabilitychanged</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth#availabilitychanged",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-onavailabilitychanged",
+          "support": {
+            "chrome": {
+              "version_added": "78"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getAvailability": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/getAvailability",

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -96,7 +96,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/1100993"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
`Bluetooth.requestDevice()` has some new options - including `options.filters.manufacturerData` and` options.exclusionFilters`. This adds these options as sub features.

There is also an event that was added in 78. There are other events and features in spec but not clear which are implemented and hard to test.

The version information comes from https://developer.chrome.com/docs/capabilities/bluetooth

I'm adding some docs to go with this here https://github.com/mdn/content/pull/32638