### PR TITLE
Add bugs and notes for the pushsubscriptionchange event

### DIFF
--- a/api/PushSubscriptionChangeEvent.json
+++ b/api/PushSubscriptionChangeEvent.json
@@ -6,7 +6,8 @@
         "spec_url": "https://w3c.github.io/push-api/#pushsubscriptionchangeevent-interface",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://crbug.com/41275327"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -14,7 +15,8 @@
             "version_removed": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "notes": "The <code>pushsubscriptionchange</code> event is fired but does not have the <code>oldSubscription</code> and <code>newSubscription</code> properties. See <a href='https://bugzil.la/1497429'>bug 1497429</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -852,7 +852,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/41275327"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -860,10 +861,14 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "44",
+              "partial_implementation": true,
+              "notes": "The event does not have the <code>oldSubscription</code> and <code>newSubscription</code> properties. See <a href='https://bugzil.la/1497429'>bug 1497429</a>."
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": "48",
+              "partial_implementation": true,
+              "notes": "The event does not have the <code>oldSubscription</code> and <code>newSubscription</code> properties. See <a href='https://bugzil.la/1497429'>bug 1497429</a>."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
The Firefox data seems contradictory without these notes. It's not a
contradiction because the event is fired, but not using a
PushSubscriptionChangeEvent object.