### PR TITLE
Ff125 shadowroot serializable

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2627,9 +2627,10 @@
             "deprecated": false
           }
         },
-        "init_clonable_parameter": {
+        "options_clonable_parameter": {
           "__compat": {
-            "description": "<code>init.clonable</code> parameter",
+            "description": "<code>options.clonable</code> parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attachShadow#clonable",
             "spec_url": "https://dom.spec.whatwg.org/#dom-shadowrootinit-clonable",
             "support": {
               "chrome": {
@@ -2667,9 +2668,10 @@
             }
           }
         },
-        "init_delegatesFocus_parameter": {
+        "options_delegatesFocus_parameter": {
           "__compat": {
-            "description": "<code>init.delegatesFocus</code> parameter",
+            "description": "<code>options.delegatesFocus</code> parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attachShadow#delegatesfocus",
             "spec_url": "https://dom.spec.whatwg.org/#dom-shadowrootinit-delegatesfocus",
             "support": {
               "chrome": {
@@ -2696,6 +2698,41 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_serializable_parameter": {
+          "__compat": {
+            "description": "<code>options.serializable</code> parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attachShadow#serializable",
+            "spec_url": "https://dom.spec.whatwg.org/#dom-shadowrootinit-serializable",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -184,6 +184,7 @@
       },
       "shadowRootSerializable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/shadowRootSerializable",
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootserializable",
           "support": {
             "chrome": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -43,6 +43,8 @@
         },
         "shadowrootclonable": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/template#shadowrootclonable",
+            "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootclonable",
             "support": {
               "chrome": {
                 "version_added": "124"
@@ -73,8 +75,43 @@
             }
           }
         },
+        "shadowrootdelegatesfocus": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/template#shadowrootdelegatesfocus",
+            "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootdelegatesfocus",
+            "support": {
+              "chrome": {
+                "version_added": "123"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "123"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "shadowrootmode": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/template#shadowrootmode",
             "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootmode",
             "tags": [
               "web-features:declarative-shadow-dom"

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -152,6 +152,40 @@
               "deprecated": false
             }
           }
+        },
+        "shadowrootserializable": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/template#shadowrootserializable",
+            "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootserializable",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Chrome 125 adds support for serialiable shadow roots in https://chromestatus.com/feature/5102952270528512 - most of this has been caught before, but we were missing some init values and values for setting this in declaratively created shadow roots.

This is part of https://github.com/mdn/content/issues/32731