### PR TITLE
Update <hr> in <select>

### DIFF
--- a/html/elements/hr.json
+++ b/html/elements/hr.json
@@ -127,9 +127,7 @@
                 ]
               },
               "chrome_android": {
-                "version_added": "119",
-                "partial_implementation": true,
-                "notes": "Exposes the <code>&lt;hr&gt;</code> as its own empty selectable option and not as a horizontal rule."
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {
@@ -150,7 +148,9 @@
                 "notes": "Does not expose the <code>&lt;hr&gt;</code> within the accessibility tree."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "17.4",
+                "partial_implementation": true,
+                "notes": "Does not expose the <code>&lt;hr&gt;</code> within the accessibility tree."
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -135,9 +135,7 @@
                 ]
               },
               "chrome_android": {
-                "version_added": "119",
-                "partial_implementation": true,
-                "notes": "Exposes the <code>&lt;hr&gt;</code> as its own empty selectable option and not as a horizontal rule."
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {
@@ -158,7 +156,9 @@
                 "notes": "Does not expose the <code>&lt;hr&gt;</code> within the accessibility tree."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "17.4",
+                "partial_implementation": true,
+                "notes": "Does not expose the <code>&lt;hr&gt;</code> within the accessibility tree."
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Android Chrome has never supported `<hr>` in `<select>`. Safari added support on iOS in Safari 17.4.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Apropos https://github.com/mdn/browser-compat-data/issues/21648 I tested https://adrianroselli.com/demos/splitting-within-selects/index.html

There, I clicked/tapped on the "Select a major" example on an iPhone 13 Pro in Safari 17.4 / iOS 17.4 and an iPad in Safari 17.4 / iPadOS 17.4.

I found that it:
    * exposes the `<hr>` visually in the page.
    * does not expose the `<hr>` within the accessibility tree;
    * does not announce the `<hr>` when using VoiceOver.

I repeated the same test on Android 13 in Google Chrome 123, and found that there was no visual `<hr>` at all.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #22729 and #22730.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
