### PR TITLE
Update all browsers data for Access-Control-Allow-Headers HTTP header

### DIFF
--- a/http/headers/Access-Control-Allow-Headers.json
+++ b/http/headers/Access-Control-Allow-Headers.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -96,9 +94,7 @@
               "firefox": {
                 "version_added": "69"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `Access-Control-Allow-Headers` HTTP header. This sets the mobile browsers to mirror, as it's very likely Chrome Android's support was introduced from the very beginning, and Firefox Android was set to false simply due to the 69-78 release gap.
