### PR TITLE
Remove MathML web-features tags

### DIFF
--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MathMLElement",
         "spec_url": "https://w3c.github.io/mathml-core/#dom-mathmlelement",
-        "tags": [
-          "web-features:mathml"
-        ],
         "support": {
           "chrome": {
             "version_added": "109"
@@ -73,9 +70,6 @@
       "autofocus": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-fe-autofocus",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -109,9 +103,6 @@
       "blur": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-blur-dev",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -145,9 +136,6 @@
       "dataset": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-dataset-dev",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -181,9 +169,6 @@
       "focus": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-focus-dev",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -250,9 +235,6 @@
       "style": {
         "__compat": {
           "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -286,9 +268,6 @@
       "tabIndex": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math",
           "spec_url": "https://w3c.github.io/mathml-core/#the-top-level-math-element",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": [
               {
@@ -78,9 +75,6 @@
         "display": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math#attr-display",
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/merror",
           "spec_url": "https://w3c.github.io/mathml-core/#error-message-merror",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mfrac",
           "spec_url": "https://w3c.github.io/mathml-core/#fractions-mfrac",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -72,9 +69,6 @@
         },
         "linethickness": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mi.json
+++ b/mathml/elements/mi.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mi",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mi",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -41,9 +38,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mi/mathvariant",
             "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathvariant",
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mmultiscripts.json
+++ b/mathml/elements/mmultiscripts.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mmultiscripts",
           "spec_url": "https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mn.json
+++ b/mathml/elements/mn.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mn",
           "spec_url": "https://w3c.github.io/mathml-core/#number-mn",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mo",
           "spec_url": "https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -71,9 +68,6 @@
         },
         "form": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -106,9 +100,6 @@
         },
         "largeop": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -141,9 +132,6 @@
         },
         "lspace": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -176,9 +164,6 @@
         },
         "maxsize": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -211,9 +196,6 @@
         },
         "minsize": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -246,9 +228,6 @@
         },
         "moveablelimits": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -350,9 +329,6 @@
         },
         "rspace": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -385,9 +361,6 @@
         },
         "stretchy": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -420,9 +393,6 @@
         },
         "symmetric": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mover",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -39,9 +36,6 @@
         },
         "accent": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mpadded",
           "spec_url": "https://w3c.github.io/mathml-core/#adjust-space-around-content-mpadded",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -39,9 +36,6 @@
         },
         "depth": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -74,9 +68,6 @@
         },
         "height": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -109,9 +100,6 @@
         },
         "lspace": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -313,9 +301,6 @@
         },
         "voffset": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -348,9 +333,6 @@
         },
         "width": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mphantom",
           "spec_url": "https://w3c.github.io/mathml-core/#making-sub-expressions-invisible-mphantom",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mroot",
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mrow",
           "spec_url": "https://w3c.github.io/mathml-core/#horizontally-group-sub-expressions-mrow",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/ms",
           "spec_url": "https://w3c.github.io/mathml-core/#string-literal-ms",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mspace",
           "spec_url": "https://w3c.github.io/mathml-core/#space-mspace",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -39,9 +36,6 @@
         },
         "depth": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -74,9 +68,6 @@
         },
         "height": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -143,9 +134,6 @@
         },
         "width": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/msqrt.json
+++ b/mathml/elements/msqrt.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msqrt",
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mstyle.json
+++ b/mathml/elements/mstyle.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle",
           "spec_url": "https://w3c.github.io/mathml-core/#style-change-mstyle",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msub",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msubsup",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msup",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtable",
           "spec_url": "https://w3c.github.io/mathml-core/#table-or-matrix-mtable",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtd",
           "spec_url": "https://w3c.github.io/mathml-core/#entry-in-table-or-matrix-mtd",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -71,9 +68,6 @@
         },
         "columnspan": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "117"
@@ -138,9 +132,6 @@
         },
         "rowspan": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "117"

--- a/mathml/elements/mtext.json
+++ b/mathml/elements/mtext.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtext",
           "spec_url": "https://w3c.github.io/mathml-core/#text-mtext",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtr",
           "spec_url": "https://w3c.github.io/mathml-core/#row-in-table-or-matrix-mtr",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/munder",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -39,9 +36,6 @@
         },
         "accentunder": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/munderover",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -39,9 +36,6 @@
         },
         "accent": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -74,9 +68,6 @@
         },
         "accentunder": {
           "__compat": {
-            "tags": [
-              "web-features:mathml"
-            ],
             "support": {
               "chrome": {
                 "version_added": "109"

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/semantics",
           "spec_url": "https://w3c.github.io/mathml-core/#semantics-and-presentation",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/dir",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-dir",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -47,9 +44,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/displaystyle",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-displaystyle",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -125,9 +119,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathbackground",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathbackground",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -170,9 +161,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathcolor",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathcolor",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -215,9 +203,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathsize",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathsize",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"
@@ -366,9 +351,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/scriptlevel",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-scriptlevel",
-          "tags": [
-            "web-features:mathml"
-          ],
           "support": {
             "chrome": {
               "version_added": "109"


### PR DESCRIPTION
Computing the status of MathML from BCD proved impractical, and needs
much more work. To avoid confusion, remove the tags which aren't being
used by web-features right now.