### PR TITLE
Update Chromium data for Weak[Map/Ref/Set] JavaScript builtins

### DIFF
--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -373,7 +373,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "109"
               },
               "chrome_android": "mirror",
               "deno": {

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -138,7 +138,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "109"
               },
               "chrome_android": "mirror",
               "deno": {

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -322,7 +322,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "109"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WeakMap`, `WeakRef` and `WeakSet` JavaScript builtins. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/WeakMap/symbol_as_keys
https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/WeakRef/symbol_as_target
https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/WeakSet/symbol_as_keys
