### PR TITLE
Update NodeJS data for api.CompressionStream.CompressionStream.deflate-raw

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -160,9 +160,15 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "21.2.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "21.2.0"
+                },
+                {
+                  "version_added": "20.12.0",
+                  "version_removed": "21.0.0"
+                }
+              ],
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -160,9 +160,15 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "21.2.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "21.2.0"
+                },
+                {
+                  "version_added": "20.12.0",
+                  "version_removed": "21.0.0"
+                }
+              ],
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -506,6 +506,13 @@
         "20.10.0": {
           "release_date": "2023-11-22",
           "release_notes": "https://nodejs.org/en/blog/release/v20.10.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.3"
+        },
+        "20.12.0": {
+          "release_date": "2024-03-26",
+          "release_notes": "https://nodejs.org/en/blog/release/v20.12.0",
           "status": "esr",
           "engine": "V8",
           "engine_version": "11.3"


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `CompressionStream.deflate-raw` member of the `CompressionStream` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.6), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CompressionStream/CompressionStream/deflate-raw

Additional Notes: Exact version number was tracked down using local, manual runs.
