### PR TITLE
Update Chromium data for api.GPUPipelineError.GPUPipelineError.message_optional

### DIFF
--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -90,7 +90,7 @@
             "description": "<code>message</code> parameter is optional",
             "support": {
               "chrome": {
-                "version_added": "116"
+                "version_added": "113"
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `GPUPipelineError.message_optional` member of the `GPUPipelineError` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/GPUPipelineError/GPUPipelineError/message_optional
