### PR TITLE
Update Firefox data for javascript.builtins.DataView.DataView.sharedarraybuffer_support

### DIFF
--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -120,7 +120,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "78"
+                  "version_added": "79"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `DataView.sharedarraybuffer_support` member of the `DataView` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/DataView/DataView/sharedarraybuffer_support
