### PR TITLE
HTML Sanitizer API - deprecate and non-standard

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -9296,7 +9296,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": true
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -9296,9 +9296,9 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -9296,7 +9296,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": true
           }

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -37,8 +37,8 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "Sanitizer": {
@@ -79,8 +79,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -114,8 +114,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -149,8 +149,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -190,8 +190,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -37,7 +37,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": true
         }
       },

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -36,7 +36,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": true
         }
@@ -78,7 +78,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": true
           }
@@ -113,7 +113,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": true
           }
@@ -148,7 +148,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": true
           }
@@ -189,7 +189,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": true
           }

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -79,7 +79,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -114,7 +114,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -149,7 +149,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -190,7 +190,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }


### PR DESCRIPTION
The HTML sanitizer API was added to chrome and then removed, and added to FF behind a flag. It's marked experimental, which is true, but it is more true to say that the API as documented no longer reflects the spec (non-standard) and it is deprecated. So what this does is make that very clear so that people hopefully don't use it.

Would be even better to remove altogether from BCD and docs, but given our process, this is the best thing we can do to make clear it shouldn't be used.

This came out of https://github.com/mdn/content/pull/33141