### PR TITLE
Set starting-style preview support for firefox

### DIFF
--- a/css/at-rules/starting-style.json
+++ b/css/at-rules/starting-style.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
`@starting-style` is enabled in Firefox Nightly only, since version 127 See https://searchfox.org/mozilla-central/rev/23efe2c8c5b3a3182d449211ff9036fb34fe0219/modules/libpref/init/StaticPrefList.yaml#8511-8512,8514