### PR TITLE
Update Chromium data for api.MediaSession.setActionHandler

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -176,7 +176,7 @@
             "description": "<code>\"hangup\"</code> type",
             "support": {
               "chrome": {
-                "version_added": "92"
+                "version_added": "93"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -606,7 +606,7 @@
             "description": "<code>\"togglecamera\"</code> type",
             "support": {
               "chrome": {
-                "version_added": "92"
+                "version_added": "93"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -641,7 +641,7 @@
             "description": "<code>\"togglemicrophone\"</code> type",
             "support": {
               "chrome": {
-                "version_added": "92"
+                "version_added": "93"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `setActionHandler` member of the `MediaSession` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaSession/setActionHandler
