### PR TITLE
HTTP Mixed-content - add feature

### DIFF
--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -22,7 +22,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": true
+            "version_added": "≤9.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -45,7 +45,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "≤23"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -74,7 +74,7 @@
           "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤79"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -108,7 +108,7 @@
           "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤79"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -1,0 +1,322 @@
+{
+  "http": {
+    "mixed_content": {
+      "__compat": {
+        "description": "Blocks some or all insecure mixed content",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/Security/Mixed_content",
+        "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+        "support": {
+          "chrome": {
+            "version_added": "79"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "23"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": true
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "allow_file_urls": {
+        "__compat": {
+          "description": "Allow mixed content from <code>file:</code> URLs",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "allow_localhost_url": {
+        "__compat": {
+          "description": "Allow mixed content from localhost addresses (<code>http://localhost/</code> and <code>http://*.localhost/</code>).",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "84"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "allow_loopback_url": {
+        "__compat": {
+          "description": "Allow mixed content from loopback address (<code>http://127.0.0.1/</code>)",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "auto_upgrade_images": {
+        "__compat": {
+          "description": "Upgradable image mixed content by default",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "127",
+              "notes": [
+                "Set <code>security.mixed_content.upgrade_display_content</code> preference to <code>true</code> to allow HTTP fetching and display of upgradable content",
+                "Set <code>security.mixed_content.block_display_content</code> preference to <code>true</code> to block all mixed content"
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "auto_upgrade_video_audio": {
+        "__compat": {
+          "description": "Upgrade video and audio content by default",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "127",
+              "notes": [
+                "Set <code>security.mixed_content.upgrade_display_content</code> preference to <code>true</code> to allow HTTP fetching and display of upgradable content",
+                "Set <code>security.mixed_content.block_display_content</code> preference to <code>true</code> to block all mixed content"
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "block_active_content": {
+        "__compat": {
+          "description": "Block active mixed content (later 'blockable' mixed content).",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "support": {
+            "chrome": {
+              "version_added": "79",
+              "notes": "From version 79 blocks iframes, scripts, and stylesheets."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "23"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "block_insecure_downloads": {
+        "__compat": {
+          "description": "Block insecure downloads from secure context",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "support": {
+            "chrome": {
+              "version_added": "84"
+            },
+            "chrome_android": {
+              "version_added": "85"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "private_network_access": {
+        "__compat": {
+          "description": "User permission in private network allows mixed content checks to be skipped",
+          "spec_url": "https://wicg.github.io/private-network-access/#intro",
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -2,7 +2,7 @@
   "http": {
     "mixed_content": {
       "__compat": {
-        "description": "Blocks some or all insecure mixed content",
+        "description": "Blocks some or all insecure mixed content.",
         "mdn_url": "https://developer.mozilla.org/docs/Web/Security/Mixed_content",
         "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
         "support": {
@@ -36,7 +36,7 @@
       },
       "allow_file_urls": {
         "__compat": {
-          "description": "Allow mixed content from <code>file:</code> URLs",
+          "description": "Allow mixed content from <code>file:</code> URLs.",
           "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
           "support": {
             "chrome": {
@@ -104,7 +104,7 @@
       },
       "allow_loopback_url": {
         "__compat": {
-          "description": "Allow mixed content from loopback address (<code>http://127.0.0.1/</code>)",
+          "description": "Allow mixed content from loopback address (<code>http://127.0.0.1/</code>).",
           "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
           "support": {
             "chrome": {
@@ -138,7 +138,7 @@
       },
       "auto_upgrade_images": {
         "__compat": {
-          "description": "Upgradable image mixed content by default",
+          "description": "Upgradable image mixed content by default.",
           "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
           "support": {
             "chrome": {
@@ -149,8 +149,8 @@
             "firefox": {
               "version_added": "127",
               "notes": [
-                "Set <code>security.mixed_content.upgrade_display_content</code> preference to <code>true</code> to allow HTTP fetching and display of upgradable content",
-                "Set <code>security.mixed_content.block_display_content</code> preference to <code>true</code> to block all mixed content"
+                "Set <code>security.mixed_content.upgrade_display_content</code> preference to <code>true</code> to allow HTTP fetching and display of upgradable content.",
+                "Set <code>security.mixed_content.block_display_content</code> preference to <code>true</code> to block all mixed content."
               ]
             },
             "firefox_android": "mirror",
@@ -176,7 +176,7 @@
       },
       "auto_upgrade_video_audio": {
         "__compat": {
-          "description": "Upgrade video and audio content by default",
+          "description": "Upgrade video and audio content by default.",
           "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
           "support": {
             "chrome": {
@@ -187,8 +187,8 @@
             "firefox": {
               "version_added": "127",
               "notes": [
-                "Set <code>security.mixed_content.upgrade_display_content</code> preference to <code>true</code> to allow HTTP fetching and display of upgradable content",
-                "Set <code>security.mixed_content.block_display_content</code> preference to <code>true</code> to block all mixed content"
+                "Set <code>security.mixed_content.upgrade_display_content</code> preference to <code>true</code> to allow HTTP fetching and display of upgradable content.",
+                "Set <code>security.mixed_content.block_display_content</code> preference to <code>true</code> to block all mixed content."
               ]
             },
             "firefox_android": "mirror",
@@ -249,18 +249,50 @@
       },
       "block_insecure_downloads": {
         "__compat": {
-          "description": "Block insecure downloads from secure context",
+          "description": "Block insecure downloads from secure context.",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#mixed-download",
+          "support": {
+            "chrome": {
+              "version_added": "92"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "90"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "block_mixed_downloads": {
+        "__compat": {
+          "description": "Block mixed downloads.",
           "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
           "support": {
             "chrome": {
-              "version_added": "84"
+              "version_added": true
             },
-            "chrome_android": {
-              "version_added": "85"
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "55"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -285,7 +317,7 @@
       },
       "private_network_access": {
         "__compat": {
-          "description": "User permission in private network allows mixed content checks to be skipped",
+          "description": "User permission in private network allows mixed content checks to be skipped.",
           "spec_url": "https://wicg.github.io/private-network-access/#intro",
           "support": {
             "chrome": {

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -139,7 +139,7 @@
       "auto_upgrade_images": {
         "__compat": {
           "description": "Upgradable image mixed content by default.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#category-upgradeable",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -177,7 +177,7 @@
       "auto_upgrade_video_audio": {
         "__compat": {
           "description": "Upgrade video and audio content by default.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#category-upgradeable",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -249,7 +249,7 @@
       "blockable_mixed_content": {
         "__compat": {
           "description": "Block 'blockable' mixed content.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#category-blockable",
           "support": {
             "chrome": {
               "version_added": "79",

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -212,41 +212,6 @@
           }
         }
       },
-      "block_active_content": {
-        "__compat": {
-          "description": "Block active mixed content (later 'blockable' mixed content).",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
-          "support": {
-            "chrome": {
-              "version_added": "79",
-              "notes": "From version 79 blocks iframes, scripts, and stylesheets."
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "23"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "block_mixed_downloads": {
         "__compat": {
           "description": "Block mixed downloads.",
@@ -269,6 +234,41 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blockable_mixed_content": {
+        "__compat": {
+          "description": "Block 'blockable' mixed content.",
+          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "support": {
+            "chrome": {
+              "version_added": "79",
+              "notes": "From version 79 blocks iframes, scripts, and stylesheets."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "23"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": true
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -247,9 +247,9 @@
           }
         }
       },
-      "block_insecure_downloads": {
+      "block_mixed_downloads": {
         "__compat": {
-          "description": "Block insecure downloads from secure context.",
+          "description": "Block mixed downloads.",
           "spec_url": "https://www.w3.org/TR/mixed-content/#mixed-download",
           "support": {
             "chrome": {
@@ -259,40 +259,6 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "90"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "block_mixed_downloads": {
-        "__compat": {
-          "description": "Block mixed downloads.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "55"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -7,12 +7,12 @@
         "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
         "support": {
           "chrome": {
-            "version_added": "79"
+            "version_added": "≤79"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "23"
+            "version_added": "≤23"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -1,6 +1,6 @@
 {
   "http": {
-    "mixed_content": {
+    "mixed-content": {
       "__compat": {
         "description": "Blocks some or all insecure mixed content.",
         "mdn_url": "https://developer.mozilla.org/docs/Web/Security/Mixed_content",


### PR DESCRIPTION
Mixed content is content served from a secure context (HTTPS) that references insecure content (HTTP URLs). Historically browsers did nothing. Then some started blocking active content such as scripts/stylesheets, then optionally either displaying, blocking or upgrading images, video and audio to HTTPS if they were HTTP links.

The current spec defines content as blockable and upgradable. Upgradeable is images, videos, audio and gets changed from HTTP to HTTPS urls. This list is expected to be constant or shrink. This more or less matches what Chrome has done since mid 80 versions, and FF does in 127.

This behaviour affects compatibility so belongs in the BCD. I've attempted to capture this. At high level:
- Safari in SOME version started blocking all mixed content, including from file urls etc. I think this was 9.0 or 9.1. I can't find an official note. They do appear to still block everything. Webkit has a positive standards position for the new upgradable/blockable but nothing else. I just say they block all.
- Chrome - more or less matches spec. I've updated this based on https://chromestatus.com/features#mixed (first 6 items)
- FF info is from https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content and https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content - after this goes in I will strip all that out.

Related docs work tracked in https://github.com/mdn/content/issues/33592