### PR TITLE
Deprecate the commit() method

### DIFF
--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -327,7 +327,6 @@
       "commit": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D/commit",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#offscreencontext2d-commit",
           "tags": [
             "web-features:offscreen-canvas"
           ],
@@ -357,8 +356,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
In https://github.com/whatwg/html/pull/9979 we removed the `commit()` method from the HTML standards, this (hopefully) marks it as such.
Might be noted that WebKit is in the process of hiding it behind a flag (https://github.com/WebKit/WebKit/pull/27196), but that can probably be handled in a follow-up when that PR is merged.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://github.com/whatwg/html/pull/9979
#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
