### PR TITLE
Remove Only supports explicit note on cookies.sameSiteStatus for Safari

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -79,12 +79,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "14",
-                  "notes": "Only supports explicit."
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": "15",
-                  "notes": "Only supports explicit."
+                  "version_added": "15"
                 }
               }
             }


### PR DESCRIPTION
#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20853
