### PR TITLE
Update Opera data for Accept-CH-Lifetime HTTP header

### DIFF
--- a/http/headers/Accept-CH-Lifetime.json
+++ b/http/headers/Accept-CH-Lifetime.json
@@ -21,9 +21,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `Accept-CH-Lifetime` HTTP header. The entire `Accept-CH` header has Opera Android set to mirror as well, so it only makes sense for this feature to mirror as well.
