### PR TITLE
Mark the push event supported in Safari iOS (with notes)

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -830,7 +830,8 @@
               "notes": "Notifications are supported on macOS Ventura and later."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4",
+              "notes": "Notifications are supported in web apps saved to the home screen."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
The event handler property is in WebKit source and controlled by the
same pref as PushEvent:
https://github.com/WebKit/WebKit/blob/0dd2540f475d5c11b3e0ebc6537052a3803a85b0/Source/WebCore/Modules/push-api/ServiceWorkerGlobalScope%2BPushAPI.idl
https://github.com/WebKit/WebKit/blob/0dd2540f475d5c11b3e0ebc6537052a3803a85b0/Source/WebCore/Modules/push-api/PushEvent.idl

Copy the version and note from PushEvent.