### PR TITLE
Remove allow-downloads-without-user-activation

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -794,39 +794,6 @@
               }
             }
           },
-          "allow-downloads-without-user-activation": {
-            "__compat": {
-              "description": "<code>sandbox=\"allow-downloads-without-user-activation\"</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
-            }
-          },
           "allow-forms": {
             "__compat": {
               "description": "<code>sandbox=\"allow-forms\"</code>",


### PR DESCRIPTION
Remove allow-downloads-without-user-activation sandbox option. It is not currently supported by any browser. This was implemented in Chrome at one time, but has been removed. No browser seems to support this currently. There is an open issue with a request to implement this, but that does not seem very active.

Related to:
- https://github.com/mdn/browser-compat-data/pull/18862
- https://github.com/mdn/content/pull/33409
