### PR TITLE
Update Safari data for api.HTMLMediaElement.preservesPitch

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2301,11 +2301,7 @@
                 "impl_url": "https://webkit.org/b/214922"
               }
             ],
-            "safari_ios": {
-              "prefix": "webkit",
-              "version_added": "4",
-              "impl_url": "https://webkit.org/b/214922"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `preservesPitch` member of the `HTMLMediaElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLMediaElement/preservesPitch
