### PR TITLE
Update ShadowRoot.json - Safari getHTML bug fixed in the shadow root

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -361,8 +361,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/271343"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The bug is fixed for getHTML() in Safari, it is serializable in the shadow root.

#### Test results and supporting details

Bug- https://bugs.webkit.org/show_bug.cgi?id=271343
Pr- https://github.com/WebKit/WebKit/pull/26975

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
