### PR TITLE
Update NodeJS data for BroadcastChannel API

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -29,14 +29,19 @@
           "ie": {
             "version_added": false
           },
-          "nodejs": {
-            "alternative_name": "worker_threads.BroadcastChannel",
-            "version_added": "15.4.0",
-            "notes": [
-              "Experimental implementation",
-              "Must be imported using either <code>require('worker_threads')</code> or <code>import * from 'worker_threads'</code>."
-            ]
-          },
+          "nodejs": [
+            {
+              "version_added": "18.0.0"
+            },
+            {
+              "alternative_name": "worker_threads.BroadcastChannel",
+              "version_added": "15.4.0",
+              "notes": [
+                "Experimental implementation",
+                "Must be imported using either <code>require('worker_threads')</code> or <code>import * from 'worker_threads'</code>."
+              ]
+            }
+          ],
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `BroadcastChannel` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.6), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Additional Notes: Exact version collected from Node docs: https://nodejs.org/docs/v20.12.1/api/globals.html#broadcastchannel
