### PR TITLE
Update Firefox Android data for api.DOMMatrix.worker_support

### DIFF
--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -268,9 +268,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `worker_support` member of the `DOMMatrix` API. This seemed to be a desync from when Firefox Android releases had paused.
