### PR TITLE
Update Edge releases

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -346,7 +346,7 @@
         },
         "121": {
           "release_date": "2024-01-26",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1210227783-january-25-2024",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1210227783-january-25-2024",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "121"
@@ -360,13 +360,15 @@
         },
         "123": {
           "release_date": "2024-03-22",
-          "status": "current",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1230242081-april-4-2024",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "123"
         },
         "124": {
           "release_date": "2024-04-18",
-          "status": "beta",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1240247851-april-18-2024",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "124"
         },

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -345,7 +345,7 @@
           "engine_version": "120"
         },
         "121": {
-          "release_date": "2024-01-26",
+          "release_date": "2024-01-25",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1210227783-january-25-2024",
           "status": "retired",
           "engine": "Blink",
@@ -360,7 +360,7 @@
         },
         "123": {
           "release_date": "2024-03-22",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1230242081-april-4-2024",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1230242053--march-22-2024",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "123"


### PR DESCRIPTION
There is a hiccup with the GitHub Action. Not sure what is wrong, this PR fixes the Edge data manually (and the script seems to run successfully with these changes).