### PR TITLE
Add anchor-center value to place-items and place-self

### DIFF
--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -34,6 +34,43 @@
             "deprecated": false
           }
         },
+        "anchor-center": {
+          "__compat": {
+            "description": "<code>anchor-center</code>",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-center",
+            "tags": [
+              "web-features:anchor-positioning"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -34,6 +34,43 @@
             "deprecated": false
           }
         },
+        "anchor-center": {
+          "__compat": {
+            "description": "<code>anchor-center</code>",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-center",
+            "tags": [
+              "web-features:anchor-positioning"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

[CSS Anchor Positioning](https://www.w3.org/TR/css-anchor-position-1/) is set to be released in Chrome 125 (see the associated [Chrome Status entry](https://chromestatus.com/feature/5124922471874560)).

Most of the BCD for this module has already been added, but I forgot to add data points for `anchor-center` value support on the `place-items` and `place-self` properties. This PR adds the missing data points.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
