### PR TITLE
Update Chrome version for NDEFReader makeReadOnly()

### DIFF
--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": "89"
+              "version_added": "100"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
Supporting evidence:
https://chromiumdash.appspot.com/commit/986313551faa8ed05f93296376352d14017f4b7e https://chromestatus.com/feature/5700853265596416