### PR TITLE
added support for align-content in display block

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -410,7 +410,7 @@
             "description": "Supported in Grid Layout",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-justify-content",
-              "https://drafts.csswg.org/css-flexbox/#align-content-property"
+              "https://drafts.csswg.org/css-grid/#grid-align"
             ],
             "tags": [
               "web-features:grid"

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -63,6 +63,42 @@
             "deprecated": false
           }
         },
+        "block_context": {
+          "__compat": {
+            "description": "Supported in Block Layout",
+            "spec_url": "https://drafts.csswg.org/css-align/#align-justify-content",
+            "support": {
+              "chrome": {
+                "version_added": "123"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "123"
+              },
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",


### PR DESCRIPTION
#### Summary

Added the browser suport for CSS property `align-content` in `display: block;`
Working on [Issue 32662](https://github.com/mdn/content/issues/32662)

#### Test results and supporting details

Tested in:
- Firefox 125
- Chrome 123
- Edge 123
- Safari 17.4

#### Related issues

- Content PR -  coming soon
- Firefox release note PR -  coming soon
- [data PR](https://github.com/mdn/data/pull/721)
