### PR TITLE
Add types argument to requestStorageAccess

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6266,7 +6266,44 @@
             "standard_track": true,
             "deprecated": false
           }
-        }
+        },
+        "types_parameter": {
+          "__compat": {
+            "description": "<code>types</code> parameter",
+            "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dictdef-storageaccesstypes",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
       },
       "requestStorageAccessFor": {
         "__compat": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -6303,6 +6303,500 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "types_all_parameter": {
+            "__compat": {
+              "description": "<code>types.all</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-all",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_cookies_parameter": {
+            "__compat": {
+              "description": "<code>types.cookies</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-cookies",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_sessionStorage_parameter": {
+            "__compat": {
+              "description": "<code>types.sessionStorage</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-sessionstorage",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_localStorage_parameter": {
+            "__compat": {
+              "description": "<code>types.localStorage</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-localstorage",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_indexedDB_parameter": {
+            "__compat": {
+              "description": "<code>types.indexedDB</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-indexeddb",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_locks_parameter": {
+            "__compat": {
+              "description": "<code>types.locks</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-locks",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_caches_parameter": {
+            "__compat": {
+              "description": "<code>types.caches</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-caches",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_getDirectory_parameter": {
+            "__compat": {
+              "description": "<code>types.getDirectory</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-getdirectory",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_estimate_parameter": {
+            "__compat": {
+              "description": "<code>types.estimate</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-estimate",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_createObjectURL_parameter": {
+            "__compat": {
+              "description": "<code>types.createObjectURL</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-createobjecturl",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_revokeObjectURL_parameter": {
+            "__compat": {
+              "description": "<code>types.revokeObjectURL</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-revokeobjecturl",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_BroadcastChannel_parameter": {
+            "__compat": {
+              "description": "<code>types.BroadcastChannel</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-broadcastchannel",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_SharedWorker_parameter": {
+            "__compat": {
+              "description": "<code>types.SharedWorker</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-sharedworker",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       },

--- a/api/Document.json
+++ b/api/Document.json
@@ -6342,162 +6342,10 @@
               }
             }
           },
-          "types_cookies_parameter": {
+          "types_BroadcastChannel_parameter": {
             "__compat": {
-              "description": "<code>types.cookies</code> parameter",
-              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-cookies",
-              "support": {
-                "chrome": {
-                  "version_added": "125"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "types_sessionStorage_parameter": {
-            "__compat": {
-              "description": "<code>types.sessionStorage</code> parameter",
-              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-sessionstorage",
-              "support": {
-                "chrome": {
-                  "version_added": "125"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "types_localStorage_parameter": {
-            "__compat": {
-              "description": "<code>types.localStorage</code> parameter",
-              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-localstorage",
-              "support": {
-                "chrome": {
-                  "version_added": "125"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "types_indexedDB_parameter": {
-            "__compat": {
-              "description": "<code>types.indexedDB</code> parameter",
-              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-indexeddb",
-              "support": {
-                "chrome": {
-                  "version_added": "125"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "types_locks_parameter": {
-            "__compat": {
-              "description": "<code>types.locks</code> parameter",
-              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-locks",
+              "description": "<code>types.BroadcastChannel</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-broadcastchannel",
               "support": {
                 "chrome": {
                   "version_added": "125"
@@ -6570,48 +6418,10 @@
               }
             }
           },
-          "types_getDirectory_parameter": {
+          "types_cookies_parameter": {
             "__compat": {
-              "description": "<code>types.getDirectory</code> parameter",
-              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-getdirectory",
-              "support": {
-                "chrome": {
-                  "version_added": "125"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "types_estimate_parameter": {
-            "__compat": {
-              "description": "<code>types.estimate</code> parameter",
-              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-estimate",
+              "description": "<code>types.cookies</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-cookies",
               "support": {
                 "chrome": {
                   "version_added": "125"
@@ -6684,6 +6494,196 @@
               }
             }
           },
+          "types_estimate_parameter": {
+            "__compat": {
+              "description": "<code>types.estimate</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-estimate",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_getDirectory_parameter": {
+            "__compat": {
+              "description": "<code>types.getDirectory</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-getdirectory",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_indexedDB_parameter": {
+            "__compat": {
+              "description": "<code>types.indexedDB</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-indexeddb",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_localStorage_parameter": {
+            "__compat": {
+              "description": "<code>types.localStorage</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-localstorage",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "types_locks_parameter": {
+            "__compat": {
+              "description": "<code>types.locks</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-locks",
+              "support": {
+                "chrome": {
+                  "version_added": "125"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "types_revokeObjectURL_parameter": {
             "__compat": {
               "description": "<code>types.revokeObjectURL</code> parameter",
@@ -6722,10 +6722,10 @@
               }
             }
           },
-          "types_BroadcastChannel_parameter": {
+          "types_sessionStorage_parameter": {
             "__compat": {
-              "description": "<code>types.BroadcastChannel</code> parameter",
-              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-broadcastchannel",
+              "description": "<code>types.sessionStorage</code> parameter",
+              "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesstypes-sessionstorage",
               "support": {
                 "chrome": {
                   "version_added": "125"

--- a/api/Document.json
+++ b/api/Document.json
@@ -6304,6 +6304,7 @@
               "deprecated": false
             }
           }
+        }
       },
       "requestStorageAccessFor": {
         "__compat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8928,9 +8928,9 @@
       }
     },
     "node_modules/web-specs": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.8.0.tgz",
-      "integrity": "sha512-tAJgIFOgHHAQiorvKW8gMCzrTDBzT+wThaXduQswmFuiMbKtQZQtBobQ74v4nIUKgPlIHi/e8ypYptcQ4OblKg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.9.0.tgz",
+      "integrity": "sha512-DJG4kyzB96cOQ7VMSGQYOFGBRQ+YlqY6lIm1TWaj07WBZc1OIj9xBcgZnzFaBMaXc281Gspvnnh53Xt9+qWTeA==",
       "dev": true
     },
     "node_modules/web-streams-polyfill": {


### PR DESCRIPTION
#### Summary

types is a new (optional) argument supported by requestStorageAccess to allow non-cookie unpartitioned storage to be requested.

#### Test results and supporting details

This only launched in Chrome: https://chromestatus.com/feature/5175585823522816

#### Related issues

Relates to https://github.com/mdn/content/pull/33391 and https://github.com/mdn/mdn/issues/543
