### PR TITLE
Add Deno versions for globals worker support

### DIFF
--- a/api/_globals/atob.json
+++ b/api/_globals/atob.json
@@ -58,7 +58,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "12"

--- a/api/_globals/btoa.json
+++ b/api/_globals/btoa.json
@@ -58,7 +58,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "12"

--- a/api/_globals/clearInterval.json
+++ b/api/_globals/clearInterval.json
@@ -59,7 +59,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "12"

--- a/api/_globals/clearTimeout.json
+++ b/api/_globals/clearTimeout.json
@@ -61,7 +61,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "12"

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -59,7 +59,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "12"

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -59,7 +59,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
This PR adds version numbers for Deno for the `worker_support` features of all the globals.  Considering when support was added into Chrome (and other browsers), it's safe to assume that Deno supported workers since the beginning.
