### PR TITLE
Update Deno data for api.Response.type

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -906,7 +906,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `type` member of the `Response` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Response/type

Additional Notes: https://deno.land/api@v1.0.0?s=Response#prop_type
