### PR TITLE
Updates for Firefox 127 beta / WebGL drawingBufferColorSpace

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -3057,7 +3057,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "127"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -2300,7 +2300,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "127"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.6 found new features shipping in Firefox 127 beta which was released last week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 21 features as shipping in Firefox 127:

- api.Clipboard.read
- api.Clipboard.write
- api.ClipboardItem
- api.ClipboardItem.ClipboardItem
- api.ClipboardItem.getType
- api.ClipboardItem.presentationStyle
- api.ClipboardItem.supports_static
- api.ClipboardItem.types
- api.WebGL2RenderingContext.drawingBufferColorSpace
- api.WebGLRenderingContext.drawingBufferColorSpace
- css.types.image.gradient.repeating-radial-gradient.interpolation_color_space
- javascript.builtins.Set.difference
- javascript.builtins.Set.intersection
- javascript.builtins.Set.isDisjointFrom
- javascript.builtins.Set.isSubsetOf
- javascript.builtins.Set.isSupersetOf
- javascript.builtins.Set.symmetricDifference
- javascript.builtins.Set.union
- webextensions.api.declarativeNetRequest.getDynamicRules.filter
- webextensions.api.declarativeNetRequest.getSessionRules.filter
- webextensions.api.management.ExtensionInfo.installType

See also https://github.com/mdn/mdn/issues/544 and https://www.mozilla.org/en-US/firefox/127.0beta/releasenotes/

@hamishwillee and others manually submitted PRs for Firefox 127 last week which I reviewed and double checked against the OWD collector results. See 

- https://github.com/mdn/browser-compat-data/pull/23164
- https://github.com/mdn/browser-compat-data/pull/23134
- https://github.com/mdn/browser-compat-data/pull/23089
- https://github.com/mdn/browser-compat-data/pull/23176
- https://github.com/mdn/browser-compat-data/pull/23114
- https://github.com/mdn/browser-compat-data/pull/23155

This means that this time the diff of this PR is small and only contains WebGL additions which weren't previously talked about by Hamish et al. The bug for that is https://bugzilla.mozilla.org/show_bug.cgi?id=1885491. r? @hamishwillee 
