### PR TITLE
Mark 41 -webkit-* properties as not standards track

### DIFF
--- a/css/properties/-webkit-app-region.json
+++ b/css/properties/-webkit-app-region.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-border-horizontal-spacing.json
+++ b/css/properties/-webkit-border-horizontal-spacing.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-border-vertical-spacing.json
+++ b/css/properties/-webkit-border-vertical-spacing.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-column-axis.json
+++ b/css/properties/-webkit-column-axis.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-column-break-after.json
+++ b/css/properties/-webkit-column-break-after.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-column-break-before.json
+++ b/css/properties/-webkit-column-break-before.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-column-break-inside.json
+++ b/css/properties/-webkit-column-break-inside.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-column-progression.json
+++ b/css/properties/-webkit-column-progression.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-cursor-visibility.json
+++ b/css/properties/-webkit-cursor-visibility.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-hyphenate-character.json
+++ b/css/properties/-webkit-hyphenate-character.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-hyphenate-limit-after.json
+++ b/css/properties/-webkit-hyphenate-limit-after.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-hyphenate-limit-before.json
+++ b/css/properties/-webkit-hyphenate-limit-before.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-hyphenate-limit-lines.json
+++ b/css/properties/-webkit-hyphenate-limit-lines.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-initial-letter.json
+++ b/css/properties/-webkit-initial-letter.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-line-align.json
+++ b/css/properties/-webkit-line-align.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-line-box-contain.json
+++ b/css/properties/-webkit-line-box-contain.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-line-grid.json
+++ b/css/properties/-webkit-line-grid.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-line-snap.json
+++ b/css/properties/-webkit-line-snap.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-locale.json
+++ b/css/properties/-webkit-locale.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-logical-height.json
+++ b/css/properties/-webkit-logical-height.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-logical-width.json
+++ b/css/properties/-webkit-logical-width.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-margin-after.json
+++ b/css/properties/-webkit-margin-after.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-margin-before.json
+++ b/css/properties/-webkit-margin-before.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-mask-source-type.json
+++ b/css/properties/-webkit-mask-source-type.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-max-logical-height.json
+++ b/css/properties/-webkit-max-logical-height.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-max-logical-width.json
+++ b/css/properties/-webkit-max-logical-width.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-min-logical-height.json
+++ b/css/properties/-webkit-min-logical-height.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-min-logical-width.json
+++ b/css/properties/-webkit-min-logical-width.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-nbsp-mode.json
+++ b/css/properties/-webkit-nbsp-mode.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-perspective-origin-x.json
+++ b/css/properties/-webkit-perspective-origin-x.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-perspective-origin-y.json
+++ b/css/properties/-webkit-perspective-origin-y.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-rtl-ordering.json
+++ b/css/properties/-webkit-rtl-ordering.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-text-combine.json
+++ b/css/properties/-webkit-text-combine.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-text-decoration-skip.json
+++ b/css/properties/-webkit-text-decoration-skip.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-text-decorations-in-effect.json
+++ b/css/properties/-webkit-text-decorations-in-effect.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-text-zoom.json
+++ b/css/properties/-webkit-text-zoom.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-transform-origin-x.json
+++ b/css/properties/-webkit-transform-origin-x.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-transform-origin-y.json
+++ b/css/properties/-webkit-transform-origin-y.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-transform-origin-z.json
+++ b/css/properties/-webkit-transform-origin-z.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-user-drag.json
+++ b/css/properties/-webkit-user-drag.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/css/properties/-webkit-user-modify.json
+++ b/css/properties/-webkit-user-modify.json
@@ -28,7 +28,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
None of these have spec URLs and none of them appear in a checkout of https://github.com/w3c/webref, so they aren't defined in any spec that webref knows about.

These are from https://github.com/mdn/browser-compat-data/pull/21621, excluding the 5 webkit-mask-box-image-* properties which are defined by https://compat.spec.whatwg.org/.