### PR TITLE
Update Safari data for css.types.overflow.overlay

### DIFF
--- a/css/types/overflow.json
+++ b/css/types/overflow.json
@@ -113,7 +113,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `overlay` member of the `overflow` CSS value type. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/types/overflow/overlay
