### PR TITLE
Add InstallEvent.addRoutes

### DIFF
--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -3,6 +3,7 @@
     "InstallEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/InstallEvent",
+        "spec_url": "https://w3c.github.io/ServiceWorker/#installevent",
         "support": {
           "chrome": {
             "version_added": "40"
@@ -30,8 +31,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "InstallEvent": {
@@ -65,6 +66,41 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
+          }
+        }
+      },
+      "addRoutes": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/ServiceWorker/#register-router-method",
+          "support": {
+            "chrome": {
+              "version_added": "123"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1855580"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/269893"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This shipped in Chrome 123
https://developer.chrome.com/blog/service-worker-static-routing
https://chromestatus.com/feature/5185352976826368

This is only collected by the @openwebdocs BCD collector now and not when Chrome 123 beta was first available because the ServiceWorker specification did not include this at the time (and thus no IDL in webref).

Also marking InstallEvent as standard given there is a spec for it now.