### PR TITLE
Update Chrome/Safari data for api.ResizeObserver.observe.options_box_parameter

### DIFF
--- a/api/ResizeObserver.json
+++ b/api/ResizeObserver.json
@@ -140,8 +140,7 @@
             "description": "<code>options.box</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "64",
-                "notes": "Before version 84, the <code>device-pixel-content-box</code> value is not supported."
+                "version_added": "84"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -157,7 +156,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "13.1"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `observe.options_box_parameter` member of the `ResizeObserver` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ResizeObserver/observe/options_box_parameter

Additional Notes: The feature was added in #12373, but no supporting documentation was provided to show the parameter was supported in those browser versions. The collector tests with `content-box` as well.
