### PR TITLE
Remove setActionHandler() partial impl. + notes for Firefox/Safari

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -139,9 +139,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "82",
-              "partial_implementation": true,
-              "notes": "Firefox does not support the <code>togglemicrophone</code>, <code>togglecamera</code>, and <code>hangup</code> action types."
+              "version_added": "82"
             },
             "firefox_android": {
               "version_added": "82",
@@ -155,9 +153,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15",
-              "partial_implementation": true,
-              "notes": "Safari does not support for the <code>togglemicrophone</code>, <code>togglecamera</code>, and <code>hangup</code> action types."
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
The status of specific action handlers is already captured in subfeatures. Notes like these are hard to keep in sync, and they're in fact not in sync as nextslide/previousslide are also not supported.

Chrome also doesn't support all action handlers, and doesn't have partial impl. like this.