### PR TITLE
Update NodeJS data for PerformanceObserver API

### DIFF
--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -167,9 +167,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "8.5.0",
-              "partial_implementation": true,
-              "notes": "Exported from the <code>perf_hooks</code> module"
+              "version_added": "8.5.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -281,7 +279,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `PerformanceObserver` API. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

const perf = require('node:perf_hooks'); perf.PerformanceObserver.prototype.takeRecords;

```
