### PR TITLE
Selection updates for parallel APIs ff125

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -710,6 +710,7 @@
       },
       "getComposedRanges": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/getComposedRanges",
           "spec_url": "https://w3c.github.io/selection-api/#dom-selection-getcomposedranges",
           "support": {
             "chrome": {
@@ -738,6 +739,39 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "returns_multiple_ranges": {
+          "__compat": {
+            "description": "Returned array can contain multiple ranges",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -1066,6 +1100,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "accepts_nodes_in_different_shadow_trees_ranges": {
+          "__compat": {
+            "description": "Accepts <code>anchorNode</code> and <code>focusNode</code> arguments in different shadow trees",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -200,7 +200,7 @@
             "deprecated": false
           }
         },
-        "accepts_nodes_in_any_tree": {
+        "accept_node_in_any_tree": {
           "__compat": {
             "description": "Accepts <code>node</code> parameter in any tree/shadow tree",
             "support": {
@@ -617,6 +617,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "accepts_node_in_any_tree": {
+          "__compat": {
+            "description": "Accepts <code>node</code> parameter in any tree/shadow tree",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "offset_parameter_optional": {

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -835,7 +835,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -200,6 +200,39 @@
             "deprecated": false
           }
         },
+        "accepts_nodes_in_any_tree": {
+          "__compat": {
+            "description": "Accepts <code>node</code> parameter in any tree/shadow tree",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "node_parameter_nullable": {
           "__compat": {
             "description": "<code>node</code> parameter is nullable",

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -200,7 +200,7 @@
             "deprecated": false
           }
         },
-        "accept_node_in_any_tree": {
+        "accepts_nodes_in_shadow_trees": {
           "__compat": {
             "description": "Accepts <code>node</code> parameter in any tree/shadow tree",
             "support": {
@@ -619,7 +619,7 @@
             "deprecated": false
           }
         },
-        "accepts_node_in_any_tree": {
+        "accepts_nodes_in_shadow_trees": {
           "__compat": {
             "description": "Accepts <code>node</code> parameter in any tree/shadow tree",
             "support": {
@@ -1168,7 +1168,7 @@
             "deprecated": false
           }
         },
-        "accepts_nodes_in_different_shadow_trees_ranges": {
+        "accepts_nodes_in_shadow_trees": {
           "__compat": {
             "description": "Accepts <code>anchorNode</code> and <code>focusNode</code> arguments in different shadow trees",
             "support": {


### PR DESCRIPTION
FF126 adds `Selection.getComposedRanges()` in nightly, but it also adds some updates to existing APIs:
- `Selection.getComposedRanges()`
  - can return multiple ranges, but only in firefox. Spec expects returning 1 range at the moment.
  - Added an URL to docs (still being written)
- `Selection.setBaseAndExtent()`  - this will now accept anchorNode and focusNode arguments that reside in different shadow trees, which will set the selection accordingly. 
- `Selection.collapse()` - can now accept a node in any tree, and will collapse the range to that Node.
- `extend()` - This should work as-expected, even if the new focusNode is in a different shadow tree.

There are other features coming but that is what is in now (according to https://bugzilla.mozilla.org/show_bug.cgi?id=1867058#c31)

FYI another thing that I don't know how to capture in BCD. I don' think I will:

> User selection via mouse, keyboard, etc. - The selection generated by this activity should be allowed to start and end anywhere in the document, including inside any open or closed shadow trees. The behavior should be equivalent to calls to setBaseAndExtent(), modulo canonicalization behavior.

Related work can be tracked in https://github.com/mdn/content/issues/33180

