### PR TITLE
Update NodeJS data for CustomEvent API

### DIFF
--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -22,9 +22,15 @@
           "ie": {
             "version_added": "9"
           },
-          "nodejs": {
-            "version_added": "19.0.0"
-          },
+          "nodejs": [
+            {
+              "version_added": "18.7.0"
+            },
+            {
+              "version_added": "16.17.0",
+              "version_removed": "17.0.0"
+            }
+          ],
           "oculus": "mirror",
           "opera": {
             "version_added": "11"
@@ -72,6 +78,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "18.7.0"
+              },
+              {
+                "version_added": "16.17.0",
+                "version_removed": "17.0.0"
+              }
+            ],
             "oculus": "mirror",
             "opera": {
               "version_added": "11.6"
@@ -153,6 +168,15 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": [
+              {
+                "version_added": "18.7.0"
+              },
+              {
+                "version_added": "16.17.0",
+                "version_removed": "17.0.0"
+              }
+            ],
             "oculus": "mirror",
             "opera": {
               "version_added": "11.6"

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -426,6 +426,13 @@
           "engine": "V8",
           "engine_version": "10.1"
         },
+        "18.7.0": {
+          "release_date": "2022-07-26",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.7.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.1"
+        },
         "18.16.0": {
           "release_date": "2023-04-13",
           "release_notes": "https://nodejs.org/en/blog/release/v18.16.0/",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `CustomEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.6), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CustomEvent

Additional Notes: Exact versions obtained from Node docs: https://nodejs.org/docs/latest/api/events.html#class-customevent
