### PR TITLE
Deno and Node support for non-registered symbols in `Weak{Map,Set,Ref}` and `FinalizationRegistry`

### DIFF
--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -130,7 +130,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.31"
               },
               "edge": "mirror",
               "firefox": {
@@ -141,7 +141,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -130,7 +130,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.31"
+                "version_added": "1.28"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -391,7 +391,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.31"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -391,7 +391,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.31"
+                "version_added": "1.28"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -130,7 +130,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.31"
+                "version_added": "1.28"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -130,7 +130,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.31"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -302,7 +302,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.31"
               },
               "edge": "mirror",
               "firefox": {
@@ -314,7 +314,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -302,7 +302,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.31"
+                "version_added": "1.28"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

Updated info about Deno and Node support for non-registered symbols as `Weak{Map,Set}` keys and as `WeakRef`/`FinalizationRegistry` targets.

I tested with the specified versions, but may well be supported by lower versions than these — not sure how important it is that the version specified is strictly the minimum requirement?

#### Test results and supporting details

```js
function assert(cond) {
    if (!cond) throw '!'
}

const tests = {
    WeakMap() {
        const wm = new WeakMap()
        const key = Symbol()
        const val = { data: 1 }
        wm.set(key, val)
        assert(wm.get(key) === val)
    },
    WeakSet() {
        const ws = new WeakSet()
        const key = Symbol()
        ws.add(key)
        assert(ws.has(key))
    },
    WeakRef() {
        new WeakRef(Symbol())
    },
    FinalizationRegistry() {
        new FinalizationRegistry(() => {}).register(Symbol())
    },
}

for (const [name, test] of Object.entries(tests)) {
    try {
        test()
        console.info(`✅ ${name} supported`)
    } catch(e) {
        console.error(`❌ ${name} unsupported`, e.message)
    }
}
```

#### Related issues

N/A