### PR TITLE
Mark window.speechSynthesis supported since Firefox Android 62

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6155,7 +6155,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This is the entry point to the API, and the rest of the API was updated in https://github.com/mdn/browser-compat-data/pull/2144.