### PR TITLE
FF127 clipboard enabled

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -70,11 +70,11 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "preview",
+              "version_added": "127",
               "notes": [
-                "From version 122, the <code>text/plain</code>, <code>text/html</code> and <code>image/png</code> MIME types are supported.",
-                "From version 122, the paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content",
-                "From version 122, Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With permission the extension does not require transient activation or paste prompt",
+                "The <code>text/plain</code>, <code>text/html</code> and <code>image/png</code> MIME types are supported.",
+                "The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content.",
+                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require transient activation or paste prompt.",
                 "Requires transient activation."
               ]
             },
@@ -132,10 +132,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "125",
+              "version_added": "preview",
               "notes": [
-                "The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content.",
-                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require transient activation or paste prompt.",
+                "From version 122 The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content",
+                "From version 122, Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With permission the extension does not require transient activation or paste prompt",
                 "Requires transient activation."
               ]
             },
@@ -190,10 +190,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "preview",
+              "version_added": "127",
               "notes": [
-                "From version 122, the <code>text/plain</code>, <code>text/html</code> and <code>image/png</code> MIME types are supported.",
-                "From version 122, Web extensions with the <code>clipboardWrite</code> permission in manifest do not require transient activation.",
+                "The <code>text/plain</code>, <code>text/html</code> and <code>image/png</code> MIME types are supported.",
+                "Web extensions with the <code>clipboardWrite</code> permission in their manifest do not require transient activation.",
                 "Requires transient activation. The Permissions API <code>clipboard-write</code> permission is not used."
               ]
             },

--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -16,7 +16,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "127"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -71,7 +71,7 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "127"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -110,7 +110,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "127"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -147,7 +147,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "127"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -182,7 +182,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "127"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -199,9 +199,81 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "optional_type_image_svg_xml": {
+          "__compat": {
+            "description": "<code>image/svg+xml</code> (optional MIME type).",
+            "spec_url": "https://w3c.github.io/clipboard-apis/#optional-data-types",
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "optional_type_web": {
+          "__compat": {
+            "description": "Custom format starting with <code>web </code> (optional MIME type).",
+            "spec_url": "https://w3c.github.io/clipboard-apis/#optional-data-types",
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -221,7 +293,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "127"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF127 enables `Clipboard.read()`/`write()` and `ClipboardItem` by default in https://bugzilla.mozilla.org/show_bug.cgi?id=1887845.
This changes all the previews to "127" and removes versioning on the notes.

FF127 also enables/implements the `ClipboardItem.supports()` static method for the mandatory MIME types _only_ in https://github.com/mdn/content/issues/33564. Since Chrome supports 2 of the three optional types - `web ` custom types and `image/svg+xml` I've added subfeatures for those two (no one supports the last type, which is a list of URIs). I didn't add a subfeature for the mandatory types, since they are mandatory and should be supported by all.

Related docs work can be tracked in:
- https://github.com/mdn/content/issues/33565 (shipping the API)
- https://github.com/mdn/content/issues/33564 (enabling `supports()`