### PR TITLE
Update Chromium data for css.types.length.cap

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -84,7 +84,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "118"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -348,7 +348,7 @@
             "spec_url": "https://drafts.csswg.org/css-values/#rcap",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "118"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `cap` member of the `length` CSS value type. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/types/length/cap
