### PR TITLE
Tag the HTML is attribute as customized built-in elements

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -961,6 +961,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/is",
           "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+          "tags": [
+            "web-features:customized-built-in-elements"
+          ],
           "support": {
             "chrome": {
               "version_added": "67"


### PR DESCRIPTION
It has the same support data as api.CustomElementRegistry.builtin_element_support.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
