### PR TITLE
Scroll-driven animation missing `impl_url` for Safari, and web-features tag

### DIFF
--- a/api/ScrollTimeline.json
+++ b/api/ScrollTimeline.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline",
         "spec_url": "https://drafts.csswg.org/scroll-animations/#scrolltimeline-interface",
+        "tags": [
+          "web-features:scroll-driven-animations"
+        ],
         "support": {
           "chrome": {
             "version_added": "115"
@@ -40,6 +43,9 @@
           "description": "<code>ScrollTimeline()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/ScrollTimeline",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-scrolltimeline-scrolltimeline",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -76,6 +82,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/axis",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-scrolltimeline-axis",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -112,6 +121,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/scroll",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-scrolltimeline-source",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"

--- a/api/ScrollTimeline.json
+++ b/api/ScrollTimeline.json
@@ -22,7 +22,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://webkit.org/b/222295"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -57,7 +58,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -92,7 +94,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -127,7 +130,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ViewTimeline.json
+++ b/api/ViewTimeline.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTimeline",
         "spec_url": "https://drafts.csswg.org/scroll-animations/#viewtimeline-interface",
+        "tags": [
+          "web-features:scroll-driven-animations"
+        ],
         "support": {
           "chrome": {
             "version_added": "115"
@@ -40,6 +43,9 @@
           "description": "<code>ViewTimeline()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTimeline/ViewTimeline",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-viewtimeline-viewtimeline",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -76,6 +82,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTimeline/endOffset",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-viewtimeline-endoffset",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -112,6 +121,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/startOffset",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-viewtimeline-startoffset",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -148,6 +160,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/subject",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-viewtimeline-subject",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"

--- a/api/ViewTimeline.json
+++ b/api/ViewTimeline.json
@@ -22,7 +22,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://webkit.org/b/222295"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -57,7 +58,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -92,7 +94,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -127,7 +130,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -162,7 +166,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -138,6 +138,9 @@
           "__compat": {
             "description": "Named timeline range keyframe selectors",
             "spec_url": "https://drafts.csswg.org/scroll-animations/#named-range-keyframes",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -156,7 +156,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/animation-range-end.json
+++ b/css/properties/animation-range-end.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range-end",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#animation-range-end",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -39,6 +42,9 @@
         "normal": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-animation-range-end-normal",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/properties/animation-range-end.json
+++ b/css/properties/animation-range-end.json
@@ -23,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -56,7 +57,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/animation-range-start.json
+++ b/css/properties/animation-range-start.json
@@ -23,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -56,7 +57,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/animation-range-start.json
+++ b/css/properties/animation-range-start.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range-start",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#animation-range-start",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -39,6 +42,9 @@
         "normal": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-animation-range-start-normal",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/properties/animation-range.json
+++ b/css/properties/animation-range.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#animation-range",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/animation-range.json
+++ b/css/properties/animation-range.json
@@ -23,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline",
           "spec_url": "https://drafts.csswg.org/css-animations-2/#animation-timeline",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -29,7 +32,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,6 +50,9 @@
             "description": "<code>scroll()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline/scroll",
             "spec_url": "https://drafts.csswg.org/scroll-animations/#scroll-notation",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -93,6 +100,9 @@
             "description": "<code>view()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline/view",
             "spec_url": "https://drafts.csswg.org/scroll-animations/#view-notation",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -74,7 +74,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -116,7 +117,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -34,7 +34,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -66,7 +67,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -100,7 +102,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -134,7 +137,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -168,7 +172,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-axis",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#propdef-scroll-timeline-axis",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -50,6 +53,9 @@
         "block": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-scroll-block",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -84,6 +90,9 @@
         "inline": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-scroll-inline",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -119,6 +128,9 @@
         "x": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-scroll-x",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -154,6 +166,9 @@
         "y": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-scroll-y",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -33,7 +33,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-name",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#scroll-timeline-name",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#scroll-timeline-shorthand",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -34,7 +34,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/timeline-scope.json
+++ b/css/properties/timeline-scope.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-scope",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#propdef-timeline-scope",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "116"
@@ -39,6 +42,9 @@
         "all": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-timeline-scope-all",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "116"
@@ -74,6 +80,9 @@
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-timeline-scope-none",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "116"

--- a/css/properties/timeline-scope.json
+++ b/css/properties/timeline-scope.json
@@ -23,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -56,7 +57,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -90,7 +92,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/view-timeline-axis.json
+++ b/css/properties/view-timeline-axis.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-axis",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#view-timeline-axis",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -46,6 +49,9 @@
         "block": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-scroll-block",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -81,6 +87,9 @@
         "inline": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-scroll-inline",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -116,6 +125,9 @@
         "x": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-scroll-x",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -151,6 +163,9 @@
         "y": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-scroll-y",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/properties/view-timeline-axis.json
+++ b/css/properties/view-timeline-axis.json
@@ -30,7 +30,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -63,7 +64,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -97,7 +99,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -131,7 +134,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -165,7 +169,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/view-timeline-inset.json
+++ b/css/properties/view-timeline-inset.json
@@ -23,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -56,7 +57,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/222295"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/view-timeline-inset.json
+++ b/css/properties/view-timeline-inset.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-inset",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#view-timeline-inset",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -39,6 +42,9 @@
         "auto": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/scroll-animations/#valdef-view-timeline-inset-auto",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/properties/view-timeline-name.json
+++ b/css/properties/view-timeline-name.json
@@ -29,7 +29,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/view-timeline-name.json
+++ b/css/properties/view-timeline-name.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-name",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#view-timeline-name",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/view-timeline.json
+++ b/css/properties/view-timeline.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#view-timeline-shorthand",
+          "tags": [
+            "web-features:scroll-driven-animations"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/view-timeline.json
+++ b/css/properties/view-timeline.json
@@ -30,7 +30,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/222295"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds `impl_url` entries for Safari's implementation of the Scroll-driven animation feature.

It also introduces the `web-features:scroll-driven-animations` tag to match the corresponding web-features entry: https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/scroll-driven-animations.yml
