### PR TITLE
Add back the anchor HTML attribute

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -122,8 +122,13 @@
           "support": {
             "chrome": {
               "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Supported on <code>Element</code>, not on <code>HTMLElement</code>"
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -37,6 +37,39 @@
           }
         }
       },
+      "anchor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/anchor",
+          "support": {
+            "chrome": {
+              "version_added": "preview"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "autocapitalize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -42,7 +42,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/anchor",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This reverts https://github.com/mdn/browser-compat-data/pull/22910 but uses version "preview" instead of "125".