### PR TITLE
Define a temporal web-feature and add `impl_url` fields for Firefox and Safari

### DIFF
--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -38,7 +38,8 @@
                   "value_to_set": "1",
                   "type": "runtime_flag"
                 }
-              ]
+              ],
+              "impl_url": "https://webkit.org/b/223166"
             },
             "safari_ios": {
               "version_added": false

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -6,6 +6,9 @@
           "description": "Temporal API",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal",
           "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-intro",
+          "tags": [
+            "web-features:temporal"
+          ],
           "support": {
             "chrome": {
               "version_added": false,
@@ -14,7 +17,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1519167"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/javascript/builtins/Temporal/Calendar.json
+++ b/javascript/builtins/Temporal/Calendar.json
@@ -7,6 +7,9 @@
             "description": "Temporal.Calendar interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-calendar-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.Calendar constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/Calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-calendar-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.Calendar.dateAdd()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dateAdd",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dateadd",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.Calendar.dateFromFields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dateFromFields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.datefromfields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.Calendar.dateUntil()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dateUntil",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dateuntil",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.Calendar.day()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.Calendar.dayOfWeek()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dayOfWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dayofweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.Calendar.dayOfYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dayOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dayofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.Calendar.daysInMonth()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/daysInMonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -438,6 +474,9 @@
               "description": "Temporal.Calendar.daysInWeek()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/daysInWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -455,7 +494,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -486,6 +526,9 @@
               "description": "Temporal.Calendar.daysInYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/daysInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -503,7 +546,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -533,6 +577,9 @@
             "__compat": {
               "description": "Temporal.Calendar.era()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -550,7 +597,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -580,6 +628,9 @@
             "__compat": {
               "description": "Temporal.Calendar.eraYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/eraYear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -597,7 +648,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -628,6 +680,9 @@
               "description": "Temporal.Calendar.fields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/fields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.fields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -645,7 +700,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -676,6 +732,9 @@
               "description": "Temporal.Calendar.from()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -693,7 +752,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -724,6 +784,9 @@
               "description": "Temporal.Calendar.id",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/id",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.calendar.prototype.id",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -741,7 +804,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -772,6 +836,9 @@
               "description": "Temporal.Calendar.inLeapYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/inLeapYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -789,7 +856,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -820,6 +888,9 @@
               "description": "Temporal.Calendar.mergeFields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/mergeFields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.mergefields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -837,7 +908,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -868,6 +940,9 @@
               "description": "Temporal.Calendar.month()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/frmonthom",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.month",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -885,7 +960,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -916,6 +992,9 @@
               "description": "Temporal.Calendar.monthCode()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/monthCode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthcode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -933,7 +1012,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -964,6 +1044,9 @@
               "description": "Temporal.Calendar.monthDayFromFields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/monthDayFromFields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthdayfromfields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -981,7 +1064,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1012,6 +1096,9 @@
               "description": "Temporal.Calendar.monthsInYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/monthsInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1029,7 +1116,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1060,6 +1148,9 @@
               "description": "Temporal.Calendar.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/toJSON",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1077,7 +1168,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1108,6 +1200,9 @@
               "description": "Temporal.Calendar.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/toJSON",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1125,7 +1220,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1156,6 +1252,9 @@
               "description": "Temporal.Calendar.weekOfYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/weekOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.weekofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1173,7 +1272,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1204,6 +1304,9 @@
               "description": "Temporal.Calendar.year()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1221,7 +1324,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1252,6 +1356,9 @@
               "description": "Temporal.Calendar.yearMonthFromFields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/yearMonthFromFields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.yearmonthfromfields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1269,7 +1376,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Calendar.json
+++ b/javascript/builtins/Temporal/Calendar.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "preview",
+                "impl_url": "https://webkit.org/b/229651"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -508,7 +517,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -560,7 +570,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -611,7 +622,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -662,7 +674,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -714,7 +727,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -766,7 +780,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -818,7 +833,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -870,7 +886,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -922,7 +939,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -974,7 +992,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1026,7 +1045,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1078,7 +1098,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1130,7 +1151,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1182,7 +1204,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1234,7 +1257,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1286,7 +1310,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1338,7 +1363,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1390,7 +1416,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229651"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "preview",
+                "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -508,7 +517,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -560,7 +570,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -612,7 +623,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -664,7 +676,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -716,7 +729,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -768,7 +782,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -820,7 +835,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -872,7 +888,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -924,7 +941,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -976,7 +994,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1028,7 +1047,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1080,7 +1100,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1132,7 +1153,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1184,7 +1206,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1236,7 +1259,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1288,7 +1312,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1340,7 +1365,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1392,7 +1418,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -7,6 +7,9 @@
             "description": "Temporal.Duration interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-duration-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.Duration constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/Duration",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-duration-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.Duration.abs()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/abs",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.abs",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.Duration.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.Duration.blank",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/blank",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.blank",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.Duration.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.Duration.days",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/days",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.days",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.Duration.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.Duration.hours",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/hours",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.hours",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -438,6 +474,9 @@
               "description": "Temporal.Duration.microseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/microseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.microseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -455,7 +494,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -486,6 +526,9 @@
               "description": "Temporal.Duration.milliseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/milliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.milliseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -503,7 +546,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -534,6 +578,9 @@
               "description": "Temporal.Duration.minutes",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/minutes",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.minutes",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -551,7 +598,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -582,6 +630,9 @@
               "description": "Temporal.Duration.months",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/months",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.months",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -599,7 +650,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -630,6 +682,9 @@
               "description": "Temporal.Duration.nanoseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/nanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.nanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -647,7 +702,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -678,6 +734,9 @@
               "description": "Temporal.Duration.negated()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/negated",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.negated",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -695,7 +754,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -726,6 +786,9 @@
               "description": "Temporal.Duration.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -743,7 +806,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -774,6 +838,9 @@
               "description": "Temporal.Duration.seconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/seconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.seconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -791,7 +858,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,6 +890,9 @@
               "description": "Temporal.Duration.sign",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/sign",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.sign",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -839,7 +910,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -870,6 +942,9 @@
               "description": "Temporal.Duration.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -887,7 +962,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -918,6 +994,9 @@
               "description": "Temporal.Duration.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -935,7 +1014,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -966,6 +1046,9 @@
               "description": "Temporal.Duration.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -983,7 +1066,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1014,6 +1098,9 @@
               "description": "Temporal.Duration.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1031,7 +1118,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1062,6 +1150,9 @@
               "description": "Temporal.Duration.total()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/total",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1079,7 +1170,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1110,6 +1202,9 @@
               "description": "Temporal.Duration.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1127,7 +1222,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1158,6 +1254,9 @@
               "description": "Temporal.Duration.weeks",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/weeks",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.weeks",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1175,7 +1274,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1206,6 +1306,9 @@
               "description": "Temporal.Duration.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1223,7 +1326,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1254,6 +1358,9 @@
               "description": "Temporal.Duration.years",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/years",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.years",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1271,7 +1378,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -7,6 +7,9 @@
             "description": "Temporal.Instant interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.Instant constructor",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/Instant",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-objects",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.Instant.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.Instant.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.Instant.epochMicroseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/epochmicroseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmicroseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.Instant.epochMilliseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/epochmilliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmilliseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.Instant.epochNanoseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/epochnanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.Instant.epochSeconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/epochseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.Instant.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -438,6 +474,9 @@
               "description": "Temporal.Instant.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -455,7 +494,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -486,6 +526,9 @@
               "description": "Temporal.Instant.fromEpochMicroseconds()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/fromepochmicroseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -503,7 +546,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -534,6 +578,9 @@
               "description": "Temporal.Instant.fromEpochMilliseconds()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/fromepochmilliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochmilliseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -551,7 +598,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -582,6 +630,9 @@
               "description": "Temporal.Instant.fromEpochNanoseconds()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/fromepochnanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochnanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -599,7 +650,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -630,6 +682,9 @@
               "description": "Temporal.Instant.fromEpochSeconds()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/fromepochseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -647,7 +702,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -678,6 +734,9 @@
               "description": "Temporal.Instant.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -695,7 +754,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -726,6 +786,9 @@
               "description": "Temporal.Instant.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -743,7 +806,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -774,6 +838,9 @@
               "description": "Temporal.Instant.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -791,7 +858,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,6 +890,9 @@
               "description": "Temporal.Instant.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -839,7 +910,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -870,6 +942,9 @@
               "description": "Temporal.Instant.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -887,7 +962,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -918,6 +994,9 @@
               "description": "Temporal.Instant.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -935,7 +1014,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -966,6 +1046,9 @@
               "description": "Temporal.Instant.toZonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tozoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -983,7 +1066,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1014,6 +1098,9 @@
               "description": "Temporal.Instant.toZonedDateTimeISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tozoneddatetimeiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1031,7 +1118,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1062,6 +1150,9 @@
               "description": "Temporal.Instant.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1079,7 +1170,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1110,6 +1202,9 @@
               "description": "Temporal.Instant.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1127,7 +1222,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "preview",
+                "impl_url": "https://webkit.org/b/229826"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -508,7 +517,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -560,7 +570,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -612,7 +623,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -664,7 +676,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -716,7 +729,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -768,7 +782,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -820,7 +835,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -872,7 +888,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -924,7 +941,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -976,7 +994,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1028,7 +1047,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1080,7 +1100,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1132,7 +1153,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1184,7 +1206,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1236,7 +1259,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229826"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -7,6 +7,9 @@
             "description": "Temporal.Now interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Now",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-now-object",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.Now.instant()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/instant",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.instant",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.Now.plainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.Now.plainDateISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindateiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindateiso",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.Now.plainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.Now.plainDateTimeISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindatetimeiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.Now.timeZone()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/timezone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.timezone",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.Now.zonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/zoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.Now.zonedDateTimeISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/zoneddatetimeiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetimeiso",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/234836"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/230033"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -508,7 +517,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -560,7 +570,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -612,7 +623,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -663,7 +675,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -714,7 +727,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -766,7 +780,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -818,7 +833,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -870,7 +886,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -922,7 +939,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -974,7 +992,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1026,7 +1045,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1078,7 +1098,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1130,7 +1151,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1182,7 +1204,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1234,7 +1257,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1286,7 +1310,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1338,7 +1363,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1390,7 +1416,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1442,7 +1469,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1494,7 +1522,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1546,7 +1575,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1598,7 +1628,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1650,7 +1681,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1702,7 +1734,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1754,7 +1787,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1806,7 +1840,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/230033"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainDate interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindate-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.PlainDate constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/PlainDate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindate-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.PlainDate.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.PlainDate.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.PlainDate.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.PlainDate.day",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.PlainDate.dayOfWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/dayofweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.PlainDate.dayOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/dayofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.PlainDate.daysInMonth",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/daysinmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -438,6 +474,9 @@
               "description": "Temporal.PlainDate.daysInWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/daysinweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -455,7 +494,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -486,6 +526,9 @@
               "description": "Temporal.PlainDate.daysInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/daysinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -503,7 +546,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -534,6 +578,9 @@
               "description": "Temporal.PlainDate.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -551,7 +598,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -581,6 +629,9 @@
             "__compat": {
               "description": "Temporal.PlainDate.era",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -598,7 +649,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -628,6 +680,9 @@
             "__compat": {
               "description": "Temporal.PlainDate.eraYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/erayear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -645,7 +700,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -676,6 +732,9 @@
               "description": "Temporal.PlainDate.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -693,7 +752,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -724,6 +784,9 @@
               "description": "Temporal.PlainDate.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -741,7 +804,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -772,6 +836,9 @@
               "description": "Temporal.PlainDate.inLeapYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/inleapyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -789,7 +856,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -820,6 +888,9 @@
               "description": "Temporal.PlainDate.month",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.month",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -837,7 +908,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -868,6 +940,9 @@
               "description": "Temporal.PlainDate.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthCode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -885,7 +960,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -916,6 +992,9 @@
               "description": "Temporal.PlainDate.monthsInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/monthsinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -933,7 +1012,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -964,6 +1044,9 @@
               "description": "Temporal.PlainDate.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -981,7 +1064,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1012,6 +1096,9 @@
               "description": "Temporal.PlainDate.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1029,7 +1116,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1060,6 +1148,9 @@
               "description": "Temporal.PlainDate.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1077,7 +1168,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1108,6 +1200,9 @@
               "description": "Temporal.PlainDate.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1125,7 +1220,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1156,6 +1252,9 @@
               "description": "Temporal.PlainDate.toPlainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/toplaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplaindatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1173,7 +1272,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1204,6 +1304,9 @@
               "description": "Temporal.PlainDate.toPlainMonthDay()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/toplainmonthday",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1221,7 +1324,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1252,6 +1356,9 @@
               "description": "Temporal.PlainDate.toPlainYearMonth()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/toplainyearmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainyearmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1269,7 +1376,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1300,6 +1408,9 @@
               "description": "Temporal.PlainDate.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1317,7 +1428,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1348,6 +1460,9 @@
               "description": "Temporal.PlainDate.toZonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/tozoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tozoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1365,7 +1480,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1396,6 +1512,9 @@
               "description": "Temporal.PlainDate.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1413,7 +1532,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1444,6 +1564,9 @@
               "description": "Temporal.PlainDate.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1461,7 +1584,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1492,6 +1616,9 @@
               "description": "Temporal.PlainDate.weekOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/weekofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.weekofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1509,7 +1636,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1540,6 +1668,9 @@
               "description": "Temporal.PlainDate.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1557,7 +1688,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1588,6 +1720,9 @@
               "description": "Temporal.PlainDate.withCalendar()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/withcalendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.withcalendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1605,7 +1740,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1636,6 +1772,9 @@
               "description": "Temporal.PlainDate.year",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1653,7 +1792,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainDateTime interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.PlainDateTime constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/PlainDateTime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.PlainDateTime.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.PlainDateTime.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.PlainDateTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.PlainDateTime.day",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.PlainDateTime.dayOfWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/dayofweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.PlainDateTime.dayOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/dayofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.PlainDateTime.daysInMonth",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/daysinmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -438,6 +474,9 @@
               "description": "Temporal.PlainDateTime.daysInWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/daysinweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -455,7 +494,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -486,6 +526,9 @@
               "description": "Temporal.PlainDateTime.daysInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/daysinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -503,7 +546,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -534,6 +578,9 @@
               "description": "Temporal.PlainDateTime.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -551,7 +598,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -581,6 +629,9 @@
             "__compat": {
               "description": "Temporal.PlainDateTime.era",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -598,7 +649,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -628,6 +680,9 @@
             "__compat": {
               "description": "Temporal.PlainDateTime.eraYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/erayear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -645,7 +700,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -676,6 +732,9 @@
               "description": "Temporal.PlainDateTime.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -693,7 +752,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -724,6 +784,9 @@
               "description": "Temporal.PlainDateTime.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -741,7 +804,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -772,6 +836,9 @@
               "description": "Temporal.PlainDateTime.hour",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.hour",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -789,7 +856,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -820,6 +888,9 @@
               "description": "Temporal.PlainDateTime.inLeapYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/inleapyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -837,7 +908,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -868,6 +940,9 @@
               "description": "Temporal.PlainDateTime.microsecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.microsecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -885,7 +960,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -916,6 +992,9 @@
               "description": "Temporal.PlainDateTime.millisecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.millisecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -933,7 +1012,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -964,6 +1044,9 @@
               "description": "Temporal.PlainDateTime.minute",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.minute",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -981,7 +1064,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1012,6 +1096,9 @@
               "description": "Temporal.PlainDateTime.month",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.month",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1029,7 +1116,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1060,6 +1148,9 @@
               "description": "Temporal.PlainDateTime.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthcode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1077,7 +1168,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1108,6 +1200,9 @@
               "description": "Temporal.PlainDateTime.monthsInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/monthsinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1125,7 +1220,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1156,6 +1252,9 @@
               "description": "Temporal.PlainDateTime.nanosecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.nanosecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1173,7 +1272,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1204,6 +1304,9 @@
               "description": "Temporal.PlainDateTime.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1221,7 +1324,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1252,6 +1356,9 @@
               "description": "Temporal.PlainDateTime.second",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.second",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1269,7 +1376,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1300,6 +1408,9 @@
               "description": "Temporal.PlainDateTime.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1317,7 +1428,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1348,6 +1460,9 @@
               "description": "Temporal.PlainDateTime.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1365,7 +1480,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1396,6 +1512,9 @@
               "description": "Temporal.PlainDateTime.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1413,7 +1532,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1444,6 +1564,9 @@
               "description": "Temporal.PlainDateTime.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1461,7 +1584,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1492,6 +1616,9 @@
               "description": "Temporal.PlainDateTime.toPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/toplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1509,7 +1636,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1540,6 +1668,9 @@
               "description": "Temporal.PlainDateTime.toPlainMonthDay()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/toplainmonthday",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplainmonthday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1557,7 +1688,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1588,6 +1720,9 @@
               "description": "Temporal.PlainDateTime.toPlainTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/toplaintime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaintime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1605,7 +1740,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1636,6 +1772,9 @@
               "description": "Temporal.PlainDateTime.toPlainYearMonth()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/toplainyearmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplainyearmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1653,7 +1792,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1684,6 +1824,9 @@
               "description": "Temporal.PlainDateTime.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1701,7 +1844,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1732,6 +1876,9 @@
               "description": "Temporal.PlainDateTime.toZonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/tozoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1749,7 +1896,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1780,6 +1928,9 @@
               "description": "Temporal.PlainDateTime.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1797,7 +1948,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1828,6 +1980,9 @@
               "description": "Temporal.PlainDateTime.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1845,7 +2000,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1876,6 +2032,9 @@
               "description": "Temporal.PlainDateTime.weekOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/weekofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.weekofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1893,7 +2052,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1924,6 +2084,9 @@
               "description": "Temporal.PlainDateTime.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1941,7 +2104,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1972,6 +2136,9 @@
               "description": "Temporal.PlainDateTime.withCalendar()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/withcalendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1989,7 +2156,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2020,6 +2188,9 @@
               "description": "Temporal.PlainDateTime.withPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/withplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2037,7 +2208,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2068,6 +2240,9 @@
               "description": "Temporal.PlainDateTime.withPlainTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/withplaintime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2085,7 +2260,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2116,6 +2292,9 @@
               "description": "Temporal.PlainDateTime.year",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2133,7 +2312,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -508,7 +517,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -560,7 +570,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -612,7 +623,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -663,7 +675,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -714,7 +727,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -766,7 +780,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -818,7 +833,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -870,7 +886,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -922,7 +939,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -974,7 +992,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1026,7 +1045,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1078,7 +1098,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1130,7 +1151,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1182,7 +1204,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1234,7 +1257,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1286,7 +1310,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1338,7 +1363,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1390,7 +1416,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1442,7 +1469,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1494,7 +1522,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1546,7 +1575,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1598,7 +1628,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1650,7 +1681,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1702,7 +1734,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1754,7 +1787,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1806,7 +1840,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1858,7 +1893,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1910,7 +1946,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1962,7 +1999,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2014,7 +2052,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2066,7 +2105,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2118,7 +2158,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2170,7 +2211,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2222,7 +2264,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2274,7 +2317,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2326,7 +2370,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainMonthDay interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.PlainMonthDay constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/PlainMonthDay",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.PlainMonthDay.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.PlainMonthDay.day",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.PlainMonthDay.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.PlainMonthDay.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.PlainMonthDay.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.PlainMonthDay.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.monthcode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.PlainMonthDay.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -438,6 +474,9 @@
               "description": "Temporal.PlainMonthDay.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -455,7 +494,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -486,6 +526,9 @@
               "description": "Temporal.PlainMonthDay.toPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/toplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -503,7 +546,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -534,6 +578,9 @@
               "description": "Temporal.PlainMonthDay.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -551,7 +598,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -582,6 +630,9 @@
               "description": "Temporal.PlainMonthDay.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -599,7 +650,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -630,6 +682,9 @@
               "description": "Temporal.PlainMonthDay.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -647,7 +702,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -508,7 +517,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -560,7 +570,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -612,7 +623,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -664,7 +676,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -716,7 +729,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainTime interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaintime-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.PlainTime constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/PlainTime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.PlainTime.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.PlainTime.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -197,6 +213,9 @@
             "__compat": {
               "description": "Temporal.PlainTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -214,7 +233,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -245,6 +265,9 @@
               "description": "Temporal.PlainTime.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -262,7 +285,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -293,6 +317,9 @@
               "description": "Temporal.PlainTime.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -310,7 +337,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -341,6 +369,9 @@
               "description": "Temporal.PlainTime.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -358,7 +389,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -389,6 +421,9 @@
               "description": "Temporal.PlainTime.hour",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.hour",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -406,7 +441,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -437,6 +473,9 @@
               "description": "Temporal.PlainTime.microsecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.microsecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -454,7 +493,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -485,6 +525,9 @@
               "description": "Temporal.PlainTime.millisecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.millisecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -502,7 +545,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -533,6 +577,9 @@
               "description": "Temporal.PlainTime.minute",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.minute",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -550,7 +597,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -581,6 +629,9 @@
               "description": "Temporal.PlainTime.nanosecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.nanosecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -598,7 +649,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -629,6 +681,9 @@
               "description": "Temporal.PlainTime.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -646,7 +701,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -677,6 +733,9 @@
               "description": "Temporal.PlainTime.second",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.second",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -694,7 +753,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -725,6 +785,9 @@
               "description": "Temporal.PlainTime.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -742,7 +805,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -773,6 +837,9 @@
               "description": "Temporal.PlainTime.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -790,7 +857,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -821,6 +889,9 @@
               "description": "Temporal.PlainTime.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -838,7 +909,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -869,6 +941,9 @@
               "description": "Temporal.PlainTime.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -886,7 +961,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -917,6 +993,9 @@
               "description": "Temporal.PlainTime.toPlainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/toplaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.toplaindatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -934,7 +1013,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -965,6 +1045,9 @@
               "description": "Temporal.PlainTime.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -982,7 +1065,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1013,6 +1097,9 @@
               "description": "Temporal.PlainTime.toZonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/tozoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tozoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1030,7 +1117,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1061,6 +1149,9 @@
               "description": "Temporal.PlainTime.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1078,7 +1169,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1109,6 +1201,9 @@
               "description": "Temporal.PlainTime.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1126,7 +1221,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1157,6 +1253,9 @@
               "description": "Temporal.PlainTime.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1174,7 +1273,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "preview",
+                "impl_url": "https://webkit.org/b/229892"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -247,7 +251,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -299,7 +304,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -351,7 +357,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -403,7 +410,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -455,7 +463,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -507,7 +516,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -559,7 +569,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -611,7 +622,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -663,7 +675,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -715,7 +728,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -767,7 +781,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -819,7 +834,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -871,7 +887,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -923,7 +940,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -975,7 +993,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1027,7 +1046,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1079,7 +1099,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1131,7 +1152,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1183,7 +1205,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1235,7 +1258,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1287,7 +1311,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229892"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainYearMonth interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.PlainYearMonth constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/PlainYearMonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.PlainYearMonth.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.PlainYearMonth.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.PlainYearMonth.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.PlainYearMonth.daysInMonth",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/daysinmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.PlainYearMonth.daysInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/daysinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.PlainYearMonth.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -389,6 +421,9 @@
             "__compat": {
               "description": "Temporal.PlainYearMonth.era",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -406,7 +441,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -436,6 +472,9 @@
             "__compat": {
               "description": "Temporal.PlainYearMonth.eraYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/erayear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -453,7 +492,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -484,6 +524,9 @@
               "description": "Temporal.PlainYearMonth.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -501,7 +544,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -532,6 +576,9 @@
               "description": "Temporal.PlainYearMonth.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -549,7 +596,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -580,6 +628,9 @@
               "description": "Temporal.PlainYearMonth.inLeapYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/inleapyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -597,7 +648,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -628,6 +680,9 @@
               "description": "Temporal.PlainYearMonth.month",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthCode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -645,7 +700,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -676,6 +732,9 @@
               "description": "Temporal.PlainYearMonth.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthCode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -693,7 +752,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -724,6 +784,9 @@
               "description": "Temporal.PlainYearMonth.monthsInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/monthsinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -741,7 +804,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -772,6 +836,9 @@
               "description": "Temporal.PlainYearMonth.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -789,7 +856,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -820,6 +888,9 @@
               "description": "Temporal.PlainYearMonth.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -837,7 +908,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -868,6 +940,9 @@
               "description": "Temporal.PlainYearMonth.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -885,7 +960,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -916,6 +992,9 @@
               "description": "Temporal.PlainYearMonth.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -933,7 +1012,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -964,6 +1044,9 @@
               "description": "Temporal.PlainYearMonth.toPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/toplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -981,7 +1064,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1012,6 +1096,9 @@
               "description": "Temporal.PlainYearMonth.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1029,7 +1116,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1060,6 +1148,9 @@
               "description": "Temporal.PlainYearMonth.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1077,7 +1168,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1108,6 +1200,9 @@
               "description": "Temporal.PlainYearMonth.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1125,7 +1220,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1156,6 +1252,9 @@
               "description": "Temporal.PlainYearMonth.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1173,7 +1272,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1204,6 +1304,9 @@
               "description": "Temporal.PlainYearMonth.year",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1221,7 +1324,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -455,7 +463,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -506,7 +515,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -558,7 +568,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -610,7 +621,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -662,7 +674,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -714,7 +727,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -766,7 +780,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -818,7 +833,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -870,7 +886,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -922,7 +939,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -974,7 +992,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1026,7 +1045,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1078,7 +1098,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1130,7 +1151,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1182,7 +1204,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1234,7 +1257,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1286,7 +1310,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1338,7 +1363,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/TimeZone.json
+++ b/javascript/builtins/Temporal/TimeZone.json
@@ -7,6 +7,9 @@
             "description": "Temporal.TimeZone interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/TimeZone",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-timezone-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.TimeZone constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/TimeZone/TimeZone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-timezone-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.TimeZone.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.TimeZone.getInstantFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getinstantfor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getinstantfor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.TimeZone.getNextTransition()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getnexttransition",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getnexttransition",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.TimeZone.getOffsetNanosecondsFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getoffsetnanosecondsfor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getoffsetnanosecondsfor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.TimeZone.getOffsetStringFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getoffsetstringfor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getoffsetstringfor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.TimeZone.getPlainDateTimeFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getplaindatetimefor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getplaindatetimefor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.TimeZone.getPossibleInstantsFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getpossibleinstantsfor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getpossibleinstantsfor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -438,6 +474,9 @@
               "description": "Temporal.TimeZone.getPreviousTransition()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getprevioustransition",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getprevioustransition",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -455,7 +494,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -486,6 +526,9 @@
               "description": "Temporal.TimeZone.id",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/id",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.timezone.prototype.id",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -503,7 +546,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -534,6 +578,9 @@
               "description": "Temporal.TimeZone.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -551,7 +598,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -582,6 +630,9 @@
               "description": "Temporal.TimeZone.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -599,7 +650,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/TimeZone.json
+++ b/javascript/builtins/Temporal/TimeZone.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "preview",
+                "impl_url": "https://webkit.org/b/229703"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -508,7 +517,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -560,7 +570,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -612,7 +623,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -664,7 +676,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "preview",
+                  "impl_url": "https://webkit.org/b/229703"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -41,7 +41,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -92,7 +93,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -144,7 +146,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -196,7 +199,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -248,7 +252,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -300,7 +305,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -352,7 +358,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -404,7 +411,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -456,7 +464,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -508,7 +517,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -560,7 +570,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -612,7 +623,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -664,7 +676,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -716,7 +729,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -768,7 +782,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -820,7 +835,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -871,7 +887,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -922,7 +939,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -974,7 +992,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1026,7 +1045,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1078,7 +1098,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1130,7 +1151,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1182,7 +1204,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1234,7 +1257,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1286,7 +1310,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1338,7 +1363,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1390,7 +1416,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1442,7 +1469,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1494,7 +1522,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1546,7 +1575,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1598,7 +1628,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1650,7 +1681,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1702,7 +1734,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1754,7 +1787,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1806,7 +1840,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1857,7 +1892,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1909,7 +1945,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1961,7 +1998,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2013,7 +2051,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2065,7 +2104,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2117,7 +2157,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2169,7 +2210,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2221,7 +2263,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2273,7 +2316,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2325,7 +2369,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2377,7 +2422,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2429,7 +2475,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2481,7 +2528,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2533,7 +2581,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2585,7 +2634,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2637,7 +2687,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2689,7 +2740,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2741,7 +2793,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2793,7 +2846,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2845,7 +2899,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -2897,7 +2952,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -7,6 +7,9 @@
             "description": "Temporal.ZonedDateTime interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -24,7 +27,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -54,6 +58,9 @@
               "description": "Temporal.ZonedDateTime constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/ZonedDateTime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -71,7 +78,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -102,6 +110,9 @@
               "description": "Temporal.ZonedDateTime.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -119,7 +130,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -150,6 +162,9 @@
               "description": "Temporal.ZonedDateTime.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -167,7 +182,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -198,6 +214,9 @@
               "description": "Temporal.ZonedDateTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -215,7 +234,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -246,6 +266,9 @@
               "description": "Temporal.ZonedDateTime.day",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -263,7 +286,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -294,6 +318,9 @@
               "description": "Temporal.ZonedDateTime.dayOfWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/dayofweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -311,7 +338,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -342,6 +370,9 @@
               "description": "Temporal.ZonedDateTime.dayOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/dayofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -359,7 +390,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -390,6 +422,9 @@
               "description": "Temporal.ZonedDateTime.daysInMonth",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/daysinmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -407,7 +442,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -438,6 +474,9 @@
               "description": "Temporal.ZonedDateTime.daysInWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/daysinweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -455,7 +494,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -486,6 +526,9 @@
               "description": "Temporal.ZonedDateTime.daysInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/daysinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -503,7 +546,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -534,6 +578,9 @@
               "description": "Temporal.ZonedDateTime.epochMicroseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/epochmicroseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmicroseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -551,7 +598,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -582,6 +630,9 @@
               "description": "Temporal.ZonedDateTime.epochMilliseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/epochmilliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -599,7 +650,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -630,6 +682,9 @@
               "description": "Temporal.ZonedDateTime.epochNanoseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/epochnanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -647,7 +702,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -678,6 +734,9 @@
               "description": "Temporal.ZonedDateTime.epochSeconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/epochseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -695,7 +754,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -726,6 +786,9 @@
               "description": "Temporal.ZonedDateTime.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -743,7 +806,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -773,6 +837,9 @@
             "__compat": {
               "description": "Temporal.ZonedDateTime.era",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -790,7 +857,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -820,6 +888,9 @@
             "__compat": {
               "description": "Temporal.ZonedDateTime.eraYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/erayear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -837,7 +908,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -868,6 +940,9 @@
               "description": "Temporal.ZonedDateTime.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -885,7 +960,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -916,6 +992,9 @@
               "description": "Temporal.ZonedDateTime.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -933,7 +1012,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -964,6 +1044,9 @@
               "description": "Temporal.ZonedDateTime.hour",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hour",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -981,7 +1064,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1012,6 +1096,9 @@
               "description": "Temporal.ZonedDateTime.hoursInDay",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/hoursinday",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hoursinday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1029,7 +1116,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1060,6 +1148,9 @@
               "description": "Temporal.ZonedDateTime.inLeapYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/inleapyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1077,7 +1168,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1108,6 +1200,9 @@
               "description": "Temporal.ZonedDateTime.microsecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.microsecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1125,7 +1220,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1156,6 +1252,9 @@
               "description": "Temporal.ZonedDateTime.millisecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.millisecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1173,7 +1272,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1204,6 +1304,9 @@
               "description": "Temporal.ZonedDateTime.minute",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.minute",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1221,7 +1324,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1252,6 +1356,9 @@
               "description": "Temporal.ZonedDateTime.month",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.month",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1269,7 +1376,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1300,6 +1408,9 @@
               "description": "Temporal.ZonedDateTime.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthcode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1317,7 +1428,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1348,6 +1460,9 @@
               "description": "Temporal.ZonedDateTime.monthsInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/monthsinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1365,7 +1480,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1396,6 +1512,9 @@
               "description": "Temporal.ZonedDateTime.nanosecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.nanosecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1413,7 +1532,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1444,6 +1564,9 @@
               "description": "Temporal.ZonedDateTime.offset",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/offset",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offset",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1461,7 +1584,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1492,6 +1616,9 @@
               "description": "Temporal.ZonedDateTime.offsetNanoseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/offsetnanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offsetnanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1509,7 +1636,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1540,6 +1668,9 @@
               "description": "Temporal.ZonedDateTime.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1557,7 +1688,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1588,6 +1720,9 @@
               "description": "Temporal.ZonedDateTime.second",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.second",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1605,7 +1740,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1636,6 +1772,9 @@
               "description": "Temporal.ZonedDateTime.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1653,7 +1792,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1683,6 +1823,9 @@
             "__compat": {
               "description": "Temporal.ZonedDateTime.startOfDay",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/startofday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1700,7 +1843,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1731,6 +1875,9 @@
               "description": "Temporal.ZonedDateTime.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1748,7 +1895,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1779,6 +1927,9 @@
               "description": "Temporal.ZonedDateTime.timeZone",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/timezone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.timezone",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1796,7 +1947,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1827,6 +1979,9 @@
               "description": "Temporal.ZonedDateTime.toInstant()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toinstant",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toinstant",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1844,7 +1999,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1875,6 +2031,9 @@
               "description": "Temporal.ZonedDateTime.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1892,7 +2051,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1923,6 +2083,9 @@
               "description": "Temporal.ZonedDateTime.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1940,7 +2103,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1971,6 +2135,9 @@
               "description": "Temporal.ZonedDateTime.toPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1988,7 +2155,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2019,6 +2187,9 @@
               "description": "Temporal.ZonedDateTime.toPlainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaindatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2036,7 +2207,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2067,6 +2239,9 @@
               "description": "Temporal.ZonedDateTime.toPlainMonthDay()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplainmonthday",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplainmonthday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2084,7 +2259,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2115,6 +2291,9 @@
               "description": "Temporal.ZonedDateTime.toPlainTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplaintime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaintime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2132,7 +2311,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2163,6 +2343,9 @@
               "description": "Temporal.ZonedDateTime.toPlainYearMonth()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplainyearmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplainyearmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2180,7 +2363,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2211,6 +2395,9 @@
               "description": "Temporal.ZonedDateTime.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2228,7 +2415,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2259,6 +2447,9 @@
               "description": "Temporal.ZonedDateTime.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2276,7 +2467,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2307,6 +2499,9 @@
               "description": "Temporal.ZonedDateTime.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2324,7 +2519,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2355,6 +2551,9 @@
               "description": "Temporal.ZonedDateTime.weekOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/weekofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.weekofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2372,7 +2571,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2403,6 +2603,9 @@
               "description": "Temporal.ZonedDateTime.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2420,7 +2623,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2451,6 +2655,9 @@
               "description": "Temporal.ZonedDateTime.withCalendar()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/withcalendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withcalendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2468,7 +2675,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2499,6 +2707,9 @@
               "description": "Temporal.ZonedDateTime.withPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/withplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2516,7 +2727,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2547,6 +2759,9 @@
               "description": "Temporal.ZonedDateTime.withPlainTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/withplaintime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaintime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2564,7 +2779,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2595,6 +2811,9 @@
               "description": "Temporal.ZonedDateTime.withTimeZone()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/withtimezone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withtimezone",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2612,7 +2831,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2643,6 +2863,9 @@
               "description": "Temporal.ZonedDateTime.year",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2660,7 +2883,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In this PR, I'm adding the corresponding `impl_url` fields for Firefox on the Temporal feature. I'm also taking this opportunity to define a `temporal` web-feature which will be useful to compute the feature's baseline status.

For Firefox, the entire feature was implemented in one bug, and then later tweaked/refined. So it makes sense that `impl_url` points to just the one bug.

For Safari, the Temporal feature was partly implemented via multiple bugs. I linked the BCD entries to the right implementation bugs, when I could find them, and then defaulted to the main parent bug when I couldn't find a more specific bug for a particular BCD entry.