### PR TITLE
RTCIceCandidate - incorrect MDN urls to the Stats docs with same name

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -418,7 +418,6 @@
       },
       "relayProtocol": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/relayProtocol",
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-relayprotocol",
           "support": {
             "chrome": {
@@ -637,7 +636,6 @@
       },
       "url": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/url",
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-url",
           "support": {
             "chrome": {


### PR DESCRIPTION
Two links, such as

`"mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/url",` are to wrong object - i..e the corresponding stats object.

Note that the desired object hasn't been documented yet, so I can't link to it.

Note that the stats properties are documented, but are not in BCD. So probably need to be removed from docs. But that's another story.

This came out of https://github.com/mdn/content/issues/33228