### PR TITLE
Fix Firefox compat for api.WebTransport options.serverCertificateHashes

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -186,7 +186,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "125.0.1",
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Updates firefox support for `api.WebTransport` `options.serverCertificateHashes` since version 125.0.1

#### Test results and supporting details

We're developing a [p2p node](https://lumina.eiger.co/) which runs in wasm and uses webtransport to communicate. We were mostly targeting chrome browsers so far because we need serverCertificateHashes to connect with a huge majority of peers, but we ran it on firefox when debugging some other thing and to our surprise it worked.

It seems an oversight from Mozilla side that they didn't include this information in their release notes, but [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1806693) got fixed [here](https://hg.mozilla.org/mozilla-central/rev/14115a54c58b).
The PR's milestone is 123.0a1 however I've checked with the 124.0.1 and it doesn't support this feature yet, so it must've been added in 125.0.1.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #23057
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
