### PR TITLE
Update firefox compatibility for property at-rule

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1774,8 +1774,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "notes": "Does not yet support interpolation of registered custom properties. See <a href='https://bugzil.la/1846516'>bug 1846516</a>."
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/CSSPropertyRule.json
+++ b/api/CSSPropertyRule.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "notes": "Does not yet support interpolation of registered custom properties. See <a href='https://bugzil.la/1846516'>bug 1846516</a>."
+            "version_added": "128"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -88,7 +87,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -125,7 +124,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -162,7 +161,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -53,7 +53,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -91,7 +91,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -129,7 +129,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

The `@property` rule will be supported by Firefox 128 stable.

#### Test results and supporting details

https://www.mozilla.org/en-US/firefox/128.0a1/releasenotes/
https://bugzilla.mozilla.org/show_bug.cgi?id=1864818

#### Related issues

n/a
