### PR TITLE
Describe slotchange event in Safari 10

### DIFF
--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -211,9 +211,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1"
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "10.1",
+                "partial_implementation": true,
+                "notes": "The <code>onslotchange</code> event handler property is not supported."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
The event was implemented long before the feature was enabled: https://github.com/WebKit/WebKit/commit/96577bfd3aecc0323f15cf77e664a95294cceb05

It was only the onslotchange property that was missing: https://github.com/WebKit/WebKit/commit/3e059eef4d8b201ca9818e8e0cbe106be2aa5e73