### PR TITLE
Remove @@species from web-features Map/Set/Promise

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -806,7 +806,6 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map-@@species",
             "tags": [
-              "web-features:map",
               "web-features:snapshot:ecmascript-2015"
             ],
             "support": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -603,7 +603,6 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species",
             "tags": [
-              "web-features:promise",
               "web-features:snapshot:ecmascript-2015"
             ],
             "support": {

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -1011,7 +1011,6 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set-@@species",
             "tags": [
-              "web-features:set",
               "web-features:snapshot:ecmascript-2015"
             ],
             "support": {


### PR DESCRIPTION
Symbol.species is newer than any of these features, and is probably best
thought of as a cross-cutting feature. The BCD entries for @@species on
Array, ArrayBuffer, RegExp, SharedArrayBuffer, and TypedArray aren't
assigned to any web-features feature (but are in a snapshot).