### PR TITLE
Fix android compat for StorageAccessHandle & requestStorageAccess(types) Android compat

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6311,9 +6311,7 @@
               "chrome": {
                 "version_added": "125"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": false
               },
@@ -6348,9 +6346,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6386,9 +6382,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6424,9 +6418,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6462,9 +6454,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6500,9 +6490,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6538,9 +6526,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6576,9 +6562,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6614,9 +6598,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6652,9 +6634,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6690,9 +6670,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6728,9 +6706,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },
@@ -6766,9 +6742,7 @@
                 "chrome": {
                   "version_added": "125"
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": false
                 },

--- a/api/Document.json
+++ b/api/Document.json
@@ -6330,7 +6330,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -6365,7 +6367,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6401,7 +6405,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6437,7 +6443,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6473,7 +6481,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6509,7 +6519,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6545,7 +6557,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6581,7 +6595,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6617,7 +6633,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6653,7 +6671,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6689,7 +6709,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6725,7 +6747,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -6761,7 +6785,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,

--- a/api/StorageAccessHandle.json
+++ b/api/StorageAccessHandle.json
@@ -8,9 +8,7 @@
           "chrome": {
             "version_added": "125"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": {
             "version_added": false
           },
@@ -45,9 +43,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -121,9 +117,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -159,9 +153,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -197,9 +189,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -235,9 +225,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -273,9 +261,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -311,9 +297,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -349,9 +333,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -387,9 +369,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },
@@ -425,9 +405,7 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": false
             },

--- a/api/StorageAccessHandle.json
+++ b/api/StorageAccessHandle.json
@@ -27,7 +27,9 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -62,7 +64,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -136,7 +140,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -172,7 +178,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -208,7 +216,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -244,7 +254,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -280,7 +292,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -316,7 +330,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -352,7 +368,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -388,7 +406,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -424,7 +444,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
#### Summary

Everything but SharedWorker is actually supported on Android (just not WebView).

#### Test results and supporting details

This only launched in Chrome: https://chromestatus.com/feature/5175585823522816

#### Related issues

Relates to https://github.com/mdn/content/pull/33391 and https://github.com/mdn/mdn/issues/543
