### PR TITLE
Add missing engine_version field to latest edge releases

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -361,22 +361,26 @@
         "123": {
           "release_date": "2024-03-22",
           "status": "current",
-          "engine": "Blink"
+          "engine": "Blink",
+          "engine_version": "123"
         },
         "124": {
           "release_date": "2024-04-18",
           "status": "beta",
-          "engine": "Blink"
+          "engine": "Blink",
+          "engine_version": "124"
         },
         "125": {
           "release_date": "2024-05-16",
           "status": "nightly",
-          "engine": "Blink"
+          "engine": "Blink",
+          "engine_version": "125"
         },
         "126": {
           "release_date": "2024-06-13",
           "status": "planned",
-          "engine": "Blink"
+          "engine": "Blink",
+          "engine_version": "126"
         }
       }
     }

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -72,9 +72,7 @@
                 "version_added": "123"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "123"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "125"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds missing engine_version field for latest MS edge releases.

I believe this is the cause of issues on MDN where data isn't mirroring correctly. (e.g. https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing#browser_compatibility shows Edge as not supported)

#### Test results and supporting details

N/A

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
