### PR TITLE
[CSS] Firefox 126 adds `shape()` function support

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -492,6 +492,53 @@
             }
           }
         },
+        "shape": {
+          "__compat": {
+            "description": "<code>shape()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/shape",
+            "spec_url": "https://drafts.csswg.org/css-shapes-2/#shape-function",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "126",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.basic-shape-shape.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "xywh": {
           "__compat": {
             "description": "<code>xywh()</code>",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Target release date

May 14, 2024 

#### Summary

Firefox 126 adds support for a new function in the [`<basic-shape>`](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape) data type: `shape()`.

The support is currently available behind the preference `layout.css.basic-shape-shape.enabled`, which is enabled by default in Nightly (https://hg.mozilla.org/integration/autoland/file/tip/modules/libpref/init/StaticPrefList.yaml#l8612).

**Related Firefox bugs:**
- [[css-shapes-2] Implement shape() function for clip-path (bug 1823463)](https://bugzilla.mozilla.org/show_bug.cgi?id=1823463)
- [[css-shapes-2] Implement shape() function for offset-path (bug 1884424)](https://bugzilla.mozilla.org/show_bug.cgi?id=1884424)
- [[css-shapes-2] Support interpolation between shape() and path() (bug 1884425)](https://bugzilla.mozilla.org/show_bug.cgi?id=1884425)

#### Related issues and pull requests

Doc issue tracker: https://github.com/mdn/content/issues/33081
PR for content update: https://github.com/mdn/content/pull/33446
