### PR TITLE
Mark font-size-adjust:none as supported since Firefox 3

### DIFF
--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -86,7 +86,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "3"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12644 shows that the initial value is none in Firefox 4. In Firefox 3 there was some error running the test, but it must have been supported, as the initial value if nothing else.