### PR TITLE
Updates for Firefox 125 beta

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -943,7 +943,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -960,7 +960,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -976,7 +976,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -993,7 +993,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -145,7 +145,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -162,7 +162,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -178,7 +178,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -195,7 +195,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -589,21 +589,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -638,21 +626,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -334,21 +334,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -1317,21 +1305,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -1911,21 +1887,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -1960,21 +1924,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -2188,21 +2140,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -2237,21 +2177,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -2281,21 +2209,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "117",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.element.popover.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "125"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1412,21 +1412,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -1461,21 +1449,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -132,7 +132,7 @@
               }
             ],
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -13,7 +13,7 @@
             "version_added": "13"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "125"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -46,7 +46,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -84,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -377,7 +377,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -415,7 +415,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -362,7 +362,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -342,7 +342,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "61"
+              "version_added": "61",
+              "version_removed": "125"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -77,7 +77,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "125"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -143,7 +143,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "125"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -173,21 +173,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "114",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.element.popover.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "125"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/selectors/popover-open.json
+++ b/css/selectors/popover-open.json
@@ -15,21 +15,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -339,21 +339,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "114",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.element.popover.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "125"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -388,21 +376,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "114",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.element.popover.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "125"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -996,21 +996,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "114",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.element.popover.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "125"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1045,21 +1033,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "114",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.element.popover.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "125"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1283,21 +1283,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.element.popover.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "125"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/javascript/builtins/Intl/Segments.json
+++ b/javascript/builtins/Intl/Segments.json
@@ -16,7 +16,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "125"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -55,7 +55,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "125"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -95,7 +95,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "125"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/webassembly/multiMemory.json
+++ b/webassembly/multiMemory.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "125"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
The [Open Web Docs BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.2 found new features shipping in Firefox 125 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 40 features as shipping in Firefox 125:

- api.Element.ariaBrailleLabel
- api.Element.ariaBrailleRoleDescription
- api.ElementInternals.ariaBrailleLabel
- api.ElementInternals.ariaBrailleRoleDescription
- api.HTMLButtonElement.popoverTargetAction
- api.HTMLButtonElement.popoverTargetElement
- api.HTMLElement.beforetoggle_event
- api.HTMLElement.hidePopover
- api.HTMLElement.popover
- api.HTMLElement.showPopover
- api.HTMLElement.toggle_event
- api.HTMLElement.togglePopover
- api.HTMLElement.togglePopover.returns_boolean
- api.HTMLInputElement.popoverTargetAction
- api.HTMLInputElement.popoverTargetElement
- api.RTCDtlsTransport.iceTransport
- api.RTCIceTransport
- api.RTCIceTransport.gatheringState
- api.RTCIceTransport.gatheringstatechange_event
- api.RTCIceTransport.state
- api.RTCIceTransport.statechange_event
- api.SVGAElement.text
- css.properties.transform-box.content-box
- css.properties.transform-box.stroke-box
- css.selectors.backdrop.popover
- css.selectors.popover-open
- html.elements.button.popovertarget
- html.elements.button.popovertargetaction
- html.elements.input.popovertarget
- html.elements.input.popovertargetaction
- html.global_attributes.popover
- javascript.builtins.Intl.Segmenter
- javascript.builtins.Intl.Segmenter.Segmenter
- javascript.builtins.Intl.Segmenter.resolvedOptions
- javascript.builtins.Intl.Segmenter.segment
- javascript.builtins.Intl.Segmenter.supportedLocalesOf
- javascript.builtins.Intl.Segments
- javascript.builtins.Intl.Segments.containing
- javascript.builtins.Intl.Segments.@@iterator
- webassembly.multiMemory

Again, I hope this generated PR is useful to update BCD for the new Firefox 125 more easily and faster. If you have feedback, let me know!

See also https://github.com/mdn/mdn/issues/532 and https://www.mozilla.org/en-US/firefox/125.0beta/releasenotes/