### PR TITLE
Revert "Release v5.5.17" (again)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,21 +1,5 @@
 # @mdn/browser-compat-data release notes
 
-## [v5.5.17](https://github.com/mdn/browser-compat-data/releases/tag/v5.5.17)
-
-March 22, 2024
-
-### Additions
-
-- `browsers.firefox_android.releases.127` ([#22652](https://github.com/mdn/browser-compat-data/pull/22652))
-- `browsers.firefox.releases.127` ([#22652](https://github.com/mdn/browser-compat-data/pull/22652))
-
-### Statistics
-
-- 6 contributors have changed 67 files with 3,091 additions and 1,005 deletions in 22 commits ([`v5.5.16...v5.5.17`](https://github.com/mdn/browser-compat-data/compare/v5.5.16...v5.5.17))
-- 16,111 total features
-- 1,075 total contributors
-- 4,755 total stargazers
-
 ## [v5.5.16](https://github.com/mdn/browser-compat-data/releases/tag/v5.5.16)
 
 March 15, 2024

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mdn/browser-compat-data",
-  "version": "5.5.17",
+  "version": "5.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mdn/browser-compat-data",
-      "version": "5.5.17",
+      "version": "5.5.16",
       "hasInstallScript": true,
       "license": "CC0-1.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/browser-compat-data",
-  "version": "5.5.17",
+  "version": "5.5.16",
   "description": "Browser compatibility data provided by MDN Web Docs",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
Reverts mdn/browser-compat-data#22689.  It appears that there's an access issue with NPM.