### PR TITLE
Update Chromium data for NotRestoredReasons API

### DIFF
--- a/api/NotRestoredReasonDetails.json
+++ b/api/NotRestoredReasonDetails.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#notrestoredreasondetails",
         "support": {
           "chrome": {
-            "version_added": "123"
+            "version_added": "125"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -39,7 +39,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reason-details-reason",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -72,7 +72,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NotRestoredReasonDetails/toJSON",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/NotRestoredReasons.json
+++ b/api/NotRestoredReasons.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#notrestoredreasons",
         "support": {
           "chrome": {
-            "version_added": "123"
+            "version_added": "125"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -39,7 +39,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reasons-children",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -73,7 +73,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reasons-id",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -107,7 +107,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reasons-name",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -141,7 +141,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reasons-reasons",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -175,7 +175,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reasons-src",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -208,7 +208,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NotRestoredReasons/toJSON",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -242,7 +242,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reasons-url",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -340,7 +340,7 @@
           "spec_url": "https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-notrestoredreasons",
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `NotRestoredReasons` API and related interfaces/properties/methods. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/NotRestoredReasons
