### PR TITLE
"Unrelease" v5.5.17

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,16 +1,5 @@
 # @mdn/browser-compat-data release notes
 
-## [v5.5.17](https://github.com/mdn/browser-compat-data/releases/tag/v5.5.17)
-
-March 19, 2024
-
-### Statistics
-
-- 5 contributors have changed 60 files with 3,055 additions and 989 deletions in 15 commits ([`v5.5.16...v5.5.17`](https://github.com/mdn/browser-compat-data/compare/v5.5.16...v5.5.17))
-- 16,111 total features
-- 1,075 total contributors
-- 4,754 total stargazers
-
 ## [v5.5.16](https://github.com/mdn/browser-compat-data/releases/tag/v5.5.16)
 
 March 15, 2024

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mdn/browser-compat-data",
-  "version": "5.5.17",
+  "version": "5.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mdn/browser-compat-data",
-      "version": "5.5.17",
+      "version": "5.5.16",
       "hasInstallScript": true,
       "license": "CC0-1.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/browser-compat-data",
-  "version": "5.5.17",
+  "version": "5.5.16",
   "description": "Browser compatibility data provided by MDN Web Docs",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
This reverts commit 5520291466ca5a5801a55d187c8b65b1d769c545.  The release had failed, and thus v5.5.17 was never actually released, so this reverts the changes to the version number and release notes.
