### PR TITLE
Update rel=noopener compat data for android webview

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -354,7 +354,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "88"
               }
             },
             "status": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -354,7 +354,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "88"
+                "version_added": "mirror"
               }
             },
             "status": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -353,9 +353,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "mirror"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds compat data for `implicit rel=noopener on target=_blank` links. The support info comes [from chromestatus](https://chromestatus.com/feature/6140064063029248).

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

I wasn't able to test it.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
