### PR TITLE
Update Chromium data for closed CSS selector

### DIFF
--- a/css/selectors/closed.json
+++ b/css/selectors/closed.json
@@ -8,6 +8,7 @@
           "support": {
             "chrome": {
               "version_added": "114",
+              "version_removed": "122",
               "partial_implementation": true,
               "notes": "The selector is recognized, but has no effect."
             },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `closed` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/closed
