### PR TITLE
Importmap integrity - Update Safari status based on Beta announcements

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -628,7 +628,7 @@
                   "opera": "mirror",
                   "opera_android": "mirror",
                   "safari": {
-                    "version_added": 18
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -628,7 +628,7 @@
                   "opera": "mirror",
                   "opera_android": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": 18
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Update Safari's status for importmap integrity, based on the [Beta announcement](https://www.webkit.org/blog/15443/news-from-wwdc24-webkit-in-safari-18-beta/#:~:text=WebKit%20for%20Safari%2018%20beta%20adds%20support%20for%20subresource%20integrity%20in%20imported%20module%20scripts%2C%20which%20gives%20cryptographic%20assurances%20about%20the%20integrity%20of%20contents%20of%20externally%2Dhosted%20module%20scripts.).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[wpt.fyi shows](https://wpt.fyi/results/import-maps?label=experimental&label=master&aligned) support in Safari Tech Preview 196.

I haven't tested Safari 18 manually, as it requires an OS install AFAICT.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
