### PR TITLE
Update Deno data for api.ReadableStream.values

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -427,6 +427,9 @@
               "version_added": "124"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.35"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "110"


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `values` member of the `ReadableStream` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ReadableStream/values

Additional Notes: Exact version was tracked down from the docs: https://deno.land/api@v1.35.0?s=ReadableStream#method_values_6
