### PR TITLE
FF127 base href forbids javascript and data URLs

### DIFF
--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -81,7 +81,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "127"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
FF127 removes support for `data:` and `javascript:` URLs in the base element href in https://bugzilla.mozilla.org/show_bug.cgi?id=1850967

Related docs changes can be tracked in https://github.com/mdn/content/issues/33566