### PR TITLE
Chromium 125 adds Attribution Reporting API support

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -87,7 +87,7 @@
           "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-htmlattributionsrcelementutils-attributionsrc",
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -170,7 +170,7 @@
           "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-htmlattributionsrcelementutils-attributionsrc",
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -87,7 +87,7 @@
           "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-htmlattributionsrcelementutils-attributionsrc",
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Request.json
+++ b/api/Request.json
@@ -141,7 +141,7 @@
             "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-requestinit-attributionreporting",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "125"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -3286,7 +3286,7 @@
             "description": "<code>features</code> parameter accepts <code>\"attributionsrc\"</code> value",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "125"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1456,7 +1456,7 @@
           "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-xmlhttprequest-setattributionreporting",
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -123,7 +123,7 @@
           "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-requestinit-attributionreporting",
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -75,7 +75,7 @@
             "spec_url": "https://wicg.github.io/attribution-reporting-api/#element-attrdef-a-attributionsrc",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "125"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -179,7 +179,7 @@
             "spec_url": "https://wicg.github.io/attribution-reporting-api/#element-attrdef-img-attributionsrc",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "125"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -83,7 +83,7 @@
             "spec_url": "https://wicg.github.io/attribution-reporting-api/#element-attrdef-script-attributionsrc",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "125"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `attributionSrc` member of various APIs. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLAnchorElement/attributionSrc
