### PR TITLE
added the support for firefox for relative color syntax

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -136,7 +136,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
@@ -407,7 +407,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
@@ -550,7 +550,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
@@ -664,7 +664,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
@@ -776,7 +776,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
@@ -1011,7 +1011,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
@@ -1123,7 +1123,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",
@@ -1312,7 +1312,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://bugzil.la/1701488"
                 },
                 "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

Added firefox support for relative color syntax

#### Test results and supporting details

Tested in FF Nightly 128
#### Related issues

- [Enable relative color syntax on nightly #33517](https://github.com/mdn/content/issues/33517)
- [Firefox Experimental release not PR](https://github.com/mdn/content/pull/34053)