### PR TITLE
Remove note on Firefox not supporting interpolation

### DIFF
--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "notes": "Does not yet support interpolation of registered custom properties. See <a href='https://bugzil.la/1846516'>bug 1846516</a>."
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Removed the note on Firefox not supporting interpolation, as Firefox supports interpolating registered custom properties now.

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1869185
