### PR TITLE
Add RTCRtpReceiver.jitterBufferTarget

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -637,6 +637,39 @@
           }
         }
       },
+      "jitterBufferTarget": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcrtpreceiver-jitterbuffertarget",
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "115"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "rtcpTransport": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/rtcpTransport",


### PR DESCRIPTION
Thanks to https://github.com/openwebdocs/mdn-bcd-collector/pull/1342 the @openwebdocs BCD collector found support for RTCRtpReceiver.jitterBufferTarget in:

- Chrome 124: https://chromestatus.com/feature/5930772496384000
- Firefox 115: https://bugzilla.mozilla.org/show_bug.cgi?id=1592988