### PR TITLE
Update checkVisibility() parameter support

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3086,9 +3086,6 @@
           "__compat": {
             "description": "<code>options.checkOpacity</code> parameter",
             "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
-            "tags": [
-              "web-features:check-visibility"
-            ],
             "support": {
               "chrome": {
                 "version_added": "105"
@@ -3106,7 +3103,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3123,9 +3120,6 @@
           "__compat": {
             "description": "<code>options.checkVisibilityCSS</code> parameter",
             "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
-            "tags": [
-              "web-features:check-visibility"
-            ],
             "support": {
               "chrome": {
                 "version_added": "105"
@@ -3143,7 +3137,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3167,7 +3161,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -3177,14 +3171,48 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_opacityProperty_parameter": {
+          "__compat": {
+            "description": "<code>options.opacityProperty</code> parameter",
+            "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "122"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -3201,7 +3229,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -3211,14 +3239,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The parameters for this method were changed in the spec, and all
implementations proceeded in the same way:

 - First checkVisibility() with checkOpacity and checkVisibilityCSS
 - Then contentVisibilityAuto, opacityProperty, and visibilityProperty,
   making the original parameters historical aliases.

Chromium:

 105: https://chromiumdash.appspot.com/commit/60a7831496032f7b132bc96ec62542150ecb1103
 121: https://chromiumdash.appspot.com/commit/21e42c2ba69d45e08009432c56a5327046c499e6

Gecko:

 106: https://bugzilla.mozilla.org/show_bug.cgi?id=1777293#c4
 122: https://bugzilla.mozilla.org/show_bug.cgi?id=1859852#c6

WebKit:

 618.1.3: https://github.com/WebKit/WebKit/commit/7d04a9c1b62bc8a8101c390f6a164cf4b3da9cfa
 618.1.5: https://github.com/WebKit/WebKit/commit/2d9a96581fafa907ffd9ddfb4d8ca2bb24ae0692

Based on the WebKit version, both ended up in Safari 17.4. Support for
all 5 parameters in Safari 17.5 was confirmed with a dev instance of the
collector with the tests fixed:
https://github.com/openwebdocs/mdn-bcd-collector/pull/1478

Remove the web-features tags from the parameters as it is not clear how
thiss will be handled in web-features yet.