### PR TITLE
Update Safari data for api.Permissions.permission_push

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -622,7 +622,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `permission_push` member of the `Permissions` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Permissions/permission_push
