### PR TITLE
Mirror CSSStyleSheet constructor data for Chromium

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -51,7 +51,7 @@
             "chrome": {
               "version_added": "73",
               "partial_implementation": true,
-              "notes": "The <code>baseURL</code> option property is not supported. See <a href='https://crbug.com/1275639'>bug 1275639</a>."
+              "notes": "The <code>baseURL</code> option property is not supported. See <a href='https://crbug.com/40207149'>bug 40207149</a>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -63,19 +63,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "16.4"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {


### PR DESCRIPTION
This got out of sync in https://github.com/mdn/browser-compat-data/pull/8823.

Also update the crbug link, which applies to all Chromium-based browsers.