### PR TITLE
Tag additional entries for web-features

### DIFF
--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule",
         "spec_url": "https://drafts.csswg.org/css-contain-3/#the-csscontainerrule-interface",
+        "tags": [
+          "web-features:container-queries"
+        ],
         "support": {
           "chrome": {
             "version_added": "105"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerName",
           "spec_url": "https://drafts.csswg.org/css-contain-3/#dom-csscontainerrule-containername",
+          "tags": [
+            "web-features:container-queries"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerQuery",
           "spec_url": "https://drafts.csswg.org/css-contain-3/#dom-csscontainerrule-containerquery",
+          "tags": [
+            "web-features:container-queries"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFeatureValuesRule",
         "spec_url": "https://drafts.csswg.org/css-fonts/#cssfontfeaturevaluesrule",
+        "tags": [
+          "web-features:font-variant-alternates"
+        ],
         "support": {
           "chrome": {
             "version_added": "111"
@@ -103,6 +106,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFeatureValuesRule/fontFamily",
           "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-fontfamily",
+          "tags": [
+            "web-features:font-variant-alternates"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -6,6 +6,9 @@
           "description": "<code>@font-feature-values</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values",
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-feature-values",
+          "tags": [
+            "web-features:font-variant-alternates"
+          ],
           "support": {
             "chrome": {
               "version_added": "111"
@@ -39,6 +42,9 @@
           "__compat": {
             "description": "<code>@annotation</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#annotation",
+            "tags": [
+              "web-features:font-variant-alternates"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -73,6 +79,9 @@
           "__compat": {
             "description": "<code>@character-variant</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#character-variant",
+            "tags": [
+              "web-features:font-variant-alternates"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -106,6 +115,9 @@
         "historical-forms": {
           "__compat": {
             "description": "<code>@historical-forms</code>",
+            "tags": [
+              "web-features:font-variant-alternates"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -140,6 +152,9 @@
           "__compat": {
             "description": "<code>@ornaments</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#ornaments",
+            "tags": [
+              "web-features:font-variant-alternates"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -174,6 +189,9 @@
           "__compat": {
             "description": "<code>@styleset</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#styleset",
+            "tags": [
+              "web-features:font-variant-alternates"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -208,6 +226,9 @@
           "__compat": {
             "description": "<code>@stylistic</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#stylistic",
+            "tags": [
+              "web-features:font-variant-alternates"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -242,6 +263,9 @@
           "__compat": {
             "description": "<code>@swash</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values#swash",
+            "tags": [
+              "web-features:font-variant-alternates"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -110,6 +110,9 @@
         "animation-timeline_included": {
           "__compat": {
             "description": "<code>animation-timeline</code> included in shorthand",
+            "tags": [
+              "web-features:scroll-driven-animations"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115",

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -156,6 +156,9 @@
         "container_query_length_units": {
           "__compat": {
             "description": "Container query length units <code>cqw</code>, <code>cqh</code>, <code>cqi</code>, <code>cqb</code>, <code>cqmin</code>, <code>cqmax</code>",
+            "tags": [
+              "web-features:container-queries"
+            ],
             "support": {
               "chrome": {
                 "version_added": "105"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -104,6 +104,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/at",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.at",
+            "tags": [
+              "web-features:array-at"
+            ],
             "support": {
               "chrome": {
                 "version_added": "92"

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/super",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-super-keyword",
+          "tags": [
+            "web-features:class-syntax"
+          ],
           "support": {
             "chrome": {
               "version_added": "42"


### PR DESCRIPTION
These are cases where the tag already exists in BCD, but additional
entries are being tagged. This is to bring tags in sync with
web-features, so that we can remove compat_keys in most cases.