### PR TITLE
Update all browsers data for data-url HTTP feature

### DIFF
--- a/http/data-url.json
+++ b/http/data-url.json
@@ -7,7 +7,7 @@
         "spec_url": "https://www.rfc-editor.org/rfc/rfc2397#section-2",
         "support": {
           "chrome": {
-            "version_added": "≤59"
+            "version_added": "≤4"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -15,7 +15,7 @@
             "notes": "Before Edge 79, the maximum size supported is 4GB."
           },
           "firefox": {
-            "version_added": "≤53"
+            "version_added": "≤2"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -31,7 +31,7 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": "≤10.1"
+            "version_added": "≤3.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -48,14 +48,14 @@
           "description": "CSS files",
           "support": {
             "chrome": {
-              "version_added": "≤59"
+              "version_added": "≤4"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "≤53"
+              "version_added": "≤2"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -67,7 +67,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤10.1"
+              "version_added": "≤3.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -85,12 +85,12 @@
           "description": "HTML files",
           "support": {
             "chrome": {
-              "version_added": "≤59"
+              "version_added": "≤4"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤53"
+              "version_added": "≤2"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -100,7 +100,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤10.1"
+              "version_added": "≤3.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -118,14 +118,14 @@
           "description": "JavaScript files",
           "support": {
             "chrome": {
-              "version_added": "≤59"
+              "version_added": "≤4"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "≤53"
+              "version_added": "≤2"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -137,7 +137,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤10.1"
+              "version_added": "≤3.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -7,7 +7,7 @@
         "spec_url": "https://www.rfc-editor.org/rfc/rfc2397#section-2",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "≤59"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -15,7 +15,7 @@
             "notes": "Before Edge 79, the maximum size supported is 4GB."
           },
           "firefox": {
-            "version_added": true
+            "version_added": "≤53"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -31,7 +31,7 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": true
+            "version_added": "≤10.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -48,14 +48,14 @@
           "description": "CSS files",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤59"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "≤53"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -67,7 +67,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -85,14 +85,12 @@
           "description": "HTML files",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤59"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "≤53"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -102,7 +100,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -120,14 +118,14 @@
           "description": "JavaScript files",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤59"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "≤53"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -139,7 +137,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `data-url` HTTP feature. This replaces the `true` values with ranges inferred by when the feature was introduced in BCD (#231).
