### PR TITLE
PerformanceResourceTiming shipped in Firefox 35

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -13,7 +13,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "31"
+            "version_added": "35"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -89,7 +89,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -129,7 +129,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -273,7 +273,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -309,7 +309,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -381,7 +381,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -452,7 +452,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -524,7 +524,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -560,7 +560,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -630,7 +630,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -666,7 +666,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -702,7 +702,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -772,7 +772,7 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -845,7 +845,7 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I was trying to figure out some discrepancies between caniuse and BCD on resource timing APIs and discovered some errors in BCD.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Confirmed by manual tests (i.e., comparing the results of https://mdn-bcd-collector.gooborg.com/tests/api/PerformanceResourceTiming in various versions in BrowserStack)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- https://bugzilla.mozilla.org/show_bug.cgi?id=1002855
- https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/35#interfacesapisdom

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

- https://github.com/web-platform-dx/web-features/pull/1083
