### PR TITLE
`sandbox=allow-storage-access-by-user-activation` is enabled by default on Firefox

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1154,14 +1154,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.storage_access.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "65"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Follows #3303.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1513021

#### Related issues

Fixes #22863

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
