### PR TITLE
Add BCD for some console.dir() options

### DIFF
--- a/api/_globals/console.json
+++ b/api/_globals/console.json
@@ -385,6 +385,123 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_colors_parameter": {
+          "__compat": {
+            "description": "<code>options.colors</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "options_depth_parameter": {
+          "__compat": {
+            "description": "<code>options.depth</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "options_showHidden_parameter": {
+          "__compat": {
+            "description": "<code>options.showHidden</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.8"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "dirxml_static": {


### PR DESCRIPTION
## Summary

Add data for some options that can be passed to [`console.dir()`](https://developer.mozilla.org/en-US/docs/Web/API/console/dir_static), specifically `colors`, `depth`, showHidden`.

This is part of https://github.com/mdn/content/issues/29329. I'm not trying to document all options here, I just took the three that are listed for [Node](https://nodejs.org/docs/latest/api/console.html#consoledirobj-options).

## Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

None of these options AFAICT are supported in browsers, because they typically have an interactive way to implement `dir()`. I've checked this in Firefox, Chrome, Safari. So they get support in Node and Deno, where the console isn't interactive.

### Node

For Node, it looks like all these options first appear in 0.12:

- https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_ARCHIVE.md#0.0.3 ("Added support for options parameter in console.dir())"
- https://nodejs.org/docs/latest-v0.12.x/api/console.html#console_console_dir_obj_options lists them, but https://nodejs.org/docs/latest-v0.10.x/api/console.html#consoledirobj-options doesn't

### Deno

#### colors

Experimentally it looks like `colors` is not supported.

Sample code:

```js
const o = { a: 1, b: "hello", c: null };

console.dir(o, { colors: false });
console.dir(o, { colors: true });
```

Results:

<img width="319" alt="Screen Shot 2024-04-02 at 5 06 37 PM" src="https://github.com/mdn/browser-compat-data/assets/432915/14238dfd-8da6-4a42-8af1-44842e4a9c82">

#### depth

It looks like `depth` was supported from 1.0: https://deno.land/api@v1.0.0?s=Deno.InspectOptions

#### showHidden

It looks like `showHidden` was shipped in 17.4: https://deno.land/api@v1.7.4?s=Deno.InspectOptions I think in https://github.com/denoland/deno/pull/9363, which means it made it into the 1.8 release.

## Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Part of the fix for https://github.com/mdn/content/issues/29329.
