### PR TITLE
Mark HTTP GET as supported since the first release of each browser

### DIFF
--- a/http/methods.json
+++ b/http/methods.json
@@ -88,28 +88,34 @@
           ],
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": true
+              "version_added": "1"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "2"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "1"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This can be done without any research, since it is a foundational
"feature" that allows a browser to show anything at all.

At least one BCD feature with real values is needed for web-features to
compute the support for HTTP/1.1.