### PR TITLE
JavaScript Float16array 

### DIFF
--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -400,7 +400,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "127",
+                "version_added": "preview",
                 "flags": [
                   {
                     "type": "preference",
@@ -941,7 +941,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "127",
+                "version_added": "preview",
                 "flags": [
                   {
                     "type": "preference",

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -390,6 +390,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat16",
             "spec_url": "https://tc39.es/proposal-float16array/#sec-dataview.prototype.getfloat16",
+            "tags": [
+              "web-features:float16array"
+            ],
             "support": {
               "chrome": {
                 "version_added": false
@@ -931,6 +934,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat16",
             "spec_url": "https://tc39.es/proposal-float16array/#sec-dataview.prototype.setfloat16",
+            "tags": [
+              "web-features:float16array"
+            ],
             "support": {
               "chrome": {
                 "version_added": false

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -880,6 +880,53 @@
             }
           }
         },
+        "setFloat16": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat16",
+            "spec_url": "https://tc39.es/proposal-float16array/#sec-dataview.prototype.setfloat16",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "127",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.float16array",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "setFloat32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat32",

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -386,6 +386,53 @@
             }
           }
         },
+        "getFloat16": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat16",
+            "spec_url": "https://tc39.es/proposal-float16array/#sec-dataview.prototype.getfloat16",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "127",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.float16array",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "getFloat32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat32",

--- a/javascript/builtins/Float16Array.json
+++ b/javascript/builtins/Float16Array.json
@@ -1,0 +1,205 @@
+{
+  "javascript": {
+    "builtins": {
+      "Float16Array": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float16Array",
+          "spec_url": "https://tc39.es/proposal-float16array/#sec-float16array",
+          "tags": [
+            "web-features:typed-arrays"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "127",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "javascript.options.experimental.float16array",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "Float16Array": {
+          "__compat": {
+            "description": "<code>Float16Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float16Array/Float16Array",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:typed-arrays"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "127",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.float16array",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "constructor_without_parameters": {
+            "__compat": {
+              "description": "Constructor without parameters",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "127",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.float16array",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Float32Array(iterable)</code>",
+              "tags": [
+                "web-features:typed-arrays"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "127",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.float16array",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/Float16Array.json
+++ b/javascript/builtins/Float16Array.json
@@ -18,7 +18,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "127",
+              "version_added": "preview",
               "flags": [
                 {
                   "type": "preference",
@@ -68,7 +68,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "127",
+                "version_added": "preview",
                 "flags": [
                   {
                     "type": "preference",
@@ -116,7 +116,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "127",
+                  "version_added": "preview",
                   "flags": [
                     {
                       "type": "preference",
@@ -165,7 +165,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "127",
+                  "version_added": "preview",
                   "flags": [
                     {
                       "type": "preference",

--- a/javascript/builtins/Float16Array.json
+++ b/javascript/builtins/Float16Array.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float16Array",
           "spec_url": "https://tc39.es/proposal-float16array/#sec-float16array",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:float16array"
           ],
           "support": {
             "chrome": {
@@ -56,7 +56,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float16Array/Float16Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:float16array"
             ],
             "support": {
               "chrome": {
@@ -98,104 +98,6 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
-            }
-          },
-          "constructor_without_parameters": {
-            "__compat": {
-              "description": "Constructor without parameters",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.float16array",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "iterable_allowed": {
-            "__compat": {
-              "description": "<code>new Float32Array(iterable)</code>",
-              "tags": [
-                "web-features:typed-arrays"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.float16array",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
             }
           }
         }

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1148,6 +1148,53 @@
             }
           }
         },
+        "f16round": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/f16round",
+            "spec_url": "https://tc39.es/proposal-float16array/#sec-math.f16round",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "127",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.float16array",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "floor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/floor",

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1162,7 +1162,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "127",
+                "version_added": "preview",
                 "flags": [
                   {
                     "type": "preference",

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1152,6 +1152,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/f16round",
             "spec_url": "https://tc39.es/proposal-float16array/#sec-math.f16round",
+            "tags": [
+              "web-features:float16array"
+            ],
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
FF127 adds support for [TC39 `Float16Array` proposal](https://github.com/tc39/proposal-float16array) in https://bugzilla.mozilla.org/show_bug.cgi?id=1833647.
This is behind a preference but is also only available in nightly (i.e. you need both). 
As far as I can tell this is not yet implemented by others. 

Note that Chrome clearly has intent to support the use case this was created for in https://chromestatus.com/feature/5180552617656320. Deno and Node JS point to a third party library that does this https://deno.land/x/float16@v3.6.6/index.d.ts (i.e. not yet implemented).

Related docs work can be tracked in https://github.com/mdn/content/issues/33561



