### PR TITLE
Update Safari data for api.IntersectionObserver.IntersectionObserver.options_root_parameter_Document

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `IntersectionObserver.options_root_parameter_Document` member of the `IntersectionObserver` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/IntersectionObserver/IntersectionObserver/options_root_parameter_Document
