### PR TITLE
added release details for content property alt text for firefox

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -50,7 +50,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Added the release note for alt text of CSS `content` property for firefox

#### Test results and supporting details

Tested in Firefox nightly 128.0a1

#### Related issues

- [MDN Content Issue 33590](https://github.com/mdn/content/issues/33590)
- [Content PR](https://github.com/mdn/content/pull/33834)
- [Firefox Release Note PR](https://github.com/mdn/content/pull/33835)
