### PR TITLE
Rename midi web-feature to web-midi to match the webdx repo

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiaccess-interface",
         "tags": [
-          "web-features:midi"
+          "web-features:web-midi"
         ],
         "support": {
           "chrome": {
@@ -44,7 +44,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/inputs",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-inputs",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -84,7 +84,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/outputs",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-outputs",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -125,7 +125,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/statechange_event",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-onstatechange",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -165,7 +165,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/sysexEnabled",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-sysexenabled",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIConnectionEvent",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiconnectionevent-interface",
         "tags": [
-          "web-features:midi"
+          "web-features:web-midi"
         ],
         "support": {
           "chrome": {
@@ -45,7 +45,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIConnectionEvent/MIDIConnectionEvent",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiconnectionevent-constructor",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -85,7 +85,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIConnectionEvent/port",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiconnectionevent-port",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIInput",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiinput-interface",
         "tags": [
-          "web-features:midi"
+          "web-features:web-midi"
         ],
         "support": {
           "chrome": {
@@ -45,7 +45,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIInput/midimessage_event",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiinput-onmidimessage",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIInputMap",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiinputmap-interface",
         "tags": [
-          "web-features:midi"
+          "web-features:web-midi"
         ],
         "support": {
           "chrome": {
@@ -42,7 +42,7 @@
       "entries": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -80,7 +80,7 @@
       "forEach": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -118,7 +118,7 @@
       "get": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -156,7 +156,7 @@
       "has": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -194,7 +194,7 @@
       "keys": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -232,7 +232,7 @@
       "size": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -270,7 +270,7 @@
       "values": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -308,7 +308,7 @@
       "@@iterator": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIMessageEvent",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midimessageevent-interface",
         "tags": [
-          "web-features:midi"
+          "web-features:web-midi"
         ],
         "support": {
           "chrome": {
@@ -47,7 +47,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIMessageEvent/MIDIMessageEvent",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midimessageevent-constructor",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -89,7 +89,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIMessageEvent/data",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midimessageevent-data",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput",
         "spec_url": "https://webaudio.github.io/web-midi-api/#MIDIOutput",
         "tags": [
-          "web-features:midi"
+          "web-features:web-midi"
         ],
         "support": {
           "chrome": {
@@ -46,7 +46,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput/clear",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midioutput-clear",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -87,7 +87,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput/send",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midioutput-send",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutputMap",
         "spec_url": "https://webaudio.github.io/web-midi-api/#midiinputmap-interface",
         "tags": [
-          "web-features:midi"
+          "web-features:web-midi"
         ],
         "support": {
           "chrome": {
@@ -42,7 +42,7 @@
       "entries": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -80,7 +80,7 @@
       "forEach": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -118,7 +118,7 @@
       "get": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -156,7 +156,7 @@
       "has": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -194,7 +194,7 @@
       "keys": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -232,7 +232,7 @@
       "size": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -270,7 +270,7 @@
       "values": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -308,7 +308,7 @@
       "@@iterator": {
         "__compat": {
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort",
         "spec_url": "https://webaudio.github.io/web-midi-api/#MIDIPort",
         "tags": [
-          "web-features:midi"
+          "web-features:web-midi"
         ],
         "support": {
           "chrome": {
@@ -44,7 +44,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/close",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-close",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -84,7 +84,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/connection",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-connection",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -124,7 +124,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/id",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-id",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -164,7 +164,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/manufacturer",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-manufacturer",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -204,7 +204,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/name",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-name",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -244,7 +244,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/open",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-open",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -284,7 +284,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/state",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-state",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -325,7 +325,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/statechange_event",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-onstatechange",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -365,7 +365,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/type",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-type",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {
@@ -405,7 +405,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/version",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-version",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4000,7 +4000,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/requestMIDIAccess",
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-navigator-requestmidiaccess",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -466,7 +466,7 @@
           "description": "<code>midi</code> permission",
           "spec_url": "https://webaudio.github.io/web-midi-api/#permissions-integration",
           "tags": [
-            "web-features:midi"
+            "web-features:web-midi"
           ],
           "support": {
             "chrome": {

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -965,7 +965,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/midi",
             "spec_url": "https://webaudio.github.io/web-midi-api/#permissions-policy-integration",
             "tags": [
-              "web-features:midi"
+              "web-features:web-midi"
             ],
             "support": {
               "chrome": [


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR replaces the `web-features:midi` tag with `web-features:web-midi` in order to match the name of the WebDX feature.

We discussed about this on the topic of the Web Bluetooth API here: https://github.com/web-platform-dx/web-features/pull/691#discussion_r1525301238 and decided to also apply this to the Web MIDI API.
