### PR TITLE
Update Safari versions for TypedArray

### DIFF
--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -398,7 +398,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -444,7 +444,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -490,7 +490,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -536,7 +536,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -582,7 +582,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -628,7 +628,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -674,7 +674,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1006,7 +1006,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1096,7 +1096,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1289,7 +1289,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1440,7 +1440,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
These 11 entries are changed by collector results:
https://github.com/openwebdocs/mdn-bcd-results/pull/1098
https://github.com/openwebdocs/mdn-bcd-results/pull/1099

The collector shows no support in Safari 9.1 and support in 10.1, so
source archeology was needed to decide between Safari 10 and 10.1.

The 10 methods `copyWithin()`, `entries()`, `every()`, `fill()`,
`filter()`, `find()`, `findIndex()`, `indexOf()`, `join()`, and `map()`
were added in WebKit 602.1.6:

https://github.com/WebKit/WebKit/commit/881b0bfc93b6e6394676fbf712681792d72b2afa
https://github.com/WebKit/WebKit/blob/881b0bfc93b6e6394676fbf712681792d72b2afa/Source/WebCore/Configurations/Version.xcconfig

(See `JSTypedArrayViewPrototype::finishCreation`.)

The static `of()` was added in WebKit 602.1.7:
https://github.com/WebKit/WebKit/commit/6fa0cb524bcdd5091d1525846064f85782b9f0dd
https://github.com/WebKit/WebKit/blob/6fa0cb524bcdd5091d1525846064f85782b9f0dd/Source/WebCore/Configurations/Version.xcconfig

Both of those WebKit versions map to Safari 10.

The Safari 9.1 data came from https://github.com/mdn/browser-compat-data/pull/6480.
That points to first commit above, but must have mapped it to a Safari 
version incorrectly.

Note that some of the data was already set to Safari 10 going back to
https://github.com/mdn/browser-compat-data/pull/351.