### PR TITLE
Link Chrome and Safari bugs for relative rgb()

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1291,16 +1291,9 @@
                 "web-features:relative-color"
               ],
               "support": {
-                "chrome": [
-                  {
-                    "version_added": "122"
-                  },
-                  {
-                    "version_added": "119",
-                    "partial_implementation": true,
-                    "notes": "Channel values incorrectly resolve to numbers between 0-1 rather than 0-255. As a result, channel value calculations require values to be specified as decimal percentage equivalents (e.g. 0.3 for 30%, which would be equivalent to a 76.5 <code>&lt;number&gt;</code> value)."
-                  }
-                ],
+                "chrome": {
+                  "version_added": "119"
+                },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
@@ -1314,9 +1307,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "16.4",
-                  "partial_implementation": true,
-                  "notes": "Implementation based on older spec version. As a result, channel value calculations do not work correctly, requiring values to be specified as percentages with units (e.g. 30%, which would be equivalent to a 76.5 <code>&lt;number&gt;</code> value)."
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1291,9 +1291,16 @@
                 "web-features:relative-color"
               ],
               "support": {
-                "chrome": {
-                  "version_added": "119"
-                },
+                "chrome": [
+                  {
+                    "version_added": "122"
+                  },
+                  {
+                    "version_added": "119",
+                    "partial_implementation": true,
+                    "notes": "Channel values incorrectly resolve to numbers between 0-1 rather than 0-255. As a result, channel value calculations require values to be specified as decimal percentage equivalents (e.g. 0.3 for 30%, which would be equivalent to a 76.5 <code>&lt;number&gt;</code> value). See <a href='https://crbug.com/41490327'>bug 41490327</a>."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
@@ -1307,7 +1314,9 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "16.4"
+                  "version_added": "16.4",
+                  "partial_implementation": true,
+                  "notes": "Implementation based on older spec version. As a result, channel value calculations do not work correctly, requiring values to be specified as percentages with units (e.g. 30%, which would be equivalent to a 76.5 <code>&lt;number&gt;</code> value). See <a href='https://webkit.org/b/267647'>bug 267647</a>."
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
Notes are originally from https://github.com/mdn/browser-compat-data/pull/21937.