### PR TITLE
FF126 Selection.getComposedRanges() in nightly

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -718,7 +718,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF126 supports `Selection.getComposedRanges()` in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1867058

You can see this in the IDL here https://hg.mozilla.org/integration/autoland/diff/0710183c2311e1db237d1db5ff8285138ba57dc3/modules/libpref/init/StaticPrefList.yaml behind nightly-enabled pref `dom.shadowdom.selection_across_boundary.enabled`

Related docs work can be tracked in https://github.com/mdn/content/issues/33180