### PR TITLE
Updates for Safari 17.5 (19618.2.4.11.2)

### DIFF
--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -217,8 +217,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/256180"
+              "version_added": "17.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CSSStartingStyleRule.json
+++ b/api/CSSStartingStyleRule.json
@@ -21,14 +21,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "17.5"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/css/at-rules/starting-style.json
+++ b/css/at-rules/starting-style.json
@@ -23,14 +23,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/text-wrap-style.json
+++ b/css/properties/text-wrap-style.json
@@ -21,14 +21,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -53,14 +53,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -86,14 +86,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -119,14 +119,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -56,7 +56,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -161,14 +161,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -785,7 +785,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
The [Open Web Docs BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.4 found new features shipping in Safari 17.5 beta (19618.2.4.11.2) which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Safari TP and/or behind flags, it is not considered here.

With this PR, BCD considers the following features as shipping in Safari 17.5:

- api.CSSImportRule.supportsText
- api.CSSStartingStyleRule
- css.at-rules.starting-style
- css.properties.text-wrap-style
- css.properties.text-wrap-style.auto
- css.properties.text-wrap-style.balance
- css.properties.text-wrap-style.stable
- css.properties.text-wrap.balance
- css.properties.text-wrap.stable
- css.types.color.light-dark

https://developer.apple.com/documentation/safari-release-notes/safari-17_5-release-notes confirms these features and lists additional new WebGL extensions for which we currently don't test automatically in the collector.

I will run the collector again once there is a new beta for 17.5, or if we see a final 17.5 release of Safari.

cc @jdatapple 