### PR TITLE
Update Chromium data for api.GPUCommandEncoder.writeTimestamp

### DIFF
--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -835,6 +835,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "version_removed": "121",
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `writeTimestamp` member of the `GPUCommandEncoder` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/GPUCommandEncoder/writeTimestamp
