### PR TITLE
Add CSSMarginRule

### DIFF
--- a/api/CSSMarginRule.json
+++ b/api/CSSMarginRule.json
@@ -1,0 +1,106 @@
+{
+  "api": {
+    "CSSMarginRule": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMarginRule",
+        "spec_url": "https://drafts.csswg.org/cssom/#the-cssmarginrule-interface",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "preview"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "name": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMarginRule/name",
+          "spec_url": "https://drafts.csswg.org/cssom/#the-cssmarginrule-interface",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMarginRule/style",
+          "spec_url": "https://drafts.csswg.org/cssom/#the-cssmarginrule-interface",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

Firefox 127 supports `CSSMarginRule` now behind the `layout.css.margin-rules.enabled` flag.

It’s in the draft for now until I figure out the `style` attribute support.

#### Test results and supporting details

- [Bugzilla: Implement CSSMarginRule](https://bugzilla.mozilla.org/show_bug.cgi?id=1833466)

#### Related issues

- https://github.com/mdn/content/issues/33519