### PR TITLE
Revert "Update Edge versions for MediaDeviceInfo API"

### DIFF
--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "14"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "39"
@@ -45,7 +45,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "39"
@@ -81,7 +81,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "39",
@@ -118,7 +118,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "39"
@@ -154,7 +154,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "39"


### PR DESCRIPTION
`MediaDeviceInfo` is the type returned by `navigator.mediaDevices.enumerateDevices()`, and that is still marked as supported in Edge 12:
https://github.com/mdn/browser-compat-data/blob/37343292148ae835abff7e2cd722c385293ac784/api/MediaDevices.json#L97-L99

That is supported by this blog post which was published before the release of Edge 12:
https://blogs.windows.com/msedgedev/2015/05/13/announcing-media-capture-functionality-in-microsoft-edge/

Reverts https://github.com/mdn/browser-compat-data/pull/18592.