### PR TITLE
Update Firefox Android data for api.DOMPoint.worker_support

### DIFF
--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -80,9 +80,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `worker_support` member of the `DOMPoint` API. This seemed to be a desync when Firefox Android releases were paused.
