### PR TITLE
Updates for Firefox 128 beta

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -148,6 +148,40 @@
           }
         }
       },
+      "bytes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/bytes",
+          "spec_url": "https://w3c.github.io/FileAPI/#dom-blob-bytes",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "128"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/size",

--- a/api/Element.json
+++ b/api/Element.json
@@ -5524,8 +5524,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1886630"
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5543,7 +5542,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2698,7 +2698,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "56"
+              "version_added": "56",
+              "version_removed": "128"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -193,7 +193,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -210,7 +210,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MediaKeys.json
+++ b/api/MediaKeys.json
@@ -85,7 +85,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -102,7 +102,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -141,6 +141,40 @@
           }
         }
       },
+      "bytes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushMessageData/bytes",
+          "spec_url": "https://w3c.github.io/push-api/#dom-pushmessagedata-bytes",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "128"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "json": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushMessageData/json",

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -365,7 +365,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -401,7 +401,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -187,11 +187,16 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": {
-                "version_added": "46",
-                "partial_implementation": true,
-                "notes": "The property is defined but not implemented/used."
-              },
+              "firefox": [
+                {
+                  "version_added": "128"
+                },
+                {
+                  "version_added": "46",
+                  "partial_implementation": true,
+                  "notes": "The property is defined but not implemented/used."
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -564,11 +569,16 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": {
-                "version_added": "46",
-                "partial_implementation": true,
-                "notes": "The property is defined but not implemented/used."
-              },
+              "firefox": [
+                {
+                  "version_added": "128"
+                },
+                {
+                  "version_added": "46",
+                  "partial_implementation": true,
+                  "notes": "The property is defined but not implemented/used."
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -351,7 +351,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -528,6 +528,43 @@
           }
         }
       },
+      "bytes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/bytes",
+          "spec_url": "https://fetch.spec.whatwg.org/#dom-body-bytes",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.44"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "128"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cache": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/cache",

--- a/api/Response.json
+++ b/api/Response.json
@@ -383,6 +383,43 @@
           }
         }
       },
+      "bytes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/bytes",
+          "spec_url": "https://fetch.spec.whatwg.org/#dom-body-bytes",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.44"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "128"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "clone": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/clone",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -350,8 +350,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1886630"
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -368,7 +367,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -603,7 +602,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "128"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -620,7 +619,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/align-tracks.json
+++ b/css/properties/align-tracks.json
@@ -16,15 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "77",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.grid-template-masonry-value.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1757446"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/justify-tracks.json
+++ b/css/properties/justify-tracks.json
@@ -16,15 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "77",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.grid-template-masonry-value.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1757446"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -90,21 +90,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "127",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.relative-color-syntax.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "128"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -123,14 +123,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "124",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.arraybuffer_resizable",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "128"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -315,14 +308,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "124",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.arraybuffer_resizable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -365,14 +351,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "124",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.arraybuffer_resizable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -415,14 +394,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "124",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.arraybuffer_resizable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -111,14 +111,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "124",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.sharedarraybuffer_growable",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "128"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -211,14 +204,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "124",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.sharedarraybuffer_growable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -263,14 +249,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "124",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.sharedarraybuffer_growable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -315,14 +294,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "124",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.sharedarraybuffer_growable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.7 found new features shipping in Firefox 128 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 37 features as shipping in Firefox 128:

- api.Blob.bytes
- api.CSS.registerProperty_static
- api.CSSPropertyRule
- api.CSSPropertyRule.inherits
- api.CSSPropertyRule.initialValue
- api.CSSPropertyRule.name
- api.CSSPropertyRule.syntax
- api.Element.getHTML
- api.HTMLMediaElement.seekToNextFrame (removal)
- api.HTMLTemplateElement.shadowRootSerializable
- api.MediaKeys.getStatusForPolicy
- api.PushMessageData.bytes
- api.RTCRtpReceiver.getParameters
- api.RTCRtpReceiver.getParameters.return_object_property_codecs
- api.RTCRtpSender.getParameters.return_object_property_codecs
- api.RTCRtpSender.setParameters.parameters_codecs_parameter
- api.RTCRtpTransceiver.setCodecPreferences
- api.Request.bytes
- api.Response.bytes
- api.ShadowRoot.getHTML
- api.ShadowRoot.serializable
- css.at-rules.property
- css.at-rules.property.inherits
- css.at-rules.property.initial-value
- css.at-rules.property.syntax
- css.properties.content.alt_text
- css.types.calc.color_component
- javascript.builtins.ArrayBuffer.ArrayBuffer.maxByteLength_option
- javascript.builtins.ArrayBuffer.maxByteLength
- javascript.builtins.ArrayBuffer.resizable
- javascript.builtins.ArrayBuffer.resize
- javascript.builtins.SharedArrayBuffer.SharedArrayBuffer.maxByteLength_option
- javascript.builtins.SharedArrayBuffer.grow
- javascript.builtins.SharedArrayBuffer.growable
- javascript.builtins.SharedArrayBuffer.maxByteLength
- webextensions.api.declarativeNetRequest.getDisabledRuleIds
- webextensions.api.declarativeNetRequest.updateStaticRules

See also https://github.com/mdn/mdn/issues/553 and https://www.mozilla.org/en-US/firefox/128.0beta/releasenotes/