### PR TITLE
Update Firefox Android data for AudioWorkletGlobalScope API

### DIFF
--- a/api/AudioWorkletGlobalScope.json
+++ b/api/AudioWorkletGlobalScope.json
@@ -13,9 +13,7 @@
           "firefox": {
             "version_added": "76"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -48,9 +46,7 @@
             "firefox": {
               "version_added": "76"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -84,9 +80,7 @@
             "firefox": {
               "version_added": "76"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -120,9 +114,7 @@
             "firefox": {
               "version_added": "76"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -156,9 +148,7 @@
             "firefox": {
               "version_added": "76"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `AudioWorkletGlobalScope` API. Scopes themselves aren't updated by the collector, so the data was pulled from `AudioWorkletNode`.
