### PR TITLE
Fix script: remove non-existent folder

### DIFF
--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -75,7 +75,6 @@ if (esMain(import.meta)) {
       'svg',
       'javascript',
       'mathml',
-      'test',
       'webassembly',
       'webdriver',
       'webextensions',


### PR DESCRIPTION
Apparently, when I first introduced this script, I included the `test` folder in the list of folders to run from.  Now that the folder has been renamed, the fix script is throwing a warning.  This PR removes the bad line.

(This will be self-merged since it is a super small change involving infrastructure.)
