### PR TITLE
Update NodeJS data for api.Event.initEvent

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -576,7 +576,7 @@
               "version_added": "9"
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "19.5.0"
             },
             "oculus": "mirror",
             "opera": {

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -447,6 +447,13 @@
           "engine": "V8",
           "engine_version": "10.7"
         },
+        "19.5.0": {
+          "release_date": "2023-01-24",
+          "release_notes": "https://nodejs.org/en/blog/release/v19.5.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.7"
+        },
         "19.7.0": {
           "release_date": "2023-02-21",
           "release_notes": "https://nodejs.org/en/blog/release/v19.7.0",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `initEvent` member of the `Event` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.6), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Event/initEvent

Additional Notes: Exact version comes from the Node.js docs: https://nodejs.org/docs/latest/api/events.html#eventiniteventtype-bubbles-cancelable
