### PR TITLE
Update HTML spec links that redirect

### DIFF
--- a/api/BarProp.json
+++ b/api/BarProp.json
@@ -3,7 +3,7 @@
     "BarProp": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarProp",
-        "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#barprop",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#barprop",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -42,7 +42,7 @@
       "visible": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarProp/visible",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-barprop-visible",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-barprop-visible",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/Document.json
+++ b/api/Document.json
@@ -2278,7 +2278,7 @@
       "defaultView": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/defaultView",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-document-defaultview-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-defaultview-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2553,7 +2553,7 @@
       "domain": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/domain",
-          "spec_url": "https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction",
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#relaxing-the-same-origin-restriction",
           "support": {
             "chrome": {
               "version_added": "1",

--- a/api/HTMLDocument.json
+++ b/api/HTMLDocument.json
@@ -3,7 +3,7 @@
     "HTMLDocument": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDocument",
-        "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#htmldocument",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#htmldocument",
         "support": {
           "chrome": {
             "version_added": "1"

--- a/api/Window.json
+++ b/api/Window.json
@@ -3,7 +3,7 @@
     "Window": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window",
-        "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#the-window-object",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-window-object",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -788,7 +788,7 @@
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/close",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-close-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-close-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -833,7 +833,7 @@
       "closed": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/closed",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-closed-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-closed-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1203,7 +1203,7 @@
       "document": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/document",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-document-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1675,7 +1675,7 @@
       "frames": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/frames",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-frames-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-frames-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2416,7 +2416,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/length",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-length-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-length-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2600,7 +2600,7 @@
       "locationbar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/locationbar",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-locationbar-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-locationbar-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2680,7 +2680,7 @@
       "menubar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/menubar",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-menubar-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-menubar-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2988,7 +2988,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/name",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-name-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-name-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -3243,7 +3243,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/open",
           "spec_url": [
-            "https://html.spec.whatwg.org/multipage/window-object.html#dom-open-dev",
+            "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open-dev",
             "https://drafts.csswg.org/cssom-view/#the-features-argument-to-the-open()-method"
           ],
           "support": {
@@ -3559,7 +3559,7 @@
       "originAgentCluster": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/originAgentCluster",
-          "spec_url": "https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters",
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#origin-keyed-agent-clusters",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -3867,7 +3867,7 @@
       "personalbar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/personalbar",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-personalbar-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-personalbar-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -5083,7 +5083,7 @@
       "scrollbars": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scrollbars",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-scrollbars-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-scrollbars-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -5761,7 +5761,7 @@
       "self": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/self",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-self-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-self-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -6189,7 +6189,7 @@
       "status": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/status",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-status",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-status",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -6229,7 +6229,7 @@
       "statusbar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/statusbar",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-statusbar-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-statusbar-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -6267,7 +6267,7 @@
       "stop": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/stop",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-stop-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-stop-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -6391,7 +6391,7 @@
       "toolbar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/toolbar",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-toolbar-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-toolbar-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -7046,7 +7046,7 @@
       "window": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/window",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-dev",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Cross-Origin-Embedder-Policy.json
+++ b/http/headers/Cross-Origin-Embedder-Policy.json
@@ -4,7 +4,7 @@
       "Cross-Origin-Embedder-Policy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy",
-          "spec_url": "https://html.spec.whatwg.org/multipage/origin.html#coep",
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#coep",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -38,7 +38,7 @@
         },
         "credentialless": {
           "__compat": {
-            "spec_url": "https://html.spec.whatwg.org/multipage/origin.html#coep-credentialless",
+            "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#coep-credentialless",
             "support": {
               "chrome": {
                 "version_added": "96"

--- a/http/headers/Cross-Origin-Opener-Policy.json
+++ b/http/headers/Cross-Origin-Opener-Policy.json
@@ -4,7 +4,7 @@
       "Cross-Origin-Opener-Policy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy",
-          "spec_url": "https://html.spec.whatwg.org/multipage/origin.html#the-coop-headers",
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#the-coop-headers",
           "support": {
             "chrome": {
               "version_added": "83"


### PR DESCRIPTION
These were found while trying to map spec URLs to spec in web-specs, as
these URLs aren't in there any longer.

Each URL was loaded in a browser to find the redirected URL and confirm
the target ID still exists.