### PR TITLE
Update scripting.json Safari support for error property in InjectionResult

### DIFF
--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -216,7 +216,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "17.4"
                   },
                   "safari_ios": "mirror"
                 }


### PR DESCRIPTION
#### Summary

Update scripting.json with support for error property in InjectionResult

#### Test results and supporting details

See [Safari 17.4 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes#Resolved-Issues)
