### PR TITLE
Revert non-snapshot additions

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -214,9 +214,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached",
             "spec_url": "https://tc39.es/proposal-arraybuffer-transfer/#sec-get-arraybuffer.prototype.detached",
-            "tags": [
-              "web-features:arraybuffer-transfer"
-            ],
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -504,9 +501,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer",
             "spec_url": "https://tc39.es/proposal-arraybuffer-transfer/#sec-arraybuffer.prototype.transfer",
-            "tags": [
-              "web-features:arraybuffer-transfer"
-            ],
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -547,9 +541,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength",
             "spec_url": "https://tc39.es/proposal-arraybuffer-transfer/#sec-arraybuffer.prototype.transfertofixedlength",
-            "tags": [
-              "web-features:arraybuffer-transfer"
-            ],
             "support": {
               "chrome": {
                 "version_added": "114"

--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -6,8 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
-            "web-features:snapshot:ecmascript-2020",
-            "web-features:bigint"
+            "web-features:snapshot:ecmascript-2020"
           ],
           "support": {
             "chrome": {
@@ -50,8 +49,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array/BigInt64Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:snapshot:ecmascript-2020",
-              "web-features:bigint"
+              "web-features:snapshot:ecmascript-2020"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -6,8 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
-            "web-features:snapshot:ecmascript-2020",
-            "web-features:bigint"
+            "web-features:snapshot:ecmascript-2020"
           ],
           "support": {
             "chrome": {
@@ -50,8 +49,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array/BigUint64Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:snapshot:ecmascript-2020",
-              "web-features:bigint"
+              "web-features:snapshot:ecmascript-2020"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -305,8 +305,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getbigint64",
             "tags": [
-              "web-features:snapshot:ecmascript-2020",
-              "web-features:bigint"
+              "web-features:snapshot:ecmascript-2020"
             ],
             "support": {
               "chrome": {
@@ -349,8 +348,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getbiguint64",
             "tags": [
-              "web-features:snapshot:ecmascript-2020",
-              "web-features:bigint"
+              "web-features:snapshot:ecmascript-2020"
             ],
             "support": {
               "chrome": {
@@ -801,8 +799,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setbigint64",
             "tags": [
-              "web-features:snapshot:ecmascript-2020",
-              "web-features:bigint"
+              "web-features:snapshot:ecmascript-2020"
             ],
             "support": {
               "chrome": {
@@ -845,8 +842,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setbiguint64",
             "tags": [
-              "web-features:snapshot:ecmascript-2020",
-              "web-features:bigint"
+              "web-features:snapshot:ecmascript-2020"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -6,8 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry",
           "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry-objects",
           "tags": [
-            "web-features:snapshot:ecmascript-2021",
-            "web-features:weak-references"
+            "web-features:snapshot:ecmascript-2021"
           ],
           "support": {
             "chrome": {
@@ -50,8 +49,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/FinalizationRegistry",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry-constructor",
             "tags": [
-              "web-features:snapshot:ecmascript-2021",
-              "web-features:weak-references"
+              "web-features:snapshot:ecmascript-2021"
             ],
             "support": {
               "chrome": {
@@ -94,8 +92,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/register",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry.prototype.register",
             "tags": [
-              "web-features:snapshot:ecmascript-2021",
-              "web-features:weak-references"
+              "web-features:snapshot:ecmascript-2021"
             ],
             "support": {
               "chrome": {
@@ -137,8 +134,7 @@
           "__compat": {
             "description": "Non-registered symbol as target",
             "tags": [
-              "web-features:snapshot:ecmascript-2023",
-              "web-features:weak-references"
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -181,8 +177,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/unregister",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry.prototype.unregister",
             "tags": [
-              "web-features:snapshot:ecmascript-2021",
-              "web-features:weak-references"
+              "web-features:snapshot:ecmascript-2021"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -50,9 +50,6 @@
             "description": "<code>Iterator()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Iterator",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iterator-constructor",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": {
                 "version_added": "122"
@@ -95,9 +92,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/drop",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.drop",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -146,9 +140,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/every",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.every",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -197,9 +188,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.filter",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -248,9 +236,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.find",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -299,9 +284,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/flatMap",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -350,9 +332,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/forEach",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.foreach",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -401,9 +380,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/from",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iterator.from",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -452,9 +428,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/map",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -503,9 +476,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/reduce",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.reduce",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -554,9 +524,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/some",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.some",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -605,9 +572,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/take",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.take",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {
@@ -656,9 +620,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.toarray",
-            "tags": [
-              "web-features:iterator-helpers"
-            ],
             "support": {
               "chrome": [
                 {

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -6,8 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef",
           "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref-objects",
           "tags": [
-            "web-features:snapshot:ecmascript-2021",
-            "web-features:weak-references"
+            "web-features:snapshot:ecmascript-2021"
           ],
           "support": {
             "chrome": {
@@ -50,8 +49,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef/WeakRef",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref-constructor",
             "tags": [
-              "web-features:snapshot:ecmascript-2021",
-              "web-features:weak-references"
+              "web-features:snapshot:ecmascript-2021"
             ],
             "support": {
               "chrome": {
@@ -94,8 +92,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef/deref",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref.prototype.deref",
             "tags": [
-              "web-features:snapshot:ecmascript-2021",
-              "web-features:weak-references"
+              "web-features:snapshot:ecmascript-2021"
             ],
             "support": {
               "chrome": {


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/pull/22211 included a few new tags accidentally that aren't snapshots. (I had a lot to rebase when I landed this, sorry!).