### PR TITLE
Adding manifest options_page support in FF126

### DIFF
--- a/webextensions/manifest/options_page.json
+++ b/webextensions/manifest/options_page.json
@@ -12,9 +12,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "alternative_name": "options_ui.page",
-              "version_added": "126",
-              "notes": "An alias to <code>options_ui.page</code>. Ignored when <code>options_ui.page</code> is set."
+              "version_added": "126"
             },
             "firefox_android": "mirror",
             "opera": {

--- a/webextensions/manifest/options_page.json
+++ b/webextensions/manifest/options_page.json
@@ -12,7 +12,9 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": false
+              "alternative_name": "options_ui.page",
+              "version_added": "126",
+              "notes": "An alias to <code>options_ui.page</code>. Ignored when <code>options_ui.page</code> is set."
             },
             "firefox_android": "mirror",
             "opera": {

--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -79,9 +79,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "alternative_name": "options_page",
-                "version_added": "48",
-                "notes": "An alias to <code>options_page</code> from Firefox 126. When set, <code>options_page</code> is ignored."
+                "version_added": "48"
               },
               "firefox_android": {
                 "version_added": "57"

--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -79,7 +79,9 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "48"
+                "alternative_name": "options_page",
+                "version_added": "48",
+                "notes": "An alias to <code>options_page</code> from Firefox 126. When set, <code>options_page</code> is ignored."
               },
               "firefox_android": {
                 "version_added": "57"


### PR DESCRIPTION
#### Summary

Added details of aliasing of options_ui.page to options_page.

#### Related issues

Addresses BCD requirements of [Bug 1816960](https://bugzilla.mozilla.org/show_bug.cgi?id=1816960) Consider aliasing options_page to options_ui.page

Content updates in https://github.com/mdn/content/pull/33212
