### PR TITLE
Update Deno data for Event API

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -750,7 +750,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.8"
             },
             "edge": {
               "version_added": "12"
@@ -800,7 +800,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.8"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `Event` API. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

Event.prototype.returnValue; Event.prototype.srcElement;

```

Additional Notes: These two features aren't mentioned in the Deno API documentation, so version numbers had to be manually tracked down.
