### PR TITLE
Intl.Locale#getTextInfo uses alternative name in Deno

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -462,7 +462,9 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": "1.19"
+                  "alternative_name": "textInfo",
+                  "version_added": "1.19",
+                  "notes": "Implemented as an accessor property."
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION

#### Summary

`Intl.Locale#getTextInfo` uses alternative name in Deno (same as other V8-powered runtimes)

#### Test results and supporting details

Screenshot:
![image](https://github.com/mdn/browser-compat-data/assets/26078826/9f11d184-2edb-47fc-964d-215c4fea4dda)

Text version:
```
➜  repos deno
Deno 1.41.3
exit using ctrl+d, ctrl+c, or close()
REPL is running with all permissions allowed.
To specify permissions, run `deno repl` with allow flags.
> const locale = new Intl.Locale('ar')
undefined
> locale.textInfo
{ direction: "rtl" }
> locale.getTextInfo
undefined
> locale.getTextInfo()
Uncaught TypeError: locale.getTextInfo is not a function
    at <anonymous>:1:29
>
```