### PR TITLE
Turn Bluetooth partial impl with notes into multiple support statements

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -8,19 +8,23 @@
           "web-features:web-bluetooth"
         ],
         "support": {
-          "chrome": {
-            "version_added": "56",
-            "partial_implementation": true,
-            "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Linux support is not enabled by default."
+            },
+            {
+              "version_added": "56",
+              "version_removed": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "56"
           },
-          "edge": {
-            "version_added": "79",
-            "partial_implementation": true,
-            "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false,
             "impl_url": "https://bugzil.la/674737"

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -8,19 +8,23 @@
           "web-features:web-bluetooth"
         ],
         "support": {
-          "chrome": {
-            "version_added": "56",
-            "partial_implementation": true,
-            "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Linux support is not enabled by default."
+            },
+            {
+              "version_added": "56",
+              "version_removed": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "56"
           },
-          "edge": {
-            "version_added": "79",
-            "partial_implementation": true,
-            "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false,
             "impl_url": "https://bugzil.la/674737"

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -8,19 +8,23 @@
           "web-features:web-bluetooth"
         ],
         "support": {
-          "chrome": {
-            "version_added": "56",
-            "partial_implementation": true,
-            "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Linux support is not enabled by default."
+            },
+            {
+              "version_added": "56",
+              "version_removed": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "56"
           },
-          "edge": {
-            "version_added": "79",
-            "partial_implementation": true,
-            "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false,
             "impl_url": "https://bugzil.la/674737"

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -8,19 +8,23 @@
           "web-features:web-bluetooth"
         ],
         "support": {
-          "chrome": {
-            "version_added": "56",
-            "partial_implementation": true,
-            "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Linux support is not enabled by default."
+            },
+            {
+              "version_added": "56",
+              "version_removed": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "56"
           },
-          "edge": {
-            "version_added": "79",
-            "partial_implementation": true,
-            "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false,
             "impl_url": "https://bugzil.la/674737"

--- a/api/BluetoothRemoteGATTDescriptor.json
+++ b/api/BluetoothRemoteGATTDescriptor.json
@@ -8,19 +8,23 @@
           "web-features:web-bluetooth"
         ],
         "support": {
-          "chrome": {
-            "version_added": "57",
-            "partial_implementation": true,
-            "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Linux support is not enabled by default."
+            },
+            {
+              "version_added": "57",
+              "version_removed": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "57"
           },
-          "edge": {
-            "version_added": "79",
-            "partial_implementation": true,
-            "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false,
             "impl_url": "https://bugzil.la/674737"

--- a/api/BluetoothRemoteGATTServer.json
+++ b/api/BluetoothRemoteGATTServer.json
@@ -8,19 +8,23 @@
           "web-features:web-bluetooth"
         ],
         "support": {
-          "chrome": {
-            "version_added": "56",
-            "partial_implementation": true,
-            "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Linux support is not enabled by default."
+            },
+            {
+              "version_added": "56",
+              "version_removed": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "56"
           },
-          "edge": {
-            "version_added": "79",
-            "partial_implementation": true,
-            "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false,
             "impl_url": "https://bugzil.la/674737"

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -8,19 +8,23 @@
           "web-features:web-bluetooth"
         ],
         "support": {
-          "chrome": {
-            "version_added": "56",
-            "partial_implementation": true,
-            "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Linux support is not enabled by default."
+            },
+            {
+              "version_added": "56",
+              "version_removed": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "56"
           },
-          "edge": {
-            "version_added": "79",
-            "partial_implementation": true,
-            "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false,
             "impl_url": "https://bugzil.la/674737"

--- a/api/BluetoothUUID.json
+++ b/api/BluetoothUUID.json
@@ -8,19 +8,23 @@
           "web-features:web-bluetooth"
         ],
         "support": {
-          "chrome": {
-            "version_added": "56",
-            "partial_implementation": true,
-            "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Linux support is not enabled by default."
+            },
+            {
+              "version_added": "56",
+              "version_removed": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "56"
           },
-          "edge": {
-            "version_added": "79",
-            "partial_implementation": true,
-            "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false,
             "impl_url": "https://bugzil.la/674737"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -344,19 +344,23 @@
             "web-features:web-bluetooth"
           ],
           "support": {
-            "chrome": {
-              "version_added": "56",
-              "partial_implementation": true,
-              "notes": "Before Chrome 70, this feature was only supported in macOS. In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Linux support is not enabled by default."
+              },
+              {
+                "version_added": "56",
+                "version_removed": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              }
+            ],
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": {
-              "version_added": "79",
-              "partial_implementation": true,
-              "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "impl_url": "https://bugzil.la/674737"

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -177,7 +177,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
-              "notes": "Only supported in ChromeOS"
+              "notes": "Only supported on ChromeOS"
             },
             "chrome_android": {
               "version_added": "38"
@@ -337,7 +337,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
-              "notes": "Only supported in ChromeOS"
+              "notes": "Only supported on ChromeOS"
             },
             "chrome_android": {
               "version_added": "38"


### PR DESCRIPTION
Lack of support on Linux should be considered partial implementation
according to our guidelines:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#operating-system-limitations-imply-partial_implementation

This allows the Edge data to be mirrored.

Also update some "Also support on" notes to use a consistent style.