### PR TITLE
Deprecate GPUCommandEncoder.writeTimestamp

### DIFF
--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -829,14 +829,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/writeTimestamp",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-writetimestamp",
-          "tags": [
-            "web-features:webgpu"
-          ],
           "support": {
             "chrome": {
               "version_added": "113",
-              "version_removed": "121",
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "version_removed": "121"
             },
             "chrome_android": {
               "version_added": false
@@ -879,9 +875,9 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
(I was a bit too quick with merging https://github.com/mdn/browser-compat-data/pull/22608)

See https://github.com/gpuweb/gpuweb/pull/4370

I think what needs to happen here is also:
- status: deprecated, non-standard and no longer experimental
- Remove web-features tag given this method is no longer needed to have a full WebGPU implementation. (cc @foolip, @ddbeck)