### PR TITLE
Update NodeJS data for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -27,11 +27,16 @@
           "ie": {
             "version_added": "9"
           },
-          "nodejs": {
-            "version_added": "8.5.0",
-            "partial_implementation": true,
-            "notes": "Exported from the <code>perf_hooks</code> module"
-          },
+          "nodejs": [
+            {
+              "version_added": "16.0.0"
+            },
+            {
+              "version_added": "8.5.0",
+              "partial_implementation": true,
+              "notes": "Exported from the <code>perf_hooks</code> module"
+            }
+          ],
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -191,9 +196,15 @@
             "ie": {
               "version_added": "10"
             },
-            "nodejs": {
-              "version_added": false
-            },
+            "nodejs": [
+              {
+                "version_added": "18.2.0"
+              },
+              {
+                "version_added": "16.17.0",
+                "version_removed": "17.0.0"
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -882,7 +893,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "18.8.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -931,7 +942,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "18.8.0"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -851,6 +851,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "18.2.0"
+              },
+              {
+                "version_added": "16.17.0",
+                "version_removed": "17.0.0"
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": "9"
           },
+          "nodejs": {
+            "version_added": "16.0.0"
+          },
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -426,9 +426,23 @@
           "engine": "V8",
           "engine_version": "10.1"
         },
+        "18.2.0": {
+          "release_date": "2022-05-17",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.2.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.1"
+        },
         "18.7.0": {
           "release_date": "2022-07-26",
           "release_notes": "https://nodejs.org/en/blog/release/v18.7.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.1"
+        },
+        "18.8.0": {
+          "release_date": "2022-08-24",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.8.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "10.1"


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `Performance` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Performance

Additional Notes: Exact version numbers were tracked down via the NodeJS docs: https://nodejs.org/docs/v20.13.1/api/perf_hooks.html
