### PR TITLE
Update Chrome/Safari data for URLSearchParams API

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -313,7 +313,7 @@
             "description": "<code>value</code> parameter",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "117"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -334,7 +334,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -562,7 +562,7 @@
             "description": "<code>value</code> parameter",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "117"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -583,7 +583,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `URLSearchParams` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/URLSearchParams
