### PR TITLE
Update Deno data for CountQueuingStrategy API

### DIFF
--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -9,6 +9,9 @@
             "version_added": "52"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": "1.0"
+          },
           "edge": {
             "version_added": "16"
           },
@@ -58,6 +61,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
             "edge": {
               "version_added": "16"
             },
@@ -97,6 +103,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
             "edge": {
               "version_added": "16"
             },
@@ -136,6 +145,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
             "edge": {
               "version_added": "16"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `CountQueuingStrategy` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.6), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Additional Notes: Exact version comes from scouring the API docs: https://deno.land/api@v1.0.0?s=CountQueuingStrategy
