### PR TITLE
Mark PressureObserver as not supported on Chrome Android

### DIFF
--- a/api/PressureObserver.json
+++ b/api/PressureObserver.json
@@ -11,7 +11,9 @@
           "chrome": {
             "version_added": "125"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -48,7 +50,9 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -85,7 +89,9 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -122,7 +128,9 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -159,7 +167,9 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -196,7 +206,9 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -233,7 +245,9 @@
             "chrome": {
               "version_added": "125"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
The API was exposed on Android but didn't actually work:
https://groups.google.com/a/chromium.org/g/blink-dev/c/7leKysvPZWk/m/-0fKweJ5AQAJ