### PR TITLE
Set downstream browsers to mirror when true/null/inaccurate

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -378,9 +378,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": true
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "12.1"
               },

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -193,12 +193,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "12.1"
               },

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -765,9 +765,7 @@
                 "chrome": {
                   "version_added": "46"
                 },
-                "chrome_android": {
-                  "version_added": true
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": "≤79"
                 },
@@ -780,17 +778,13 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": null
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "46"
-                }
+                "webview_android": "mirror"
               },
               "status": {
                 "experimental": false,

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -318,12 +318,8 @@
                   "version_added": "≤11"
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": true
                 },

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -524,10 +524,7 @@
                 "version_added": "3",
                 "notes": "Defaults to <code>metadata</code> in Chrome 64."
               },
-              "chrome_android": {
-                "version_added": true,
-                "notes": "Defaults to <code>metadata</code> in Chrome 64."
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -539,14 +536,8 @@
                 "version_added": "9"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true,
-                "notes": "Defaults to <code>metadata</code> in Opera 51."
-              },
-              "opera_android": {
-                "version_added": true,
-                "notes": "Defaults to <code>metadata</code> in Opera 51."
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "3.1"
               },

--- a/http/headers/Access-Control-Allow-Credentials.json
+++ b/http/headers/Access-Control-Allow-Credentials.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },

--- a/http/headers/Access-Control-Allow-Methods.json
+++ b/http/headers/Access-Control-Allow-Methods.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },

--- a/http/headers/Access-Control-Allow-Origin.json
+++ b/http/headers/Access-Control-Allow-Origin.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },

--- a/http/headers/Access-Control-Expose-Headers.json
+++ b/http/headers/Access-Control-Expose-Headers.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },

--- a/http/headers/Access-Control-Max-Age.json
+++ b/http/headers/Access-Control-Max-Age.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },

--- a/http/headers/Access-Control-Request-Headers.json
+++ b/http/headers/Access-Control-Request-Headers.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },

--- a/http/headers/Access-Control-Request-Method.json
+++ b/http/headers/Access-Control-Request-Method.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },

--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -9,25 +9,19 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "1"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": true
@@ -52,25 +46,19 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "1"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": true

--- a/http/headers/Content-Security-Policy-Report-Only.json
+++ b/http/headers/Content-Security-Policy-Report-Only.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "25"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "14"
             },
@@ -24,9 +22,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "7"
             },

--- a/http/headers/Content-Security-Policy-Report-Only.json
+++ b/http/headers/Content-Security-Policy-Report-Only.json
@@ -28,9 +28,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "4.4"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -15,9 +15,7 @@
                 "version_added": "14"
               }
             ],
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "14"
             },
@@ -105,9 +103,7 @@
               "chrome": {
                 "version_added": "40"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "35"
@@ -178,9 +174,7 @@
               "chrome": {
                 "version_added": "40"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "15"
               },
@@ -218,9 +212,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -265,9 +257,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -337,9 +327,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -375,9 +363,7 @@
               "chrome": {
                 "version_added": "40"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "15"
               },
@@ -415,9 +401,7 @@
               "chrome": {
                 "version_added": "40"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "15"
               },
@@ -473,9 +457,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -511,9 +493,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -585,9 +565,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -658,9 +636,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -879,9 +855,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -954,9 +928,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -992,9 +964,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },
@@ -1237,9 +1207,7 @@
               "chrome": {
                 "version_added": "25"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "14"
               },

--- a/http/headers/DNT.json
+++ b/http/headers/DNT.json
@@ -8,34 +8,25 @@
             "chrome": {
               "version_added": "23"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "9"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "6",
               "version_removed": "12.1"
             },
-            "safari_ios": {
-              "version_added": true,
-              "version_removed": "12.2"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/http/headers/Proxy-Authenticate.json
+++ b/http/headers/Proxy-Authenticate.json
@@ -9,25 +9,19 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "≤79"
             },
             "firefox": {
               "version_added": "1"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": null
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": null

--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -45,9 +45,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -70,9 +68,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/http/headers/Strict-Transport-Security.json
+++ b/http/headers/Strict-Transport-Security.json
@@ -16,9 +16,7 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "11"
             },
@@ -27,7 +25,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari": {
               "version_added": "7"

--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -9,25 +9,19 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "1"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": true
@@ -52,25 +46,19 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "1"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": true

--- a/http/headers/X-Content-Type-Options.json
+++ b/http/headers/X-Content-Type-Options.json
@@ -16,16 +16,7 @@
                 "notes": "Not supported for stylesheets."
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "64"
-              },
-              {
-                "version_added": true,
-                "partial_implementation": true,
-                "notes": "Not supported for stylesheets."
-              }
-            ],
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -37,12 +28,8 @@
               "version_added": "8"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11"
             },

--- a/http/headers/X-DNS-Prefetch-Control.json
+++ b/http/headers/X-DNS-Prefetch-Control.json
@@ -20,22 +20,14 @@
               "version_added": null
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/http/headers/X-Frame-Options.json
+++ b/http/headers/X-Frame-Options.json
@@ -9,18 +9,14 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "8"
             },
@@ -32,9 +28,7 @@
             "safari": {
               "version_added": "4"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -68,9 +62,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -107,19 +99,12 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": true,
-                "notes": "Starting in Opera 48, this applies to all of a frame's ancestors."
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": true
               },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {

--- a/http/headers/X-XSS-Protection.json
+++ b/http/headers/X-XSS-Protection.json
@@ -9,10 +9,7 @@
               "version_added": "4",
               "version_removed": "78"
             },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "78"
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12",
               "version_removed": "17"
@@ -25,10 +22,7 @@
               "version_added": "8"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true,
-              "version_removed": "65"
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": true,

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -2030,12 +2030,8 @@
               "version_added": "9"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },
@@ -3140,12 +3136,8 @@
               "version_added": "9"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },


### PR DESCRIPTION
This PR updates a number of features to mirror from upstream when the downstream browsers are set to `true` or `null`, particularly for mobile browsers.  This also handles a few cases where the downstream is clearly incorrect, such as Opera or WebView data.
