### PR TITLE
Bulk delete tags

### DIFF
--- a/scripts/bulk-editor/tags/remove.ts
+++ b/scripts/bulk-editor/tags/remove.ts
@@ -4,7 +4,7 @@
 import { updateFeatures } from '../utils.js';
 
 const command = {
-  command: 'remove <tag> <bcd-id..>',
+  command: 'remove <tag> [bcd-id..]',
   desc: 'Remove the following tag from the BCD features',
   /**
    * handler - Action to perform for 'tags remove'

--- a/scripts/bulk-editor/utils.ts
+++ b/scripts/bulk-editor/utils.ts
@@ -59,18 +59,27 @@ export const updateFeatures = (featureIDs, updater) => {
       const contents = JSON.parse(rawcontents.toString('utf8'));
       let changed = false;
 
+      const applyToAnyFeatureID = !featureIDs || featureIDs.length === 0;
       const walker = walk(undefined, contents);
       for (const { path: featureID } of walker) {
         if (
+          applyToAnyFeatureID ||
           featureIDs.some(
             (fid) =>
               fid === featureID ||
               (fid.endsWith('*') && featureID.startsWith(fid.slice(0, -1))),
           )
         ) {
-          console.log(chalk`{yellow Updating ${featureID}...}`);
-          performUpdate(featureID, contents, updater);
-          changed = true;
+          const before = JSON.stringify(contents, undefined, 2);
+          const after = JSON.stringify(
+            performUpdate(featureID, contents, updater),
+            undefined,
+            2,
+          );
+          if (before != after) {
+            console.log(chalk`{yellow Updated ${featureID}}`);
+            changed = true;
+          }
         }
       }
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This changes the bulk editor's `remove` command so that specifying target feature IDs is optional. This makes it possible to delete a tag completely, without knowing which features the tag applies to.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Inspired by https://github.com/mdn/browser-compat-data/pull/23188
