### PR TITLE
Add the Web MIDI API web-features tag

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiaccess-interface",
+        "tags": [
+          "web-features:midi"
+        ],
         "support": {
           "chrome": {
             "version_added": "43"
@@ -40,6 +43,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/inputs",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-inputs",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -77,6 +83,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/outputs",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-outputs",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -115,6 +124,9 @@
           "description": "<code>statechange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/statechange_event",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-onstatechange",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -152,6 +164,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/sysexEnabled",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-sysexenabled",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIConnectionEvent",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiconnectionevent-interface",
+        "tags": [
+          "web-features:midi"
+        ],
         "support": {
           "chrome": {
             "version_added": "43"
@@ -41,6 +44,9 @@
           "description": "<code>MIDIConnectionEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIConnectionEvent/MIDIConnectionEvent",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiconnectionevent-constructor",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -78,6 +84,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIConnectionEvent/port",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiconnectionevent-port",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIInput",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiinput-interface",
+        "tags": [
+          "web-features:midi"
+        ],
         "support": {
           "chrome": {
             "version_added": "43"
@@ -41,6 +44,9 @@
           "description": "<code>midimessage</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIInput/midimessage_event",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiinput-onmidimessage",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIInputMap",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiinputmap-interface",
+        "tags": [
+          "web-features:midi"
+        ],
         "support": {
           "chrome": {
             "version_added": "43"
@@ -38,6 +41,9 @@
       },
       "entries": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -73,6 +79,9 @@
       },
       "forEach": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -108,6 +117,9 @@
       },
       "get": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -143,6 +155,9 @@
       },
       "has": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -178,6 +193,9 @@
       },
       "keys": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -213,6 +231,9 @@
       },
       "size": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -248,6 +269,9 @@
       },
       "values": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -283,6 +307,9 @@
       },
       "@@iterator": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIMessageEvent",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midimessageevent-interface",
+        "tags": [
+          "web-features:midi"
+        ],
         "support": {
           "chrome": {
             "version_added": "43"
@@ -43,6 +46,9 @@
           "description": "<code>MIDIMessageEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIMessageEvent/MIDIMessageEvent",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midimessageevent-constructor",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -82,6 +88,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIMessageEvent/data",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midimessageevent-data",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput",
         "spec_url": "https://webaudio.github.io/web-midi-api/#MIDIOutput",
+        "tags": [
+          "web-features:midi"
+        ],
         "support": {
           "chrome": {
             "version_added": "43"
@@ -42,6 +45,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput/clear",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midioutput-clear",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": false,
@@ -80,6 +86,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput/send",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midioutput-send",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutputMap",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiinputmap-interface",
+        "tags": [
+          "web-features:midi"
+        ],
         "support": {
           "chrome": {
             "version_added": "43"
@@ -38,6 +41,9 @@
       },
       "entries": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -73,6 +79,9 @@
       },
       "forEach": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -108,6 +117,9 @@
       },
       "get": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -143,6 +155,9 @@
       },
       "has": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -178,6 +193,9 @@
       },
       "keys": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -213,6 +231,9 @@
       },
       "size": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -248,6 +269,9 @@
       },
       "values": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -283,6 +307,9 @@
       },
       "@@iterator": {
         "__compat": {
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort",
         "spec_url": "https://webaudio.github.io/web-midi-api/#MIDIPort",
+        "tags": [
+          "web-features:midi"
+        ],
         "support": {
           "chrome": {
             "version_added": "43"
@@ -40,6 +43,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/close",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-close",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -77,6 +83,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/connection",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-connection",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -114,6 +123,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/id",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-id",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -151,6 +163,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/manufacturer",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-manufacturer",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -188,6 +203,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/name",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-name",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -225,6 +243,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/open",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-open",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -262,6 +283,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/state",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-state",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -300,6 +324,9 @@
           "description": "<code>statechange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/statechange_event",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-onstatechange",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -337,6 +364,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/type",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-type",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -374,6 +404,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/version",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-version",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3999,6 +3999,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/requestMIDIAccess",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-navigator-requestmidiaccess",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -4019,7 +4022,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/107250"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -465,6 +465,9 @@
         "__compat": {
           "description": "<code>midi</code> permission",
           "spec_url": "https://webaudio.github.io/web-midi-api/#permissions-integration",
+          "tags": [
+            "web-features:midi"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -482,7 +485,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/107250"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -964,6 +964,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/midi",
             "spec_url": "https://webaudio.github.io/web-midi-api/#permissions-policy-integration",
+            "tags": [
+              "web-features:midi"
+            ],
             "support": {
               "chrome": [
                 {
@@ -995,7 +998,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/107250"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds the required `web-features` tags to the Web MIDI API features in BCD, so that they can be linked to the [web-features](https://github.com/web-platform-dx/web-features/) repository and get their baseline status computed.