### PR TITLE
Update Safari data for api.Response.Response.accept_readablestream

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -119,7 +119,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
               "safari_ios": {
                 "version_added": "10.3"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `Response.accept_readablestream` member of the `Response` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Response/Response/accept_readablestream
