### PR TITLE
Update Chrome data for align-content: last baseline

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -215,18 +215,10 @@
               "description": "<code>last baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": "59",
-                  "version_removed": "86",
-                  "partial_implementation": true,
-                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                  "version_added": "108"
                 },
                 "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "≤79",
-                  "version_removed": "86",
-                  "partial_implementation": true,
-                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "52"
                 },


### PR DESCRIPTION
The linked bug was fixed in Chrome 108:
https://chromiumdash.appspot.com/commit/3879406517fb19168eb0944866f77f7352c05962

The other two properties were done here:
https://github.com/mdn/browser-compat-data/pull/18814