### PR TITLE
Remove web-features tags for CSS Typed OM bits

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -111,9 +111,6 @@
         "__compat": {
           "description": "<code>cap()</code> static method",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-cap",
-          "tags": [
-            "web-features:cap"
-          ],
           "support": {
             "chrome": {
               "version_added": "118"
@@ -1011,9 +1008,6 @@
         "__compat": {
           "description": "<code>ic()</code> static method",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ic",
-          "tags": [
-            "web-features:ic"
-          ],
           "support": {
             "chrome": {
               "version_added": "118"
@@ -1121,9 +1115,6 @@
         "__compat": {
           "description": "<code>lh()</code> static method",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lh",
-          "tags": [
-            "web-features:lh"
-          ],
           "support": {
             "chrome": {
               "version_added": "118"


### PR DESCRIPTION
There are defined by CSS Typed OM:
https://drafts.css-houdini.org/css-typed-om/#numeric-factory

In other words, these are things that a browser would support only if both the CSS units and CSS Typed OM are supported.