### PR TITLE
Update Chromium data for api.GPURenderPassEncoder.setVertexBuffer.unset_vertex_buffer

### DIFF
--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -1185,7 +1185,7 @@
             "description": "Pass <code>null</code> to unset vertex buffer",
             "support": {
               "chrome": {
-                "version_added": "115",
+                "version_added": "117",
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `setVertexBuffer.unset_vertex_buffer` member of the `GPURenderPassEncoder` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/GPURenderPassEncoder/setVertexBuffer/unset_vertex_buffer
