### PR TITLE
Add spec links for assorted HTML attributes

### DIFF
--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -87,6 +87,7 @@
         },
         "form": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -121,6 +122,7 @@
         },
         "name": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name",
             "support": {
               "chrome": {
                 "version_added": "19"

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -38,6 +38,7 @@
         },
         "accept-charset": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#attr-form-accept-charset",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -72,6 +73,7 @@
         },
         "action": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -106,6 +108,7 @@
         },
         "autocomplete": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#attr-form-autocomplete",
             "support": {
               "chrome": {
                 "version_added": "14",
@@ -141,6 +144,7 @@
         },
         "enctype": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-enctype",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -175,6 +179,7 @@
         },
         "method": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -209,6 +214,7 @@
         },
         "name": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#attr-form-name",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -243,6 +249,7 @@
         },
         "novalidate": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-novalidate",
             "support": {
               "chrome": {
                 "version_added": "10"
@@ -279,6 +286,7 @@
         },
         "rel": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#attr-form-rel",
             "support": {
               "chrome": {
                 "version_added": "108"
@@ -311,6 +319,7 @@
         },
         "target": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-target",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/li.json
+++ b/html/elements/li.json
@@ -82,6 +82,7 @@
         },
         "value": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#attr-li-value",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -42,6 +42,7 @@
         },
         "charset": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -76,6 +77,7 @@
         },
         "content": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -114,6 +116,7 @@
         },
         "http-equiv": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -151,6 +154,7 @@
           },
           "content-language": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-content-language",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -185,6 +189,7 @@
           },
           "content-security-policy": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-content-security-policy",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -219,6 +224,7 @@
           },
           "content-type": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-content-type",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -253,6 +259,7 @@
           },
           "refresh": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-refresh",
               "support": {
                 "chrome": {
                   "version_added": "1"
@@ -291,6 +298,7 @@
           },
           "set-cookie": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-set-cookie",
               "support": {
                 "chrome": {
                   "version_added": true,
@@ -375,6 +383,7 @@
           },
           "color-scheme": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme",
               "support": {
                 "chrome": {
                   "version_added": "81"
@@ -409,6 +418,7 @@
           },
           "referrer": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer",
               "support": {
                 "chrome": {
                   "version_added": "17",

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -46,6 +46,7 @@
         },
         "high": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-high",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -88,6 +89,7 @@
         },
         "low": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-low",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -218,6 +220,7 @@
         },
         "optimum": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-optimum",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -260,6 +263,7 @@
         },
         "value": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-value",
             "support": {
               "chrome": {
                 "version_added": "6"

--- a/html/elements/ol.json
+++ b/html/elements/ol.json
@@ -72,6 +72,7 @@
         },
         "reversed": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#attr-ol-reversed",
             "support": {
               "chrome": {
                 "version_added": "18"
@@ -106,6 +107,7 @@
         },
         "start": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#attr-ol-start",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -140,6 +142,7 @@
         },
         "type": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#attr-ol-type",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/optgroup.json
+++ b/html/elements/optgroup.json
@@ -74,6 +74,7 @@
         },
         "label": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-optgroup-label",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/option.json
+++ b/html/elements/option.json
@@ -74,6 +74,7 @@
         },
         "label": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-option-label",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -116,6 +117,7 @@
         },
         "selected": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-option-selected",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -150,6 +152,7 @@
         },
         "value": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-option-value",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/output.json
+++ b/html/elements/output.json
@@ -82,6 +82,7 @@
         },
         "form": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form",
             "support": {
               "chrome": {
                 "version_added": "10"
@@ -120,6 +121,7 @@
         },
         "name": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name",
             "support": {
               "chrome": {
                 "version_added": "10"

--- a/html/elements/progress.json
+++ b/html/elements/progress.json
@@ -91,6 +91,7 @@
         },
         "value": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-progress-value",
             "support": {
               "chrome": {
                 "version_added": "6"

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -90,6 +90,7 @@
         },
         "form": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -208,6 +209,7 @@
         },
         "name": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
The URLs were found by following the spec link for the element and
clicking on the attribute.