### PR TITLE
Update Chrome/Safari data for html.elements.base.href.relative_url

### DIFF
--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -109,7 +109,7 @@
               "description": "Relative URIs.",
               "support": {
                 "chrome": {
-                  "version_added": "≤59"
+                  "version_added": "1"
                 },
                 "chrome_android": "mirror",
                 "edge": {
@@ -126,7 +126,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "≤10.1"
+                  "version_added": "3"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -109,7 +109,7 @@
               "description": "Relative URIs.",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "chrome_android": "mirror",
                 "edge": {
@@ -126,7 +126,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `href.relative_url` member of the `base` HTML element. This sets the version to be a range corresponding to the date the feature was first tracked in BCD (1e76c2ec4001b790ecfee95815c8b72663e47ee9).
