### PR TITLE
Correct and simplify Firefox data for image-set()

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -176,12 +176,16 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "88",
-                  "notes": "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                  "version_added": "89"
                 },
                 {
                   "prefix": "-webkit-",
                   "version_added": "90"
+                },
+                {
+                  "version_added": "88",
+                  "version_removed": "89",
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -185,6 +185,7 @@
                 {
                   "version_added": "88",
                   "version_removed": "89",
+                  "partial_implementation": true,
                   "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 }
               ],

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -171,6 +171,7 @@
                 {
                   "version_added": "88",
                   "version_removed": "89",
+                  "partial_implementation": true,
                   "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 }
               ],

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -160,11 +160,20 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "113",
-                "partial_implementation": true,
-                "notes": "<code>content: image-set(…);</code>` doesn't paint on ::before/::after pseudo elements. See <a href='https://bugzil.la/1832901'>bug 1832901</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "89"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "90"
+                },
+                {
+                  "version_added": "88",
+                  "version_removed": "89",
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1912,6 +1912,7 @@
                 {
                   "version_added": "88",
                   "version_removed": "89",
+                  "partial_implementation": true,
                   "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 }
               ],

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1903,15 +1903,16 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "88",
-                  "notes": [
-                    "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>.",
-                    "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
-                  ]
+                  "version_added": "89"
                 },
                 {
                   "prefix": "-webkit-",
                   "version_added": "90"
+                },
+                {
+                  "version_added": "88",
+                  "version_removed": "89",
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 }
               ],
               "firefox_android": "mirror",


### PR DESCRIPTION
https://bugzil.la/1832901 is about `content: linear-gradient(...)`, but
`content: image-set(...)` works in Firefox 88 in this test:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12629

That `type()` didn't work in Firefox 88 was confirmed with this test:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12631

Use `partial_implementation` for that single-version issue.

Support for `content: -webkit-image-set()` starting in Firefox 90 was
confirmed with additional manual testing (tweaking above tests).

https://bugzil.la/1696314 is only about the `cursor` property, the
`content` property was fixed in Firefox 113:
https://bugzilla.mozilla.org/show_bug.cgi?id=1684958

The exact scope of the changes in Firefox 113 is hard to discern, but
since `content: image-set(...)` works and `cursor: image-set(...)` isn't
in the spec, there's nothing worth noting.