### PR TITLE
Update Deno data for Location API

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -60,7 +60,14 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ],
+              "notes": "This value is always empty in Deno."
             },
             "edge": "mirror",
             "firefox": {
@@ -97,7 +104,15 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "This method exists but has no effect in Deno. A location can be assigned using the <code>--location</code> runtime flag."
             },
             "edge": {
               "version_added": "12"
@@ -536,7 +551,15 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "This method exists but has no effect in Deno."
             },
             "edge": {
               "version_added": "12",
@@ -581,7 +604,15 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.7",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--location [url]"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "This method exists but has no effect in Deno. A location can be assigned using the <code>--location</code> runtime flag."
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `Location` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7), using results collected via [UnJS' runtime-compat project](https://github.com/unjs/runtime-compat).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Location

Additional Notes: Version numbers and notes come from Deno docs: https://deno.land/api@v1.7.0?s=Location
