### PR TITLE
Update Chrome/Safari data for api.Request.cache.only-if-cached

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -556,7 +556,7 @@
             "description": "<code>only-if-cached</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "≤83"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -576,14 +576,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `cache.only-if-cached` member of the `Request` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Request/cache/only-if-cached
