### PR TITLE
added pretty to text-wrap-style

### DIFF
--- a/css/properties/text-wrap-style.json
+++ b/css/properties/text-wrap-style.json
@@ -97,6 +97,38 @@
             }
           }
         },
+        "pretty": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "stable": {
           "__compat": {
             "support": {


### PR DESCRIPTION
#### Summary

Added `pretty` value to the `text-wrap-style` property

#### Test results and supporting details

The property is not supported in Chromium browsers and the value is not supported in FF 124

#### Related issues

- Content PR - coming soon
- Firefox Release note PR - coming soon
- [Interactive examples PR](https://github.com/mdn/interactive-examples/pull/2746)
- [data PR](https://github.com/mdn/data/pull/720)