### PR TITLE
Update  data for flex-direction CSS property

### DIFF
--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -30,19 +30,12 @@
             ],
             "firefox": [
               {
-                "version_added": "81"
+                "version_added": "20",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "version_added": "20",
-                "partial_implementation": true,
-                "notes": [
-                  "Since Firefox 28, multi-line flexbox is supported.",
-                  "Before Firefox 81, overflow with <code>*-reverse</code> is unsupported. See <a href='https://bugzil.la/1042151'>bug 1042151</a>."
-                ]
               }
             ],
             "firefox_android": "mirror",
@@ -139,9 +132,16 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": {
-                "version_added": "≤72"
-              },
+              "firefox": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "version_added": "≤72",
+                  "partial_implementation": true,
+                  "notes": "Before Firefox 81, overflow with <code>column-reverse</code> was unsupported. See <a href='https://bugzil.la/1042151'>bug 1042151</a>."
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "≤11"
@@ -209,9 +209,16 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": {
-                "version_added": "≤72"
-              },
+              "firefox": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "version_added": "≤72",
+                  "partial_implementation": true,
+                  "notes": "Before Firefox 81, overflow with <code>column-reverse</code> was unsupported. See <a href='https://bugzil.la/1042151'>bug 1042151</a>."
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "≤11"


### PR DESCRIPTION
This PR updates and corrects version values for  for the `flex-direction` CSS property. This moves the partial implementation note into the specific values the note is referring to.
