### PR TITLE
"incognito": "split" support

### DIFF
--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -17,7 +17,7 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": "mirror"
           }
@@ -37,7 +37,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": "mirror"
             }
@@ -58,7 +58,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": "mirror"
             }
@@ -75,12 +75,16 @@
               },
               "firefox": {
                 "version_added": "127",
+                "impl_url": "https://bugzil.la/1380812",
+                "partial_implementation": true,
                 "notes": "Split mode is not supported in Firefox. Extensions using this value are treated as requesting \"incognito\":\"not_allowed\"."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "Split mode is not supported in Safari. Extensions using this value are treated as requesting \"incognito\":\"spanning\"."
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -74,8 +74,8 @@
                 "version_added": "17"
               },
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1380812"
+                "version_added": "127",
+                "notes": "Split mode is not supported in Firefox. Extensions using this value are treated as requesting \"incognito\":\"not_allowed\"."
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Address browser compatibility documentation requirements for [Bug 1876924](https://bugzilla.mozilla.org/show_bug.cgi?id=1876924) Treat "incognito":"split" as a warning instead of a hard error

#### Related issues

Related MDN changes: https://github.com/mdn/content/pull/33661