### PR TITLE
Add PerformanceScriptTiming.sourceFunctionName

### DIFF
--- a/api/PerformanceScriptTiming.json
+++ b/api/PerformanceScriptTiming.json
@@ -258,6 +258,43 @@
           }
         }
       },
+      "sourceFunctionName": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/sourceFunctionName",
+          "spec_url": "https://w3c.github.io/long-animation-frames/#dom-performancescripttiming-sourcefunctionname",
+          "tags": [
+            "web-features:long-animation-frame-timing"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sourceURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceScriptTiming/sourceURL",


### PR DESCRIPTION
This was forgotten in this manually submitted PR https://github.com/mdn/browser-compat-data/pull/22758. The Open Web Docs BCD collector discovered the oversight ;) 