### PR TITLE
Mark mask CSS property fully supported in Chromium

### DIFF
--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -8,12 +8,16 @@
           "support": {
             "chrome": [
               {
+                "version_added": "120"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "1",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               },
               {
                 "version_added": "1",
+                "version_removed": "120",
                 "partial_implementation": true,
                 "notes": "While the property is recognized, values applied to it don't have any effect."
               }
@@ -21,12 +25,16 @@
             "chrome_android": "mirror",
             "edge": [
               {
+                "version_added": "120"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "79",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               },
               {
                 "version_added": "79",
+                "version_removed": "120",
                 "partial_implementation": true,
                 "notes": "While the property is recognized, values applied to it don't have any effect."
               },
@@ -73,12 +81,16 @@
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
+                "version_added": "120"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "2",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               },
               {
                 "version_added": "2",
+                "version_removed": "120",
                 "partial_implementation": true,
                 "notes": "While the property is recognized, values applied to it don't have any effect."
               }


### PR DESCRIPTION
The longhand properties were updated here:
https://github.com/mdn/browser-compat-data/pull/21148

Because the shorthand was recognized but had no effect, the collector
couldn't detect this change.

Supporting evidence:
https://chromestatus.com/feature/5839739127332864

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
