### PR TITLE
ambient sensor permissions behind flag on chrome

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -111,7 +111,14 @@
           "description": "<code>ambient-light-sensor</code> permission",
           "support": {
             "chrome": {
-              "version_added": "62"
+              "version_added": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -130,9 +137,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -93,11 +93,25 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "88"
+                  "version_added": "88",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 {
                   "alternative_name": "Feature-Policy",
-                  "version_added": "66"
+                  "version_added": "66",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 }
               ],
               "chrome_android": "mirror",


### PR DESCRIPTION
The ambient sensor permission API and permission policy are behind same flag as the rest of the API

Fixes #22752