### PR TITLE
Add Firefox support for gradient colour spaces

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1783,10 +1783,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://phabricator.services.mozilla.com/D203397"
+                    },
+                    {
+                      "version_added": "121",
+                      "impl_url": "https://bugzil.la/1838740",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ]
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1786,18 +1786,18 @@
                   "firefox": [
                     {
                       "version_added": "127",
-                      "impl_url": "https://phabricator.services.mozilla.com/D203397"
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
                     },
                     {
                       "version_added": "121",
-                      "impl_url": "https://bugzil.la/1838740",
                       "flags": [
                         {
                           "type": "preference",
                           "name": "layout.css.gradient-color-interpolation-method.enabled",
                           "value_to_set": "true"
                         }
-                      ]
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
                     }
                   ],
                   "firefox_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Adds the Firefox support for colour space interpolation in gradients.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
I used browserstack to find the lowest version where it works with the flag.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
A dev confirmed that it will be enabled by default in 127 here: https://bugzilla.mozilla.org/show_bug.cgi?id=1899006#c2

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
