### PR TITLE
Mark Worker `name` option as available under android_webview

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -238,9 +238,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This was originally added as unavailable back in 2018 (#3049).  However, testing using the android webview shell shows that it is working fine.

#### Test results and supporting details

The test I used was:

```
new Worker(URL.createObjectURL(new Blob(["console.log('my name is ' + self.name)"], {type: 'application/javascript'})), {name: "foo"})
```

I ran this is DevTools and it printed `my name is foo`.

#### Related issues

https://github.com/emscripten-core/emscripten/pull/21701#discussion_r1566183974
