### PR TITLE
Remove all "Thing() without new throws" entries

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -146,49 +146,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>ArrayBuffer()</code> without <code>new</code> throws",
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         },
         "byteLength": {

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -96,49 +96,6 @@
               "deprecated": false
             }
           },
-          "new_required": {
-            "__compat": {
-              "description": "<code>DataView()</code> without <code>new</code> throws",
-              "support": {
-                "chrome": {
-                  "version_added": "11"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "13"
-                },
-                "firefox": {
-                  "version_added": "40"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.10.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "sharedarraybuffer_support": {
             "__compat": {
               "description": "<code>SharedArrayBuffer</code> accepted as buffer",

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -199,52 +199,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Float32Array()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -199,52 +199,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Float64Array()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -196,52 +196,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Int16Array()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -199,52 +199,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Int32Array()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -199,52 +199,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Int8Array()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -134,50 +134,6 @@
               }
             }
           },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Map()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:map"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "38"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "firefox": {
-                  "version_added": "42"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": "11"
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "9"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "null_allowed": {
             "__compat": {
               "description": "<code>new Map(null)</code>",

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -134,50 +134,6 @@
               }
             }
           },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Set()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:set"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "38"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "firefox": {
-                  "version_added": "42"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": "11"
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "9"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "null_allowed": {
             "__compat": {
               "description": "<code>new Set(null)</code>",

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1374,52 +1374,6 @@
             }
           }
         },
-        "new_required": {
-          "__compat": {
-            "description": "<code>TypedArray()</code> without <code>new</code> throws",
-            "tags": [
-              "web-features:typed-arrays"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "7"
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12.0"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "of": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/of",

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -199,52 +199,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Uint16Array()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -187,49 +187,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Uint32Array()</code> without <code>new</code> throws",
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -199,52 +199,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Uint8Array()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -196,52 +196,6 @@
                 "deprecated": false
               }
             }
-          },
-          "new_required": {
-            "__compat": {
-              "description": "<code>Uint8ClampedArray()</code> without <code>new</code> throws",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "7"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "44"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "5.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -125,47 +125,6 @@
               }
             }
           },
-          "new_required": {
-            "__compat": {
-              "description": "<code>WeakMap()</code> without <code>new</code> throws",
-              "support": {
-                "chrome": {
-                  "version_added": "36"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "firefox": {
-                  "version_added": "42"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": "11"
-                },
-                "nodejs": {
-                  "version_added": "0.12.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "9"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "null_allowed": {
             "__compat": {
               "description": "<code>new WeakMap(null)</code>",


### PR DESCRIPTION
These entries document the absence of a bug. If inverted, they describe
a feature which was supported, but has long been removed. Such entries
are irrelevant per this guidline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features

Another way to look at this is that the standard behavior works before
and after this bug was fixed, and the non-standard beahvior is
additional API surface which no longer exists.