### PR TITLE
Mark Blob text() and arrayBuffer() as shipping in iOS 14.5

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -135,7 +135,9 @@
             "safari": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "14.5"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -332,7 +334,9 @@
             "safari": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "14.5"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
Testing and investigation was done in https://github.com/mdn/browser-compat-data/issues/8798#issuecomment-2008484492.

These shipped in iOS 14.2, but since we only have 14 and 14.5 in BCD, our best option is to record 14.5.

On macOS it was supported in 14.0.1, so 14 is still the right version there.