### PR TITLE
Update Chromium data for javascript.builtins.Intl.PluralRules.PluralRules.options_parameter

### DIFF
--- a/javascript/builtins/Intl/PluralRules.json
+++ b/javascript/builtins/Intl/PluralRules.json
@@ -98,7 +98,7 @@
                 "description": "<code>options</code> parameter",
                 "support": {
                   "chrome": {
-                    "version_added": false
+                    "version_added": "106"
                   },
                   "chrome_android": "mirror",
                   "deno": {
@@ -125,7 +125,7 @@
                   "webview_android": "mirror"
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
                 }
@@ -173,7 +173,7 @@
                   "description": "<code>options.roundingMode</code> parameter",
                   "support": {
                     "chrome": {
-                      "version_added": false
+                      "version_added": "117"
                     },
                     "chrome_android": "mirror",
                     "deno": {
@@ -200,7 +200,7 @@
                     "webview_android": "mirror"
                   },
                   "status": {
-                    "experimental": true,
+                    "experimental": false,
                     "standard_track": true,
                     "deprecated": false
                   }
@@ -211,7 +211,7 @@
                   "description": "<code>options.roundingPriority</code> parameter",
                   "support": {
                     "chrome": {
-                      "version_added": false
+                      "version_added": "106"
                     },
                     "chrome_android": "mirror",
                     "deno": {
@@ -238,7 +238,7 @@
                     "webview_android": "mirror"
                   },
                   "status": {
-                    "experimental": true,
+                    "experimental": false,
                     "standard_track": true,
                     "deprecated": false
                   }


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PluralRules.PluralRules.options_parameter` member of the `Intl` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Intl/PluralRules/PluralRules/options_parameter
