### PR TITLE
Mirror Chrome Android data for Edit Context API

### DIFF
--- a/api/CharacterBoundsUpdateEvent.json
+++ b/api/CharacterBoundsUpdateEvent.json
@@ -11,9 +11,7 @@
           "chrome": {
             "version_added": "121"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -50,9 +48,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -89,9 +85,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -128,9 +122,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/EditContext.json
+++ b/api/EditContext.json
@@ -11,9 +11,7 @@
           "chrome": {
             "version_added": "121"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -50,9 +48,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -89,9 +85,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -128,9 +122,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -167,9 +159,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -207,9 +197,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -247,9 +235,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -287,9 +273,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -326,9 +310,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -365,9 +347,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -404,9 +384,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -444,9 +422,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -484,9 +460,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -523,9 +497,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -562,9 +534,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -601,9 +571,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -640,9 +608,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -679,9 +645,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1029,9 +1029,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/TextFormat.json
+++ b/api/TextFormat.json
@@ -11,9 +11,7 @@
           "chrome": {
             "version_added": "121"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -50,9 +48,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -89,9 +85,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -128,9 +122,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -167,9 +159,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -206,9 +196,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/TextFormatUpdateEvent.json
+++ b/api/TextFormatUpdateEvent.json
@@ -11,9 +11,7 @@
           "chrome": {
             "version_added": "121"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -50,9 +48,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -89,9 +85,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/TextUpdateEvent.json
+++ b/api/TextUpdateEvent.json
@@ -11,9 +11,7 @@
           "chrome": {
             "version_added": "121"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -50,9 +48,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -89,9 +85,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -128,9 +122,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -167,9 +159,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -206,9 +196,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -245,9 +233,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
https://chromestatus.com/feature/5041440373604352 says this is supported
in Chrome for Android, and wpt.fyi results agree:
https://wpt.fyi/results/editing/edit-context?label=master&product=chrome&product=chrome_android

This updates all features tagged with web-features:edit-context,
originally added here:
https://github.com/mdn/browser-compat-data/pull/21603