### PR TITLE
Add TextEvent

### DIFF
--- a/api/TextEvent.json
+++ b/api/TextEvent.json
@@ -8,19 +8,21 @@
             "version_added": "1"
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": "12"
+          },
           "firefox": {
             "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
-            "version_added": false
+            "version_added": "≤10"
           },
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "5"
+            "version_added": "3"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -40,19 +42,21 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": false
+              "version_added": "≤10"
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -73,19 +77,21 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": false
+              "version_added": "≤10"
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/TextEvent.json
+++ b/api/TextEvent.json
@@ -1,0 +1,103 @@
+{
+  "api": {
+    "TextEvent": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/uievents/#legacy-textevent-events",
+        "support": {
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "5"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "data": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/uievents/#dom-textevent-data",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initTextEvent": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/uievents/#dom-textevent-inittextevent",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The legacy `TextEvent` interface got specified 🎉  See https://w3c.github.io/uievents/#legacy-textevent-events. This means that the @openwebdocs collector discovered this as a new standardized IDL with implementations.

- Chrome: 1
- Safari: 5 https://github.com/WebKit/WebKit/commit/c4604525bdb5d0cb901ea454bd2bff8df8987843
- Firefox: Soon in nightly, currently unsupported.
- Edge: I used mirror but maybe this was in Edge.
- IE: We default to false but maybe this was supported.