### PR TITLE
Add runtime.MessageSender.origin support in Firefox 126

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -141,8 +141,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1787379"
+                  "version_added": "126"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
#### Summary

Updates BCD to note that runtime.MessageSender.origin is supported in Firefox 126.

#### Related issues

Addresses the dev-docs-needed request for [Bug 1787379](https://bugzilla.mozilla.org/show_bug.cgi?id=1787379) Support MessageSender.origin for extension messages

Release notes added in https://github.com/mdn/content/pull/33097

