### PR TITLE
Update NodeJS data for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -489,7 +489,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "16.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -528,7 +528,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.5.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -622,7 +622,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "16.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -661,7 +661,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.5.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `Performance` API. The version numbers were obtained by scouring the Node.js docs: https://nodejs.org/docs/latest/api/perf_hooks.html
