### PR TITLE
Remove css.properties.box-sizing.padding-box from BCD

### DIFF
--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -155,40 +155,6 @@
               "deprecated": false
             }
           }
-        },
-        "padding-box": {
-          "__compat": {
-            "description": "<code>padding-box</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "50"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `padding-box` member of the `box-sizing` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/box-sizing/padding-box
