### PR TITLE
Update Chrome/Safari data for image-set()

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -169,7 +169,14 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": "113"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "20",
+                  "version_removed": "113",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
                 }
               ],
               "chrome_android": "mirror",
@@ -197,7 +204,18 @@
                 },
                 {
                   "prefix": "-webkit-",
+                  "version_added": "14"
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "14",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
+                },
+                {
+                  "prefix": "-webkit-",
                   "version_added": "6",
+                  "version_removed": "14",
                   "partial_implementation": true,
                   "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
                 }

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -155,9 +155,22 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image-set",
             "spec_url": "https://drafts.csswg.org/css-images-4/#image-set-notation",
             "support": {
-              "chrome": {
-                "version_added": "113"
-              },
+              "chrome": [
+                {
+                  "version_added": "113"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "113"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "20",
+                  "version_removed": "113",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -172,9 +185,28 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": "≤13.1"
-              },
+              "safari": [
+                {
+                  "version_added": "14"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "14"
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "14",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6",
+                  "version_removed": "14",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
+                }
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1896,7 +1896,14 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "21"
+                  "version_added": "113"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "20",
+                  "version_removed": "113",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
                 }
               ],
               "chrome_android": "mirror",
@@ -1927,7 +1934,18 @@
                 },
                 {
                   "prefix": "-webkit-",
+                  "version_added": "14"
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "14",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
+                },
+                {
+                  "prefix": "-webkit-",
                   "version_added": "6",
+                  "version_removed": "14",
                   "partial_implementation": true,
                   "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
                 }


### PR DESCRIPTION
The history of this feature is complicated, with a long history of
prefixed support and recent extened syntax which should also work with
the prefixed form because it's defined as an alias:
https://drafts.csswg.org/css-images-4/#deprecated

This would be nicer with https://github.com/mdn/browser-compat-data/issues/17857
but for now this results in split entries with duplicated notes.

The details:

-webkit-image-set() was implementated in WebKit 536.4 for Safari:
https://github.com/WebKit/WebKit/commit/63ee6e4e5f867a55faedef4a7f02fb1b9775dd7b
https://github.com/WebKit/WebKit/blob/63ee6e4e5f867a55faedef4a7f02fb1b9775dd7b/Source/WebCore/Configurations/Version.xcconfig

It was enabled in WebKit 536.8 for Chromium:
https://github.com/WebKit/WebKit/commit/68a3754b19f8e92fabfc263b17baad33a895bd35
https://github.com/WebKit/WebKit/blob/68a3754b19f8e92fabfc263b17baad33a895bd35/Source/WebCore/Configurations/Version.xcconfig

That maps to Safari 6 and Chrome 20. The data previously said Chrome 21,
so Chrome 20 was confirmed in BrowserStack using this test:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12632

image-set() was unprefixed in WebKit 603.1.11 (Safari 10.1):
https://github.com/WebKit/WebKit/commit/ea622e8b67a6bc11cc45d1d34953ac795df4dfb3
https://github.com/WebKit/WebKit/blob/ea622e8b67a6bc11cc45d1d34953ac795df4dfb3/Source/WebCore/Configurations/Version.xcconfig

The extended syntax was added in WebKit 610.1.1 (Safari 14):
https://github.com/WebKit/WebKit/commit/52692677632e50f8d0e3a4b0f62c94e5520a47d9
https://github.com/WebKit/WebKit/blob/52692677632e50f8d0e3a4b0f62c94e5520a47d9/Source/WebCore/Configurations/Version.xcconfig