### PR TITLE
fix(css.at-rules.scope): Add missing mdn_url to css.at-rules.scope

### DIFF
--- a/css/at-rules/scope.json
+++ b/css/at-rules/scope.json
@@ -4,6 +4,7 @@
       "scope": {
         "__compat": {
           "description": "<code>@scope</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@scope",
           "spec_url": "https://drafts.csswg.org/css-cascade-6/#scoped-styles",
           "support": {
             "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Added the missing mdn_url property to the css.at-rules.scope file

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Functional link: [https://developer.mozilla.org/en-US/docs/Web/CSS/@scope](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope)

#### Related issues

None
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
