### PR TITLE
Speculation rule source key optional

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -966,7 +966,7 @@
                 }
               }
             },
-            "source_key_optional": {
+            "source_optional": {
               "__compat": {
                 "description": "<code>source</code> key is optional",
                 "support": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -966,6 +966,39 @@
                 }
               }
             },
+            "source_key_optional": {
+              "__compat": {
+                "description": "<code>source</code> key is optional",
+                "support": {
+                  "chrome": {
+                    "version_added": "122"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "urls": {
               "__compat": {
                 "description": "<code>urls</code> key",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The speculation rules `source` key is optional as of Chrome 122; its value is now implied by the presence of the `url` or `where` keys. See https://developer.chrome.com/blog/speculation-rules-improvements#optional_source.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Related content update: https://github.com/mdn/content/pull/32455

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
