### PR TITLE
Add BCD for JSON.rawJSON and JSON.isRawJSON

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -50,6 +50,46 @@
             "deprecated": false
           }
         },
+        "isRawJSON": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/isRawJSON",
+            "spec_url": "https://tc39.es/proposal-json-parse-with-source/#sec-json.israwjson",
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.33"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "21.0.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "json_superset": {
           "__compat": {
             "description": "JavaScript is a superset of JSON",
@@ -135,6 +175,46 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "rawJSON": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/rawJSON",
+            "spec_url": "https://tc39.es/proposal-json-parse-with-source/#sec-json.rawjson",
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.33"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "21.0.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary

Added browser compat data for `JSON.rawJSON()` and `JSON.isRawJSON()`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Quick Test to check if a browser supports both the functions and their integration in `JSON.stringify()`:

```ts
function testRawJSON(){
  const bigInt = BigInt(Number.MAX_SAFE_INTEGER) + 20n
  const bigIntString = bigInt.toString(10)
  
  try {
    const raw = JSON.rawJSON(bigIntString)
    const isRaw = JSON.isRawJSON(raw)
    
    const stringified = JSON.stringify({ number: raw })
    
    console.info({ raw, isRaw, stringified })
    console.info('Is supported: %s', isRaw === true && stringified === `{"number":${bigIntString}}`)
  } catch(error) {
    console.error(error)
    console.info('Is supported: false')
  }
}
```

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

##### Spec

[tc39.es proposal | Spec | isRawJSON](https://tc39.es/proposal-json-parse-with-source/#sec-json.israwjson)
[tc39.es proposal | Spec | rawJSON](https://tc39.es/proposal-json-parse-with-source/#sec-json.rawjson)
[tc39.es proposal | GitHub](https://github.com/tc39/proposal-json-parse-with-source)

##### Implementation | Chrome

[Chromium Ticket](https://bugs.chromium.org/p/v8/issues/detail?id=12955)
[Related Chromium Commits](https://chromium-review.googlesource.com/q/hashtag:%22json-parse-with-source%22+(status:open%20OR%20status:merged))

Landed as "dev trial" in V8 version [10.8](https://chromium.googlesource.com/v8/v8.git/+/branch-heads/10.8)
Landed as "default on" flag in V8 version [11.4](https://chromium.googlesource.com/v8/v8.git/+/branch-heads/11.4)

[chromestatus.com](https://chromestatus.com/feature/5121582673428480)

##### Implementation | Firefox

[Bugzilla Ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1855468) (open)

##### Implementation | Safari

[WebKit Ticket](https://bugs.webkit.org/show_bug.cgi?id=248031) (open)