### PR TITLE
Add Firefox impl_url for symbols as property keys

### DIFF
--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -395,7 +395,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1710433"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -306,7 +306,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1710433"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1710433 is the tracking bug. I couldn't find a bug that is specifically about enabling this feature by default.

cc @captainbrosset 