### PR TITLE
Correct the import assertions and attributes compat table

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1297,6 +1297,49 @@
               "deprecated": true
             }
           },
+          "type_css": {
+            "__compat": {
+              "description": "<code>assert {type: 'css'}</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "91"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          },
           "type_json": {
             "__compat": {
               "description": "<code>assert {type: 'json'}</code>",
@@ -1352,7 +1395,7 @@
             "description": "Import attributes (<code>with</code> syntax)",
             "support": {
               "chrome": {
-                "version_added": false,
+                "version_added": "123",
                 "impl_url": "https://crbug.com/v8/13856"
               },
               "chrome_android": "mirror",
@@ -1375,16 +1418,55 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "type_css": {
+            "__compat": {
+              "description": "<code>with {type: 'css'}</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "123"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           },
           "type_json": {
@@ -1392,7 +1474,7 @@
               "description": "<code>with {type: 'json'}</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "123"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -1421,7 +1503,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1302,7 +1302,7 @@
               "description": "<code>assert {type: 'css'}</code>",
               "support": {
                 "chrome": {
-                  "version_added": "91"
+                  "version_added": "93"
                 },
                 "chrome_android": "mirror",
                 "deno": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1414,7 +1414,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "17.2"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The compat data for import assertions and attributes is out of date. This PR, hopefully, corrects it.

Some background info:

* `import ... from ... assert ...` is now deprecated, but still implemented in Chromium (aka import assertions).
* `import ... from ... with ...` is the new way of doing this (aka import attributes).
* Both syntax can be used with `{type: json}` or `{type: css}`. The latter is missing from BCD altogether.
* Safari 17.2 added support for import attributes in 17.2, but only for `{type: json}`. https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes#JavaScript
* Chromium supports import attributes for both types.

#### Test results and supporting details

I tested with a local HTML file on Chrome, Edge, Firefox, and Safari. And checked [chromestatus.com](https://chromestatus.com/feature/5205869105250304), and the Safari release notes linked above.