### PR TITLE
Updates for Chrome 124 beta

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5138,7 +5138,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsehtmlunsafe",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "124"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -2630,7 +2630,7 @@
             "spec_url": "https://dom.spec.whatwg.org/#dom-shadowrootinit-clonable",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "124"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -9254,7 +9254,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-sethtmlunsafe",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "124"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -1025,6 +1025,39 @@
           }
         }
       },
+      "sharedStorageWritable": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#ref-for-dom-htmlsharedstoragewritableelementutils-sharedstoragewritable",
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "src": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/src",

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -983,6 +983,39 @@
           }
         }
       },
+      "sharedStorageWritable": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#ref-for-dom-htmlsharedstoragewritableelementutils-sharedstoragewritable",
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sizes": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/sizes",

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -414,6 +414,40 @@
           }
         }
       },
+      "relayProtocol": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/relayProtocol",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-relayprotocol",
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sdpMid": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/sdpMid",
@@ -589,6 +623,40 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "url": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/url",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-url",
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -424,7 +424,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#readablestream",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "124"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -446,7 +446,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -458,7 +458,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#rs-asynciterator",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "124"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -486,7 +486,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Request.json
+++ b/api/Request.json
@@ -1266,6 +1266,39 @@
           }
         }
       },
+      "targetAddressSpace": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/private-network-access/#dom-request-targetaddressspace",
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "text": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/text",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -115,7 +115,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "124"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -554,7 +554,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-shadowroot-sethtmlunsafe",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "124"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
The [Open Web Docs BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.2 found new features shipping in Chrome 124 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following features as shipping in Chrome 124:

- api.Document.parseHTMLUnsafe_static
- api.Element.attachShadow.init_clonable_parameter
- api.Element.setHTMLUnsafe
- api.HTMLIFrameElement.sharedStorageWritable
- api.HTMLImageElement.sharedStorageWritable
- api.RTCIceCandidate.relayProtocol
- api.RTCIceCandidate.url
- api.ReadableStream.values
- api.ReadableStream.@@asyncIterator
- api.Request.targetAddressSpace
- api.ShadowRoot.clonable
- api.ShadowRoot.setHTMLUnsafe
- css.properties.direction.vertical_slider_direction
- css.properties.writing-mode.vertical_oriented_form_controls
- html.elements.input.type_range.vertical_orientation

There are some features on [chromestatus](https://chromestatus.com/roadmap) that weren't collected and I've identified some reasons for that:
- [jitterBufferTarget](https://chromestatus.com/feature/5930772496384000): Unfortunately part of a spec that is not included in browser-specs and therefore unavailable to the collector, see https://github.com/w3c/browser-specs/issues/305.
- ['pageswap' event](https://chromestatus.com/feature/5479301497749504): Handled separately in https://github.com/mdn/browser-compat-data/pull/22638
- ['priority' HTTP request header](https://chromestatus.com/feature/5109106573049856): Needs manual updating. Collector doesn't support HTTP features currently.
- [Sec-CH-UA-Form-Factors client hint](https://chromestatus.com/feature/5162545698045952): Needs manual updating. Collector doesn't support HTTP features currently.
- [SVG context-fill and context-stroke](https://chromestatus.com/feature/5146558556536832): Needs manual sub features (I think).
- [WebGPU: ServiceWorker and SharedWorker support](https://chromestatus.com/feature/4875951026733056): Needs manual sub features.
- [WebSocketStream](https://chromestatus.com/feature/5189728691290112): The spec PR is not merged so we have no IDL available for the collector to create the BCD structure from.
-  ['writingsuggestions' attribute](https://chromestatus.com/feature/5153375153029120): Seems like this might be shipping in Edge only for the moment, see https://groups.google.com/a/chromium.org/g/blink-dev/c/NhWn64yxB5Q/m/1DnBEqxXAQAJ and https://github.com/whatwg/html/issues/10209#issuecomment-2011693329)
- [X25519Kyber768 key encapsulation for TLS](https://chromestatus.com/feature/5257822742249472): Not tested in the collector.


Again, I hope this PR is useful to update BCD for the new Chrome 124 more easily and faster. If you have feedback, let me know! /cc @chrisdavidmills