### PR TITLE
Update Chromium data for css.properties.display.ruby

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -747,7 +747,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "121"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -852,7 +852,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "121"
               },
               "chrome_android": "mirror",
               "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ruby` member of the `display` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/display/ruby
