### PR TITLE
Mark getContributingSources() audioLevel property supported in Chrome

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -180,7 +180,7 @@
             "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcrtpcontributingsource-audiolevel",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "73"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
It was enabled in Chrome 73:
https://chromiumdash.appspot.com/commit/86c8a3c5f1fee11f65b22897ef822cda7750ce23

This data was added to BCD in 2018, well before Chrome 73 was released:
https://github.com/mdn/browser-compat-data/pull/948