### PR TITLE
STP 193 supports api.PopStateEvent.hasUAVisualTransition

### DIFF
--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -96,7 +96,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Update "hasUAVisualTransition" in PopStateEvent to "preview" for Safari.

#### Test results and supporting details

https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-193

PopStateEvent Commit(https://github.com/WebKit/WebKit/commit/f034bb9b9246d75317a80d37f3f59e6f7520938d)
Enabling Commit(https://github.com/WebKit/WebKit/commit/f876ff89c61f56e2259a2a27e8168defe01f96f8)

#### Related issues