### PR TITLE
Update Deno data for Location API

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -10,7 +10,13 @@
           },
           "chrome_android": "mirror",
           "deno": {
-            "version_added": "1.7"
+            "version_added": "1.7",
+            "flags": [
+              {
+                "type": "runtime_flag",
+                "name": "--location [url]"
+              }
+            ]
           },
           "edge": {
             "version_added": "12"
@@ -136,7 +142,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -179,7 +191,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -222,7 +240,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -265,7 +289,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -308,7 +338,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -351,7 +387,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -396,7 +438,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -439,7 +487,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -570,7 +624,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"
@@ -614,7 +674,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.7"
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ]
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `Location` API. The `runtime-compat-data` project's results stated that Deno did not support this API, but upon further research, it is supported as long as a runtime flag is passed (see https://docs.deno.com/runtime/manual/runtime/location_api#location-api).
