### PR TITLE
Migrate most compat_keys from web-features

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController",
         "spec_url": "https://dom.spec.whatwg.org/#interface-abortcontroller",
+        "tags": [
+          "web-features:aborting"
+        ],
         "support": {
           "chrome": {
             "version_added": "66"
@@ -53,6 +56,9 @@
           "description": "<code>AbortController()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/AbortController",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-abortcontroller①",
+          "tags": [
+            "web-features:aborting"
+          ],
           "support": {
             "chrome": {
               "version_added": "66"
@@ -102,6 +108,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/abort",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-abortcontroller①",
+          "tags": [
+            "web-features:aborting"
+          ],
           "support": {
             "chrome": {
               "version_added": "66"
@@ -151,6 +160,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/signal",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-signal②",
+          "tags": [
+            "web-features:aborting"
+          ],
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal",
         "spec_url": "https://dom.spec.whatwg.org/#interface-AbortSignal",
+        "tags": [
+          "web-features:aborting"
+        ],
         "support": {
           "chrome": {
             "version_added": "66"
@@ -48,6 +51,9 @@
           "spec_url": [
             "https://dom.spec.whatwg.org/#eventdef-abortsignal-abort",
             "https://dom.spec.whatwg.org/#abortsignal-onabort"
+          ],
+          "tags": [
+            "web-features:aborting"
           ],
           "support": {
             "chrome": {
@@ -178,6 +184,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/aborted",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-aborted①",
+          "tags": [
+            "web-features:aborting"
+          ],
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSCounterStyleRule.json
+++ b/api/CSSCounterStyleRule.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule",
         "spec_url": "https://drafts.csswg.org/css-counter-styles/#the-csscounterstylerule-interface",
+        "tags": [
+          "web-features:counter-style"
+        ],
         "support": {
           "chrome": {
             "version_added": "91"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/additiveSymbols",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-additivesymbols",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/fallback",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-fallback",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -105,6 +114,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/name",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-name",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -139,6 +151,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/negative",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-negative",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -173,6 +188,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/pad",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-pad",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -207,6 +225,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/prefix",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-prefix",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -241,6 +262,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/range",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-range",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -275,6 +299,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/speakAs",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-speakas",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -309,6 +336,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/suffix",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-suffix",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -343,6 +373,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/symbols",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-symbols",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -377,6 +410,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/system",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-system",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"

--- a/api/CSSFontPaletteValuesRule.json
+++ b/api/CSSFontPaletteValuesRule.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule",
         "spec_url": "https://drafts.csswg.org/css-fonts/#om-fontpalettevalues",
+        "tags": [
+          "web-features:font-palette"
+        ],
         "support": {
           "chrome": {
             "version_added": "101"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule/basePalette",
           "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontpalettevaluesrule-basepalette",
+          "tags": [
+            "web-features:font-palette"
+          ],
           "support": {
             "chrome": {
               "version_added": "101"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule/fontFamily",
           "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontpalettevaluesrule-fontfamily",
+          "tags": [
+            "web-features:font-palette"
+          ],
           "support": {
             "chrome": {
               "version_added": "101"
@@ -105,6 +114,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule/name",
           "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontpalettevaluesrule-name",
+          "tags": [
+            "web-features:font-palette"
+          ],
           "support": {
             "chrome": {
               "version_added": "101"
@@ -139,6 +151,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule/overrideColors",
           "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontpalettevaluesrule-overridecolors",
+          "tags": [
+            "web-features:font-palette"
+          ],
           "support": {
             "chrome": {
               "version_added": "101"

--- a/api/CSSStartingStyleRule.json
+++ b/api/CSSStartingStyleRule.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStartingStyleRule",
         "spec_url": "https://drafts.csswg.org/css-transitions-2/#the-cssstartingstylerule-interface",
+        "tags": [
+          "web-features:starting-style"
+        ],
         "support": {
           "chrome": {
             "version_added": "117"

--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -44,6 +44,9 @@
           "description": "<code>CSSStyleSheet()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/CSSStyleSheet",
           "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylesheet-cssstylesheet",
+          "tags": [
+            "web-features:constructed-stylesheets"
+          ],
           "support": {
             "chrome": {
               "version_added": "73",
@@ -359,6 +362,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replace",
           "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylesheet-replace",
+          "tags": [
+            "web-features:constructed-stylesheets"
+          ],
           "support": {
             "chrome": {
               "version_added": "73"
@@ -393,6 +399,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replaceSync",
           "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylesheet-replacesync",
+          "tags": [
+            "web-features:constructed-stylesheets"
+          ],
           "support": {
             "chrome": {
               "version_added": "73"

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream",
         "spec_url": "https://wicg.github.io/compression/#compression-stream",
+        "tags": [
+          "web-features:compression-streams"
+        ],
         "support": {
           "chrome": {
             "version_added": "80"
@@ -54,6 +57,9 @@
           "description": "<code>CompressionStream()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/CompressionStream",
           "spec_url": "https://wicg.github.io/compression/#dom-compressionstream-compressionstream",
+          "tags": [
+            "web-features:compression-streams"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"
@@ -93,6 +99,9 @@
           "__compat": {
             "description": "\"deflate\" compression",
             "spec_url": "https://wicg.github.io/compression/#supported-formats",
+            "tags": [
+              "web-features:compression-streams"
+            ],
             "support": {
               "chrome": {
                 "version_added": "80"
@@ -132,6 +141,9 @@
           "__compat": {
             "description": "\"deflate-raw\" compression",
             "spec_url": "https://wicg.github.io/compression/#supported-formats",
+            "tags": [
+              "web-features:compression-streams"
+            ],
             "support": {
               "chrome": {
                 "version_added": "103"
@@ -171,6 +183,9 @@
           "__compat": {
             "description": "\"gzip\" compression",
             "spec_url": "https://wicg.github.io/compression/#supported-formats",
+            "tags": [
+              "web-features:compression-streams"
+            ],
             "support": {
               "chrome": {
                 "version_added": "80"
@@ -211,6 +226,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/readable",
           "spec_url": "https://streams.spec.whatwg.org/#dom-generictransformstream-readable",
+          "tags": [
+            "web-features:compression-streams"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"
@@ -251,6 +269,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/writable",
           "spec_url": "https://streams.spec.whatwg.org/#dom-generictransformstream-writable",
+          "tags": [
+            "web-features:compression-streams"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream",
         "spec_url": "https://wicg.github.io/compression/#decompression-stream",
+        "tags": [
+          "web-features:compression-streams"
+        ],
         "support": {
           "chrome": {
             "version_added": "80"
@@ -54,6 +57,9 @@
           "description": "<code>DecompressionStream()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream/DecompressionStream",
           "spec_url": "https://wicg.github.io/compression/#dom-decompressionstream-decompressionstream",
+          "tags": [
+            "web-features:compression-streams"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"
@@ -93,6 +99,9 @@
           "__compat": {
             "description": "\"deflate\" compression",
             "spec_url": "https://wicg.github.io/compression/#supported-formats",
+            "tags": [
+              "web-features:compression-streams"
+            ],
             "support": {
               "chrome": {
                 "version_added": "80"
@@ -132,6 +141,9 @@
           "__compat": {
             "description": "\"deflate-raw\" compression",
             "spec_url": "https://wicg.github.io/compression/#supported-formats",
+            "tags": [
+              "web-features:compression-streams"
+            ],
             "support": {
               "chrome": {
                 "version_added": "103"
@@ -171,6 +183,9 @@
           "__compat": {
             "description": "\"gzip\" compression",
             "spec_url": "https://wicg.github.io/compression/#supported-formats",
+            "tags": [
+              "web-features:compression-streams"
+            ],
             "support": {
               "chrome": {
                 "version_added": "80"
@@ -211,6 +226,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream/readable",
           "spec_url": "https://streams.spec.whatwg.org/#dom-generictransformstream-readable",
+          "tags": [
+            "web-features:compression-streams"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"
@@ -251,6 +269,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream/writable",
           "spec_url": "https://streams.spec.whatwg.org/#dom-generictransformstream-writable",
+          "tags": [
+            "web-features:compression-streams"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"

--- a/api/Document.json
+++ b/api/Document.json
@@ -211,6 +211,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/adoptedStyleSheets",
           "spec_url": "https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets",
+          "tags": [
+            "web-features:constructed-stylesheets"
+          ],
           "support": {
             "chrome": {
               "version_added": "73"
@@ -3173,6 +3176,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/exitPictureInPicture",
           "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-document-exitpictureinpicture",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"
@@ -3211,6 +3217,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/exitPointerLock",
           "spec_url": "https://w3c.github.io/pointerlock/#dom-document-exitpointerlock",
+          "tags": [
+            "web-features:pointer-lock"
+          ],
           "support": {
             "chrome": [
               {
@@ -3484,6 +3493,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fragmentDirective",
           "spec_url": "https://wicg.github.io/scroll-to-text-fragment/#dom-document-fragmentdirective",
+          "tags": [
+            "web-features:text-fragments"
+          ],
           "support": {
             "chrome": {
               "version_added": "86"
@@ -5170,6 +5182,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pictureInPictureElement",
           "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-documentorshadowroot-pictureinpictureelement①⑤",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"
@@ -5208,6 +5223,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pictureInPictureEnabled",
           "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-document-pictureinpictureenabled",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"
@@ -5332,6 +5350,9 @@
             "https://w3c.github.io/pointerlock/#pointerlockchange-and-pointerlockerror-events",
             "https://w3c.github.io/pointerlock/#dom-document-onpointerlockchange"
           ],
+          "tags": [
+            "web-features:pointer-lock"
+          ],
           "support": {
             "chrome": [
               {
@@ -5384,6 +5405,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerLockElement",
           "spec_url": "https://w3c.github.io/pointerlock/#dom-documentorshadowroot-pointerlockelement",
+          "tags": [
+            "web-features:pointer-lock"
+          ],
           "support": {
             "chrome": {
               "version_added": "37"
@@ -5432,6 +5456,9 @@
           "spec_url": [
             "https://w3c.github.io/pointerlock/#pointerlockchange-and-pointerlockerror-events",
             "https://w3c.github.io/pointerlock/#dom-document-onpointerlockerror"
+          ],
+          "tags": [
+            "web-features:pointer-lock"
           ],
           "support": {
             "chrome": [
@@ -6440,6 +6467,9 @@
           "spec_url": [
             "https://drafts.csswg.org/cssom-view/#eventdef-document-scrollend",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onscrollend"
+          ],
+          "tags": [
+            "web-features:scrollend"
           ],
           "support": {
             "chrome": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2558,6 +2558,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/assignedSlot",
           "spec_url": "https://dom.spec.whatwg.org/#dom-slotable-assignedslot",
+          "tags": [
+            "web-features:slot"
+          ],
           "support": {
             "chrome": {
               "version_added": "53"
@@ -3047,6 +3050,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/checkVisibility",
           "spec_url": "https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility",
+          "tags": [
+            "web-features:check-visibility"
+          ],
           "support": {
             "chrome": {
               "version_added": "105"
@@ -3080,6 +3086,9 @@
           "__compat": {
             "description": "<code>options.checkOpacity</code> parameter",
             "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
+            "tags": [
+              "web-features:check-visibility"
+            ],
             "support": {
               "chrome": {
                 "version_added": "105"
@@ -3114,6 +3123,9 @@
           "__compat": {
             "description": "<code>options.checkVisibilityCSS</code> parameter",
             "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
+            "tags": [
+              "web-features:check-visibility"
+            ],
             "support": {
               "chrome": {
                 "version_added": "105"
@@ -7956,6 +7968,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/requestPointerLock",
           "spec_url": "https://w3c.github.io/pointerlock/#dom-element-requestpointerlock",
+          "tags": [
+            "web-features:pointer-lock"
+          ],
           "support": {
             "chrome": [
               {
@@ -8400,6 +8415,9 @@
           "spec_url": [
             "https://drafts.csswg.org/cssom-view/#eventdef-document-scrollend",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onscrollend"
+          ],
+          "tags": [
+            "web-features:scrollend"
           ],
           "support": {
             "chrome": {
@@ -9369,6 +9387,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/slot",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-element-slot①",
+          "tags": [
+            "web-features:slot"
+          ],
           "support": {
             "chrome": {
               "version_added": "53"

--- a/api/FragmentDirective.json
+++ b/api/FragmentDirective.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FragmentDirective",
         "spec_url": "https://wicg.github.io/scroll-to-text-fragment/#fragmentdirective",
+        "tags": [
+          "web-features:text-fragments"
+        ],
         "support": {
           "chrome": {
             "version_added": "81"

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement",
         "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#htmldetailselement",
+        "tags": [
+          "web-features:details"
+        ],
         "support": {
           "chrome": {
             "version_added": "10"
@@ -37,6 +40,9 @@
       },
       "name": {
         "__compat": {
+          "tags": [
+            "web-features:details-name"
+          ],
           "support": {
             "chrome": {
               "version_added": "120"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement/open",
           "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-details-open",
+          "tags": [
+            "web-features:details"
+          ],
           "support": {
             "chrome": {
               "version_added": "10"
@@ -108,6 +117,9 @@
           "description": "<code>toggle</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement/toggle_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
+          "tags": [
+            "web-features:details"
+          ],
           "support": {
             "chrome": {
               "version_added": "36"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2004,6 +2004,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/showPicker",
           "spec_url": "https://html.spec.whatwg.org/multipage/input.html#dom-input-showpicker",
+          "tags": [
+            "web-features:show-picker-input"
+          ],
           "support": {
             "chrome": {
               "version_added": "99"
@@ -2036,6 +2039,9 @@
         "autocomplete_input": {
           "__compat": {
             "description": "<code>autocomplete</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2070,6 +2076,9 @@
         "color_input": {
           "__compat": {
             "description": "<code>color</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2105,6 +2114,9 @@
         "datalist_input": {
           "__compat": {
             "description": "<code>datalist</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2141,6 +2153,9 @@
         "date_input": {
           "__compat": {
             "description": "<code>date</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2177,6 +2192,9 @@
         "datetime_local_input": {
           "__compat": {
             "description": "<code>datetime-local</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2213,6 +2231,9 @@
         "file_input": {
           "__compat": {
             "description": "<code>file</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2246,6 +2267,9 @@
         "month_input": {
           "__compat": {
             "description": "<code>month</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2288,6 +2312,9 @@
         "time_input": {
           "__compat": {
             "description": "<code>time</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2326,6 +2353,9 @@
         "week_input": {
           "__compat": {
             "description": "<code>week</code> input",
+            "tags": [
+              "web-features:show-picker-input"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -80,6 +80,9 @@
       "blocking": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-blocking",
+          "tags": [
+            "web-features:blocking-render"
+          ],
           "support": {
             "chrome": {
               "version_added": "105"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1232,6 +1232,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/fastSeek",
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek-dev",
+          "tags": [
+            "web-features:fast-seek"
+          ],
           "support": {
             "chrome": {
               "version_added": false,

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -117,6 +117,9 @@
       "blocking": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-script-blocking",
+          "tags": [
+            "web-features:blocking-render"
+          ],
           "support": {
             "chrome": {
               "version_added": "105"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -857,6 +857,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/showPicker",
           "spec_url": "https://html.spec.whatwg.org/multipage/input.html#dom-select-showpicker",
+          "tags": [
+            "web-features:show-picker-select"
+          ],
           "support": {
             "chrome": {
               "version_added": "121"

--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -42,6 +42,9 @@
       "blocking": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-style-blocking",
+          "tags": [
+            "web-features:blocking-render"
+          ],
           "support": {
             "chrome": {
               "version_added": "105"

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement",
         "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement",
+        "tags": [
+          "web-features:template"
+        ],
         "support": {
           "chrome": {
             "version_added": "26"
@@ -39,6 +42,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/content",
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-content-dev",
+          "tags": [
+            "web-features:template"
+          ],
           "support": {
             "chrome": {
               "version_added": "26"
@@ -107,6 +113,9 @@
       "shadowRootMode": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootmode",
+          "tags": [
+            "web-features:declarative-shadow-dom"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -81,6 +81,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/disablePictureInPicture",
           "spec_url": "https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-disablepictureinpicture",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"
@@ -135,6 +138,9 @@
           "spec_url": [
             "https://w3c.github.io/picture-in-picture/#eventdef-htmlvideoelement-enterpictureinpicture",
             "https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-onenterpictureinpicture"
+          ],
+          "tags": [
+            "web-features:picture-in-picture"
           ],
           "support": {
             "chrome": {
@@ -260,6 +266,9 @@
           "spec_url": [
             "https://w3c.github.io/picture-in-picture/#eventdef-htmlvideoelement-leavepictureinpicture",
             "https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-onleavepictureinpicture"
+          ],
+          "tags": [
+            "web-features:picture-in-picture"
           ],
           "support": {
             "chrome": {
@@ -574,6 +583,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/requestPictureInPicture",
           "spec_url": "https://w3c.github.io/picture-in-picture/#request-pip",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver",
         "spec_url": "https://w3c.github.io/IntersectionObserver/#intersection-observer-interface",
+        "tags": [
+          "web-features:intersection-observer"
+        ],
         "support": {
           "chrome": {
             "version_added": "51"
@@ -40,6 +43,9 @@
           "description": "<code>IntersectionObserver()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/IntersectionObserver",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-intersectionobserver",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -114,6 +120,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/disconnect",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-disconnect",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -151,6 +160,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/observe",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-observe",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -187,6 +199,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/root",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-root",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -223,6 +238,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/rootMargin",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-rootmargin",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -292,6 +310,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/takeRecords",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-takerecords",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -329,6 +350,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/thresholds",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-thresholds",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "52"
@@ -365,6 +389,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/unobserve",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-unobserve",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry",
         "spec_url": "https://w3c.github.io/IntersectionObserver/#intersection-observer-entry",
+        "tags": [
+          "web-features:intersection-observer"
+        ],
         "support": {
           "chrome": {
             "version_added": "51"
@@ -75,6 +78,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/boundingClientRect",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-boundingclientrect",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -111,6 +117,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/intersectionRatio",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-intersectionratio",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -147,6 +156,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/intersectionRect",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-intersectionrect",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -183,6 +195,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/isIntersecting",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-isintersecting",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "58"
@@ -219,6 +234,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/rootBounds",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-rootbounds",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -255,6 +273,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/target",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-target",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"
@@ -291,6 +312,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/time",
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-time",
+          "tags": [
+            "web-features:intersection-observer"
+          ],
           "support": {
             "chrome": {
               "version_added": "51"

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MathMLElement",
         "spec_url": "https://w3c.github.io/mathml-core/#dom-mathmlelement",
+        "tags": [
+          "web-features:mathml"
+        ],
         "support": {
           "chrome": {
             "version_added": "109"
@@ -70,6 +73,9 @@
       "autofocus": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-fe-autofocus",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -103,6 +109,9 @@
       "blur": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-blur-dev",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -136,6 +145,9 @@
       "dataset": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-dataset-dev",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -169,6 +181,9 @@
       "focus": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-focus-dev",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -235,6 +250,9 @@
       "style": {
         "__compat": {
           "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -268,6 +286,9 @@
       "tabIndex": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -556,6 +556,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/movementX",
           "spec_url": "https://w3c.github.io/pointerlock/#dom-mouseevent-movementx",
+          "tags": [
+            "web-features:pointer-lock"
+          ],
           "support": {
             "chrome": [
               {
@@ -631,6 +634,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/movementY",
           "spec_url": "https://w3c.github.io/pointerlock/#dom-mouseevent-movementy",
+          "tags": [
+            "web-features:pointer-lock"
+          ],
           "support": {
             "chrome": [
               {

--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PictureInPictureEvent",
         "spec_url": "https://w3c.github.io/picture-in-picture/#event-types",
+        "tags": [
+          "web-features:picture-in-picture"
+        ],
         "support": {
           "chrome": [
             {
@@ -55,6 +58,9 @@
           "description": "<code>PictureInPictureEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PictureInPictureEvent/PictureInPictureEvent",
           "spec_url": "https://w3c.github.io/picture-in-picture/#dom-pictureinpictureevent-pictureinpictureevent",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": [
               {
@@ -106,6 +112,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PictureInPictureEvent/pictureInPictureWindow",
           "spec_url": "https://w3c.github.io/picture-in-picture/#dom-pictureinpictureevent-pictureinpicturewindow",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/api/PictureInPictureWindow.json
+++ b/api/PictureInPictureWindow.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PictureInPictureWindow",
         "spec_url": "https://w3c.github.io/picture-in-picture/#interface-picture-in-picture-window",
+        "tags": [
+          "web-features:picture-in-picture"
+        ],
         "support": {
           "chrome": {
             "version_added": "69"
@@ -41,6 +44,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PictureInPictureWindow/height",
           "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-pictureinpicturewindow-height",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"
@@ -83,6 +89,9 @@
             "https://w3c.github.io/picture-in-picture/#eventdef-pictureinpicturewindow-resize",
             "https://w3c.github.io/picture-in-picture/#dom-pictureinpicturewindow-onresize"
           ],
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"
@@ -121,6 +130,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PictureInPictureWindow/width",
           "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-pictureinpicturewindow-width",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -74,6 +74,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/adoptedStyleSheets",
           "spec_url": "https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets",
+          "tags": [
+            "web-features:constructed-stylesheets"
+          ],
           "support": {
             "chrome": {
               "version_added": "73"
@@ -481,6 +484,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/pictureInPictureElement",
           "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-documentorshadowroot-pictureinpictureelement①⑤",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"
@@ -517,6 +523,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/pointerLockElement",
           "spec_url": "https://w3c.github.io/pointerlock/#dom-documentorshadowroot-pointerlockelement",
+          "tags": [
+            "web-features:pointer-lock"
+          ],
           "support": {
             "chrome": {
               "version_added": "53"
@@ -586,6 +595,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/slotAssignment",
           "spec_url": "https://dom.spec.whatwg.org/#dom-shadowroot-slotassignment",
+          "tags": [
+            "web-features:slot"
+          ],
           "support": {
             "chrome": {
               "version_added": "86"

--- a/api/Text.json
+++ b/api/Text.json
@@ -82,6 +82,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Text/assignedSlot",
           "spec_url": "https://dom.spec.whatwg.org/#dom-slotable-assignedslot",
+          "tags": [
+            "web-features:slot"
+          ],
           "support": {
             "chrome": {
               "version_added": "53"

--- a/api/TrustedHTML.json
+++ b/api/TrustedHTML.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedHTML",
         "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trusted-html",
+        "tags": [
+          "web-features:trusted-types"
+        ],
         "support": {
           "chrome": {
             "version_added": "83"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedHTML/toJSON",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedhtml-tojson",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "90"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedHTML/toString",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trustedhtml-stringification-behavior",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/TrustedScript.json
+++ b/api/TrustedScript.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScript",
         "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trusted-script",
+        "tags": [
+          "web-features:trusted-types"
+        ],
         "support": {
           "chrome": {
             "version_added": "83"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScript/toJSON",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedscript-tojson",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "90"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScript/toString",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trustedscripturl-stringification-behavior",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/TrustedScriptURL.json
+++ b/api/TrustedScriptURL.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScriptURL",
         "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trused-script-url",
+        "tags": [
+          "web-features:trusted-types"
+        ],
         "support": {
           "chrome": {
             "version_added": "83"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScriptURL/toJSON",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedscripturl-tojson",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "90"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScriptURL/toString",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trustedscripturl-stringification-behavior",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/TrustedTypePolicy.json
+++ b/api/TrustedTypePolicy.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy",
         "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trusted-type-policy",
+        "tags": [
+          "web-features:trusted-types"
+        ],
         "support": {
           "chrome": {
             "version_added": "83"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy/createHTML",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicy-createhtml",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy/createScript",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicy-createscript",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -105,6 +114,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy/createScriptURL",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicy-createscripturl",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -139,6 +151,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy/name",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicy-name",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/TrustedTypePolicyFactory.json
+++ b/api/TrustedTypePolicyFactory.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory",
         "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trusted-type-policy-factory",
+        "tags": [
+          "web-features:trusted-types"
+        ],
         "support": {
           "chrome": {
             "version_added": "83"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/createPolicy",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-createpolicy",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/defaultPolicy",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-defaultpolicy",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -105,6 +114,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/emptyHTML",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-emptyhtml",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -139,6 +151,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/emptyScript",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-emptyscript",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -173,6 +188,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/getAttributeType",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-getattributetype",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -207,6 +225,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/getPropertyType",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-getpropertytype",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -241,6 +262,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/isHTML",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-ishtml",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -275,6 +299,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/isScript",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-isscript",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -309,6 +336,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/isScriptURL",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicyfactory-isscripturl",
+          "tags": [
+            "web-features:trusted-types"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport",
         "spec_url": "https://drafts.csswg.org/cssom-view/#the-visualviewport-interface",
+        "tags": [
+          "web-features:visual-viewport"
+        ],
         "support": {
           "chrome": {
             "version_added": "61"
@@ -39,6 +42,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/height",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-visualviewport-height",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -75,6 +81,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/offsetLeft",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsetleft",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -111,6 +120,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/offsetTop",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsettop",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -147,6 +159,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/pageLeft",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-visualviewport-pageleft",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -183,6 +198,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/pageTop",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-visualviewport-pagetop",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -220,6 +238,9 @@
           "description": "<code>resize</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/resize_event",
           "spec_url": "https://drafts.csswg.org/cssom-view/#eventdef-window-resize",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": [
               {
@@ -267,6 +288,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/scale",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-visualviewport-scale",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -304,6 +328,9 @@
           "description": "<code>scroll</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/scroll_event",
           "spec_url": "https://drafts.csswg.org/cssom-view/#eventdef-document-scroll",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": [
               {
@@ -352,6 +379,9 @@
           "description": "<code>scrollend</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/scrollend_event",
           "spec_url": "https://drafts.csswg.org/cssom-view/#eventdef-document-scrollend",
+          "tags": [
+            "web-features:scrollend"
+          ],
           "support": {
             "chrome": {
               "version_added": "114",
@@ -390,6 +420,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/width",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-visualviewport-width",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/Window.json
+++ b/api/Window.json
@@ -6526,6 +6526,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/visualViewport",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-window-visualviewport",
+          "tags": [
+            "web-features:visual-viewport"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/_globals/trustedTypes.json
+++ b/api/_globals/trustedTypes.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/trustedTypes",
         "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#extensions-to-the-windoworworkerglobalscope-interface",
+        "tags": [
+          "web-features:trusted-types"
+        ],
         "support": {
           "chrome": {
             "version_added": "83"

--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -43,6 +43,9 @@
             "description": "Style queries for custom properties",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@container",
             "spec_url": "https://drafts.csswg.org/css-contain-3/#style-container",
+            "tags": [
+              "web-features:container-style-queries"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111",

--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -6,6 +6,9 @@
           "description": "<code>@counter-style</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style",
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#the-counter-style-rule",
+          "tags": [
+            "web-features:counter-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "91"
@@ -40,6 +43,9 @@
             "description": "<code>additive-symbols</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/additive-symbols",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-symbols",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91"
@@ -75,6 +81,9 @@
             "description": "<code>fallback</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/fallback",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-fallback",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91"
@@ -110,6 +119,9 @@
             "description": "<code>negative</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/negative",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-system",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91"
@@ -145,6 +157,9 @@
             "description": "<code>pad</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/pad",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-pad",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91"
@@ -180,6 +195,9 @@
             "description": "<code>prefix</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/prefix",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-prefix",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91"
@@ -215,6 +233,9 @@
             "description": "<code>range</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/range",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-range",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91"
@@ -250,6 +271,9 @@
             "description": "<code>speak-as</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/speak-as",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-speak-as",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": false
@@ -285,6 +309,9 @@
             "description": "<code>suffix</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/suffix",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-suffix",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91"
@@ -320,6 +347,9 @@
             "description": "<code>symbols</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/symbols",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-symbols",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91",
@@ -359,6 +389,9 @@
             "description": "<code>system</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@counter-style/system",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#counter-style-system",
+            "tags": [
+              "web-features:counter-style"
+            ],
             "support": {
               "chrome": {
                 "version_added": "91"

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -115,6 +115,9 @@
         "OpenType_COLRv1": {
           "__compat": {
             "description": "OpenType COLRv1 rendering",
+            "tags": [
+              "web-features:colrv1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "98"

--- a/css/at-rules/font-palette-values.json
+++ b/css/at-rules/font-palette-values.json
@@ -6,6 +6,9 @@
           "description": "<code>@font-palette-values</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-palette-values",
           "spec_url": "https://drafts.csswg.org/css-fonts/#at-ruledef-font-palette-values",
+          "tags": [
+            "web-features:font-palette"
+          ],
           "support": {
             "chrome": {
               "version_added": "101"
@@ -38,6 +41,9 @@
         "base-palette": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-fonts/#base-palette-desc",
+            "tags": [
+              "web-features:font-palette"
+            ],
             "support": {
               "chrome": {
                 "version_added": "101"
@@ -71,6 +77,9 @@
         "font-family": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-fonts/#font-family-2-desc",
+            "tags": [
+              "web-features:font-palette"
+            ],
             "support": {
               "chrome": {
                 "version_added": "101"
@@ -104,6 +113,9 @@
         "override-colors": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-fonts/#override-color",
+            "tags": [
+              "web-features:font-palette"
+            ],
             "support": {
               "chrome": {
                 "version_added": "101"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1166,6 +1166,9 @@
             "description": "<code>prefers-color-scheme</code> media feature",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme",
             "spec_url": "https://drafts.csswg.org/mediaqueries-5/#prefers-color-scheme",
+            "tags": [
+              "web-features:prefers-color-scheme"
+            ],
             "support": {
               "chrome": {
                 "version_added": "76"
@@ -1447,6 +1450,9 @@
           "__compat": {
             "description": "Range syntax from Media Queries Level 4",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax_improvements_in_level_4",
+            "tags": [
+              "web-features:media-query-range-syntax"
+            ],
             "support": {
               "chrome": {
                 "version_added": "104"

--- a/css/at-rules/starting-style.json
+++ b/css/at-rules/starting-style.json
@@ -6,6 +6,9 @@
           "description": "<code>@starting-style</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@starting-style",
           "spec_url": "https://drafts.csswg.org/css-transitions-2/#defining-before-change-style",
+          "tags": [
+            "web-features:starting-style"
+          ],
           "support": {
             "chrome": {
               "version_added": "117"

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/accent-color",
           "spec_url": "https://drafts.csswg.org/css-ui/#widget-accent",
+          "tags": [
+            "web-features:accent-color"
+          ],
           "support": {
             "chrome": {
               "version_added": "93"
@@ -36,6 +39,9 @@
         },
         "auto": {
           "__compat": {
+            "tags": [
+              "web-features:accent-color"
+            ],
             "support": {
               "chrome": {
                 "version_added": "93"

--- a/css/properties/animation-composition.json
+++ b/css/properties/animation-composition.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-composition",
           "spec_url": "https://drafts.csswg.org/css-animations-2/#animation-composition",
+          "tags": [
+            "web-features:animation-composition"
+          ],
           "support": {
             "chrome": {
               "version_added": "112"

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/aspect-ratio",
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#aspect-ratio",
+          "tags": [
+            "web-features:aspect-ratio"
+          ],
           "support": {
             "chrome": {
               "version_added": "88"

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backdrop-filter",
           "spec_url": "https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty",
+          "tags": [
+            "web-features:backdrop-filter"
+          ],
           "support": {
             "chrome": {
               "version_added": "76"

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backface-visibility",
           "spec_url": "https://drafts.csswg.org/css-transforms-2/#backface-visibility-property",
+          "tags": [
+            "web-features:transforms3d"
+          ],
           "support": {
             "chrome": [
               {

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-clip",
           "spec_url": "https://drafts.csswg.org/css-backgrounds/#background-clip",
+          "tags": [
+            "web-features:background-clip"
+          ],
           "support": {
             "chrome": [
               {
@@ -101,6 +104,9 @@
         "border-box": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-background-clip-border-box",
+            "tags": [
+              "web-features:background-clip"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -136,6 +142,9 @@
         "content-box": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-background-clip-content-box",
+            "tags": [
+              "web-features:background-clip"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -178,6 +187,9 @@
         "padding-box": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-background-clip-padding-box",
+            "tags": [
+              "web-features:background-clip"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -213,6 +225,9 @@
         "text": {
           "__compat": {
             "description": "<code>text</code>",
+            "tags": [
+              "web-features:background-clip-text"
+            ],
             "support": {
               "chrome": [
                 {

--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color-scheme",
           "spec_url": "https://drafts.csswg.org/css-color-adjust/#color-scheme-prop",
+          "tags": [
+            "web-features:color-scheme"
+          ],
           "support": {
             "chrome": {
               "version_added": "81"
@@ -37,6 +40,9 @@
         "only_dark": {
           "__compat": {
             "description": "<code>only dark</code> keyword",
+            "tags": [
+              "web-features:color-scheme"
+            ],
             "support": {
               "chrome": [
                 {
@@ -76,6 +82,9 @@
         "only_light": {
           "__compat": {
             "description": "<code>only light</code> keyword",
+            "tags": [
+              "web-features:color-scheme"
+            ],
             "support": {
               "chrome": [
                 {

--- a/css/properties/contain-intrinsic-block-size.json
+++ b/css/properties/contain-intrinsic-block-size.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-block-size",
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-block-size",
+          "tags": [
+            "web-features:contain-intrinsic-size"
+          ],
           "support": {
             "chrome": {
               "version_added": "95"

--- a/css/properties/contain-intrinsic-height.json
+++ b/css/properties/contain-intrinsic-height.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height",
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-height",
+          "tags": [
+            "web-features:contain-intrinsic-size"
+          ],
           "support": {
             "chrome": {
               "version_added": "95"

--- a/css/properties/contain-intrinsic-inline-size.json
+++ b/css/properties/contain-intrinsic-inline-size.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-inline-size",
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-inline-size",
+          "tags": [
+            "web-features:contain-intrinsic-size"
+          ],
           "support": {
             "chrome": {
               "version_added": "95"

--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size",
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-size",
+          "tags": [
+            "web-features:contain-intrinsic-size"
+          ],
           "support": {
             "chrome": {
               "version_added": "83"
@@ -37,6 +40,9 @@
         "auto_none": {
           "__compat": {
             "description": "<code>auto none</code> value",
+            "tags": [
+              "web-features:contain-intrinsic-size"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117"

--- a/css/properties/contain-intrinsic-width.json
+++ b/css/properties/contain-intrinsic-width.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width",
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-width",
+          "tags": [
+            "web-features:contain-intrinsic-size"
+          ],
           "support": {
             "chrome": {
               "version_added": "95"

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-optical-sizing",
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-optical-sizing-def",
+          "tags": [
+            "web-features:font-optical-sizing"
+          ],
           "support": {
             "chrome": {
               "version_added": "79"

--- a/css/properties/font-palette.json
+++ b/css/properties/font-palette.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-palette",
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-palette-prop",
+          "tags": [
+            "web-features:font-palette"
+          ],
           "support": {
             "chrome": {
               "version_added": "101"
@@ -170,6 +173,9 @@
           "__compat": {
             "description": "<code>palette-mix()</code>",
             "spec_url": "https://drafts.csswg.org/css-fonts/#typedef-font-palette-palette-mix",
+            "tags": [
+              "web-features:font-palette-animation"
+            ],
             "support": {
               "chrome": {
                 "version_added": "121"

--- a/css/properties/font-synthesis-position.json
+++ b/css/properties/font-synthesis-position.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-position",
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis-position",
+          "tags": [
+            "web-features:font-synthesis"
+          ],
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/font-synthesis-small-caps.json
+++ b/css/properties/font-synthesis-small-caps.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps",
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis-small-caps",
+          "tags": [
+            "web-features:font-synthesis"
+          ],
           "support": {
             "chrome": {
               "version_added": "97"

--- a/css/properties/font-synthesis-style.json
+++ b/css/properties/font-synthesis-style.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style",
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis-style",
+          "tags": [
+            "web-features:font-synthesis"
+          ],
           "support": {
             "chrome": {
               "version_added": "97"

--- a/css/properties/font-synthesis-weight.json
+++ b/css/properties/font-synthesis-weight.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight",
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis-weight",
+          "tags": [
+            "web-features:font-synthesis"
+          ],
           "support": {
             "chrome": {
               "version_added": "97"

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis",
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis",
+          "tags": [
+            "web-features:font-synthesis"
+          ],
           "support": {
             "chrome": {
               "version_added": "97"
@@ -37,6 +40,9 @@
         "position": {
           "__compat": {
             "description": "<code>position</code>",
+            "tags": [
+              "web-features:font-synthesis"
+            ],
             "support": {
               "chrome": {
                 "version_added": false
@@ -70,6 +76,9 @@
         "small-caps": {
           "__compat": {
             "description": "<code>small-caps</code>",
+            "tags": [
+              "web-features:font-synthesis"
+            ],
             "support": {
               "chrome": {
                 "version_added": "97"
@@ -103,6 +112,9 @@
         "style": {
           "__compat": {
             "description": "<code>style</code>",
+            "tags": [
+              "web-features:font-synthesis"
+            ],
             "support": {
               "chrome": {
                 "version_added": "97"
@@ -136,6 +148,9 @@
         "weight": {
           "__compat": {
             "description": "<code>weight</code>",
+            "tags": [
+              "web-features:font-synthesis"
+            ],
             "support": {
               "chrome": {
                 "version_added": "97"

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/perspective-origin",
           "spec_url": "https://drafts.csswg.org/css-transforms-2/#perspective-origin-property",
+          "tags": [
+            "web-features:transforms3d"
+          ],
           "support": {
             "chrome": [
               {
@@ -84,6 +87,9 @@
         "bottom": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#valdef-perspective-origin-bottom",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "≤83"
@@ -119,6 +125,9 @@
         "center": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#valdef-perspective-origin-center",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "≤83"
@@ -154,6 +163,9 @@
         "left": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#valdef-perspective-origin-left",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "≤83"
@@ -189,6 +201,9 @@
         "right": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#valdef-perspective-origin-right",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "≤83"
@@ -224,6 +239,9 @@
         "top": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#valdef-perspective-origin-top",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "≤83"

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/perspective",
           "spec_url": "https://drafts.csswg.org/css-transforms-2/#perspective-property",
+          "tags": [
+            "web-features:transforms3d"
+          ],
           "support": {
             "chrome": [
               {
@@ -84,6 +87,9 @@
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#valdef-perspective-none",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"

--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rotate",
           "spec_url": "https://drafts.csswg.org/css-transforms-2/#individual-transforms",
+          "tags": [
+            "web-features:individual-transforms"
+          ],
           "support": {
             "chrome": {
               "version_added": "104"

--- a/css/properties/scale.json
+++ b/css/properties/scale.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scale",
           "spec_url": "https://drafts.csswg.org/css-transforms-2/#individual-transforms",
+          "tags": [
+            "web-features:individual-transforms"
+          ],
           "support": {
             "chrome": {
               "version_added": "104"

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-end",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-start",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-block.json
+++ b/css/properties/scroll-margin-block.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-margin-block",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-bottom",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-physical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-end",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-start",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-inline.json
+++ b/css/properties/scroll-margin-inline.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-margin-inline",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-left",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-physical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-right",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-physical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-top",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-physical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#scroll-margin",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-block.json
+++ b/css/properties/scroll-padding-block.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-padding-block",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-bottom",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-physical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-inline.json
+++ b/css/properties/scroll-padding-inline.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-padding-inline",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-left",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-physical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-right",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-physical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-top",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-physical",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#scroll-padding",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-snap-align.json
+++ b/css/properties/scroll-snap-align.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#scroll-snap-align",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scroll-snap-stop.json
+++ b/css/properties/scroll-snap-stop.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#scroll-snap-stop",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "75"

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#scroll-snap-type",
+          "tags": [
+            "web-features:scroll-snap"
+          ],
           "support": {
             "chrome": {
               "version_added": "69"

--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-color",
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-color",
+          "tags": [
+            "web-features:scrollbar-color"
+          ],
           "support": {
             "chrome": {
               "version_added": "121"

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter",
           "spec_url": "https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property",
+          "tags": [
+            "web-features:scrollbar-gutter"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"

--- a/css/properties/scrollbar-width.json
+++ b/css/properties/scrollbar-width.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-width",
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-width",
+          "tags": [
+            "web-features:scrollbar-width"
+          ],
           "support": {
             "chrome": {
               "version_added": "121"

--- a/css/properties/text-spacing-trim.json
+++ b/css/properties/text-spacing-trim.json
@@ -4,6 +4,9 @@
       "text-spacing-trim": {
         "__compat": {
           "spec_url": "https://drafts.csswg.org/css-text-4/#text-spacing-trim-property",
+          "tags": [
+            "web-features:text-spacing-trim"
+          ],
           "support": {
             "chrome": {
               "version_added": "123"

--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -39,6 +39,9 @@
             "description": "<code>balance</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap#balance",
             "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-balance",
+            "tags": [
+              "web-features:text-wrap-balance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -109,6 +112,9 @@
             "description": "<code>pretty</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap#pretty",
             "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-pretty",
+            "tags": [
+              "web-features:text-wrap-pretty"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117"

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-box",
           "spec_url": "https://drafts.csswg.org/css-transforms/#transform-box",
+          "tags": [
+            "web-features:transforms2d"
+          ],
           "support": {
             "chrome": {
               "version_added": "64"

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-origin",
           "spec_url": "https://drafts.csswg.org/css-transforms/#transform-origin-property",
+          "tags": [
+            "web-features:transforms2d"
+          ],
           "support": {
             "chrome": [
               {

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-style",
           "spec_url": "https://drafts.csswg.org/css-transforms-2/#transform-style-property",
+          "tags": [
+            "web-features:transforms3d"
+          ],
           "support": {
             "chrome": [
               {

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -8,6 +8,9 @@
             "https://drafts.csswg.org/css-transforms-2/#transform-functions",
             "https://drafts.csswg.org/css-transforms/#transform-property"
           ],
+          "tags": [
+            "web-features:transforms2d"
+          ],
           "support": {
             "chrome": [
               {
@@ -134,6 +137,9 @@
         "3d": {
           "__compat": {
             "description": "3D support",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"

--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-behavior",
           "spec_url": "https://drafts.csswg.org/css-transitions-2/#transition-behavior-property",
+          "tags": [
+            "web-features:transition-behavior"
+          ],
           "support": {
             "chrome": {
               "version_added": "117"

--- a/css/properties/translate.json
+++ b/css/properties/translate.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/translate",
           "spec_url": "https://drafts.csswg.org/css-transforms-2/#individual-transforms",
+          "tags": [
+            "web-features:individual-transforms"
+          ],
           "support": {
             "chrome": {
               "version_added": "104"

--- a/css/selectors/autofill.json
+++ b/css/selectors/autofill.json
@@ -6,6 +6,9 @@
           "description": "<code>:autofill</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:autofill",
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill",
+          "tags": [
+            "web-features:autofill"
+          ],
           "support": {
             "chrome": [
               {

--- a/css/selectors/picture-in-picture.json
+++ b/css/selectors/picture-in-picture.json
@@ -6,6 +6,9 @@
           "description": "<code>:picture-in-picture</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:picture-in-picture",
           "spec_url": "https://drafts.csswg.org/selectors/#pip-state",
+          "tags": [
+            "web-features:picture-in-picture"
+          ],
           "support": {
             "chrome": {
               "version_added": "110"

--- a/css/selectors/slotted.json
+++ b/css/selectors/slotted.json
@@ -6,6 +6,9 @@
           "description": "<code>::slotted</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::slotted",
           "spec_url": "https://drafts.csswg.org/css-scoping/#slotted-pseudo",
+          "tags": [
+            "web-features:slot"
+          ],
           "support": {
             "chrome": {
               "version_added": "50"

--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -6,6 +6,9 @@
           "description": "<code>::target-text</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::target-text",
           "spec_url": "https://drafts.csswg.org/css-pseudo/#selectordef-target-text",
+          "tags": [
+            "web-features:text-fragments"
+          ],
           "support": {
             "chrome": {
               "version_added": "89"

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -6,6 +6,9 @@
           "description": "<code>:user-invalid</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-invalid",
           "spec_url": "https://drafts.csswg.org/selectors/#user-invalid-pseudo",
+          "tags": [
+            "web-features:user-pseudos"
+          ],
           "support": {
             "chrome": {
               "version_added": "119",

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -6,6 +6,9 @@
           "description": "<code>:user-valid</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-valid",
           "spec_url": "https://drafts.csswg.org/selectors/#user-valid-pseudo",
+          "tags": [
+            "web-features:user-pseudos"
+          ],
           "support": {
             "chrome": {
               "version_added": "119",

--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -6,6 +6,9 @@
           "description": "<code>abs()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/abs",
           "spec_url": "https://drafts.csswg.org/css-values/#sign-funcs",
+          "tags": [
+            "web-features:abs-sign"
+          ],
           "support": {
             "chrome": {
               "version_added": false,

--- a/css/types/acos.json
+++ b/css/types/acos.json
@@ -6,6 +6,9 @@
           "description": "<code>acos()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/acos",
           "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "tags": [
+            "web-features:trig-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/types/asin.json
+++ b/css/types/asin.json
@@ -6,6 +6,9 @@
           "description": "<code>asin()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/asin",
           "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "tags": [
+            "web-features:trig-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/types/atan.json
+++ b/css/types/atan.json
@@ -6,6 +6,9 @@
           "description": "<code>atan()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/atan",
           "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "tags": [
+            "web-features:trig-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/types/atan2.json
+++ b/css/types/atan2.json
@@ -6,6 +6,9 @@
           "description": "<code>atan2()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/atan2",
           "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "tags": [
+            "web-features:trig-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -6,6 +6,9 @@
           "description": "&lt;calc-constant&gt;",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc-constant",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-constants",
+          "tags": [
+            "web-features:calc-constants"
+          ],
           "support": {
             "chrome": {
               "version_added": "99"
@@ -38,6 +41,9 @@
         "NaN": {
           "__compat": {
             "description": "<code>NaN</code> constant",
+            "tags": [
+              "web-features:calc-constants"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -71,6 +77,9 @@
         "e": {
           "__compat": {
             "description": "<code>e</code> constant",
+            "tags": [
+              "web-features:calc-constants"
+            ],
             "support": {
               "chrome": {
                 "version_added": false
@@ -104,6 +113,9 @@
         "infinity": {
           "__compat": {
             "description": "<code>infinity</code> and <code>-infinity</code> constants",
+            "tags": [
+              "web-features:calc-constants"
+            ],
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -137,6 +149,9 @@
         "pi": {
           "__compat": {
             "description": "<code>pi</code> constant",
+            "tags": [
+              "web-features:calc-constants"
+            ],
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -6,6 +6,9 @@
           "description": "<code>calc()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-func",
+          "tags": [
+            "web-features:calc"
+          ],
           "support": {
             "chrome": [
               {
@@ -78,6 +81,9 @@
         "gradient_color_stops": {
           "__compat": {
             "description": "Gradient color stops support",
+            "tags": [
+              "web-features:calc"
+            ],
             "support": {
               "chrome": {
                 "version_added": "19"
@@ -117,6 +123,9 @@
         "nested": {
           "__compat": {
             "description": "Nested <code>calc()</code> support",
+            "tags": [
+              "web-features:calc"
+            ],
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -152,6 +161,9 @@
         "number_values": {
           "__compat": {
             "description": "<code>&lt;number&gt;</code> value support",
+            "tags": [
+              "web-features:calc"
+            ],
             "support": {
               "chrome": {
                 "version_added": "31"

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -6,6 +6,9 @@
           "description": "<code>clamp()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-notation",
+          "tags": [
+            "web-features:min-max-clamp"
+          ],
           "support": {
             "chrome": {
               "version_added": "79"

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -46,6 +46,9 @@
             "description": "<code>color()</code> (Profiled color values)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color",
             "spec_url": "https://drafts.csswg.org/css-color/#color-function",
+            "tags": [
+              "web-features:color-function"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -86,6 +89,9 @@
           "mixed_type_parameters": {
             "__compat": {
               "description": "Mix <code>&lt;percentage&gt;</code> and <code>&lt;number&gt;</code> in parameters",
+              "tags": [
+                "web-features:color-function"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "111"
@@ -120,6 +126,9 @@
             "__compat": {
               "description": "Relative <code>color()</code> syntax",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-color-function",
+              "tags": [
+                "web-features:relative-color"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "119"
@@ -199,6 +208,9 @@
             "description": "<code>color-mix()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix",
             "spec_url": "https://drafts.csswg.org/css-color-5/#color-mix",
+            "tags": [
+              "web-features:color-mix"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -382,6 +394,9 @@
             "__compat": {
               "description": "Relative HSL colors",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-HSL",
+              "tags": [
+                "web-features:relative-color"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "119",
@@ -521,6 +536,9 @@
             "__compat": {
               "description": "Relative HWB colors",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-HWB",
+              "tags": [
+                "web-features:relative-color"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "119",
@@ -561,6 +579,9 @@
             "description": "<code>lab()</code> (Lab color model)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/lab",
             "spec_url": "https://drafts.csswg.org/css-color/#lab-colors",
+            "tags": [
+              "web-features:lab"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -593,6 +614,9 @@
           "mixed_type_parameters": {
             "__compat": {
               "description": "Mix <code>&lt;percentage&gt;</code> and <code>&lt;number&gt;</code> in parameters",
+              "tags": [
+                "web-features:lab"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "116"
@@ -627,6 +651,9 @@
             "__compat": {
               "description": "Relative Lab colors",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-Lab",
+              "tags": [
+                "web-features:relative-color"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "119"
@@ -663,6 +690,9 @@
             "description": "<code>lch()</code> (LCH color model)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/lch",
             "spec_url": "https://drafts.csswg.org/css-color/#lab-colors",
+            "tags": [
+              "web-features:lab"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -695,6 +725,9 @@
           "mixed_type_parameters": {
             "__compat": {
               "description": "Mix <code>&lt;percentage&gt;</code> and <code>&lt;number&gt;</code> in parameters",
+              "tags": [
+                "web-features:lab"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "116"
@@ -729,6 +762,9 @@
             "__compat": {
               "description": "Relative LCH colors",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-LCH",
+              "tags": [
+                "web-features:relative-color"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "119"
@@ -767,6 +803,9 @@
             "description": "<code>light-dark()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark",
             "spec_url": "https://drafts.csswg.org/css-color-5/#light-dark",
+            "tags": [
+              "web-features:light-dark"
+            ],
             "support": {
               "chrome": {
                 "version_added": "123",
@@ -884,6 +923,9 @@
             "description": "<code>oklab()</code> (Oklab color model)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklab",
             "spec_url": "https://drafts.csswg.org/css-color/#ok-lab",
+            "tags": [
+              "web-features:oklab"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -916,6 +958,9 @@
           "mixed_type_parameters": {
             "__compat": {
               "description": "Mix <code>&lt;percentage&gt;</code> and <code>&lt;number&gt;</code> in parameters",
+              "tags": [
+                "web-features:oklab"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "116"
@@ -950,6 +995,9 @@
             "__compat": {
               "description": "Relative Oklab colors",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-Oklab",
+              "tags": [
+                "web-features:relative-color"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "119"
@@ -986,6 +1034,9 @@
             "description": "<code>oklch()</code> (OKLCH color model)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklch",
             "spec_url": "https://drafts.csswg.org/css-color/#ok-lab",
+            "tags": [
+              "web-features:oklab"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -1018,6 +1069,9 @@
           "mixed_type_parameters": {
             "__compat": {
               "description": "Mix <code>&lt;percentage&gt;</code> and <code>&lt;number&gt;</code> in parameters",
+              "tags": [
+                "web-features:oklab"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "116"
@@ -1052,6 +1106,9 @@
             "__compat": {
               "description": "Relative Oklch colors",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-Oklch",
+              "tags": [
+                "web-features:relative-color"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "119"
@@ -1230,6 +1287,9 @@
             "__compat": {
               "description": "Relative RGB colors",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-RGB",
+              "tags": [
+                "web-features:relative-color"
+              ],
               "support": {
                 "chrome": [
                   {

--- a/css/types/cos.json
+++ b/css/types/cos.json
@@ -6,6 +6,9 @@
           "description": "<code>cos()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cos",
           "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "tags": [
+            "web-features:trig-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/types/easing-function.json
+++ b/css/types/easing-function.json
@@ -83,6 +83,9 @@
         "linear-function": {
           "__compat": {
             "description": "<code>linear()</code>",
+            "tags": [
+              "web-features:linear-easing"
+            ],
             "support": {
               "chrome": {
                 "version_added": "113"

--- a/css/types/exp.json
+++ b/css/types/exp.json
@@ -6,6 +6,9 @@
           "description": "<code>exp()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/exp",
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
+          "tags": [
+            "web-features:exp-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "120"

--- a/css/types/hypot.json
+++ b/css/types/hypot.json
@@ -6,6 +6,9 @@
           "description": "<code>hypot()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hypot",
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
+          "tags": [
+            "web-features:exp-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "120"

--- a/css/types/log.json
+++ b/css/types/log.json
@@ -6,6 +6,9 @@
           "description": "<code>log()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/log",
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
+          "tags": [
+            "web-features:exp-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "120"

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -6,6 +6,9 @@
           "description": "<code>max()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-notation",
+          "tags": [
+            "web-features:min-max-clamp"
+          ],
           "support": {
             "chrome": {
               "version_added": "79"

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -6,6 +6,9 @@
           "description": "<code>min()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-notation",
+          "tags": [
+            "web-features:min-max-clamp"
+          ],
           "support": {
             "chrome": {
               "version_added": "79"

--- a/css/types/mod.json
+++ b/css/types/mod.json
@@ -6,6 +6,9 @@
           "description": "<code>mod()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mod",
           "spec_url": "https://drafts.csswg.org/css-values/#funcdef-mod",
+          "tags": [
+            "web-features:round-mod-rem"
+          ],
           "support": {
             "chrome": {
               "version_added": false,

--- a/css/types/pow.json
+++ b/css/types/pow.json
@@ -6,6 +6,9 @@
           "description": "<code>pow()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/pow",
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
+          "tags": [
+            "web-features:exp-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "120"

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -6,6 +6,9 @@
           "description": "<code>rem()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rem",
           "spec_url": "https://drafts.csswg.org/css-values/#funcdef-rem",
+          "tags": [
+            "web-features:round-mod-rem"
+          ],
           "support": {
             "chrome": {
               "version_added": false,

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -6,6 +6,9 @@
           "description": "<code>round()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/round",
           "spec_url": "https://drafts.csswg.org/css-values/#funcdef-round",
+          "tags": [
+            "web-features:round-mod-rem"
+          ],
           "support": {
             "chrome": {
               "version_added": false,

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -6,6 +6,9 @@
           "description": "<code>sign()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sign()",
           "spec_url": "https://drafts.csswg.org/css-values/#sign-funcs",
+          "tags": [
+            "web-features:abs-sign"
+          ],
           "support": {
             "chrome": {
               "version_added": false,

--- a/css/types/sin.json
+++ b/css/types/sin.json
@@ -6,6 +6,9 @@
           "description": "<code>sin()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sin",
           "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "tags": [
+            "web-features:trig-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/types/sqrt.json
+++ b/css/types/sqrt.json
@@ -6,6 +6,9 @@
           "description": "<code>sqrt()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sqrt",
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
+          "tags": [
+            "web-features:exp-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "120"

--- a/css/types/tan.json
+++ b/css/types/tan.json
@@ -6,6 +6,9 @@
           "description": "<code>tan()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/tan",
           "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "tags": [
+            "web-features:trig-functions"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -9,6 +9,9 @@
             "https://drafts.csswg.org/css-transforms/#transform-functions",
             "https://drafts.csswg.org/css-transforms-2/#transform-functions"
           ],
+          "tags": [
+            "web-features:transforms2d"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -54,6 +57,9 @@
             "description": "<code>matrix()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/matrix",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-matrix",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -102,6 +108,9 @@
             "description": "<code>matrix3d()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/matrix3d",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -144,6 +153,9 @@
             "description": "<code>perspective()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/perspective",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-perspective",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -183,6 +195,9 @@
             "description": "<code>rotate()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotate",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-rotate",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -228,6 +243,9 @@
             "description": "<code>rotate3d()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotate3d",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-rotate3d",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -267,6 +285,9 @@
             "description": "<code>rotateX()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateX",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-rotatex",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -306,6 +327,9 @@
             "description": "<code>rotateY()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateY",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-rotatey",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -345,6 +369,9 @@
             "description": "<code>rotateZ()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateZ",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-rotatez",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -384,6 +411,9 @@
             "description": "<code>scale()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scale",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-scale",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -429,6 +459,9 @@
             "description": "<code>scale3d()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scale3d",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -468,6 +501,9 @@
             "description": "<code>scaleX()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleX",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-scalex",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -513,6 +549,9 @@
             "description": "<code>scaleY()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleY",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-scaley",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -558,6 +597,9 @@
             "description": "<code>scaleZ()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleZ",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-scalez",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -597,6 +639,9 @@
             "description": "<code>skew()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skew",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-skew",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -645,6 +690,9 @@
             "description": "<code>skewX()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skewX",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-skewx",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -690,6 +738,9 @@
             "description": "<code>skewY()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skewY",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-skewy",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -735,6 +786,9 @@
             "description": "<code>translate()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translate",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-translate",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -780,6 +834,9 @@
             "description": "<code>translate3d()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translate3d",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"
@@ -819,6 +876,9 @@
             "description": "<code>translateX()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateX",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-translatex",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -864,6 +924,9 @@
             "description": "<code>translateY()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateY",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-translatey",
+            "tags": [
+              "web-features:transforms2d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -909,6 +972,9 @@
             "description": "<code>translateZ()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateZ",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-translatez",
+            "tags": [
+              "web-features:transforms3d"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"

--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/details",
           "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element",
+          "tags": [
+            "web-features:details"
+          ],
           "support": {
             "chrome": {
               "version_added": "12"
@@ -40,6 +43,9 @@
         },
         "name": {
           "__compat": {
+            "tags": [
+              "web-features:details-name"
+            ],
             "support": {
               "chrome": {
                 "version_added": "120",
@@ -75,6 +81,9 @@
         },
         "open": {
           "__compat": {
+            "tags": [
+              "web-features:details"
+            ],
             "support": {
               "chrome": {
                 "version_added": "12"

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -933,6 +933,9 @@
             "__compat": {
               "description": "<code>sandbox=\"allow-pointer-lock\"</code>",
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-pointer-lock",
+              "tags": [
+                "web-features:pointer-lock"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "≤49"

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -133,6 +133,9 @@
         "aspect_ratio_computed_from_attributes": {
           "__compat": {
             "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
+            "tags": [
+              "web-features:aspect-ratio"
+            ],
             "support": {
               "chrome": {
                 "version_added": "79"

--- a/html/elements/input/search.json
+++ b/html/elements/input/search.json
@@ -7,6 +7,9 @@
             "description": "<code>type=\"search\"</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/search",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)",
+            "tags": [
+              "web-features:search-input-type"
+            ],
             "support": {
               "chrome": {
                 "version_added": "5"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -77,6 +77,9 @@
         },
         "blocking": {
           "__compat": {
+            "tags": [
+              "web-features:blocking-render"
+            ],
             "support": {
               "chrome": {
                 "version_added": "105"
@@ -879,6 +882,9 @@
               "description": "rel=modulepreload",
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/modulepreload",
               "spec_url": "https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload",
+              "tags": [
+                "web-features:modulepreload"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "66"

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -112,6 +112,9 @@
         },
         "blocking": {
           "__compat": {
+            "tags": [
+              "web-features:blocking-render"
+            ],
             "support": {
               "chrome": {
                 "version_added": "105"
@@ -302,6 +305,9 @@
         },
         "nomodule": {
           "__compat": {
+            "tags": [
+              "web-features:js-modules"
+            ],
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -594,6 +600,9 @@
           "module": {
             "__compat": {
               "description": "<code>type=\"module\"</code>",
+              "tags": [
+                "web-features:js-modules"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "61",

--- a/html/elements/search.json
+++ b/html/elements/search.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/search",
           "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element",
+          "tags": [
+            "web-features:search"
+          ],
           "support": {
             "chrome": {
               "version_added": "118"

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -42,6 +42,9 @@
         },
         "blocking": {
           "__compat": {
+            "tags": [
+              "web-features:blocking-render"
+            ],
             "support": {
               "chrome": {
                 "version_added": "105"

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/template",
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#the-template-element",
+          "tags": [
+            "web-features:template"
+          ],
           "support": {
             "chrome": {
               "version_added": "26"
@@ -41,6 +44,9 @@
         "shadowrootmode": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootmode",
+            "tags": [
+              "web-features:declarative-shadow-dom"
+            ],
             "support": {
               "chrome": [
                 {

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -43,6 +43,9 @@
         "aspect_ratio_computed_from_attributes": {
           "__compat": {
             "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
+            "tags": [
+              "web-features:aspect-ratio"
+            ],
             "support": {
               "chrome": {
                 "version_added": "79"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1134,6 +1134,9 @@
             "https://html.spec.whatwg.org/multipage/dom.html#attr-slot",
             "https://dom.spec.whatwg.org/#ref-for-dom-element-slot①"
           ],
+          "tags": [
+            "web-features:slot"
+          ],
           "support": {
             "chrome": {
               "version_added": "53"

--- a/http/headers/Accept-Encoding.json
+++ b/http/headers/Accept-Encoding.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Encoding",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-encoding",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept-Language.json
+++ b/http/headers/Accept-Language.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Language",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-language",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept-Ranges.json
+++ b/http/headers/Accept-Ranges.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Ranges",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-ranges",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept.json
+++ b/http/headers/Accept.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Age.json
+++ b/http/headers/Age.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Age",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.age",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Authorization",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.authorization",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -8,6 +8,9 @@
             "https://www.rfc-editor.org/rfc/rfc9111#field.cache-control",
             "https://httpwg.org/specs/rfc8246.html#the-immutable-cache-control-extension"
           ],
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Connection.json
+++ b/http/headers/Connection.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Connection",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.connection",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-encoding",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Language.json
+++ b/http/headers/Content-Language.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Language",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-language",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Length.json
+++ b/http/headers/Content-Length.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Length",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-length",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Location.json
+++ b/http/headers/Content-Location.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Location",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-location",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Range.json
+++ b/http/headers/Content-Range.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Range",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-range",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -913,6 +913,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#require-trusted-types-for-csp-directive",
+            "tags": [
+              "web-features:trusted-types"
+            ],
             "support": {
               "chrome": {
                 "version_added": "83"
@@ -1336,6 +1339,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trusted-types-csp-directive",
+            "tags": [
+              "web-features:trusted-types"
+            ],
             "support": {
               "chrome": {
                 "version_added": "83"

--- a/http/headers/Content-Type.json
+++ b/http/headers/Content-Type.json
@@ -8,6 +8,9 @@
             "https://www.rfc-editor.org/rfc/rfc9110#status.206",
             "https://www.rfc-editor.org/rfc/rfc9110#field.content-type"
           ],
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Date.json
+++ b/http/headers/Date.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.date",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/ETag.json
+++ b/http/headers/ETag.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/ETag",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.etag",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Expect.json
+++ b/http/headers/Expect.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expect",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.expect",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/Expires.json
+++ b/http/headers/Expires.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expires",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.expires",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/From.json
+++ b/http/headers/From.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/From",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.from",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Host.json
+++ b/http/headers/Host.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Host",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.host",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Match.json
+++ b/http/headers/If-Match.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Match",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-match",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Modified-Since.json
+++ b/http/headers/If-Modified-Since.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Modified-Since",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-modified-since",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-None-Match.json
+++ b/http/headers/If-None-Match.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-None-Match",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-none-match",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Range.json
+++ b/http/headers/If-Range.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Range",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-range",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Unmodified-Since.json
+++ b/http/headers/If-Unmodified-Since.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Unmodified-Since",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-unmodified-since",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Last-Modified.json
+++ b/http/headers/Last-Modified.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Last-Modified",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.last-modified",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Location.json
+++ b/http/headers/Location.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Location",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.location",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1136,6 +1136,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/picture-in-picture",
             "spec_url": "https://w3c.github.io/picture-in-picture/#permissions-policy",
+            "tags": [
+              "web-features:picture-in-picture"
+            ],
             "support": {
               "chrome": [
                 {

--- a/http/headers/Pragma.json
+++ b/http/headers/Pragma.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Pragma",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.pragma",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Proxy-Authenticate.json
+++ b/http/headers/Proxy-Authenticate.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Proxy-Authenticate",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.proxy-authenticate",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Range.json
+++ b/http/headers/Range.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Range",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.range",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Referer.json
+++ b/http/headers/Referer.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Referer",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.referer",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Retry-After.json
+++ b/http/headers/Retry-After.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Retry-After",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.retry-after",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/Server.json
+++ b/http/headers/Server.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Server",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.server",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/TE.json
+++ b/http/headers/TE.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/TE",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.te",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Trailer.json
+++ b/http/headers/Trailer.json
@@ -8,6 +8,9 @@
             "https://www.rfc-editor.org/rfc/rfc9110#field.trailer",
             "https://www.rfc-editor.org/rfc/rfc9112#chunked.trailer.section"
           ],
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Transfer-Encoding.json
+++ b/http/headers/Transfer-Encoding.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Transfer-Encoding",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9112#field.transfer-encoding",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/User-Agent.json
+++ b/http/headers/User-Agent.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.user-agent",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Vary.json
+++ b/http/headers/Vary.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Vary",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.vary",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Via.json
+++ b/http/headers/Via.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Via",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.via",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/WWW-Authenticate",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.www-authenticate",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Warning.json
+++ b/http/headers/Warning.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Warning",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.warning",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/methods.json
+++ b/http/methods.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/CONNECT",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#CONNECT",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -41,6 +44,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/DELETE",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#DELETE",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -77,6 +83,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/GET",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#GET",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -113,6 +122,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/HEAD",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#HEAD",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -149,6 +161,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/OPTIONS",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#OPTIONS",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -185,6 +200,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/POST",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#POST",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -221,6 +239,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/PUT",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#PUT",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -257,6 +278,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/TRACE",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#TRACE",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": null

--- a/http/status.json
+++ b/http/status.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/100",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.100",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -130,6 +133,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/200",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.200",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -166,6 +172,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/201",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.201",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -202,6 +211,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/204",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.204",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -238,6 +250,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/206",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.206",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -274,6 +289,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/301",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.301",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -310,6 +328,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/302",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.302",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -346,6 +367,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/303",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.303",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -382,6 +406,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/304",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.304",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -418,6 +445,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/307",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.307",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -493,6 +523,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/401",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.401",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -529,6 +562,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/403",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.403",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -565,6 +601,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/404",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.404",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -601,6 +640,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/406",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.406",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -637,6 +679,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/407",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.407",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -673,6 +718,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/409",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.409",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -709,6 +757,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/410",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.410",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -745,6 +796,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/412",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.412",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -781,6 +835,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/416",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.416",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -923,6 +980,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/500",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.500",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -959,6 +1019,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/501",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.501",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -995,6 +1058,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/502",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.502",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -1031,6 +1097,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/503",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.503",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -1067,6 +1136,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/504",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.504",
+          "tags": [
+            "web-features:http11"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array-objects",
+          "tags": [
+            "web-features:array"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -53,6 +56,9 @@
             "description": "<code>Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array-constructor",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -144,6 +150,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/concat",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.concat",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -190,6 +199,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.copywithin",
+            "tags": [
+              "web-features:array-copywithin"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -232,6 +244,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.entries",
+            "tags": [
+              "web-features:array-iterators"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -274,6 +289,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/every",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.every",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -324,6 +342,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fill",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.fill",
+            "tags": [
+              "web-features:array-fill"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -366,6 +387,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/filter",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.filter",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -416,6 +440,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/find",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.find",
+            "tags": [
+              "web-features:array-find"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -460,6 +487,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.findindex",
+            "tags": [
+              "web-features:array-find"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -504,6 +534,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.findlast",
+            "tags": [
+              "web-features:array-findlast"
+            ],
             "support": {
               "chrome": {
                 "version_added": "97"
@@ -544,6 +577,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.findlastindex",
+            "tags": [
+              "web-features:array-findlast"
+            ],
             "support": {
               "chrome": {
                 "version_added": "97"
@@ -670,6 +706,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.foreach",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -720,6 +759,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/from",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.from",
+            "tags": [
+              "web-features:array-from"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -762,6 +804,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync",
             "spec_url": "https://tc39.es/proposal-array-from-async/#sec-array.fromAsync",
+            "tags": [
+              "web-features:array-fromasync"
+            ],
             "support": {
               "chrome": {
                 "version_added": "121"
@@ -802,6 +847,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/includes",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.includes",
+            "tags": [
+              "web-features:array-includes"
+            ],
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -844,6 +892,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.indexof",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -894,6 +945,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.isarray",
+            "tags": [
+              "web-features:array-isarray"
+            ],
             "support": {
               "chrome": {
                 "version_added": "4"
@@ -940,6 +994,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/join",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.join",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -986,6 +1043,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.keys",
+            "tags": [
+              "web-features:array-iterators"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1028,6 +1088,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.lastindexof",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1078,6 +1141,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/length",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-properties-of-array-instances-length",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1126,6 +1192,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/map",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.map",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1176,6 +1245,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/of",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.of",
+            "tags": [
+              "web-features:array-of"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1222,6 +1294,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/pop",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.pop",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1268,6 +1343,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/push",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.push",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1314,6 +1392,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reduce",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -1360,6 +1441,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reduceright",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -1406,6 +1490,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reverse",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1452,6 +1539,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/shift",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.shift",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1498,6 +1588,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.slice",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1544,6 +1637,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/some",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.some",
+            "tags": [
+              "web-features:array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1594,6 +1690,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.sort",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1638,6 +1737,9 @@
           "stable_sorting": {
             "__compat": {
               "description": "Stable sorting",
+              "tags": [
+                "web-features:stable-array-sort"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "70"
@@ -1679,6 +1781,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.splice",
+            "tags": [
+              "web-features:array-splice"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1728,6 +1833,9 @@
             "spec_url": [
               "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tolocalestring",
               "https://tc39.es/ecma402/#sup-array.prototype.tolocalestring"
+            ],
+            "tags": [
+              "web-features:array"
             ],
             "support": {
               "chrome": {
@@ -1878,6 +1986,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.toreversed",
+            "tags": [
+              "web-features:array-by-copy"
+            ],
             "support": {
               "chrome": {
                 "version_added": "110"
@@ -1918,6 +2029,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tosorted",
+            "tags": [
+              "web-features:array-by-copy"
+            ],
             "support": {
               "chrome": {
                 "version_added": "110"
@@ -1958,6 +2072,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tospliced",
+            "tags": [
+              "web-features:array-by-copy"
+            ],
             "support": {
               "chrome": {
                 "version_added": "110"
@@ -1998,6 +2115,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tostring",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2046,6 +2166,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.unshift",
+            "tags": [
+              "web-features:array"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2092,6 +2215,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/values",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.values",
+            "tags": [
+              "web-features:array-iterators"
+            ],
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -2140,6 +2266,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/with",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.with",
+            "tags": [
+              "web-features:array-by-copy"
+            ],
             "support": {
               "chrome": {
                 "version_added": "110"
@@ -2180,6 +2309,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-@@iterator",
+            "tags": [
+              "web-features:array-iterators"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Float32Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array/Float32Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -103,6 +109,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -150,6 +159,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Float32Array(iterable)</code>",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"
@@ -191,6 +203,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Float32Array()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Float64Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array/Float64Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -103,6 +109,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -150,6 +159,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Float64Array(iterable)</code>",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"
@@ -191,6 +203,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Float64Array()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Int16Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array/Int16Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -103,6 +109,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -191,6 +200,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Int16Array()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Int32Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array/Int32Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -103,6 +109,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -150,6 +159,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Int32Array(iterable)</code>",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"
@@ -191,6 +203,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Int32Array()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Int8Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array/Int8Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -103,6 +109,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -150,6 +159,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Int8Array(iterable)</code>",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"
@@ -191,6 +203,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Int8Array()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map",
           "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map-objects",
+          "tags": [
+            "web-features:map"
+          ],
           "support": {
             "chrome": {
               "version_added": "38"
@@ -47,6 +50,9 @@
             "description": "<code>Map()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/Map",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map-constructor",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -87,6 +93,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Map(iterable)</code>",
+              "tags": [
+                "web-features:map"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "38"
@@ -128,6 +137,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Map()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:map"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "38"
@@ -169,6 +181,9 @@
           "null_allowed": {
             "__compat": {
               "description": "<code>new Map(null)</code>",
+              "tags": [
+                "web-features:map"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "38"
@@ -212,6 +227,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/clear",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.clear",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -254,6 +272,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/delete",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.delete",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -296,6 +317,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.entries",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -338,6 +362,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.foreach",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -380,6 +407,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/get",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.get",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -472,6 +502,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/has",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.has",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -513,6 +546,9 @@
         "key_equality_for_zeros": {
           "__compat": {
             "description": "Key equality for -0 and 0",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -555,6 +591,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.keys",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -597,6 +636,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/set",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.set",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -641,6 +683,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/size",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map.prototype.size",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -684,6 +729,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/values",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.values",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -726,6 +774,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype-@@iterator",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -782,6 +833,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map-@@species",
+            "tags": [
+              "web-features:map"
+            ],
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-objects",
+          "tags": [
+            "web-features:promise"
+          ],
           "support": {
             "chrome": {
               "version_added": "32"
@@ -47,6 +50,9 @@
             "description": "<code>Promise()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-constructor",
+            "tags": [
+              "web-features:promise"
+            ],
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -93,6 +99,9 @@
             "description": "<code>all()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/all",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.all",
+            "tags": [
+              "web-features:promise"
+            ],
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -136,6 +145,9 @@
             "description": "<code>allSettled()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.allsettled",
+            "tags": [
+              "web-features:promise-allsettled"
+            ],
             "support": {
               "chrome": {
                 "version_added": "76"
@@ -176,6 +188,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/any",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.any",
+            "tags": [
+              "web-features:promise-any"
+            ],
             "support": {
               "chrome": {
                 "version_added": "85"
@@ -217,6 +232,9 @@
             "description": "<code>catch()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.catch",
+            "tags": [
+              "web-features:promise"
+            ],
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -260,6 +278,9 @@
             "description": "<code>finally()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.finally",
+            "tags": [
+              "web-features:promise-finally"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -344,6 +365,9 @@
             "description": "<code>race()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/race",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.race",
+            "tags": [
+              "web-features:promise"
+            ],
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -387,6 +411,9 @@
             "description": "<code>reject()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.reject",
+            "tags": [
+              "web-features:promise"
+            ],
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -430,6 +457,9 @@
             "description": "<code>resolve()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.resolve",
+            "tags": [
+              "web-features:promise"
+            ],
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -473,6 +503,9 @@
             "description": "<code>then()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/then",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.then",
+            "tags": [
+              "web-features:promise"
+            ],
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -515,6 +548,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers",
             "spec_url": "https://tc39.es/proposal-promise-with-resolvers/#sec-promise.withResolvers",
+            "tags": [
+              "web-features:promise-withresolvers"
+            ],
             "support": {
               "chrome": {
                 "version_added": "119"
@@ -555,6 +591,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species",
+            "tags": [
+              "web-features:promise"
+            ],
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set",
           "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set-objects",
+          "tags": [
+            "web-features:set"
+          ],
           "support": {
             "chrome": {
               "version_added": "38"
@@ -47,6 +50,9 @@
             "description": "<code>Set()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/Set",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set-constructor",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -87,6 +93,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Set(iterable)</code>",
+              "tags": [
+                "web-features:set"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "38"
@@ -128,6 +137,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Set()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:set"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "38"
@@ -169,6 +181,9 @@
           "null_allowed": {
             "__compat": {
               "description": "<code>new Set(null)</code>",
+              "tags": [
+                "web-features:set"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "38"
@@ -212,6 +227,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/add",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.add",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -256,6 +274,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/clear",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.clear",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -298,6 +319,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/delete",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.delete",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -390,6 +414,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.entries",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -432,6 +459,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.foreach",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -474,6 +504,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/has",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.has",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -715,6 +748,9 @@
         "key_equality_for_zeros": {
           "__compat": {
             "description": "Key equality for -0 and 0",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -757,6 +793,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.keys",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -799,6 +838,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/size",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set.prototype.size",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -942,6 +984,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/values",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.values",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -984,6 +1029,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype-@@iterator",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "43"
@@ -1040,6 +1088,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set-@@species",
+            "tags": [
+              "web-features:set"
+            ],
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -54,6 +57,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray.bytes_per_element",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -144,6 +150,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/buffer",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.buffer",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -194,6 +203,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.bytelength",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -244,6 +256,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.byteoffset",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -293,6 +308,9 @@
         "constructor_without_parameters": {
           "__compat": {
             "description": "Constructor without parameters",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -341,6 +359,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.copywithin",
+            "tags": [
+              "web-features:array-copywithin"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -383,6 +404,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.entries",
+            "tags": [
+              "web-features:typed-array-iterators"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -425,6 +449,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/every",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.every",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -467,6 +494,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.fill",
+            "tags": [
+              "web-features:array-fill"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -509,6 +539,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/filter",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.filter",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -551,6 +584,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/find",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.find",
+            "tags": [
+              "web-features:array-find"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -593,6 +629,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findindex",
+            "tags": [
+              "web-features:array-find"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -635,6 +674,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLast",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findlast",
+            "tags": [
+              "web-features:array-findlast"
+            ],
             "support": {
               "chrome": {
                 "version_added": "97"
@@ -675,6 +717,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLastIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findlastindex",
+            "tags": [
+              "web-features:array-findlast"
+            ],
             "support": {
               "chrome": {
                 "version_added": "97"
@@ -715,6 +760,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/forEach",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.foreach",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -757,6 +805,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.from",
+            "tags": [
+              "web-features:array-from"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -799,6 +850,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.includes",
+            "tags": [
+              "web-features:array-includes"
+            ],
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -897,6 +951,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.indexof",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -981,6 +1038,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/join",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.join",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1023,6 +1083,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.keys",
+            "tags": [
+              "web-features:typed-array-iterators"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1065,6 +1128,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/lastIndexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.lastindexof",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1108,6 +1174,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.length",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1158,6 +1227,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/map",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.map",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1200,6 +1272,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/name",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-properties-of-the-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1249,6 +1324,9 @@
         "named_properties": {
           "__compat": {
             "description": "Named properties",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1296,6 +1374,9 @@
         "new_required": {
           "__compat": {
             "description": "<code>TypedArray()</code> without <code>new</code> throws",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1340,6 +1421,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/of",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.of",
+            "tags": [
+              "web-features:array-of"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1382,6 +1466,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduce",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reduce",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1424,6 +1511,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reduceright",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1466,6 +1556,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reverse",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reverse",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1508,6 +1601,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.set",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1558,6 +1654,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.slice",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1600,6 +1699,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/some",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.some",
+            "tags": [
+              "web-features:typed-array-iteration-methods"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1642,6 +1744,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/sort",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.sort",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1684,6 +1789,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.subarray",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1734,6 +1842,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tolocalestring",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1782,6 +1893,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toReversed",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.toreversed",
+            "tags": [
+              "web-features:array-by-copy"
+            ],
             "support": {
               "chrome": {
                 "version_added": "110"
@@ -1822,6 +1936,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toSorted",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tosorted",
+            "tags": [
+              "web-features:array-by-copy"
+            ],
             "support": {
               "chrome": {
                 "version_added": "110"
@@ -1862,6 +1979,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tostring",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1910,6 +2030,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/values",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.values",
+            "tags": [
+              "web-features:typed-array-iterators"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1952,6 +2075,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/with",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.with",
+            "tags": [
+              "web-features:array-by-copy"
+            ],
             "support": {
               "chrome": {
                 "version_added": "110"
@@ -1992,6 +2118,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype-@@iterator",
+            "tags": [
+              "web-features:typed-array-iterators"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Uint16Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array/Uint16Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -103,6 +109,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -150,6 +159,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Uint16Array(iterable)</code>",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"
@@ -191,6 +203,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Uint16Array()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Uint8Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -103,6 +109,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -150,6 +159,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Uint8Array(iterable)</code>",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"
@@ -191,6 +203,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Uint8Array()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Uint8ClampedArray()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray/Uint8ClampedArray",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -150,6 +156,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Uint8ClampedArray(iterable)</code>",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"
@@ -191,6 +200,9 @@
           "new_required": {
             "__compat": {
               "description": "<code>Uint8ClampedArray()</code> without <code>new</code> throws",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -6,6 +6,9 @@
           "description": "Array literals (<code>[1, 2, 3]</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Array_literals",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-array-initializer",
+          "tags": [
+            "web-features:array"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -472,6 +472,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-exports",
+          "tags": [
+            "web-features:js-modules"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -515,6 +518,9 @@
             "description": "<code>default</code> keyword with <code>export</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
             "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-exports",
+            "tags": [
+              "web-features:js-modules"
+            ],
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -1162,6 +1168,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-imports",
+          "tags": [
+            "web-features:js-modules"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math",
           "spec_url": "https://w3c.github.io/mathml-core/#the-top-level-math-element",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": [
               {
@@ -75,6 +78,9 @@
         "display": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math#attr-display",
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/merror",
           "spec_url": "https://w3c.github.io/mathml-core/#error-message-merror",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mfrac",
           "spec_url": "https://w3c.github.io/mathml-core/#fractions-mfrac",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -69,6 +72,9 @@
         },
         "linethickness": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mi.json
+++ b/mathml/elements/mi.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mi",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mi",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -38,6 +41,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mi/mathvariant",
             "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathvariant",
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mmultiscripts.json
+++ b/mathml/elements/mmultiscripts.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mmultiscripts",
           "spec_url": "https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mn.json
+++ b/mathml/elements/mn.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mn",
           "spec_url": "https://w3c.github.io/mathml-core/#number-mn",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mo",
           "spec_url": "https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -68,6 +71,9 @@
         },
         "form": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -100,6 +106,9 @@
         },
         "largeop": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -132,6 +141,9 @@
         },
         "lspace": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -164,6 +176,9 @@
         },
         "maxsize": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -196,6 +211,9 @@
         },
         "minsize": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -228,6 +246,9 @@
         },
         "moveablelimits": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -329,6 +350,9 @@
         },
         "rspace": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -361,6 +385,9 @@
         },
         "stretchy": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -393,6 +420,9 @@
         },
         "symmetric": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mover",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -36,6 +39,9 @@
         },
         "accent": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mpadded",
           "spec_url": "https://w3c.github.io/mathml-core/#adjust-space-around-content-mpadded",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -36,6 +39,9 @@
         },
         "depth": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -68,6 +74,9 @@
         },
         "height": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -100,6 +109,9 @@
         },
         "lspace": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -301,6 +313,9 @@
         },
         "voffset": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -333,6 +348,9 @@
         },
         "width": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mphantom",
           "spec_url": "https://w3c.github.io/mathml-core/#making-sub-expressions-invisible-mphantom",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mroot",
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mrow",
           "spec_url": "https://w3c.github.io/mathml-core/#horizontally-group-sub-expressions-mrow",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/ms",
           "spec_url": "https://w3c.github.io/mathml-core/#string-literal-ms",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mspace",
           "spec_url": "https://w3c.github.io/mathml-core/#space-mspace",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -36,6 +39,9 @@
         },
         "depth": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -68,6 +74,9 @@
         },
         "height": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -134,6 +143,9 @@
         },
         "width": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/msqrt.json
+++ b/mathml/elements/msqrt.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msqrt",
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mstyle.json
+++ b/mathml/elements/mstyle.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle",
           "spec_url": "https://w3c.github.io/mathml-core/#style-change-mstyle",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msub",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msubsup",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msup",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtable",
           "spec_url": "https://w3c.github.io/mathml-core/#table-or-matrix-mtable",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtd",
           "spec_url": "https://w3c.github.io/mathml-core/#entry-in-table-or-matrix-mtd",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -68,6 +71,9 @@
         },
         "columnspan": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117"
@@ -132,6 +138,9 @@
         },
         "rowspan": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117"

--- a/mathml/elements/mtext.json
+++ b/mathml/elements/mtext.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtext",
           "spec_url": "https://w3c.github.io/mathml-core/#text-mtext",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtr",
           "spec_url": "https://w3c.github.io/mathml-core/#row-in-table-or-matrix-mtr",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/munder",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -36,6 +39,9 @@
         },
         "accentunder": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/munderover",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -36,6 +39,9 @@
         },
         "accent": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -68,6 +74,9 @@
         },
         "accentunder": {
           "__compat": {
+            "tags": [
+              "web-features:mathml"
+            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/semantics",
           "spec_url": "https://w3c.github.io/mathml-core/#semantics-and-presentation",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/dir",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-dir",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/displaystyle",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-displaystyle",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -119,6 +125,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathbackground",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathbackground",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -161,6 +170,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathcolor",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathcolor",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -203,6 +215,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathsize",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathsize",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -351,6 +366,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/scriptlevel",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-scriptlevel",
+          "tags": [
+            "web-features:mathml"
+          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -147,7 +147,8 @@
             "__compat": {
               "description": "<code>type='module'</code>",
               "tags": [
-                "web-features:svg2-script-html-equivalence"
+                "web-features:svg2-script-html-equivalence",
+                "web-features:js-modules"
               ],
               "support": {
                 "chrome": {


### PR DESCRIPTION
This was done using the script in https://github.com/web-platform-dx/web-features/pull/473
with a few local changes to exclude features that are already tagged in
BCD and will need a closer look to ensure everything is in sync:

- array-at
- class-syntax
- container-queries
- font-variant-alternates
- scroll-driven-animations
- svg2-script-html-equivalence

The slot feature is also excluded to avoid conflicts:
https://github.com/mdn/browser-compat-data/pull/22781

In other words, this change is the simple cases, only new tags that are not
anywhere in BCD yet.