### PR TITLE
Link bug for font-variation-settings descriptor

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -659,7 +659,8 @@
             "spec_url": "https://drafts.csswg.org/css-fonts/#font-rend-desc",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40398871"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
The same bug is already linked for font-feature-settings.