### PR TITLE
Update Deno data for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -478,7 +478,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.2"
               },
               "edge": "mirror",
               "firefox": {
@@ -517,7 +517,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.2"
               },
               "edge": "mirror",
               "firefox": {
@@ -611,7 +611,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.2"
               },
               "edge": "mirror",
               "firefox": {
@@ -650,7 +650,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.2"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `Performance` API. The data comes from the Deno docs: https://deno.land/api@v1.2.3?s=Performance
