### PR TITLE
Update Chromium data for javascript.builtins.FinalizationRegistry.symbol_as_target

### DIFF
--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -138,7 +138,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "109"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `symbol_as_target` member of the `FinalizationRegistry` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/FinalizationRegistry/symbol_as_target
