### PR TITLE
Update Edge data for backdrop-filter

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -10,9 +10,16 @@
               "version_added": "76"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "17"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "17",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "103"
             },


### PR DESCRIPTION
https://caniuse.com/css-backdrop-filter has a note for Edge 17-18 which
turns out to be correct. It was only supported as
-webkit-backdrop-filter, presumably due to site compat issues.

This was verified by testing https://wpt.live/css/filter-effects/backdrop-filter-basic.html
in Edge 17. The test doesn't pass as-is, but changing backdrop-filter to
-webkit-backdrop-filter and it does render as expected.