### PR TITLE
Treat -webkit-line-clamp as a prefix of line-clamp

### DIFF
--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -1,22 +1,26 @@
 {
   "css": {
     "properties": {
-      "-webkit-line-clamp": {
+      "line-clamp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-line-clamp",
-          "spec_url": "https://drafts.csswg.org/css-overflow-4/#propdef--webkit-line-clamp",
+          "spec_url": "https://drafts.csswg.org/css-overflow-4/#propdef-line-clamp",
           "tags": [
             "web-features:line-clamp"
           ],
           "support": {
             "chrome": {
-              "version_added": "6"
+              "prefix": "-webkit-",
+              "version_added": "6",
+              "impl_url": "https://crbug.com/40336192"
             },
             "chrome_android": "mirror",
             "edge": {
+              "prefix": "-webkit-",
               "version_added": "17"
             },
             "firefox": {
+              "prefix": "-webkit-",
               "version_added": "68"
             },
             "firefox_android": "mirror",
@@ -27,6 +31,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "prefix": "-webkit-",
               "version_added": "5"
             },
             "safari_ios": "mirror",


### PR DESCRIPTION
This property is currently in an in-between state, in the progress of being standardized and implemented without a prefix, but still only supported with a prefix in all browsers.

Renaming and using `prefix` aligns with https://caniuse.com/css-line-clamp and will make it possible for web-features to use this BCD entry to represent support of the unprefixed CSS property.