### PR TITLE
Update Chromium data for api.HTMLElement.togglePopover.returns_boolean

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2277,7 +2277,7 @@
             "description": "Returns <code>true</code> or <code>false</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "116"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `togglePopover.returns_boolean` member of the `HTMLElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLElement/togglePopover/returns_boolean
