### PR TITLE
Add the `web-features:temporal` tag

### DIFF
--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -6,6 +6,9 @@
           "description": "Temporal API",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal",
           "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-intro",
+          "tags": [
+            "web-features:temporal"
+          ],
           "support": {
             "chrome": {
               "version_added": false,

--- a/javascript/builtins/Temporal/Calendar.json
+++ b/javascript/builtins/Temporal/Calendar.json
@@ -7,6 +7,9 @@
             "description": "Temporal.Calendar interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-calendar-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.Calendar constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/Calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-calendar-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.Calendar.dateAdd()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dateAdd",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dateadd",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.Calendar.dateFromFields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dateFromFields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.datefromfields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.Calendar.dateUntil()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dateUntil",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dateuntil",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.Calendar.day()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.Calendar.dayOfWeek()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dayOfWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dayofweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.Calendar.dayOfYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/dayOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dayofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.Calendar.daysInMonth()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/daysInMonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -438,6 +465,9 @@
               "description": "Temporal.Calendar.daysInWeek()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/daysInWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -486,6 +516,9 @@
               "description": "Temporal.Calendar.daysInYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/daysInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -533,6 +566,9 @@
             "__compat": {
               "description": "Temporal.Calendar.era()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -580,6 +616,9 @@
             "__compat": {
               "description": "Temporal.Calendar.eraYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/eraYear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -628,6 +667,9 @@
               "description": "Temporal.Calendar.fields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/fields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.fields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -676,6 +718,9 @@
               "description": "Temporal.Calendar.from()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -724,6 +769,9 @@
               "description": "Temporal.Calendar.id",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/id",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.calendar.prototype.id",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -772,6 +820,9 @@
               "description": "Temporal.Calendar.inLeapYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/inLeapYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -820,6 +871,9 @@
               "description": "Temporal.Calendar.mergeFields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/mergeFields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.mergefields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -868,6 +922,9 @@
               "description": "Temporal.Calendar.month()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/frmonthom",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.month",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -916,6 +973,9 @@
               "description": "Temporal.Calendar.monthCode()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/monthCode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthcode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -964,6 +1024,9 @@
               "description": "Temporal.Calendar.monthDayFromFields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/monthDayFromFields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthdayfromfields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1012,6 +1075,9 @@
               "description": "Temporal.Calendar.monthsInYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/monthsInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1060,6 +1126,9 @@
               "description": "Temporal.Calendar.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/toJSON",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1108,6 +1177,9 @@
               "description": "Temporal.Calendar.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/toJSON",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1156,6 +1228,9 @@
               "description": "Temporal.Calendar.weekOfYear()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/weekOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.weekofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1204,6 +1279,9 @@
               "description": "Temporal.Calendar.year()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1252,6 +1330,9 @@
               "description": "Temporal.Calendar.yearMonthFromFields()",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/yearMonthFromFields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.yearmonthfromfields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -7,6 +7,9 @@
             "description": "Temporal.Duration interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-duration-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.Duration constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/Duration",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-duration-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.Duration.abs()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/abs",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.abs",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.Duration.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.Duration.blank",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/blank",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.blank",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.Duration.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.Duration.days",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/days",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.days",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.Duration.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.Duration.hours",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/hours",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.hours",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -438,6 +465,9 @@
               "description": "Temporal.Duration.microseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/microseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.microseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -486,6 +516,9 @@
               "description": "Temporal.Duration.milliseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/milliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.milliseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -534,6 +567,9 @@
               "description": "Temporal.Duration.minutes",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/minutes",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.minutes",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -582,6 +618,9 @@
               "description": "Temporal.Duration.months",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/months",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.months",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -630,6 +669,9 @@
               "description": "Temporal.Duration.nanoseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/nanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.nanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -678,6 +720,9 @@
               "description": "Temporal.Duration.negated()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/negated",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.negated",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -726,6 +771,9 @@
               "description": "Temporal.Duration.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -774,6 +822,9 @@
               "description": "Temporal.Duration.seconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/seconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.seconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -822,6 +873,9 @@
               "description": "Temporal.Duration.sign",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/sign",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.sign",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -870,6 +924,9 @@
               "description": "Temporal.Duration.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -918,6 +975,9 @@
               "description": "Temporal.Duration.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -966,6 +1026,9 @@
               "description": "Temporal.Duration.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1014,6 +1077,9 @@
               "description": "Temporal.Duration.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1062,6 +1128,9 @@
               "description": "Temporal.Duration.total()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/total",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1110,6 +1179,9 @@
               "description": "Temporal.Duration.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1158,6 +1230,9 @@
               "description": "Temporal.Duration.weeks",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/weeks",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.weeks",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1206,6 +1281,9 @@
               "description": "Temporal.Duration.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1254,6 +1332,9 @@
               "description": "Temporal.Duration.years",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/years",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.years",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -7,6 +7,9 @@
             "description": "Temporal.Instant interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.Instant constructor",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/Instant",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-objects",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.Instant.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.Instant.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.Instant.epochMicroseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/epochmicroseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmicroseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.Instant.epochMilliseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/epochmilliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmilliseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.Instant.epochNanoseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/epochnanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.Instant.epochSeconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/epochseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.Instant.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -438,6 +465,9 @@
               "description": "Temporal.Instant.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -486,6 +516,9 @@
               "description": "Temporal.Instant.fromEpochMicroseconds()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/fromepochmicroseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -534,6 +567,9 @@
               "description": "Temporal.Instant.fromEpochMilliseconds()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/fromepochmilliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochmilliseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -582,6 +618,9 @@
               "description": "Temporal.Instant.fromEpochNanoseconds()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/fromepochnanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochnanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -630,6 +669,9 @@
               "description": "Temporal.Instant.fromEpochSeconds()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/fromepochseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -678,6 +720,9 @@
               "description": "Temporal.Instant.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -726,6 +771,9 @@
               "description": "Temporal.Instant.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -774,6 +822,9 @@
               "description": "Temporal.Instant.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -822,6 +873,9 @@
               "description": "Temporal.Instant.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -870,6 +924,9 @@
               "description": "Temporal.Instant.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -918,6 +975,9 @@
               "description": "Temporal.Instant.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -966,6 +1026,9 @@
               "description": "Temporal.Instant.toZonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tozoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1014,6 +1077,9 @@
               "description": "Temporal.Instant.toZonedDateTimeISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/tozoneddatetimeiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1062,6 +1128,9 @@
               "description": "Temporal.Instant.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1110,6 +1179,9 @@
               "description": "Temporal.Instant.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -7,6 +7,9 @@
             "description": "Temporal.Now interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Now",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-now-object",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.Now.instant()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/instant",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.instant",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.Now.plainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.Now.plainDateISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindateiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindateiso",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.Now.plainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.Now.plainDateTimeISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindatetimeiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.Now.timeZone()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/timezone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.timezone",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.Now.zonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/zoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.Now.zonedDateTimeISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/zoneddatetimeiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetimeiso",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainDate interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindate-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.PlainDate constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/PlainDate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindate-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.PlainDate.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.PlainDate.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.PlainDate.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.PlainDate.day",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.PlainDate.dayOfWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/dayofweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.PlainDate.dayOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/dayofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.PlainDate.daysInMonth",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/daysinmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -438,6 +465,9 @@
               "description": "Temporal.PlainDate.daysInWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/daysinweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -486,6 +516,9 @@
               "description": "Temporal.PlainDate.daysInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/daysinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -534,6 +567,9 @@
               "description": "Temporal.PlainDate.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -581,6 +617,9 @@
             "__compat": {
               "description": "Temporal.PlainDate.era",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -628,6 +667,9 @@
             "__compat": {
               "description": "Temporal.PlainDate.eraYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/erayear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -676,6 +718,9 @@
               "description": "Temporal.PlainDate.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -724,6 +769,9 @@
               "description": "Temporal.PlainDate.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -772,6 +820,9 @@
               "description": "Temporal.PlainDate.inLeapYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/inleapyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -820,6 +871,9 @@
               "description": "Temporal.PlainDate.month",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.month",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -868,6 +922,9 @@
               "description": "Temporal.PlainDate.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthCode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -916,6 +973,9 @@
               "description": "Temporal.PlainDate.monthsInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/monthsinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -964,6 +1024,9 @@
               "description": "Temporal.PlainDate.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1012,6 +1075,9 @@
               "description": "Temporal.PlainDate.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1060,6 +1126,9 @@
               "description": "Temporal.PlainDate.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1108,6 +1177,9 @@
               "description": "Temporal.PlainDate.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1156,6 +1228,9 @@
               "description": "Temporal.PlainDate.toPlainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/toplaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplaindatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1204,6 +1279,9 @@
               "description": "Temporal.PlainDate.toPlainMonthDay()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/toplainmonthday",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1252,6 +1330,9 @@
               "description": "Temporal.PlainDate.toPlainYearMonth()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/toplainyearmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainyearmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1300,6 +1381,9 @@
               "description": "Temporal.PlainDate.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1348,6 +1432,9 @@
               "description": "Temporal.PlainDate.toZonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/tozoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tozoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1396,6 +1483,9 @@
               "description": "Temporal.PlainDate.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1444,6 +1534,9 @@
               "description": "Temporal.PlainDate.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1492,6 +1585,9 @@
               "description": "Temporal.PlainDate.weekOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/weekofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.weekofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1540,6 +1636,9 @@
               "description": "Temporal.PlainDate.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1588,6 +1687,9 @@
               "description": "Temporal.PlainDate.withCalendar()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/withcalendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.withcalendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1636,6 +1738,9 @@
               "description": "Temporal.PlainDate.year",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainDateTime interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.PlainDateTime constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/PlainDateTime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.PlainDateTime.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.PlainDateTime.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.PlainDateTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.PlainDateTime.day",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.PlainDateTime.dayOfWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/dayofweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.PlainDateTime.dayOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/dayofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.PlainDateTime.daysInMonth",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/daysinmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -438,6 +465,9 @@
               "description": "Temporal.PlainDateTime.daysInWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/daysinweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -486,6 +516,9 @@
               "description": "Temporal.PlainDateTime.daysInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/daysinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -534,6 +567,9 @@
               "description": "Temporal.PlainDateTime.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -581,6 +617,9 @@
             "__compat": {
               "description": "Temporal.PlainDateTime.era",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -628,6 +667,9 @@
             "__compat": {
               "description": "Temporal.PlainDateTime.eraYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/erayear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -676,6 +718,9 @@
               "description": "Temporal.PlainDateTime.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -724,6 +769,9 @@
               "description": "Temporal.PlainDateTime.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -772,6 +820,9 @@
               "description": "Temporal.PlainDateTime.hour",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.hour",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -820,6 +871,9 @@
               "description": "Temporal.PlainDateTime.inLeapYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/inleapyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -868,6 +922,9 @@
               "description": "Temporal.PlainDateTime.microsecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.microsecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -916,6 +973,9 @@
               "description": "Temporal.PlainDateTime.millisecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.millisecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -964,6 +1024,9 @@
               "description": "Temporal.PlainDateTime.minute",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.minute",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1012,6 +1075,9 @@
               "description": "Temporal.PlainDateTime.month",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.month",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1060,6 +1126,9 @@
               "description": "Temporal.PlainDateTime.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthcode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1108,6 +1177,9 @@
               "description": "Temporal.PlainDateTime.monthsInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/monthsinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1156,6 +1228,9 @@
               "description": "Temporal.PlainDateTime.nanosecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.nanosecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1204,6 +1279,9 @@
               "description": "Temporal.PlainDateTime.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1252,6 +1330,9 @@
               "description": "Temporal.PlainDateTime.second",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.second",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1300,6 +1381,9 @@
               "description": "Temporal.PlainDateTime.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1348,6 +1432,9 @@
               "description": "Temporal.PlainDateTime.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1396,6 +1483,9 @@
               "description": "Temporal.PlainDateTime.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1444,6 +1534,9 @@
               "description": "Temporal.PlainDateTime.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1492,6 +1585,9 @@
               "description": "Temporal.PlainDateTime.toPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/toplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1540,6 +1636,9 @@
               "description": "Temporal.PlainDateTime.toPlainMonthDay()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/toplainmonthday",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplainmonthday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1588,6 +1687,9 @@
               "description": "Temporal.PlainDateTime.toPlainTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/toplaintime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaintime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1636,6 +1738,9 @@
               "description": "Temporal.PlainDateTime.toPlainYearMonth()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/toplainyearmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplainyearmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1684,6 +1789,9 @@
               "description": "Temporal.PlainDateTime.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1732,6 +1840,9 @@
               "description": "Temporal.PlainDateTime.toZonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/tozoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1780,6 +1891,9 @@
               "description": "Temporal.PlainDateTime.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1828,6 +1942,9 @@
               "description": "Temporal.PlainDateTime.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1876,6 +1993,9 @@
               "description": "Temporal.PlainDateTime.weekOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/weekofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.weekofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1924,6 +2044,9 @@
               "description": "Temporal.PlainDateTime.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1972,6 +2095,9 @@
               "description": "Temporal.PlainDateTime.withCalendar()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/withcalendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2020,6 +2146,9 @@
               "description": "Temporal.PlainDateTime.withPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/withplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2068,6 +2197,9 @@
               "description": "Temporal.PlainDateTime.withPlainTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/withplaintime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2116,6 +2248,9 @@
               "description": "Temporal.PlainDateTime.year",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainMonthDay interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.PlainMonthDay constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/PlainMonthDay",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.PlainMonthDay.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.PlainMonthDay.day",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.PlainMonthDay.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.PlainMonthDay.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.PlainMonthDay.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.PlainMonthDay.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.monthcode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.PlainMonthDay.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -438,6 +465,9 @@
               "description": "Temporal.PlainMonthDay.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -486,6 +516,9 @@
               "description": "Temporal.PlainMonthDay.toPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/toplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -534,6 +567,9 @@
               "description": "Temporal.PlainMonthDay.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -582,6 +618,9 @@
               "description": "Temporal.PlainMonthDay.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -630,6 +669,9 @@
               "description": "Temporal.PlainMonthDay.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainTime interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaintime-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.PlainTime constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/PlainTime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.PlainTime.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.PlainTime.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -197,6 +209,9 @@
             "__compat": {
               "description": "Temporal.PlainTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -245,6 +260,9 @@
               "description": "Temporal.PlainTime.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -293,6 +311,9 @@
               "description": "Temporal.PlainTime.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -341,6 +362,9 @@
               "description": "Temporal.PlainTime.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -389,6 +413,9 @@
               "description": "Temporal.PlainTime.hour",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.hour",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -437,6 +464,9 @@
               "description": "Temporal.PlainTime.microsecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.microsecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -485,6 +515,9 @@
               "description": "Temporal.PlainTime.millisecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.millisecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -533,6 +566,9 @@
               "description": "Temporal.PlainTime.minute",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.minute",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -581,6 +617,9 @@
               "description": "Temporal.PlainTime.nanosecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.nanosecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -629,6 +668,9 @@
               "description": "Temporal.PlainTime.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -677,6 +719,9 @@
               "description": "Temporal.PlainTime.second",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.second",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -725,6 +770,9 @@
               "description": "Temporal.PlainTime.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -773,6 +821,9 @@
               "description": "Temporal.PlainTime.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -821,6 +872,9 @@
               "description": "Temporal.PlainTime.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -869,6 +923,9 @@
               "description": "Temporal.PlainTime.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -917,6 +974,9 @@
               "description": "Temporal.PlainTime.toPlainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/toplaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.toplaindatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -965,6 +1025,9 @@
               "description": "Temporal.PlainTime.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1013,6 +1076,9 @@
               "description": "Temporal.PlainTime.toZonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/tozoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tozoneddatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1061,6 +1127,9 @@
               "description": "Temporal.PlainTime.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1109,6 +1178,9 @@
               "description": "Temporal.PlainTime.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1157,6 +1229,9 @@
               "description": "Temporal.PlainTime.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -7,6 +7,9 @@
             "description": "Temporal.PlainYearMonth interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.PlainYearMonth constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/PlainYearMonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.PlainYearMonth.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.PlainYearMonth.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.PlainYearMonth.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.PlainYearMonth.daysInMonth",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/daysinmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.PlainYearMonth.daysInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/daysinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.PlainYearMonth.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -389,6 +413,9 @@
             "__compat": {
               "description": "Temporal.PlainYearMonth.era",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -436,6 +463,9 @@
             "__compat": {
               "description": "Temporal.PlainYearMonth.eraYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/erayear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -484,6 +514,9 @@
               "description": "Temporal.PlainYearMonth.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -532,6 +565,9 @@
               "description": "Temporal.PlainYearMonth.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -580,6 +616,9 @@
               "description": "Temporal.PlainYearMonth.inLeapYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/inleapyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -628,6 +667,9 @@
               "description": "Temporal.PlainYearMonth.month",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthCode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -676,6 +718,9 @@
               "description": "Temporal.PlainYearMonth.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthCode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -724,6 +769,9 @@
               "description": "Temporal.PlainYearMonth.monthsInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/monthsinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -772,6 +820,9 @@
               "description": "Temporal.PlainYearMonth.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -820,6 +871,9 @@
               "description": "Temporal.PlainYearMonth.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -868,6 +922,9 @@
               "description": "Temporal.PlainYearMonth.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -916,6 +973,9 @@
               "description": "Temporal.PlainYearMonth.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -964,6 +1024,9 @@
               "description": "Temporal.PlainYearMonth.toPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/toplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1012,6 +1075,9 @@
               "description": "Temporal.PlainYearMonth.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1060,6 +1126,9 @@
               "description": "Temporal.PlainYearMonth.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1108,6 +1177,9 @@
               "description": "Temporal.PlainYearMonth.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1156,6 +1228,9 @@
               "description": "Temporal.PlainYearMonth.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1204,6 +1279,9 @@
               "description": "Temporal.PlainYearMonth.year",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/TimeZone.json
+++ b/javascript/builtins/Temporal/TimeZone.json
@@ -7,6 +7,9 @@
             "description": "Temporal.TimeZone interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/TimeZone",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-timezone-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.TimeZone constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/TimeZone/TimeZone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-timezone-constructor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.TimeZone.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.TimeZone.getInstantFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getinstantfor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getinstantfor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.TimeZone.getNextTransition()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getnexttransition",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getnexttransition",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.TimeZone.getOffsetNanosecondsFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getoffsetnanosecondsfor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getoffsetnanosecondsfor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.TimeZone.getOffsetStringFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getoffsetstringfor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getoffsetstringfor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.TimeZone.getPlainDateTimeFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getplaindatetimefor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getplaindatetimefor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.TimeZone.getPossibleInstantsFor()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getpossibleinstantsfor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getpossibleinstantsfor",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -438,6 +465,9 @@
               "description": "Temporal.TimeZone.getPreviousTransition()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/getprevioustransition",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getprevioustransition",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -486,6 +516,9 @@
               "description": "Temporal.TimeZone.id",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/id",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.timezone.prototype.id",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -534,6 +567,9 @@
               "description": "Temporal.TimeZone.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -582,6 +618,9 @@
               "description": "Temporal.TimeZone.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/timezone/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -7,6 +7,9 @@
             "description": "Temporal.ZonedDateTime interface",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects",
+            "tags": [
+              "web-features:temporal"
+            ],
             "support": {
               "chrome": {
                 "version_added": false,
@@ -54,6 +57,9 @@
               "description": "Temporal.ZonedDateTime constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/ZonedDateTime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -102,6 +108,9 @@
               "description": "Temporal.ZonedDateTime.add()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/add",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.add",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -150,6 +159,9 @@
               "description": "Temporal.ZonedDateTime.calendar",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.calendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -198,6 +210,9 @@
               "description": "Temporal.ZonedDateTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -246,6 +261,9 @@
               "description": "Temporal.ZonedDateTime.day",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.day",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -294,6 +312,9 @@
               "description": "Temporal.ZonedDateTime.dayOfWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/dayofweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -342,6 +363,9 @@
               "description": "Temporal.ZonedDateTime.dayOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/dayofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -390,6 +414,9 @@
               "description": "Temporal.ZonedDateTime.daysInMonth",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/daysinmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -438,6 +465,9 @@
               "description": "Temporal.ZonedDateTime.daysInWeek",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/daysinweek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinweek",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -486,6 +516,9 @@
               "description": "Temporal.ZonedDateTime.daysInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/daysinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -534,6 +567,9 @@
               "description": "Temporal.ZonedDateTime.epochMicroseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/epochmicroseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmicroseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -582,6 +618,9 @@
               "description": "Temporal.ZonedDateTime.epochMilliseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/epochmilliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -630,6 +669,9 @@
               "description": "Temporal.ZonedDateTime.epochNanoseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/epochnanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -678,6 +720,9 @@
               "description": "Temporal.ZonedDateTime.epochSeconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/epochseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -726,6 +771,9 @@
               "description": "Temporal.ZonedDateTime.equals()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/equals",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.equals",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -773,6 +821,9 @@
             "__compat": {
               "description": "Temporal.ZonedDateTime.era",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/era",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -820,6 +871,9 @@
             "__compat": {
               "description": "Temporal.ZonedDateTime.eraYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/erayear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -868,6 +922,9 @@
               "description": "Temporal.ZonedDateTime.from()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/from",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -916,6 +973,9 @@
               "description": "Temporal.ZonedDateTime.getISOFields()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/getisofields",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -964,6 +1024,9 @@
               "description": "Temporal.ZonedDateTime.hour",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hour",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1012,6 +1075,9 @@
               "description": "Temporal.ZonedDateTime.hoursInDay",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/hoursinday",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hoursinday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1060,6 +1126,9 @@
               "description": "Temporal.ZonedDateTime.inLeapYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/inleapyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.inleapyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1108,6 +1177,9 @@
               "description": "Temporal.ZonedDateTime.microsecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.microsecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1156,6 +1228,9 @@
               "description": "Temporal.ZonedDateTime.millisecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.millisecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1204,6 +1279,9 @@
               "description": "Temporal.ZonedDateTime.minute",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.minute",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1252,6 +1330,9 @@
               "description": "Temporal.ZonedDateTime.month",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.month",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1300,6 +1381,9 @@
               "description": "Temporal.ZonedDateTime.monthCode",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/monthcode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthcode",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1348,6 +1432,9 @@
               "description": "Temporal.ZonedDateTime.monthsInYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/monthsinyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthsinyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1396,6 +1483,9 @@
               "description": "Temporal.ZonedDateTime.nanosecond",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.nanosecond",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1444,6 +1534,9 @@
               "description": "Temporal.ZonedDateTime.offset",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/offset",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offset",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1492,6 +1585,9 @@
               "description": "Temporal.ZonedDateTime.offsetNanoseconds",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/offsetnanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offsetnanoseconds",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1540,6 +1636,9 @@
               "description": "Temporal.ZonedDateTime.round()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/round",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1588,6 +1687,9 @@
               "description": "Temporal.ZonedDateTime.second",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.second",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1636,6 +1738,9 @@
               "description": "Temporal.ZonedDateTime.since()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/since",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.since",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1683,6 +1788,9 @@
             "__compat": {
               "description": "Temporal.ZonedDateTime.startOfDay",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/startofday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1731,6 +1839,9 @@
               "description": "Temporal.ZonedDateTime.subtract()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/subtract",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.subtract",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1779,6 +1890,9 @@
               "description": "Temporal.ZonedDateTime.timeZone",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/timezone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.timezone",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1827,6 +1941,9 @@
               "description": "Temporal.ZonedDateTime.toInstant()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toinstant",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toinstant",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1875,6 +1992,9 @@
               "description": "Temporal.ZonedDateTime.toJSON()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/tojson",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tojson",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1923,6 +2043,9 @@
               "description": "Temporal.ZonedDateTime.toLocaleString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/tolocalestring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tolocalestring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -1971,6 +2094,9 @@
               "description": "Temporal.ZonedDateTime.toPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2019,6 +2145,9 @@
               "description": "Temporal.ZonedDateTime.toPlainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaindatetime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2067,6 +2196,9 @@
               "description": "Temporal.ZonedDateTime.toPlainMonthDay()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplainmonthday",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplainmonthday",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2115,6 +2247,9 @@
               "description": "Temporal.ZonedDateTime.toPlainTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplaintime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaintime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2163,6 +2298,9 @@
               "description": "Temporal.ZonedDateTime.toPlainYearMonth()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/toplainyearmonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplainyearmonth",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2211,6 +2349,9 @@
               "description": "Temporal.ZonedDateTime.toString()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/tostring",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tostring",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2259,6 +2400,9 @@
               "description": "Temporal.ZonedDateTime.until()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/until",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.until",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2307,6 +2451,9 @@
               "description": "Temporal.ZonedDateTime.valueOf()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/valueof",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.valueof",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2355,6 +2502,9 @@
               "description": "Temporal.ZonedDateTime.weekOfYear",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/weekofyear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.weekofyear",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2403,6 +2553,9 @@
               "description": "Temporal.ZonedDateTime.with()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/with",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.with",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2451,6 +2604,9 @@
               "description": "Temporal.ZonedDateTime.withCalendar()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/withcalendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withcalendar",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2499,6 +2655,9 @@
               "description": "Temporal.ZonedDateTime.withPlainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/withplaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaindate",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2547,6 +2706,9 @@
               "description": "Temporal.ZonedDateTime.withPlainTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/withplaintime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaintime",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2595,6 +2757,9 @@
               "description": "Temporal.ZonedDateTime.withTimeZone()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/withtimezone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withtimezone",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,
@@ -2643,6 +2808,9 @@
               "description": "Temporal.ZonedDateTime.year",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
               "support": {
                 "chrome": {
                   "version_added": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds the `web-features:temporal` tag to the JavaScript Temporal BCD entries in order to match the WebDX web-feature entry here: https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/temporal.yml