### PR TITLE
Set Firefox Android to mirror when Firefox Desktop is 69-78

### DIFF
--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -268,9 +268,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -80,9 +80,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -138,9 +138,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -143,9 +143,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/Element.json
+++ b/api/Element.json
@@ -272,9 +272,7 @@
               "firefox": {
                 "version_added": "75"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -412,9 +410,7 @@
               "firefox": {
                 "version_added": "75"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -92,9 +92,7 @@
               "firefox": {
                 "version_added": "76"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -395,9 +395,7 @@
               "firefox": {
                 "version_added": "70"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -63,9 +63,7 @@
             "firefox": {
               "version_added": "75"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -56,9 +56,7 @@
               "version_added": "42",
               "version_removed": "73"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "11",
               "notes": "Only works on Windows 8+."

--- a/http/headers/Access-Control-Allow-Methods.json
+++ b/http/headers/Access-Control-Allow-Methods.json
@@ -56,9 +56,7 @@
               "firefox": {
                 "version_added": "69"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/http/headers/Access-Control-Expose-Headers.json
+++ b/http/headers/Access-Control-Expose-Headers.json
@@ -56,9 +56,7 @@
               "firefox": {
                 "version_added": "69"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/http/headers/Cross-Origin-Resource-Policy.json
+++ b/http/headers/Cross-Origin-Resource-Policy.json
@@ -20,9 +20,7 @@
             "firefox": {
               "version_added": "74"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/http/headers/Referer.json
+++ b/http/headers/Referer.json
@@ -48,9 +48,7 @@
               "firefox": {
                 "version_added": "70"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -2023,9 +2023,7 @@
             "firefox": {
               "version_added": "73"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "9"
             },
@@ -2958,9 +2956,7 @@
             "firefox": {
               "version_added": "77"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": null
             },
@@ -3133,9 +3129,7 @@
             "firefox": {
               "version_added": "73"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "9"
             },


### PR DESCRIPTION
This PR sets Firefox Android to mirror from its desktop counterpart, when Firefox Desktop is set to 68-79.  This fixes the desync when Firefox Android releases were paused.
