### PR TITLE
New unsanitized formats BCD key

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -112,9 +112,10 @@
             "deprecated": false
           }
         },
-        "formats_parameter": {
+        "formats_unsanitized_parameter": {
           "__compat": {
-            "description": "<code>formats</code> parameter",
+            "description": "<code>formats.unsanitized</code> parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Clipboard/read#unsanitized",
             "spec_url": "https://w3c.github.io/clipboard-apis/#dictdef-clipboardunsanitizedformats",
             "support": {
               "chrome": {

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -111,6 +111,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "formats_parameter": {
+          "__compat": {
+            "description": "<code>formats</code> parameter",
+            "spec_url": "https://w3c.github.io/clipboard-apis/#dictdef-clipboardunsanitizedformats",
+            "support": {
+              "chrome": {
+                "version_added": "122"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "readText": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `navigator.clipboard.read()` function accepts an optional `formats` parameter that can be used to pass mime-type which you want to read unsanitized.

Documented here: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/read#formats

#### Test results and supporting details

This was added by the Edge team in Chromium and shipped with Edge and Chrome 122.
Chromestatus: https://chromestatus.com/feature/5203909459312640
Bug: https://issues.chromium.org/issues/40204798