### PR TITLE
Add selectors introduced by view transition types

### DIFF
--- a/css/selectors/active-view-transition-type.json
+++ b/css/selectors/active-view-transition-type.json
@@ -1,0 +1,44 @@
+{
+  "css": {
+    "selectors": {
+      "active-view-transition-type": {
+        "__compat": {
+          "description": "<code>:active-view-transition-type()</code>",
+          "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#the-active-view-transition-type-pseudo",
+          "tags": [
+            "web-features:view-transitions"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "125",
+              "impl_url": "https://crbug.com/40276317"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/active-view-transition-type.json
+++ b/css/selectors/active-view-transition-type.json
@@ -5,9 +5,6 @@
         "__compat": {
           "description": "<code>:active-view-transition-type()</code>",
           "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#the-active-view-transition-type-pseudo",
-          "tags": [
-            "web-features:view-transitions"
-          ],
           "support": {
             "chrome": {
               "version_added": "125",

--- a/css/selectors/active-view-transition.json
+++ b/css/selectors/active-view-transition.json
@@ -5,9 +5,6 @@
         "__compat": {
           "description": "<code>:active-view-transition</code>",
           "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#the-active-view-transition-pseudo",
-          "tags": [
-            "web-features:view-transitions"
-          ],
           "support": {
             "chrome": {
               "version_added": "125",

--- a/css/selectors/active-view-transition.json
+++ b/css/selectors/active-view-transition.json
@@ -1,0 +1,44 @@
+{
+  "css": {
+    "selectors": {
+      "active-view-transition": {
+        "__compat": {
+          "description": "<code>:active-view-transition</code>",
+          "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#the-active-view-transition-pseudo",
+          "tags": [
+            "web-features:view-transitions"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "125",
+              "impl_url": "https://crbug.com/40276317"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
_(👋  Hi, Chrome DevRel here!)_

This PR introduces to new selectors introduced in View Transitions L2: the `:active-view-transition` and `:active-view-transition-types()` pseudo-class selectors.

This feature shipped to stable in Chrome 125.

There is no documentation on MDN available yet. Documentation on Chrome’s side is to be published on May 16.

Links:
- Spec: https://www.w3.org/TR/css-view-transitions-2/#the-active-view-transition-pseudo
- Spec: https://www.w3.org/TR/css-view-transitions-2/#the-active-view-transition-type-pseudo
- ChromeStatus: https://chromestatus.com/feature/5089552511533056
- CrBug: https://crbug.com/40276317