### PR TITLE
Remove web-features:shadow-dom from <slot>

### DIFF
--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSlotElement",
         "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#htmlslotelement",
-        "tags": [
-          "web-features:shadow-dom"
-        ],
         "support": {
           "chrome": {
             "version_added": "53"
@@ -179,9 +176,6 @@
           "spec_url": [
             "https://dom.spec.whatwg.org/#eventdef-htmlslotelement-slotchange",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onslotchange"
-          ],
-          "tags": [
-            "web-features:shadow-dom"
           ],
           "support": {
             "chrome": {

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -8,9 +8,6 @@
             "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element",
             "https://dom.spec.whatwg.org/#shadow-tree-slots"
           ],
-          "tags": [
-            "web-features:shadow-dom"
-          ],
           "support": {
             "chrome": {
               "version_added": "53"


### PR DESCRIPTION
This matches https://github.com/web-platform-dx/web-features/pull/795.

The slot feature will be migrated separately, and covers more than this.