### PR TITLE
FF125 Intl.Segmenter

### DIFF
--- a/javascript/builtins/Intl/Segmenter.json
+++ b/javascript/builtins/Intl/Segmenter.json
@@ -16,7 +16,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "125"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -56,7 +56,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "125"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -96,7 +96,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "125"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -136,7 +136,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "125"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -176,7 +176,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "125"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
FF125 supports [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) in https://bugzilla.mozilla.org/show_bug.cgi?id=1883914.
This just changes the supported version from preview to 125.

FYI I know that you would have caught this later on anyway @Elchi3 :-)

Related docs can be tracked in https://github.com/mdn/content/issues/32661