### PR TITLE
Update Deno data for javascript.builtins.DataView.getFloat16

### DIFF
--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -399,7 +399,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.43"
               },
               "edge": "mirror",
               "firefox": {
@@ -943,7 +943,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.43"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/Float16Array.json
+++ b/javascript/builtins/Float16Array.json
@@ -14,7 +14,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.43"
             },
             "edge": "mirror",
             "firefox": {
@@ -64,7 +64,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.43"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1161,7 +1161,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.43"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `getFloat16` member of the `DataView` JavaScript builtin. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

DataView.prototype.getFloat16

```
