### PR TITLE
Update Edge release dates to match release notes

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -205,7 +205,7 @@
           "engine_version": "100"
         },
         "101": {
-          "release_date": "2022-04-29",
+          "release_date": "2022-04-28",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1010121032-april-28",
           "status": "retired",
           "engine": "Blink",
@@ -219,14 +219,14 @@
           "engine_version": "102"
         },
         "103": {
-          "release_date": "2022-07-01",
+          "release_date": "2022-06-23",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1030126437-june-23",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
-          "release_date": "2022-08-09",
+          "release_date": "2022-08-05",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1040129347-august-5",
           "status": "retired",
           "engine": "Blink",
@@ -254,7 +254,7 @@
           "engine_version": "107"
         },
         "108": {
-          "release_date": "2022-12-06",
+          "release_date": "2022-12-05",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1080146242-december-5-2022",
           "status": "retired",
           "engine": "Blink",


### PR DESCRIPTION
Only cases where the URL and release date didn't match were checked. It's possible there are additional cases where the linked Edge release notes are not the earliest for that Chromium milestone.