### PR TITLE
Update NodeJS data for DOMException API

### DIFF
--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -66,6 +66,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "17.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -104,6 +107,9 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": {
@@ -148,6 +154,9 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "17.0.0"
+            },
             "oculus": "mirror",
             "opera": {
               "version_added": "≤12.1"
@@ -190,6 +199,9 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "17.0.0"
             },
             "oculus": "mirror",
             "opera": {

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -108,9 +108,6 @@
             "ie": {
               "version_added": "9"
             },
-            "nodejs": {
-              "version_added": false
-            },
             "oculus": "mirror",
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `DOMException` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.6), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DOMException
