### PR TITLE
Update Firefox Android data for api.DOMRect.worker_support

### DIFF
--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -138,9 +138,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -143,9 +143,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `worker_support` member of the `DOMRect` API. This appears to have been a desync from when Firefox Android releases were paused.
