### PR TITLE
Note about activeTab permission for tabs.captureVisibleTab

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1470,7 +1470,8 @@
                 "version_added": "15"
               },
               "firefox": {
-                "version_added": "47"
+                "version_added": "47",
+                "notes": "In Firefox 125 and earlier, only available with the <code>&lt;all_urls&gt;</code> permission. From Firefox 126, available with either the <code>&lt;all_urls&gt;</code> or <code>activeTab</code> permissions."
               },
               "firefox_android": {
                 "version_added": "54"


### PR DESCRIPTION
#### Summary

Add to note to the `tabs.captureVisibleTab` method in support of [Bug 1784920](https://bugzilla.mozilla.org/show_bug.cgi?id=1784920) Add `activeTab` as permission for `tabs.captureVisibleTab` API

#### Related issues

Related content updates in https://github.com/mdn/content/pull/33841
