### PR TITLE
Updates for Firefox 126 beta

### DIFF
--- a/api/CustomStateSet.json
+++ b/api/CustomStateSet.json
@@ -11,14 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "121",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.element.customstateset.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "126"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,14 +44,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -92,14 +78,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -133,14 +112,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -174,14 +146,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -215,14 +180,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -256,14 +214,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -297,14 +248,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -338,14 +282,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -379,14 +316,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -419,14 +349,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -4059,6 +4059,39 @@
           }
         }
       },
+      "currentCSSZoom": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "126"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cut_event": {
         "__compat": {
           "description": "<code>cut</code> event",

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -2048,14 +2048,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -150,7 +150,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -226,7 +226,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -497,7 +497,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -131,7 +131,8 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "65"
+              "version_added": "65",
+              "version_removed": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -206,7 +207,8 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "65"
+              "version_added": "65",
+              "version_removed": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -476,7 +478,8 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "65"
+              "version_added": "65",
+              "version_removed": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -148,8 +148,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/934640"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -298,7 +298,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4941,7 +4941,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -695,7 +695,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -731,7 +731,9 @@
             "chrome_android": {
               "version_added": "120"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "85"
+            },
             "firefox": {
               "version_added": "117"
             },
@@ -764,7 +766,7 @@
           "spec_url": "https://privacycg.github.io/requestStorageAccessFor/#permissions-integration",
           "support": {
             "chrome": {
-              "version_added": "119"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "120"
@@ -802,7 +804,7 @@
           "spec_url": "https://w3c.github.io/window-management/#api-permission-api-integration",
           "support": {
             "chrome": {
-              "version_added": "100"
+              "version_added": "111"
             },
             "chrome_android": {
               "version_added": false

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -151,10 +151,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "notes": "Before Firefox 126, the property was not read-only."
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": "24",
+              "notes": "Before Firefox 126, the property was not read-only."
             },
             "ie": {
               "version_added": false
@@ -461,10 +463,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "notes": "Before Firefox 126, the property was not read-only."
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": "24",
+              "notes": "Before Firefox 126, the property was not read-only."
             },
             "ie": {
               "version_added": false
@@ -499,10 +503,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "notes": "Before Firefox 126, the property was not read-only."
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": "24",
+              "notes": "Before Firefox 126, the property was not read-only."
             },
             "ie": {
               "version_added": false
@@ -673,7 +679,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "67"
+              "version_added": "67",
+              "notes": "Before Firefox 126, the property was not read-only."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -428,7 +428,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href="https://bugzil.la/1886013">bug 1886013</a>."
+              "notes": "See <a href='https://bugzil.la/1886013'>bug 1886013</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -647,7 +647,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href="https://bugzil.la/1886013">bug 1886013</a>."
+              "notes": "See <a href='https://bugzil.la/1886013'>bug 1886013</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -115,7 +115,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -187,7 +187,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -221,7 +221,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -255,7 +255,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -289,7 +289,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -323,7 +323,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -357,7 +357,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -391,7 +391,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -535,7 +535,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -605,7 +605,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -427,7 +427,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href="https://bugzil.la/1886013">bug 1886013</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -645,7 +646,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href="https://bugzil.la/1886013">bug 1886013</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -487,7 +487,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -504,7 +504,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/URL.json
+++ b/api/URL.json
@@ -441,6 +441,40 @@
           }
         }
       },
+      "parse_static": {
+        "__compat": {
+          "description": "<code>parse()</code> static method",
+          "spec_url": "https://url.spec.whatwg.org/#dom-url-parse",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "126"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "password": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/password",

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "126"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -54,7 +54,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "126"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -54,7 +54,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -96,7 +96,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -137,7 +137,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -178,7 +178,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -13,15 +13,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.zoom.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/390936"
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -14,14 +14,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.customstateset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -38,7 +31,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1309,7 +1309,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "126"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.5 found new features shipping in Firefox 126 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 45 features as shipping in Firefox 126:

- api.CustomStateSet
- api.CustomStateSet.add
- api.CustomStateSet.clear
- api.CustomStateSet.delete
- api.CustomStateSet.entries
- api.CustomStateSet.forEach
- api.CustomStateSet.has
- api.CustomStateSet.keys
- api.CustomStateSet.size
- api.CustomStateSet.values
- api.CustomStateSet.@@iterator
- api.Element.currentCSSZoom
- api.ElementInternals.states
- api.HTMLMarqueeElement.bounce_event (removal)
- api.HTMLMarqueeElement.finish_event (removal)
- api.HTMLMarqueeElement.start_event (removal)
- api.IDBFactory.databases
- api.IDBTransaction.durability
- api.Navigator.wakeLock
- api.Permissions.permission_screen-wake-lock
- api.RTCIceCandidate.address
- api.RTCIceCandidate.component
- api.RTCIceCandidate.foundation
- api.RTCIceCandidate.port
- api.RTCIceCandidate.priority
- api.RTCIceCandidate.protocol
- api.RTCIceCandidate.relatedAddress
- api.RTCIceCandidate.relatedPort
- api.RTCIceCandidate.tcpType
- api.RTCIceCandidate.type
- api.Selection.direction
- api.URL.parse_static
- api.WakeLock
- api.WakeLock.request
- api.WakeLockSentinel
- api.WakeLockSentinel.release
- api.WakeLockSentinel.release_event
- api.WakeLockSentinel.released
- api.WakeLockSentinel.type
- css.properties.zoom
- css.selectors.state
- http.headers.Content-Encoding.zstd
- http.headers.Permissions-Policy.screen-wake-lock
- webextensions.api.commands.onCommand.tab
- webextensions.api.runtime.MessageSender.origin

Again, I hope this PR is useful to provide updates to BCD in an easy, fast and accurate way. If you have feedback, let me know!

See also https://github.com/mdn/mdn/issues/537 and https://www.mozilla.org/en-US/firefox/126.0beta/releasenotes/