### PR TITLE
FF127 TC39 Set methods supported

### DIFF
--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -340,14 +340,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.new_set_methods",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "127"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -528,14 +521,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.new_set_methods",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "127"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -578,14 +564,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.new_set_methods",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "127"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -628,14 +607,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.new_set_methods",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "127"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -678,14 +650,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.new_set_methods",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "127"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -866,14 +831,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.new_set_methods",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "127"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -916,14 +874,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.new_set_methods",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "127"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF127 supports the following Set methods in https://bugzilla.mozilla.org/show_bug.cgi?id=1868423:

- [`Set.prototype.intersection()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/intersection) 
- [`Set.prototype.union()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/union) 
- [`Set.prototype.difference()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference) 
- [`Set.prototype.symmetricDifference()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/symmetricDifference)
- [`Set.prototype.isSubsetOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/isSubsetOf)
- [`Set.prototype.isSupersetOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/isSupersetOf)
- [`Set.prototype.isDisjointFrom()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/isDisjointFrom)

Related docs work can be tracked in https://github.com/mdn/content/issues/33563