### PR TITLE
Update Edge data for api.CSSImportRule.supportsText

### DIFF
--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -205,9 +205,7 @@
               "version_added": "121"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "114"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `supportsText` member of the `CSSImportRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSImportRule/supportsText
