### PR TITLE
Mirror flexbox data for Firefox Android

### DIFF
--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -25,9 +25,7 @@
             "firefox": {
               "version_added": "28"
             },
-            "firefox_android": {
-              "version_added": "52"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -69,9 +67,7 @@
               "firefox": {
                 "version_added": "28"
               },
-              "firefox_android": {
-                "version_added": "52"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "11"
               },
@@ -106,9 +102,7 @@
               "firefox": {
                 "version_added": "28"
               },
-              "firefox_android": {
-                "version_added": "52"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "11"
               },
@@ -143,9 +137,7 @@
               "firefox": {
                 "version_added": "28"
               },
-              "firefox_android": {
-                "version_added": "52"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "11"
               },

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -42,20 +42,7 @@
                 "version_added": "49"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "20",
-                "notes": [
-                  "Since Firefox 28, multi-line flexbox is supported.",
-                  "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>.",
-                  "Until Firefox 61, flex items that are sized according to their content are sized using <a href='https://drafts.csswg.org/css-sizing-3/#column-sizing'>fit-content, not max-content</a>."
-                ]
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "11",


### PR DESCRIPTION
Firefox Android 52 is from wiki migration:
https://github.com/mdn/browser-compat-data/pull/437

It's implausible that this property alone would be different between
desktop and mobile.

The flex property can also be mirrored and will result only in minor
changes to the notes, the versions are already aligned.