### PR TITLE
Updates for Safari 18 beta

### DIFF
--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -24,7 +24,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -61,7 +61,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -98,7 +98,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Document.json
+++ b/api/Document.json
@@ -7250,14 +7250,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -955,7 +955,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -988,7 +988,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -5535,15 +5535,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/271343"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -158,7 +158,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -191,7 +191,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -549,14 +549,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -231,14 +231,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -927,8 +927,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/244117"
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -98,7 +98,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -132,7 +132,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -203,14 +203,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -253,14 +253,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -417,14 +417,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MediaSourceHandle.json
+++ b/api/MediaSourceHandle.json
@@ -21,14 +21,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -23,14 +23,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -57,14 +57,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -91,14 +91,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -348,7 +348,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "16.4",
+              "version_removed": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -96,14 +96,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/SVGAnimateColorElement.json
+++ b/api/SVGAnimateColorElement.json
@@ -28,7 +28,8 @@
             "version_removed": "21"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "18"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -361,14 +361,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -613,14 +613,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/URL.json
+++ b/api/URL.json
@@ -469,7 +469,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/VideoTrackGenerator.json
+++ b/api/VideoTrackGenerator.json
@@ -1,15 +1,11 @@
 {
   "api": {
-    "ViewTransition": {
+    "VideoTrackGenerator": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition",
-        "spec_url": "https://drafts.csswg.org/css-view-transitions/#viewtransition",
-        "tags": [
-          "web-features:view-transitions"
-        ],
+        "spec_url": "https://w3c.github.io/mediacapture-transform/#videotrackgenerator",
         "support": {
           "chrome": {
-            "version_added": "111"
+            "version_added": false
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -31,21 +27,18 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
       },
-      "finished": {
+      "VideoTrackGenerator": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition/finished",
-          "spec_url": "https://drafts.csswg.org/css-view-transitions/#dom-viewtransition-finished",
-          "tags": [
-            "web-features:view-transitions"
-          ],
+          "description": "<code>VideoTrackGenerator()</code> constructor",
+          "spec_url": "https://w3c.github.io/mediacapture-transform/#dom-videotrackgenerator-videotrackgenerator",
           "support": {
             "chrome": {
-              "version_added": "111"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -61,113 +54,6 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "18"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "ready": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition/ready",
-          "spec_url": "https://drafts.csswg.org/css-view-transitions/#dom-viewtransition-ready",
-          "tags": [
-            "web-features:view-transitions"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "111"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "18"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "skipTransition": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition/skipTransition",
-          "spec_url": "https://drafts.csswg.org/css-view-transitions/#dom-viewtransition-skiptransition",
-          "tags": [
-            "web-features:view-transitions"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "111"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "18"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "types": {
-        "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#dom-viewtransition-types",
-          "support": {
-            "chrome": {
-              "version_added": "125"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -180,16 +66,12 @@
           }
         }
       },
-      "updateCallbackDone": {
+      "muted": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition/updateCallbackDone",
-          "spec_url": "https://drafts.csswg.org/css-view-transitions/#dom-viewtransition-updatecallbackdone",
-          "tags": [
-            "web-features:view-transitions"
-          ],
+          "spec_url": "https://w3c.github.io/mediacapture-transform/#dom-videotrackgenerator-muted",
           "support": {
             "chrome": {
-              "version_added": "111"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -211,7 +93,73 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "track": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-transform/#dom-videotrackgenerator-track",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "18"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writable": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-transform/#dom-videotrackgenerator-writable",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "18"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -65,15 +65,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/246605"
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -273,8 +273,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -287,8 +287,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -294,8 +294,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/alt.json
+++ b/css/properties/alt.json
@@ -22,11 +22,13 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "9"
+                "version_added": "9",
+                "version_removed": "18"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "8"
+                "version_added": "8",
+                "version_removed": "18"
               }
             ],
             "safari_ios": "mirror",

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -33,10 +33,15 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "9"
-            },
+            "safari": [
+              {
+                "version_added": "18"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "9"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -57,7 +57,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -90,7 +90,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -127,14 +127,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -164,14 +164,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -197,7 +197,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/d.json
+++ b/css/properties/d.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18"
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/d.json
+++ b/css/properties/d.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/d.json
+++ b/css/properties/d.json
@@ -23,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false,
+              "notes": "The property parses, but has no effect."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -519,14 +519,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -556,14 +556,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -179,8 +179,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -88,7 +88,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/view-transition-name.json
+++ b/css/properties/view-transition-name.json
@@ -25,14 +25,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -57,14 +57,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/view-transition-group.json
+++ b/css/selectors/view-transition-group.json
@@ -26,14 +26,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/view-transition-image-pair.json
+++ b/css/selectors/view-transition-image-pair.json
@@ -26,14 +26,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/view-transition-new.json
+++ b/css/selectors/view-transition-new.json
@@ -26,14 +26,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/view-transition-old.json
+++ b/css/selectors/view-transition-old.json
@@ -26,14 +26,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/view-transition.json
+++ b/css/selectors/view-transition.json
@@ -26,14 +26,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The @openwebdocs [BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.7 found new features shipping in Safari 18 beta (20619.1.15.11.1) which was made available for beta testing this week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Safari TP and/or behind flags, it is not considered here.

With this PR, BCD considers the following 64 features as shipping in Safari 18:

- api.ContentVisibilityAutoStateChangeEvent
- api.ContentVisibilityAutoStateChangeEvent.ContentVisibilityAutoStateChangeEvent
- api.ContentVisibilityAutoStateChangeEvent.skipped
- api.Document.startViewTransition
- api.Element.ariaBrailleLabel
- api.Element.ariaBrailleRoleDescription
- api.Element.getHTML
- api.ElementInternals.ariaBrailleLabel
- api.ElementInternals.ariaBrailleRoleDescription
- api.GeolocationCoordinates.toJSON
- api.GeolocationPosition.toJSON
- api.HTMLCanvasElement.getContext.2d_context.options_willReadFrequently_parameter
- api.HTMLTemplateElement.shadowRootClonable
- api.HTMLTemplateElement.shadowRootDelegatesFocus
- api.HTMLTemplateElement.shadowRootSerializable
- api.MediaSource.canConstructInDedicatedWorker_static
- api.MediaSource.handle
- api.MediaSourceHandle
- api.MediaStreamTrackProcessor
- api.MediaStreamTrackProcessor.MediaStreamTrackProcessor
- api.MediaStreamTrackProcessor.readable
- api.OffscreenCanvasRenderingContext2D.commit (removal)
- api.PopStateEvent.hasUAVisualTransition
- api.SVGAnimateColorElement (removal)
- api.ShadowRoot.getHTML
- api.ShadowRoot.serializable
- api.URL.parse_static
- api.VideoTrackGenerator
- api.VideoTrackGenerator.VideoTrackGenerator
- api.VideoTrackGenerator.muted
- api.VideoTrackGenerator.track
- api.VideoTrackGenerator.writable
- api.ViewTransition
- api.ViewTransition.finished
- api.ViewTransition.ready
- api.ViewTransition.skipTransition
- api.ViewTransition.updateCallbackDone
- css.at-rules.container.style_queries_for_custom_properties
- css.properties.align-content.flex_context.safe_unsafe
- css.properties.align-items.flex_context.safe_unsafe
- css.properties.align-self.flex_context.safe_unsafe
- css.properties.alt (removal)
- css.properties.alt (-webkit- prefix) (removal)
- css.properties.backdrop-filter
- css.properties.content-visibility
- css.properties.content-visibility.auto
- css.properties.content-visibility.hidden
- css.properties.content-visibility.is_transitionable
- css.properties.content-visibility.keyframe_animatable
- css.properties.content-visibility.visible
- css.properties.d
- css.properties.display.is_transitionable
- css.properties.display.keyframe_animatable
- css.properties.justify-content.flex_context.safe_unsafe
- css.properties.offset-path.basic_shape
- css.properties.offset-path.coord_box
- css.properties.view-transition-name
- css.properties.view-transition-name.none
- css.selectors.view-transition-group
- css.selectors.view-transition-image-pair
- css.selectors.view-transition-new
- css.selectors.view-transition-old
- css.selectors.view-transition
- html.elements.script.type.importmap.integrity

See also https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes

I will run the collector again once there is a new beta for Safari 18, or if we see a final Safari 18 release.

cc @jdatapple @jensimmons 