### PR TITLE
HTMLTemplateElement.shadow RootMode/DelegatesFocus/Clonable link to docs

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -79,6 +79,7 @@
       },
       "shadowRootClonable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/shadowRootClonable",
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootclonable",
           "support": {
             "chrome": {
@@ -112,6 +113,7 @@
       },
       "shadowRootDelegatesFocus": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/shadowRootDelegatesFocus",
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootdelegatesfocus",
           "support": {
             "chrome": {
@@ -145,6 +147,7 @@
       },
       "shadowRootMode": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/shadowRootMode",
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootmode",
           "tags": [
             "web-features:declarative-shadow-dom"


### PR DESCRIPTION
Docs for `HTMLTemplateElement.shadowRootMode`, `HTMLTemplateElement.shadowRootDelegatesFocus`, `HTMLTemplateElement.shadowRootClonable` are coming in https://github.com/mdn/content/pull/33325 - this just adds the links.

Related docs work in https://github.com/mdn/content/issues/33160