### PR TITLE
Remove transform-box from web-features:transforms2d

### DIFF
--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-box",
           "spec_url": "https://drafts.csswg.org/css-transforms/#transform-box",
-          "tags": [
-            "web-features:transforms2d"
-          ],
           "support": {
             "chrome": {
               "version_added": "64"


### PR DESCRIPTION
While it can be used together with 2D transforms (and individual transform properties) it was shipped significantly later than the rest of the feature: https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box#browser_compatibility