### PR TITLE
Update Chrome support for CSSKeyframesRule length

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -308,8 +308,7 @@
           "spec_url": "https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-length",
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/1502758"
+              "version_added": "123"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
https://chromiumdash.appspot.com/commit/a22c1207bb2c8ba2e6f88bb00c09062f980dd04f

Also confirmed by testing Chrome 123 with the collector: https://mdn-bcd-collector.gooborg.com/tests/api/CSSKeyframesRule/length

Note that the chromestatus entry is wrong:
https://chromestatus.com/feature/6289894144212992