### PR TITLE
Set IE "true" to "≤11" for css/

### DIFF
--- a/css/properties/flood-color.json
+++ b/css/properties/flood-color.json
@@ -17,7 +17,7 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": true
+              "version_added": "≤11"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/css/properties/flood-opacity.json
+++ b/css/properties/flood-opacity.json
@@ -17,7 +17,7 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": true
+              "version_added": "≤11"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/css/properties/lighting-color.json
+++ b/css/properties/lighting-color.json
@@ -17,7 +17,7 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": true
+              "version_added": "≤11"
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
This PR replaces all instances where Internet Explorer says `true` with `≤11` for the `css/` category, so that we can forbid `true` values in the near future.