### PR TITLE
Update Deno data for api.URL.parse_static

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -450,6 +450,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.43"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "126"


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `parse` static method of the `URL` API. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

URL.parse()

```

Additional Notes: The Deno docs don't mention the feature, so the version number had to be manually determined.
