### PR TITLE
Update Chromium data for CloseWatcher API

### DIFF
--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -5,7 +5,8 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#closewatcher",
         "support": {
           "chrome": {
-            "version_added": "120"
+            "version_added": "120",
+            "version_removed": "121"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -38,7 +39,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher",
           "support": {
             "chrome": {
-              "version_added": "120"
+              "version_added": "120",
+              "version_removed": "121"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -72,7 +74,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#handler-closewatcher-oncancel",
           "support": {
             "chrome": {
-              "version_added": "120"
+              "version_added": "120",
+              "version_removed": "121"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -105,7 +108,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-close",
           "support": {
             "chrome": {
-              "version_added": "120"
+              "version_added": "120",
+              "version_removed": "121"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -139,7 +143,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#handler-closewatcher-onclose",
           "support": {
             "chrome": {
-              "version_added": "120"
+              "version_added": "120",
+              "version_removed": "121"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -172,7 +177,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-destroy",
           "support": {
             "chrome": {
-              "version_added": "120"
+              "version_added": "120",
+              "version_removed": "121"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -205,7 +211,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-requestclose",
           "support": {
             "chrome": {
-              "version_added": "120"
+              "version_added": "120",
+              "version_removed": "121"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CloseWatcher` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CloseWatcher

Additional Notes: Fixes #22602.
