### PR TITLE
Firefox 125 shipped context loss events for canvas

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1559,7 +1559,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1576,7 +1576,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -92,7 +92,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -109,7 +109,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -130,7 +130,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -147,7 +147,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -91,7 +91,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "105"
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -131,7 +131,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "105"
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1221,7 +1221,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1238,7 +1238,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Firefox 125 was released and the @openwebdocs BCD Collector discovered support for context loss events for canvas. 

Can be confirmed by https://bugzilla.mozilla.org/show_bug.cgi?id=1887729 and https://www.mozilla.org/en-US/firefox/125.0.1/releasenotes/