### PR TITLE
`page-break-{before,after}: avoid` not supported in Safari and Firefox

### DIFF
--- a/css/properties/page-break-after.json
+++ b/css/properties/page-break-after.json
@@ -123,7 +123,8 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/775617"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -133,7 +134,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/34155"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/page-break-before.json
+++ b/css/properties/page-break-before.json
@@ -123,7 +123,8 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/775617"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -133,7 +134,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/34155"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This came up in the course of [defining page break features in web-features](https://github.com/web-platform-dx/web-features/pull/331). caniuse reports partial support due to lack of support in Safari and Firefox.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tests and test results:

- https://github.com/Fyrd/caniuse/issues/7045#issuecomment-2081627762

Vendor bugs:

- https://bugzil.la/775617
- https://webkit.org/b/34155

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

- https://github.com/web-platform-dx/web-features/pull/331