### PR TITLE
Adds CSS state for Chrome 125

### DIFF
--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -8,7 +8,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-custom",
           "support": {
             "chrome": {
-              "version_added": false,
+              "version_added": "125",
               "notes": "From version 90 Chromium supports custom state selection using a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>."
             },
             "chrome_android": "mirror",

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -13,7 +13,8 @@
               },
               {
                 "version_added": "90",
-                "notes": "Uses a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>."
+                "notes": "Uses a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>.",
+                "partial_implementation": true
               }
             ],
             "chrome_android": "mirror",

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -9,7 +9,7 @@
           "support": {
             "chrome": {
               "version_added": "125",
-              "notes": "From version 90 Chromium supports custom state selection using a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>."
+              "notes": "Before version 125, custom state selection was supported using a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -7,10 +7,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:state",
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-custom",
           "support": {
-            "chrome": {
-              "version_added": "125",
-              "notes": "Before version 125, custom state selection was supported using a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>."
-            },
+            "chrome": [
+              {
+                "version_added": "125"
+              },
+              {
+                "version_added": "90",
+                "notes": "Uses a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -13,8 +13,8 @@
               },
               {
                 "version_added": "90",
-                "notes": "Uses a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Uses a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>."
               }
             ],
             "chrome_android": "mirror",


### PR DESCRIPTION
Chrome is shipping the updated syntax, the old dashed ident syntax will be deprecated.

https://chromestatus.com/feature/5586433790443520

Is leaving the note the right thing to do here?