### PR TITLE
Don't label changes to package.json as dependencies

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,7 +24,6 @@ data:webext :game_die::
   - "webextensions/**"
 dependencies :chains::
   - "package-lock.json"
-  - "package.json"
 docs :writing_hand::
   - "**/*.md"
 infra :building_construction::


### PR DESCRIPTION
This PR drops the auto-labeling of any changes to `package.json` as dependency changes.  This is because `package.json` also includes scripts which can be changed without changing dependencies, and if the dependencies are updated, `package-lock.json` will also update.