### PR TITLE
FF126 HTTP Content-Encoding supports zstd encoding

### DIFF
--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -88,7 +88,7 @@
         "zstd": {
           "__compat": {
             "description": "<code>zstd</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Zstandard_compression",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding#zstd",
             "spec_url": "https://www.rfc-editor.org/rfc/rfc8878#name-content-encoding",
             "support": {
               "chrome": {
@@ -97,7 +97,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "126"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -114,7 +114,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF126 supports zstd encoding in the [`Content-Encoding`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding#zstd) header in https://bugzilla.mozilla.org/show_bug.cgi?id=1871963

This adds BCD entry, updates the MDN URL, and marks as not experimental (chrome also supports it).

Related docs work can be tracked in https://github.com/mdn/content/issues/33086