### PR TITLE
Mark mask-* properties supported in Edge

### DIFF
--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -19,6 +19,9 @@
             "chrome_android": "mirror",
             "edge": [
               {
+                "version_added": "120"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "79"
               },

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -18,6 +18,9 @@
             "chrome_android": "mirror",
             "edge": [
               {
+                "version_added": "120"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "79"
               },

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -18,6 +18,9 @@
             "chrome_android": "mirror",
             "edge": [
               {
+                "version_added": "120"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "79"
               },

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -18,6 +18,9 @@
             "chrome_android": "mirror",
             "edge": [
               {
+                "version_added": "120"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "79"
               },


### PR DESCRIPTION
This data can't be mirrored, and so was missed in https://github.com/mdn/browser-compat-data/pull/21148.