### PR TITLE
WebGL2RenderingContext.drawingBufferSpace - mdn link

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -3049,6 +3049,7 @@
       },
       "drawingBufferColorSpace": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawingBufferColorSpace",
           "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#DOM-WebGLRenderingContext-drawingBufferColorSpace",
           "support": {
             "chrome": {


### PR DESCRIPTION
Adds link in `WebGL2RenderingContext.drawingBufferSpace` entry to the `WebGLRenderingContext.drawingBufferColorSpace` doc on MDN.

Note, `WebGL2RenderingContext` is an extension of `WebGL2RenderingContext` so has all the same methods, but possibly with extra arguments. MDN does not "redocument" these so we have to link here (arguably we should at least list in the top page of `WebGL2RenderingContext` but we don't)

Follows on from #23198

Related docs work can be tracked in https://github.com/mdn/content/issues/33850