### PR TITLE
Update public_class_fields for Safari

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -310,7 +310,13 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
+              },
+              {
+                "version_added": "14.1",
+                "version_removed": "16",
+                "partial_implementation": true,
+                "notes": "Parenthesis in field initializers can lead to ReferenceErrors. See <a href='https://webkit.org/b/236843'>bug 236843</a>."
               },
               {
                 "version_added": "14",

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -316,7 +316,7 @@
                 "version_added": "14.1",
                 "version_removed": "16",
                 "partial_implementation": true,
-                "notes": "Parenthesis in field initializers can lead to ReferenceErrors. See <a href='https://webkit.org/b/236843'>bug 236843</a>."
+                "notes": "Parentheses in field initializers can lead to <code>ReferenceError</code>s. See <a href='https://webkit.org/b/236843'>bug 236843</a>."
               },
               {
                 "version_added": "14",


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marks Safari 14-15 as having partial support for public class fields. While they do have a basic implementation, there is a critical bug which leads to exceptions in many cases. The exceptions are especially hard to identify/debug because they are resolved when dev-tools are open.

The bug is resolved in Safari 16.

#### Test results and supporting details

- Safari bug: https://bugs.webkit.org/show_bug.cgi?id=236843

- `babel/babel` discussion regarding adding 'bugfix' behavior for this issue: https://github.com/babel/babel/issues/14289

