### PR TITLE
Adds Commands.on command.tab support

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -47,6 +47,29 @@
               }
             }
           },
+          "description": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
           "name": {
             "__compat": {
               "support": {
@@ -70,25 +93,26 @@
               }
             }
           },
-          "tab": {
+          "shortcut": {
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "86"
+                  "version_added": true
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1843866"
+                  "version_added": "48"
                 },
                 "firefox_android": {
                   "version_added": false
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           }
@@ -198,8 +222,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1843866"
+                  "version_added": "126"
                 },
                 "firefox_android": {
                   "version_added": false

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -279,69 +279,67 @@
               "safari_ios": "mirror"
             }
           },
-          "details": {
-            "description": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "60"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
+          "description": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
               }
-            },
-            "name": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "60"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
+            }
+          },
+          "name": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
               }
-            },
-            "shortcut": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "60",
-                    "notes": "From Firefox 74 can be set as an empty string to clear the shortcut assignment."
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
+            }
+          },
+          "shortcut": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "60",
+                  "notes": "From Firefox 74 can be set as an empty string to clear the shortcut assignment."
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
               }
             }
           }


### PR DESCRIPTION
#### Summary

- Adds Commands.on command.tab support
- Corrects Command type to list description, name. and shortcut
- removes unnecessary update.details, which will exemplify update.name etc. on MDN

#### Related issues

Provides dev-doc-needed for [Bug 1843866](https://bugzilla.mozilla.org/show_bug.cgi?id=1843866) Add tab parameter to commands.onCommand
Fixed #22803

Release note documentation in https://github.com/mdn/content/pull/33094