### PR TITLE
IDBDatabase.transaction() has non standard FF option readwriteflush

### DIFF
--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -365,6 +365,46 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "option_durability_parameter_readwriteflush": {
+          "__compat": {
+            "description": "<code>option.durability</code> parameter supports <code>readwriteflush</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "40",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.indexedDB.experimental",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "version": {


### PR DESCRIPTION
As part of cleaning up docs in https://github.com/mdn/content/pull/33429 I found some very old FF40 notes. One is still valid - a behind a preference option called readwriteflush, which I have added to BCD. Removed notes are:

> **Note:** In Firefox, if you wish to ensure durability for some reason (e.g. you're storing critical data that cannot be recomputed later) you can force a transaction to flush to disk before delivering the `complete` event by creating a transaction using the experimental (non-standard) `readwriteflush` mode (see {{domxref("IDBDatabase.transaction")}}.)
    > This is currently experimental, and can only be used if the `dom.indexedDB.experimental` pref is set to `true` in `about:config`.

Related docs work can be found in https://github.com/mdn/content/issues/33220
	
FYI Only I also remove an additional note for FF40 that the transaction default changed to `relaxed` to match the spec and other browsers. Given that is so long ago, I have not bothered to capture the point at which this compatibility happened. Shown below just for record keeping.

> As of Firefox 40, IndexedDB transactions have relaxed durability guarantees to increase performance (see [Firefox bug 1112702](https://bugzil.la/1112702)), which is the same behavior as other IndexedDB-supporting browsers.
>    Previously in a `readwrite` transaction, a {{domxref("IDBTransaction.complete_event", "complete")}} event was fired only when all data was guaranteed to have been flushed to disk.
    In Firefox 40+ the `complete` event is fired after the OS has been told to write the data but potentially before that data has actually been flushed to disk.
    The `complete` event may thus be delivered quicker than before, however, there exists a small chance that the entire transaction will be lost if the OS crashes or there is a loss of system power before the data is flushed to disk.
    Since such catastrophic events are rare most consumers should not need to concern themselves further.

