### PR TITLE
Add misssing Firefox grandient colour space support

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -338,10 +338,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -372,10 +385,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -551,10 +577,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -585,10 +624,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -952,10 +1004,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -986,10 +1051,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -1127,10 +1205,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -1161,10 +1252,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -1341,10 +1445,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -1375,10 +1492,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false
@@ -1749,10 +1879,23 @@
                   },
                   "chrome_android": "mirror",
                   "edge": "mirror",
-                  "firefox": {
-                    "version_added": false,
-                    "impl_url": "https://bugzil.la/1824041"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "127",
+                      "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
+                    },
+                    {
+                      "version_added": "121",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "layout.css.gradient-color-interpolation-method.enabled",
+                          "value_to_set": "true"
+                        }
+                      ],
+                      "impl_url": "https://bugzil.la/1838740"
+                    }
+                  ],
                   "firefox_android": "mirror",
                   "ie": {
                     "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This is a continuation of my previous PR #23176 - all the notes there apply here. In my original PR I misunderstood the file, and thought I'd added the syntax support for all gradient types, when in fact I'd only added it for one of them.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

See #23176


#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
