### PR TITLE
Add sameSiteCookies option to SharedWorker options

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -238,55 +238,54 @@
         }
       },
       "options_sameSiteCookies_parameter": {
-          "__compat": {
-            "description": "<code>options.sameSiteCookies</code> parameter",
-            "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/",
-            "support": {
-              "chrome": {
-                "version_added": "125"
-              },
-              "chrome_android": {
-                "version_added": "125"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "oculus": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": "125"
-              }
+        "__compat": {
+          "description": "<code>options.sameSiteCookies</code> parameter",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-sharedworkeroptions-samesitecookies",
+          "support": {
+            "chrome": {
+              "version_added": "125"
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "125"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "125"
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -237,6 +237,59 @@
           }
         }
       },
+      "options_sameSiteCookies_parameter": {
+          "__compat": {
+            "description": "<code>options.sameSiteCookies</code> parameter",
+            "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": {
+                "version_added": "125"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "125"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
       "error_event": {
         "__compat": {
           "description": "<code>error</code> event",

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -237,58 +237,6 @@
           }
         }
       },
-      "options_sameSiteCookies_parameter": {
-        "__compat": {
-          "description": "<code>options.sameSiteCookies</code> parameter",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-sharedworkeroptions-samesitecookies",
-          "support": {
-            "chrome": {
-              "version_added": "125"
-            },
-            "chrome_android": {
-              "version_added": "125"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "125"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "error_event": {
         "__compat": {
           "description": "<code>error</code> event",
@@ -341,6 +289,44 @@
               "version_added": "4.0",
               "version_removed": "5.0"
             },
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "options_sameSiteCookies_parameter": {
+        "__compat": {
+          "description": "<code>options.sameSiteCookies</code> parameter",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-sharedworkeroptions-samesitecookies",
+          "support": {
+            "chrome": {
+              "version_added": "125"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -235,6 +235,44 @@
               "deprecated": false
             }
           }
+        },
+        "options_sameSiteCookies_parameter": {
+          "__compat": {
+            "description": "<code>options.sameSiteCookies</code> parameter",
+            "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-sharedworkeroptions-samesitecookies",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "error_event": {
@@ -289,44 +327,6 @@
               "version_added": "4.0",
               "version_removed": "5.0"
             },
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "options_sameSiteCookies_parameter": {
-        "__compat": {
-          "description": "<code>options.sameSiteCookies</code> parameter",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-sharedworkeroptions-samesitecookies",
-          "support": {
-            "chrome": {
-              "version_added": "125"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8928,9 +8928,9 @@
       }
     },
     "node_modules/web-specs": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.8.0.tgz",
-      "integrity": "sha512-tAJgIFOgHHAQiorvKW8gMCzrTDBzT+wThaXduQswmFuiMbKtQZQtBobQ74v4nIUKgPlIHi/e8ypYptcQ4OblKg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.9.0.tgz",
+      "integrity": "sha512-DJG4kyzB96cOQ7VMSGQYOFGBRQ+YlqY6lIm1TWaj07WBZc1OIj9xBcgZnzFaBMaXc281Gspvnnh53Xt9+qWTeA==",
       "dev": true
     },
     "node_modules/web-streams-polyfill": {


### PR DESCRIPTION
#### Summary

sameSiteCookies is a new option for SharedWorker construction that allows a given worker to be restricted to `SameSite=None` cookies even when created in a first-party context. This is important as only workers without access to `SameSite=Lax` and `SameSite=Strict` cookies can be accessed via requestStorageAccess.

#### Test results and supporting details

This only launched in Chrome: https://chromestatus.com/feature/5175585823522816

#### Related issues

Relates to https://github.com/mdn/content/pull/33350 and https://github.com/mdn/mdn/issues/543
