### PR TITLE
Link prel preload supported as values

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1013,8 +1013,7 @@
                 },
                 "firefox": [
                   {
-                    "version_added": "85",
-                    "notes": "Track is not supported."
+                    "version_added": "85"
                   },
                   {
                     "version_added": "56",
@@ -1043,6 +1042,268 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
+              }
+            },
+            "as-fetch": {
+              "__compat": {
+                "description": "<code>as=fetch</code>",
+                "support": {
+                  "chrome": {
+                    "version_added": "50"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": {
+                    "version_added": "≤79"
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "85"
+                    },
+                    {
+                      "version_added": "56",
+                      "version_removed": "57",
+                      "partial_implementation": true,
+                      "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                    }
+                  ],
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": null
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": "11.1"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "as-font": {
+              "__compat": {
+                "description": "<code>as=font</code>",
+                "support": {
+                  "chrome": {
+                    "version_added": "50"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": {
+                    "version_added": "≤79"
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "85"
+                    },
+                    {
+                      "version_added": "56",
+                      "version_removed": "57",
+                      "partial_implementation": true,
+                      "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                    }
+                  ],
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": null
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": "11.1"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "as-image": {
+              "__compat": {
+                "description": "<code>as=image</code>",
+                "support": {
+                  "chrome": {
+                    "version_added": "50"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": {
+                    "version_added": "≤79"
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "85"
+                    },
+                    {
+                      "version_added": "56",
+                      "version_removed": "57",
+                      "partial_implementation": true,
+                      "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                    }
+                  ],
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": null
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": "11.1"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "as-script": {
+              "__compat": {
+                "description": "<code>as=script</code>",
+                "support": {
+                  "chrome": {
+                    "version_added": "50"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": {
+                    "version_added": "≤79"
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "85"
+                    },
+                    {
+                      "version_added": "56",
+                      "version_removed": "57",
+                      "partial_implementation": true,
+                      "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                    }
+                  ],
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": null
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": "11.1"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "as-style": {
+              "__compat": {
+                "description": "<code>as=style</code>",
+                "support": {
+                  "chrome": {
+                    "version_added": "50"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": {
+                    "version_added": "≤79"
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "85"
+                    },
+                    {
+                      "version_added": "56",
+                      "version_removed": "57",
+                      "partial_implementation": true,
+                      "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                    }
+                  ],
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": null
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": "11.1"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "as-track": {
+              "__compat": {
+                "description": "<code>as=track</code>",
+                "support": {
+                  "chrome": {
+                    "version_added": "50"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": {
+                    "version_added": "≤79"
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": null
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": {
+                    "version_added": null
+                  },
+                  "safari": {
+                    "version_added": "11.1"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
               }
             }
           },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add preload types as suggested in https://github.com/mdn/browser-compat-data/pull/22658#pullrequestreview-1963423648

I'm not 100% sure when each of these `as` values support was added and not sure there's an easy way to check so have just copied the main `preload` values.

Currently the only difference is `track` which is unsupported by Firefox.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://wpt.fyi/results/preload?label=experimental&label=master&aligned

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Enhancement to #22658

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
