### PR TITLE
Safari 17.4 adds support for web app categories

### DIFF
--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -28,7 +28,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "17.4",
+              "notes": "Only available on macOS Sonoma (14) and above."
             },
             "safari_ios": {
               "version_added": false

--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -40,7 +40,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary
Safari 17.4 adds support for web app categories.

#### Test results and supporting details
Tested locally; https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes

#### Related issues
Fixes #22564