### PR TITLE
Update Firefox Android data for api.Element.animate

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -272,9 +272,7 @@
               "firefox": {
                 "version_added": "75"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -412,9 +410,7 @@
               "firefox": {
                 "version_added": "75"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `animate` member of the `Element` API. This appears to be caused by a desync from when Firefox Android releases were paused.
