### PR TITLE
Drop spec link to css-grid-3 from grid-template-columns|rows

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -6,8 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-columns",
           "spec_url": [
             "https://drafts.csswg.org/css-grid/#track-sizing",
-            "https://drafts.csswg.org/css-grid/#subgrids",
-            "https://drafts.csswg.org/css-grid-3/#masonry-layout"
+            "https://drafts.csswg.org/css-grid/#subgrids"
           ],
           "tags": [
             "web-features:grid"

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -6,8 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-rows",
           "spec_url": [
             "https://drafts.csswg.org/css-grid/#track-sizing",
-            "https://drafts.csswg.org/css-grid/#subgrids",
-            "https://drafts.csswg.org/css-grid-3/#masonry-layout"
+            "https://drafts.csswg.org/css-grid/#subgrids"
           ],
           "tags": [
             "web-features:grid"


### PR DESCRIPTION
Support data for `grid-template-columns` and `grid-template-rows` document the properties and property values defined in CSS Grid 2: https://drafts.csswg.org/css-grid/#track-sizing

... but not to the new property value `masonry` defined in CSS Grid 3: https://drafts.csswg.org/css-grid-3/#grid-template-masonry

CSS Grid 2 is well supported across browsers. The new `masonry` value is not.

This update makes the `spec_url` property consistent with `support`.

@Elchi3 This is the mismatch I spotted while exploring web features and standardization. This is why CSS Grid 3 appears as a potentially "late incubation" with Baseline high features in the first list in https://github.com/tidoust/web-features-standardization/issues/1