### PR TITLE
Add Safari and Firefox bug links for the CSS Painting API

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1486,7 +1486,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1302328"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1496,7 +1497,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/190217"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -11,7 +11,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1302328"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -21,7 +22,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://webkit.org/b/190217"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -44,7 +46,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1302328"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -54,7 +57,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/190217"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -78,7 +82,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1302328"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -88,7 +93,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/190217"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -2144,7 +2144,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1302328"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2154,7 +2155,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/190217"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
@@ -2178,7 +2180,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                "impl_url": "https://bugzil.la/1302328"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2188,7 +2191,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                "impl_url": "https://webkit.org/b/190217"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -2181,7 +2181,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                "impl_url": "https://bugzil.la/1302328"
+                  "impl_url": "https://bugzil.la/1302328"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2192,7 +2192,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                "impl_url": "https://webkit.org/b/190217"
+                  "impl_url": "https://webkit.org/b/190217"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds links to the WebKit and Mozilla bug tracker entries for the various CSS Painting API entry points.

#### Test results and supporting details

There aren't that many places in BCD where these links need to be added: the `CSS.paintWorklet` static property, the `paint()` CSS function, and the `PaintWorkletGlobalScope` object (which is quite limited).

The entry point to load a paint worklet module (`CSS.paintWorklet.addModule`) is not part of the CSS Painting API, it's part of the more general Worklets spec, which supports Audio as well, and which is already implemented in Safari and Firefox anyway.

And then, the directives to actually do the painting from within the worklet are canvas.

#### Related issues

These are the bug url I found:

* Firefox: https://bugzil.la/1302328
* Safari: https://webkit.org/b/190217

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
