### PR TITLE
chore(relnotes): Enable CSS transition-behavior in Nightly

### DIFF
--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -15,7 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1805727"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -156,7 +156,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1805727"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
__Description:__

By using `transition-behavior`, authors can choose to enable animations for properties with discrete values, so transitions can happen at the >50% mark, flipping between two values.


__Bugzilla:__

- impl bug [bugzilla.mozilla.org/show_bug.cgi?id=1805727](https://bugzilla.mozilla.org/show_bug.cgi?id=1805727)
- (`display` bug) https://bugzilla.mozilla.org/show_bug.cgi?id=1882408

Pref: https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml#8362

__Related issues and pull requests:__

- [ ] Parent issue https://github.com/mdn/content/issues/32664
- [ ] Content: https://github.com/mdn/content/pull/33103

__Existing docs:__

- https://developer.mozilla.org/en-US/docs/Web/CSS/transition-behavior



