### PR TITLE
Update Chromium data for javascript.builtins.Intl.Collator.Collator.options_collation_parameter

### DIFF
--- a/javascript/builtins/Intl/Collator.json
+++ b/javascript/builtins/Intl/Collator.json
@@ -145,7 +145,7 @@
                 "description": "<code>options.collation</code> parameter",
                 "support": {
                   "chrome": {
-                    "version_added": "87"
+                    "version_added": "86"
                   },
                   "chrome_android": "mirror",
                   "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Collator.Collator.options_collation_parameter` member of the `Intl` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Intl/Collator/Collator/options_collation_parameter
