### PR TITLE
FF125 Clipboard.readText supported

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -132,10 +132,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "125",
               "notes": [
-                "From version 122 The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content",
-                "From version 122, Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With permission the extension does not require transient activation or paste prompt",
+                "The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content",
+                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With permission the extension does not require transient activation or paste prompt",
                 "Requires transient activation."
               ]
             },

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -134,8 +134,8 @@
             "firefox": {
               "version_added": "125",
               "notes": [
-                "The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content",
-                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With permission the extension does not require transient activation or paste prompt",
+                "The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content.",
+                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require transient activation or paste prompt.",
                 "Requires transient activation."
               ]
             },


### PR DESCRIPTION
FF125 enables [Clipboard.readText()]() in release in https://bugzilla.mozilla.org/show_bug.cgi?id=1877400

Verified using the BCD collector.

Found this as part of https://github.com/mdn/content/issues/33565. Looks like late addition to release or similar.