### PR TITLE
Add latest samsung internet android releases

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -273,9 +273,21 @@
         },
         "23.0": {
           "release_date": "2023-10-18",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "115"
+        },
+        "24.0": {
+          "release_date": "2024-01-25",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "117"
+        },
+        "25.0": {
+          "release_date": "2024-04-24",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "121"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add samsung internet 24 and 25.

#### Test results and supporting details

Manually tested on my phone, no available release notes that I could find.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
