### PR TITLE
Chrome now provides full release notes

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -51,8 +51,15 @@ const getReleaseNotesURL = async (version, date, core, status) => {
     }
   }
 
-  // After release 54, we have an easier release note
-  url = `https://developer.chrome.com/blog/new-in-chrome-${version}`;
+  // After release 53, we have new-in-chrome highlight posts
+  if (version > 53) {
+    url = `https://developer.chrome.com/blog/new-in-chrome-${version}`;
+  }
+
+  // After release 123, we have complete release notes
+  if (version > 123) {
+    url = `https://developer.chrome.com/release-notes/${version}`;
+  }
 
   const releaseNote = await fetch(url);
 


### PR DESCRIPTION
#### Summary

From 124 onwards https://developer.chrome.com/release-notes/124 is the pattern for where to find Chrome release notes

#### Test results and supporting details

ran `npm run update-browser-releases` and saw that the script corrects this for Chrome, chrome android and webview for 124 in the browser/ data

#### Related issues

none.