### PR TITLE
Update NodeJS data for api.PerformanceResourceTiming.toJSON

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -851,6 +851,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "18.2.0"
+              },
+              {
+                "version_added": "16.17.0",
+                "version_removed": "17.0.0"
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `toJSON` member of the `PerformanceResourceTiming` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PerformanceResourceTiming/toJSON

Additional Notes: Exact versions come from the NodeJS docs: https://nodejs.org/docs/v20.13.1/api/perf_hooks.html#performanceresourcetimingtojson
