### PR TITLE
Update Long Animation Frames API data

### DIFF
--- a/api/PerformanceLongAnimationFrameTiming.json
+++ b/api/PerformanceLongAnimationFrameTiming.json
@@ -2,6 +2,7 @@
   "api": {
     "PerformanceLongAnimationFrameTiming": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongAnimationFrameTiming",
         "spec_url": "https://w3c.github.io/long-animation-frames/#sec-PerformanceLongAnimationFrameTiming",
         "tags": [
           "web-features:long-animation-frame-timing"
@@ -37,6 +38,7 @@
       },
       "blockingDuration": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongAnimationFrameTiming/blockingDuration",
           "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancelonganimationframetiming-blockingduration",
           "tags": [
             "web-features:long-animation-frame-timing"
@@ -73,6 +75,7 @@
       },
       "firstUIEventTimestamp": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongAnimationFrameTiming/firstUIEventTimestamp",
           "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancelonganimationframetiming-firstuieventtimestamp",
           "tags": [
             "web-features:long-animation-frame-timing"
@@ -109,6 +112,7 @@
       },
       "renderStart": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongAnimationFrameTiming/renderStart",
           "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancelonganimationframetiming-renderstart",
           "tags": [
             "web-features:long-animation-frame-timing"
@@ -145,6 +149,7 @@
       },
       "scripts": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongAnimationFrameTiming/scripts",
           "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancelonganimationframetiming-scripts",
           "tags": [
             "web-features:long-animation-frame-timing"
@@ -181,6 +186,7 @@
       },
       "styleAndLayoutStart": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongAnimationFrameTiming/styleAndLayoutStart",
           "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancelonganimationframetiming-styleandlayoutstart",
           "tags": [
             "web-features:long-animation-frame-timing"
@@ -217,6 +223,7 @@
       },
       "toJSON": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongAnimationFrameTiming/toJSON",
           "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancelonganimationframetiming-tojson",
           "tags": [
             "web-features:long-animation-frame-timing"

--- a/api/PerformanceScriptTiming.json
+++ b/api/PerformanceScriptTiming.json
@@ -2,7 +2,8 @@
   "api": {
     "PerformanceScriptTiming": {
       "__compat": {
-        "spec_url": "https://w3c.github.io/longtasks/#performancescripttiming",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming",
+        "spec_url": "https://w3c.github.io/long-animation-frames/#sec-PerformanceScriptTiming",
         "tags": [
           "web-features:long-animation-frame-timing"
         ],
@@ -37,7 +38,8 @@
       },
       "executionStart": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/longtasks/#dom-performancescripttiming-executionstart",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/executionStart",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-executionstart",
           "tags": [
             "web-features:long-animation-frame-timing"
           ],
@@ -73,7 +75,8 @@
       },
       "forcedStyleAndLayoutDuration": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/longtasks/#dom-performancescripttiming-forcedstyleandlayoutduration",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/forcedStyleAndLayoutDuration",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-forcedstyleandlayoutduration",
           "tags": [
             "web-features:long-animation-frame-timing"
           ],
@@ -109,7 +112,8 @@
       },
       "invoker": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/longtasks/#dom-performancescripttiming-invoker",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/invoker",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-invoker",
           "tags": [
             "web-features:long-animation-frame-timing"
           ],
@@ -145,7 +149,8 @@
       },
       "invokerType": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/longtasks/#dom-performancescripttiming-invokertype",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/invokerType",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-invokertype",
           "tags": [
             "web-features:long-animation-frame-timing"
           ],
@@ -181,7 +186,82 @@
       },
       "pauseDuration": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/longtasks/#dom-performancescripttiming-pauseduration",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/pauseDuration",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-pauseduration",
+          "tags": [
+            "web-features:long-animation-frame-timing"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sourceCharPosition": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/sourceCharPosition",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-sourcecharposition",
+          "tags": [
+            "web-features:long-animation-frame-timing"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sourceURL": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/sourceURL",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-sourceurl",
           "tags": [
             "web-features:long-animation-frame-timing"
           ],
@@ -217,7 +297,8 @@
       },
       "toJSON": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/longtasks/#dom-performancescripttiming-tojson",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/toJSON",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-tojson",
           "tags": [
             "web-features:long-animation-frame-timing"
           ],
@@ -253,7 +334,8 @@
       },
       "window": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/longtasks/#dom-performancescripttiming-window",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/window",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-window",
           "tags": [
             "web-features:long-animation-frame-timing"
           ],
@@ -289,7 +371,8 @@
       },
       "windowAttribution": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/longtasks/#dom-performancescripttiming-windowattribution",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/windowAttribution",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-windowattribution",
           "tags": [
             "web-features:long-animation-frame-timing"
           ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The [Long Animation Frames API](https://w3c.github.io/long-animation-frames/) was release in Chrome 123, and most of it was already added to BCD. This follow-up PR specifically:

- Adds `"mdn_url"` fields to the `PerformanceLongAnimationFrameTiming` and `PerformanceScriptTiming` interfaces
- Updates the `PerformanceScriptTiming` interface's `"spec_url"` fields to point to the current correct spec URLs (previously they were pointing to the old locations in the [Long Tasks API](https://w3c.github.io/longtasks/) spec)
- Adds three missing properties to the `PerformanceScriptTiming` interface — `sourceCharPosition`, `sourceFunctionName`, and `sourceURL`.

See also https://developer.chrome.com/docs/web-platform/long-animation-frames for more details.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
