### PR TITLE
Add `spec_urls` for Attribution Reporting API headers

### DIFF
--- a/http/headers/Attribution-Reporting-Register-Source.json
+++ b/http/headers/Attribution-Reporting-Register-Source.json
@@ -4,6 +4,7 @@
       "Attribution-Reporting-Register-Source": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Attribution-Reporting-Register-Source",
+          "spec_url": "https://wicg.github.io/attribution-reporting-api/#parse-source-registration-json",
           "support": {
             "chrome": {
               "version_added": "117"

--- a/http/headers/Attribution-Reporting-Register-Trigger.json
+++ b/http/headers/Attribution-Reporting-Register-Trigger.json
@@ -4,6 +4,7 @@
       "Attribution-Reporting-Register-Trigger": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Attribution-Reporting-Register-Trigger",
+          "spec_url": "https://wicg.github.io/attribution-reporting-api/#create-an-attribution-trigger",
           "support": {
             "chrome": {
               "version_added": "117"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The [Attribution Reporting API](https://wicg.github.io/attribution-reporting-api/) had BCD added a already, but we missed out on adding `spec_url`s for the `Attribution-Reporting-Register-Source` and `Attribution-Reporting-Register-Trigger` headers. This PR fixes that.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
