### PR TITLE
Split `api.Headers.lexicographical_sorting` in two and update the data

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -375,6 +375,82 @@
           }
         }
       },
+      "iterate_combined_duplicates": {
+        "__compat": {
+          "description": "Iteration combines duplicate header names",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "iterate_lexicographically": {
+        "__compat": {
+          "description": "Iteration is lexicographically sorted",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/keys",
@@ -404,42 +480,6 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "10.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "lexicographical_sorting": {
-        "__compat": {
-          "description": "Lexicographical sorting, and values from duplicate header names combined when iterated.",
-          "support": {
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "44"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Split two wrongly combined features for iterating over `Headers` objects and update their support data.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Manually tested with something close to this (extraneous logging and such removed):

```js
var populate = [];
var abc = ["A", "B", "C", "D", "E", "F"].reverse();
for (var index = 0; index < 512; index++) {
  populate[index] = ["X-" + abc[index % abc.length], "_"];
}

var headers = new Headers([
  ["Accept-Language", "en-US,en;q=0.5"],
  ["Accept-Language", "en-US,en;q=0.5"],
  ["Accept-Language", "en-US,en;q=0.5"],
].concat(populate));
console.log(headers);
for (var header of headers) {
  console.log(header);
}
```

I was investigating this feature in the course of creating a fetch feature in web-features. The data for Safari looked dubious. I soon found out that the two parts of this (sorting and combining) have different histories. Instead of using partial implementations, I split the feature in two.

The highlights here:

- Safari always supported both (from 10.1)
- Edge acquired them separately (in 16 and 18)
- Firefox got both at the same time, but later than reported (57, not 44)
