### PR TITLE
Note re proxy.ProxyInfo.proxyAuthorizationHeader HTTP support from 125

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -39,6 +39,26 @@
               },
               "safari_ios": "mirror"
             }
+          },
+          "proxyAuthorizationHeader": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "60",
+                  "notes": "Support for HTTP proxies (in addition to HTTPS proxies) added in Firefox 125."
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "RequestDetails": {


### PR DESCRIPTION
#### Summary

Added 'proxy.ProxyInfo.proxyAuthorizationHeader' with note that it also supports settings for HTTP proxies. This change was made in [Bug 1794464](https://bugzilla.mozilla.org/show_bug.cgi?id=1794464) 
"Allow HTTP authentication in proxy.onRequest."

#### Related issues

Related content changes in https://github.com/mdn/content/pull/32536
