### PR TITLE
Add unprefixed `mask` support in Chromium

### DIFF
--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -8,12 +8,16 @@
           "support": {
             "chrome": [
               {
+                "version_added": "120"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "1",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               },
               {
                 "version_added": "1",
+                "version_removed": "120",
                 "partial_implementation": true,
                 "notes": "While the property is recognized, values applied to it don't have any effect."
               }


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

All of the other `mask-` properties were unprefixed at the same time, only this one was left unmodified. I think this was missed in the course of running automatic updates for Chrome 120. See: https://github.com/mdn/browser-compat-data/pull/21148#issuecomment-1814638269

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Using the demo here (with the prefixes removed) worked in Chrome: https://css-tricks.com/almanac/properties/m/mask/#aa-example

This status entry says the shorthand was included: https://chromestatus.com/feature/5839739127332864

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

https://github.com/mdn/browser-compat-data/pull/21148
