### PR TITLE
Adding a few impl_urls to help developers learn more when features aren't available

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -984,7 +984,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -3188,7 +3188,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5228,7 +5229,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5269,7 +5271,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -54,7 +54,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1800882"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -151,7 +152,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -279,7 +281,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -595,7 +598,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -631,7 +635,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1800882"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Highlight.json
+++ b/api/Highlight.json
@@ -14,7 +14,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "preview",
+            "impl_url": "https://bugzil.la/1703961"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,7 +52,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -87,7 +89,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -123,7 +126,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -159,7 +163,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -195,7 +200,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -231,7 +237,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -267,7 +274,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -303,7 +311,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -340,7 +349,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -376,7 +386,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -413,7 +424,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -449,7 +461,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -484,7 +497,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -14,7 +14,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "preview",
+            "impl_url": "https://bugzil.la/1703961"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -49,7 +50,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -85,7 +87,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -121,7 +124,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -157,7 +161,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -193,7 +198,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -229,7 +235,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -265,7 +272,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -301,7 +309,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -337,7 +346,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -373,7 +383,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -408,7 +419,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -23,7 +23,8 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1463402"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -77,7 +78,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -124,7 +126,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PictureInPictureWindow.json
+++ b/api/PictureInPictureWindow.json
@@ -16,7 +16,8 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1463402"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -56,7 +57,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -101,7 +103,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -142,7 +145,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -531,7 +531,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/margin-trim.json
+++ b/css/properties/margin-trim.json
@@ -7,7 +7,8 @@
           "spec_url": "https://drafts.csswg.org/css-box-4/#margin-trim",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/40886857"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -40,12 +41,14 @@
             "spec_url": "https://drafts.csswg.org/css-box-4/#valdef-margin-trim-block",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1506241"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -73,12 +76,14 @@
             "spec_url": "https://drafts.csswg.org/css-box-4/#valdef-margin-trim-block-end",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1506241"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -106,12 +111,14 @@
             "spec_url": "https://drafts.csswg.org/css-box-4/#valdef-margin-trim-block-start",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1506241"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -139,12 +146,14 @@
             "spec_url": "https://drafts.csswg.org/css-box-4/#valdef-margin-trim-inline",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1506241"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -172,12 +181,14 @@
             "spec_url": "https://drafts.csswg.org/css-box-4/#valdef-margin-trim-inline-end",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1506241"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -205,12 +216,14 @@
             "spec_url": "https://drafts.csswg.org/css-box-4/#valdef-margin-trim-inline-end",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1506241"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -238,12 +251,14 @@
             "spec_url": "https://drafts.csswg.org/css-box-4/#valdef-margin-trim-none",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1506241"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -18,7 +18,8 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Cannot yet be used with <code>text-decoration</code> and <code>text-shadow</code>. See <a href='https://bugzil.la/1703961'>bug 1703961</a>."
+              "notes": "Cannot yet be used with <code>text-decoration</code> and <code>text-shadow</code>.",
+              "impl_url": "https://bugzil.la/1703961"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/picture-in-picture.json
+++ b/css/selectors/picture-in-picture.json
@@ -16,7 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1463402"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -136,7 +136,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -406,7 +407,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -548,7 +550,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -661,7 +664,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -772,7 +776,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -824,7 +829,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "17.5"
+                "version_added": "17.5",
+                "impl_url": "https://webkit.org/b/262914"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1005,7 +1011,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1116,7 +1123,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1304,7 +1312,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1209,7 +1209,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1463402"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This is no particular order, and not complete, but hopefully this helps users of BCD like MDN and Can I Use tell a more complete story to web developers wondering why some features they'd like to use are not available.

#### Summary

This adds a few `impl_url` fields for features like TBD.

#### Test results and supporting details

Found these details by searching through various bug trackers and standard positions.