### PR TITLE
Update Safari data for css.properties.initial-letter.normal

### DIFF
--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -57,14 +57,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -32,7 +32,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `normal` member of the `initial-letter` CSS property. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

CSS.supports('-webkit-initial-letter', 'normal');

```
