### PR TITLE
Add BCD for JSON.parse with source context

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -178,6 +178,47 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "source_context": {
+            "__compat": {
+              "description": "Reviver has <code>context</code> parameter",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter",
+              "spec_url": "https://tc39.es/proposal-json-parse-with-source/#sec-internalizejsonproperty",
+              "support": {
+                "chrome": {
+                  "version_added": "114"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.33"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "21.0.0"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "rawJSON": {

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -179,7 +179,7 @@
               "deprecated": false
             }
           },
-          "source_context": {
+          "reviver_parameter_context_argument": {
             "__compat": {
               "description": "Reviver has <code>context</code> parameter",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Added browser compat data for `JSON.parse()` and a reviver that expects a third argument `context`, containing the parsed source text.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Quick Test to check if a browser supports the context param:

```ts
function testJSONParseWithSource() {
  const unsafeInt = (BigInt(Number.MAX_SAFE_INTEGER) + 1n);

  try {
    const parsedInt = JSON.parse(unsafeInt.toString(10), function (key, value, context) {
      return BigInt(context.source);
    });

    console.info({ parsedInt })
    console.info('Is supported: %s', parsedInt === unsafeInt)
  } catch (error) {
    console.error(error)
    console.info('Is supported: false')
  }
}
```

##### Spec

[tc39.es proposal | Spec | parse](https://tc39.es/proposal-json-parse-with-source/#sec-internalizejsonproperty)
[tc39.es proposal | GitHub](https://github.com/tc39/proposal-json-parse-with-source)

##### Implementation | Chrome

[Chromium Ticket](https://bugs.chromium.org/p/v8/issues/detail?id=12955)
[Related Chromium Commits](https://chromium-review.googlesource.com/q/hashtag:%22json-parse-with-source%22+(status:open%20OR%20status:merged))

Landed as "dev trial" in V8 version [10.8](https://chromium.googlesource.com/v8/v8.git/+/branch-heads/10.8)
Landed as "default on" flag in V8 version [11.4](https://chromium.googlesource.com/v8/v8.git/+/branch-heads/11.4)

[chromestatus.com](https://chromestatus.com/feature/5121582673428480)

##### Implementation | Firefox

[Bugzilla Ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1855468) (open)

##### Implementation | Safari

[WebKit Ticket](https://bugs.webkit.org/show_bug.cgi?id=248031) (open)

#### Related issues

Relates to #22766 