### PR TITLE
Remove textLength as a global SVG attribute

### DIFF
--- a/svg/elements/textPath.json
+++ b/svg/elements/textPath.json
@@ -209,6 +209,41 @@
             }
           }
         },
+        "textLength": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/textLength",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": true
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "xlink_href": {
           "__compat": {
             "description": "<code>xlink:href</code>",

--- a/svg/elements/tspan.json
+++ b/svg/elements/tspan.json
@@ -176,6 +176,7 @@
         },
         "textLength": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/textLength",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -547,42 +547,6 @@
           }
         }
       },
-      "textLength": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/textLength",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElementTextLengthAttribute",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": "11"
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/class",


### PR DESCRIPTION
It can only be used on SVG `<text>`, `<tspan>`, and `<textPath>`, and
previously `<tref>` which has been removed now.