### PR TITLE
Update Firefox data for ContentVisibilityAutoStateChangeEvent API

### DIFF
--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "124"
+            "version_added": "125"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -88,7 +88,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "125"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `ContentVisibilityAutoStateChangeEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.6).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ContentVisibilityAutoStateChangeEvent
