### PR TITLE
Mark Worker constructor options.type supported in Safari

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -276,7 +276,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
It has been in WebKit source for a very long time:
https://github.com/WebKit/WebKit/commit/9fe29e5b48b64cadbaffd6385818c1a7e93b3139
https://github.com/WebKit/WebKit/commit/94f1437aa28fd1fc32fde25e8ff3224d4f712724

It was controlled by a runtime flag, which I have not researched when it was flipped. Since this is the way to use worker modules, it must be supported at least since Safari 15, and any "support" before that is a no-op since the enum only has two values: "classic" and "module".