### PR TITLE
Mark calc constants e and pi supported in Chrome

### DIFF
--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -82,7 +82,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "110"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -154,7 +154,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "109"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
e: https://chromiumdash.appspot.com/commit/48ec6eb35ac1dc73a2a48dd39efbc14576ba35b2
pi: https://chromiumdash.appspot.com/commit/c1490d0ec81e0ecb0aa78c6fc39be9f9f6d0ec67

These tests passing in stable show it wasn't behind a flag:
https://wpt.fyi/results/css/css-values/acos-asin-atan-atan2-computed.html?label=master&label=stable&aligned
https://wpt.fyi/results/css/css-values/sin-cos-tan-computed.html?label=stable&label=master&aligned