### PR TITLE
Firefox 125 ships shadowrootclonable

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -87,7 +87,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -50,7 +50,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "125"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -67,7 +67,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Originally added in https://github.com/mdn/browser-compat-data/pull/22768 but with Firefox marked as no support.

Per the @openwebdocs BCD collector and https://bugzilla.mozilla.org/show_bug.cgi?id=1880188 it seems to be supported in Firefox 125.