### PR TITLE
Mark support for image-set() in Safari as partial until 17

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -205,11 +205,24 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "14"
+                  "version_added": "17"
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "14"
+                  "version_added": "17"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "17",
+                  "partial_implementation": true,
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "14",
+                  "version_removed": "17",
+                  "partial_implementation": true,
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 },
                 {
                   "version_added": "10.1",

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -197,11 +197,24 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "14"
+                  "version_added": "17"
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "14"
+                  "version_added": "17"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "17",
+                  "partial_implementation": true,
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "14",
+                  "version_removed": "17",
+                  "partial_implementation": true,
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 },
                 {
                   "version_added": "10.1",

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1932,11 +1932,24 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "14"
+                  "version_added": "17"
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "14"
+                  "version_added": "17"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "17",
+                  "partial_implementation": true,
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "14",
+                  "version_removed": "17",
+                  "partial_implementation": true,
+                  "notes": "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 },
                 {
                   "version_added": "10.1",


### PR DESCRIPTION
This is to be consistent with the Firefox data and with caniuse.com,
which treats Safari 14-16.6 support as partial:
https://caniuse.com/css-image-set

This was implemented in WebKit 616.1.4:
https://github.com/webkit/WebKit/commit/e3554c53fff0e1d9ed207af749cd1dbaf7853300
https://github.com/WebKit/WebKit/blob/e3554c53fff0e1d9ed207af749cd1dbaf7853300/Configurations/Version.xcconfig

That maps to Safari 17.

https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12651 was
also tested in Safari 16.5 (no support) and 17.3 (supported).