### PR TITLE
image-set: Note should only be shown for the relevant Firefox version

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -177,7 +177,11 @@
               "firefox": [
                 {
                   "version_added": "88",
-                  "notes": "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                  "partial_implementation": true,
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                },
+                {
+                  "version_added": "89"
                 },
                 {
                   "prefix": "-webkit-",


### PR DESCRIPTION
#### Summary

The note displayed for all Firefox versions only applies to Firefox 88, so lets display it only there.
![image](https://github.com/mdn/browser-compat-data/assets/36442/48e75474-2869-4599-97c0-dadced0018a0)

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
