### PR TITLE
Update Chromium data for api.HTMLTemplateElement.shadowRootDelegatesFocus

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -76,7 +76,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootdelegatesfocus",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "123"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -98,7 +98,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `shadowRootDelegatesFocus` member of the `HTMLTemplateElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLTemplateElement/shadowRootDelegatesFocus
