### PR TITLE
Add compat data for position-anchor: auto value

### DIFF
--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -48,6 +48,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
+                "partial_implementation": true,
                 "notes": "The generic <code>auto</code> value exists, but it does not yet have the effect described in the spec."
               },
               "chrome_android": "mirror",

--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -37,6 +37,45 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "auto": {
+          "__compat": {
+            "description": "<code>auto</code> value",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#position-anchor",
+            "tags": [
+              "web-features:anchor-positioning"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "The generic <code>auto</code> value exists, but it does not yet have the effect described in the spec."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -47,7 +47,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
+                "version_added": "125",
                 "partial_implementation": true,
                 "notes": "The generic <code>auto</code> value exists, but it does not yet have the effect described in the spec."
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The [CSS Anchor Positioning](https://www.w3.org/TR/css-anchor-position-1/) BCD was added a while ago, but we neglected to add a separate data point for the `auto` value, which isn't really supported right now (see the note).

Also be aware that the spec changed — the value was `implicit`, but it changed to `auto`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
