### PR TITLE
Fix the linter fix script

### DIFF
--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -27,7 +27,7 @@ const dirname = fileURLToPath(new URL('.', import.meta.url));
 const load = async (...files: string[]): Promise<void> => {
   for (let file of files) {
     if (file.indexOf(dirname) !== 0) {
-      file = path.resolve(dirname, '..', '..', file);
+      file = path.resolve(dirname, '..', file);
     }
 
     let fsStats: Stats;


### PR DESCRIPTION
This PR fixes a bad path in the fix script, following a recent file moving.

Self-merging since this is a critical bug.
