### PR TITLE
Add manifest permissions.webRequestAuthProvider supported from FF126

### DIFF
--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -1082,8 +1082,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1820569"
+                "version_added": "126"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Updates BCD to note that manifest permissions.webRequestAuthProvider is supported in Firefox 126.

#### Related issues

Addresses the dev-docs-needed request for [Bug 1820569](https://bugzilla.mozilla.org/show_bug.cgi?id=1820569) Implement webRequestAuthProvider permission for webRequest.onAuthRequired

Release notes added in https://github.com/mdn/content/pull/33151