### PR TITLE
Remove PushManager "Available in workers"

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -44,45 +44,6 @@
           "deprecated": false
         }
       },
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {
-            "chrome": {
-              "version_added": "42"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "17"
-            },
-            "firefox": {
-              "version_added": "44"
-            },
-            "firefox_android": {
-              "version_added": "48"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "getSubscription": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/getSubscription",


### PR DESCRIPTION
PushManager is only supported in workers, and this data should be identical to the parent feature. It's not for Safari, and that's wrong, so just remove the entry.

Note that it might be available in the window context in the future: https://github.com/w3c/push-api/pull/368