### PR TITLE
Remove HTTP/1.1 tags

### DIFF
--- a/http/headers/Accept-Encoding.json
+++ b/http/headers/Accept-Encoding.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Encoding",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-encoding",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept-Language.json
+++ b/http/headers/Accept-Language.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Language",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-language",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept-Ranges.json
+++ b/http/headers/Accept-Ranges.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Ranges",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-ranges",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept.json
+++ b/http/headers/Accept.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Age.json
+++ b/http/headers/Age.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Age",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.age",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Authorization",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.authorization",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -8,9 +8,6 @@
             "https://www.rfc-editor.org/rfc/rfc9111#field.cache-control",
             "https://httpwg.org/specs/rfc8246.html#the-immutable-cache-control-extension"
           ],
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Connection.json
+++ b/http/headers/Connection.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Connection",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.connection",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-encoding",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Language.json
+++ b/http/headers/Content-Language.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Language",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-language",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Length.json
+++ b/http/headers/Content-Length.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Length",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-length",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Location.json
+++ b/http/headers/Content-Location.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Location",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-location",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Range.json
+++ b/http/headers/Content-Range.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Range",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-range",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Type.json
+++ b/http/headers/Content-Type.json
@@ -8,9 +8,6 @@
             "https://www.rfc-editor.org/rfc/rfc9110#status.206",
             "https://www.rfc-editor.org/rfc/rfc9110#field.content-type"
           ],
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Date.json
+++ b/http/headers/Date.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.date",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/ETag.json
+++ b/http/headers/ETag.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/ETag",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.etag",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Expect.json
+++ b/http/headers/Expect.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expect",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.expect",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/Expires.json
+++ b/http/headers/Expires.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expires",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.expires",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/From.json
+++ b/http/headers/From.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/From",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.from",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Host.json
+++ b/http/headers/Host.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Host",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.host",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Match.json
+++ b/http/headers/If-Match.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Match",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-match",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Modified-Since.json
+++ b/http/headers/If-Modified-Since.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Modified-Since",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-modified-since",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-None-Match.json
+++ b/http/headers/If-None-Match.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-None-Match",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-none-match",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Range.json
+++ b/http/headers/If-Range.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Range",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-range",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Unmodified-Since.json
+++ b/http/headers/If-Unmodified-Since.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Unmodified-Since",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-unmodified-since",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Last-Modified.json
+++ b/http/headers/Last-Modified.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Last-Modified",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.last-modified",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Location.json
+++ b/http/headers/Location.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Location",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.location",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Pragma.json
+++ b/http/headers/Pragma.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Pragma",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.pragma",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Proxy-Authenticate.json
+++ b/http/headers/Proxy-Authenticate.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Proxy-Authenticate",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.proxy-authenticate",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Range.json
+++ b/http/headers/Range.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Range",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.range",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Referer.json
+++ b/http/headers/Referer.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Referer",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.referer",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Retry-After.json
+++ b/http/headers/Retry-After.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Retry-After",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.retry-after",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/Server.json
+++ b/http/headers/Server.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Server",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.server",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/TE.json
+++ b/http/headers/TE.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/TE",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.te",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Trailer.json
+++ b/http/headers/Trailer.json
@@ -8,9 +8,6 @@
             "https://www.rfc-editor.org/rfc/rfc9110#field.trailer",
             "https://www.rfc-editor.org/rfc/rfc9112#chunked.trailer.section"
           ],
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Transfer-Encoding.json
+++ b/http/headers/Transfer-Encoding.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Transfer-Encoding",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9112#field.transfer-encoding",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/User-Agent.json
+++ b/http/headers/User-Agent.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.user-agent",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Vary.json
+++ b/http/headers/Vary.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Vary",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.vary",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Via.json
+++ b/http/headers/Via.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Via",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.via",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/WWW-Authenticate",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.www-authenticate",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Warning.json
+++ b/http/headers/Warning.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Warning",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.warning",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/methods.json
+++ b/http/methods.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/CONNECT",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#CONNECT",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -44,9 +41,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/DELETE",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#DELETE",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -83,9 +77,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/GET",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#GET",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -128,9 +119,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/HEAD",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#HEAD",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -167,9 +155,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/OPTIONS",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#OPTIONS",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -206,9 +191,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/POST",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#POST",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -245,9 +227,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/PUT",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#PUT",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -284,9 +263,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/TRACE",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#TRACE",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": null

--- a/http/status.json
+++ b/http/status.json
@@ -5,9 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/100",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.100",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -133,9 +130,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/200",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.200",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -172,9 +166,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/201",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.201",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -211,9 +202,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/204",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.204",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -250,9 +238,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/206",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.206",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -289,9 +274,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/301",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.301",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -328,9 +310,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/302",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.302",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -367,9 +346,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/303",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.303",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -406,9 +382,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/304",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.304",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -445,9 +418,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/307",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.307",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -523,9 +493,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/401",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.401",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -562,9 +529,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/403",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.403",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -601,9 +565,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/404",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.404",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -640,9 +601,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/406",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.406",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -679,9 +637,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/407",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.407",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -718,9 +673,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/409",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.409",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -757,9 +709,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/410",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.410",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -796,9 +745,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/412",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.412",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -835,9 +781,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/416",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.416",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -980,9 +923,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/500",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.500",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -1019,9 +959,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/501",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.501",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -1058,9 +995,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/502",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.502",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -1097,9 +1031,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/503",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.503",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -1136,9 +1067,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/504",
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.504",
-          "tags": [
-            "web-features:http11"
-          ],
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
Computing the web-features status from these did not work out:
https://github.com/web-platform-dx/web-features/pull/946

As a category for what was in HTTP/1.1 the tags are probably mostly
correct, but because of all of the true values we can't compute anything
from BCD, and also not show any Baseline badge on MDN with confidence.

Hopefully these tags will make a comeback in the future.