### PR TITLE
Note Safari's support for options.type parameter to Worker()

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -276,7 +276,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The compatibility data for the `Worker()` constructor confusingly claimed Safari supported ECMAScript modules but not the `options.type` parameter to specify that a worker is an ECMAScript module. I had a look around, and none of the documentation of Safari adding support for modules (e.g. https://webkit.org/blog/11577/release-notes-for-safari-technology-preview-122/ and https://bugs.webkit.org/show_bug.cgi?id=164860) said they had to be used some way besides `options.type`.