### PR TITLE
Add engine_version for Edge when automatically updating data

### DIFF
--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -361,7 +361,7 @@ export const updateEdgeReleases = async (options) => {
       releaseDate,
       'planned',
       '',
-      '',
+      planned,
     );
   } else {
     // New entry
@@ -373,7 +373,7 @@ export const updateEdgeReleases = async (options) => {
       options.browserEngine,
       releaseDate,
       '',
-      '',
+      planned.toString(),
     );
   }
 


### PR DESCRIPTION
The engine_version property is not added when automatically updating release info for Edge. See https://github.com/mdn/browser-compat-data/pull/22842

I think this should add it.

