### PR TITLE
Chrome 125 supports ShareStorageWorklet.{run,selectURL}

### DIFF
--- a/api/SharedStorageWorklet.json
+++ b/api/SharedStorageWorklet.json
@@ -32,6 +32,72 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "run": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworklet-run",
+          "support": {
+            "chrome": {
+              "version_added": "125"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectURL": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworklet-selecturl",
+          "support": {
+            "chrome": {
+              "version_added": "125"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Found by the @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.6.

Probably shipped late in the 125 beta cycle and therefore not detected in https://github.com/mdn/browser-compat-data/pull/22924.

Confirmed by https://chromestatus.com/feature/5145686840705024
