### PR TITLE
flex has not justify-self. 

### DIFF
--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -72,47 +72,6 @@
             }
           }
         },
-        "flex_context": {
-          "__compat": {
-            "description": "Supported in Flex Layout",
-            "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
-            "tags": [
-              "web-features:flexbox"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "57"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "16"
-              },
-              "firefox": {
-                "version_added": "45"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
https://web.dev/learn/css/flexbox?continue=https%3A%2F%2Fweb.dev%2Flearn%2Fcss#why_is_there_no_justify-self_in_flexbox:~:text=as%20a%20group.-,Why%20is%20there%20no%20justify%2Dself%20in%20flexbox%3F,-Flex%20items%20act

so i think here is a mistake, or maybe

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
