### PR TITLE
Element.currentCSSZoom - add doc link

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4061,6 +4061,7 @@
       },
       "currentCSSZoom": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/currentCSSZoom",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom",
           "support": {
             "chrome": {


### PR DESCRIPTION
This adds links to docs for `Element.currentCSSZoom` being written in https://github.com/mdn/content/pull/33427

Related docs work can be tracked in https://github.com/mdn/content/issues/33241