### PR TITLE
install_type added to management API

### DIFF
--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -64,6 +64,35 @@
               }
             }
           },
+          "installType": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": [
+                  {
+                    "version_added": "127"
+                  },
+                  {
+                    "version_added": "51",
+                    "version_removed": "127",
+                    "partial_implementation": true,
+                    "notes": "When the add-on is installed using an enterprise policy the value \"other\" is set, rather than the expected value of \"admin\"."
+                  }
+                ],
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "offlineEnabled": {
             "__compat": {
               "support": {

--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": true
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "51"
             },
@@ -29,9 +27,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "51"
               },
@@ -49,9 +45,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -70,9 +64,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": [
                   {
                     "version_added": "127"
@@ -99,9 +91,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -120,9 +110,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "55"
                 },
@@ -141,9 +129,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -164,9 +150,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "56"
               },
@@ -186,9 +170,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55",
                 "notes": "Before version 56, only extensions whose 'type' is 'theme' are returned."
@@ -209,9 +191,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -231,9 +211,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -253,9 +231,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "51"
               },
@@ -296,9 +272,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55",
                 "notes": "Before version 56, only extensions whose <code>type</code> is <code>'theme'</code> are supported."
@@ -319,9 +293,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55",
                 "notes": "Before version 56, only extensions whose <code>type</code> is <code>'theme'</code> are supported."
@@ -342,9 +314,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55",
                 "notes": "Before version 56, only extensions whose <code>type</code> is <code>'theme'</code> are supported."
@@ -365,9 +335,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55",
                 "notes": [
@@ -391,9 +359,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55",
                 "notes": "Only extensions whose 'type' is 'theme' can be enabled and disabled."
@@ -414,9 +380,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -436,9 +400,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "51"
               },


### PR DESCRIPTION
#### Summary

Adds details in support of [Bug 1895341](https://bugzilla.mozilla.org/show_bug.cgi?id=1895341) Add install_type “admin” to the management API. Specifically, it adds BCD for the `install_type` of the management API `ExtensionInfo` type, noting that, prior to Firefox 127, the value `"admin"` wasn't set when the add-on was installed from an enterprise police.

#### Related issues

Release notes provided in https://github.com/mdn/content/pull/33714
