### PR TITLE
Firefox 127: `calc()` can parse color components in Nightly

### DIFF
--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -78,6 +78,54 @@
             "deprecated": false
           }
         },
+        "color_component": {
+          "__compat": {
+            "description": "Color component support",
+            "tags": [
+              "web-features:calc"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "127",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.relative-color-syntax.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "gradient_color_stops": {
           "__compat": {
             "description": "Gradient color stops support",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

CSS [`calc()`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) function can parse color components in Firefox 127 nightly (`layout.css.relative-color-syntax.enabled`).

#### Test results and supporting details

- To test: Try the example in the [Using math functions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors#using_math_functions) section in Firefox 127 beta (behind perf) or in Firefox Nightly.
- Info about Chrome and Safari versions (relative colors): https://groups.google.com/a/mozilla.org/g/dev-platform/c/McZfEwrqce8/m/H_1JuPVAAQAJ

#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/33586
Firefox release note update: https://github.com/mdn/content/pull/34042
Content update: https://github.com/mdn/content/pull/34046
