### PR TITLE
update data for Chrome and Safari for modern with syntax

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1343,8 +1343,7 @@
             "description": "Import attributes (<code>with</code> syntax)",
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13856"
+                "version_added": "123"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -1366,7 +1365,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary
Updates data to show that Safari and Chrome do support the modern `with` import attributes syntax.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

[Safari 17.2 release notes](https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes#JavaScript)
[Chrome 123 release notes](https://chromestatus.com/feature/5205869105250304)

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22716

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
