### PR TITLE
Add runtime.onPerformanceWarning types

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -246,6 +246,46 @@
             }
           }
         },
+        "OnPerformanceWarningCategory": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnPerformanceWarningCategory",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "124"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "OnPerformanceWarningSeverity": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnPerformanceWarningSeverity",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "124"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "OnRestartRequiredReason": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnRestartRequiredReason",


### PR DESCRIPTION
#### Summary

Adds compatibility details for the `runtime.OnPerformanceWarningCategory` and `runtime.OnPerformanceWarningSeverity`tvpev introduced by [Bug 1861445](https://bugzilla.mozilla.org/show_bug.cgi?id=1861445) Add new hang warning event API for WebExtensionswarning.

See https://github.com/mdn/content/pull/32222 for the MDN content update.

DO NOT MERGE until related MDN content is ready to merge.