### PR TITLE
Update Deno data for BroadcastChannel API

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -67,7 +67,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11"
+              "version_added": "1.11",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-broadcast-channel"
+                }
+              ]
             },
             "edge": "mirror",
             "firefox": {
@@ -110,7 +116,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11"
+              "version_added": "1.11",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-broadcast-channel"
+                }
+              ]
             },
             "edge": "mirror",
             "firefox": {
@@ -157,7 +169,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11"
+              "version_added": "1.11",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-broadcast-channel"
+                }
+              ]
             },
             "edge": "mirror",
             "firefox": {
@@ -204,7 +222,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11"
+              "version_added": "1.11",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-broadcast-channel"
+                }
+              ]
             },
             "edge": "mirror",
             "firefox": {
@@ -249,7 +273,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11"
+              "version_added": "1.11",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-broadcast-channel"
+                }
+              ]
             },
             "edge": "mirror",
             "firefox": {
@@ -292,7 +322,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11"
+              "version_added": "1.11",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-broadcast-channel"
+                }
+              ]
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `BroadcastChannel` API. This propagates the flag data down to children features, otherwise the collector marks these features as unsupported.
