### PR TITLE
Updates for Chrome 126 beta

### DIFF
--- a/api/CSSViewTransitionRule.json
+++ b/api/CSSViewTransitionRule.json
@@ -1,13 +1,11 @@
 {
   "api": {
-    "PageRevealEvent": {
+    "CSSViewTransitionRule": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageRevealEvent",
-        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagerevealevent-interface",
+        "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#cssviewtransitionrule",
         "support": {
           "chrome": {
-            "version_added": "123",
-            "impl_url": "https://crbug.com/40276316"
+            "version_added": "126"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -34,15 +32,12 @@
           "deprecated": false
         }
       },
-      "PageRevealEvent": {
+      "navigation": {
         "__compat": {
-          "description": "<code>PageRevealEvent()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageRevealEvent/PageRevealEvent",
-          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagerevealevent-interface",
+          "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#dom-cssviewtransitionrule-navigation",
           "support": {
             "chrome": {
-              "version_added": "123",
-              "impl_url": "https://crbug.com/40276316"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -70,10 +65,9 @@
           }
         }
       },
-      "viewTransition": {
+      "types": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageRevealEvent/viewTransition",
-          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-pagerevealevent-viewtransition",
+          "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#dom-cssviewtransitionrule-types",
           "support": {
             "chrome": {
               "version_added": "126"

--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -5,8 +5,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#closewatcher",
         "support": {
           "chrome": {
-            "version_added": "120",
-            "version_removed": "121"
+            "version_added": "126"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -39,8 +38,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher",
           "support": {
             "chrome": {
-              "version_added": "120",
-              "version_removed": "121"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -74,8 +72,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#handler-closewatcher-oncancel",
           "support": {
             "chrome": {
-              "version_added": "120",
-              "version_removed": "121"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -108,8 +105,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-close",
           "support": {
             "chrome": {
-              "version_added": "120",
-              "version_removed": "121"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -143,8 +139,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#handler-closewatcher-onclose",
           "support": {
             "chrome": {
-              "version_added": "120",
-              "version_removed": "121"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -177,8 +172,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-destroy",
           "support": {
             "chrome": {
-              "version_added": "120",
-              "version_removed": "121"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -211,8 +205,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-requestclose",
           "support": {
             "chrome": {
-              "version_added": "120",
-              "version_removed": "121"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -108,8 +108,42 @@
           }
         }
       },
+      "effects": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/gamepad/#dom-gamepadhapticactuator-effects",
+          "support": {
+            "chrome": {
+              "version_added": "126"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "playEffect": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/gamepad/#dom-gamepadhapticactuator-playeffect",
           "support": {
             "chrome": {
               "version_added": "68"
@@ -137,7 +171,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -181,6 +215,7 @@
       },
       "reset": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/gamepad/#dom-gamepadhapticactuator-reset",
           "support": {
             "chrome": {
               "version_added": "68"
@@ -208,7 +243,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -528,6 +528,39 @@
             "deprecated": false
           }
         }
+      },
+      "toJSON": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/geolocation-api/#tojson-method-0",
+          "support": {
+            "chrome": {
+              "version_added": "126"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -210,6 +210,39 @@
             "deprecated": false
           }
         }
+      },
+      "toJSON": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/geolocation-api/#tojson-method",
+          "support": {
+            "chrome": {
+              "version_added": "126"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/PageSwapEvent.json
+++ b/api/PageSwapEvent.json
@@ -111,14 +111,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-pageswapevent-viewtransition",
           "support": {
             "chrome": {
-              "version_added": "123",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "viewTransition API for navigations",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/URL.json
+++ b/api/URL.json
@@ -444,10 +444,11 @@
       "parse_static": {
         "__compat": {
           "description": "<code>parse()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/parse_static",
           "spec_url": "https://url.spec.whatwg.org/#dom-url-parse",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -469,7 +470,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -383,11 +383,16 @@
             "web-features:scrollend"
           ],
           "support": {
-            "chrome": {
-              "version_added": "114",
-              "partial_implementation": true,
-              "notes": "The <code>onscrollend</code> event handler property is not supported. See <a href='https://crbug.com/325307785'>bug 325307785</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "126"
+              },
+              {
+                "version_added": "114",
+                "partial_implementation": true,
+                "notes": "The <code>onscrollend</code> event handler property is not supported. See <a href='https://crbug.com/325307785'>bug 325307785</a>."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -1,0 +1,38 @@
+{
+  "api": {
+    "WebGLObject": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLObject",
+        "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#5.3",
+        "support": {
+          "chrome": {
+            "version_added": "126"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.7 found new features shipping in Chrome 126 beta which was released last week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 19 features are marked as shipping in Chrome 126:

- api.CSSViewTransitionRule
- api.CSSViewTransitionRule.navigation
- api.CSSViewTransitionRule.types
- api.CloseWatcher
- api.CloseWatcher.CloseWatcher
- api.CloseWatcher.cancel_event
- api.CloseWatcher.close
- api.CloseWatcher.close_event
- api.CloseWatcher.destroy
- api.CloseWatcher.requestClose
- api.GamepadHapticActuator.effects
- api.GeolocationCoordinates.toJSON
- api.GeolocationPosition.toJSON
- api.PageRevealEvent.viewTransition
- api.PageSwapEvent.viewTransition
- api.URL.parse_static
- api.VisualViewport.scrollend_event
- api.WebGLObject
- css.at-rules.view-transition

See also the 126 "Enabled by default" column on https://chromestatus.com/roadmap.

I'm also seeing the MutationEvent interface gone in Chrome 126 beta in the collector: https://mdn-bcd-collector.gooborg.com/tests/api/MutationEvent.
However, this posts says they will be gone in 127 only: https://developer.chrome.com/blog/mutation-events-deprecation
Either it is a beta thing or the interface is gone early. I've not added this topic to this PR, maybe we can try to sort it separately.

Again, I hope this PR is useful to update BCD for the new Chrome 126 more easily and faster. If you have feedback, let me know! /cc @chrisdavidmills