### PR TITLE
Updates for Chrome 127 beta

### DIFF
--- a/api/ChapterInformation.json
+++ b/api/ChapterInformation.json
@@ -1,20 +1,16 @@
 {
   "api": {
-    "RTCEncodedAudioFrame": {
+    "ChapterInformation": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame",
-        "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#ref-for-rtcencodedaudioframe%E2%91%A1",
-        "tags": [
-          "web-features:webrtc-encoded-transform"
-        ],
+        "spec_url": "https://w3c.github.io/mediasession/#chapterinformation",
         "support": {
           "chrome": {
-            "version_added": "86"
+            "version_added": "127"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "117"
+            "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
@@ -24,22 +20,21 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "15.4"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
       },
-      "RTCEncodedAudioFrame": {
+      "artwork": {
         "__compat": {
-          "description": "<code>RTCEncodedAudioFrame()</code> constructor",
-          "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframe-constructor",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-chapterinformation-artwork",
           "support": {
             "chrome": {
               "version_added": "127"
@@ -70,21 +65,17 @@
           }
         }
       },
-      "data": {
+      "startTime": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame/data",
-          "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframe-data",
-          "tags": [
-            "web-features:webrtc-encoded-transform"
-          ],
+          "spec_url": "https://w3c.github.io/mediasession/#dom-chapterinformation-starttime",
           "support": {
             "chrome": {
-              "version_added": "86"
+              "version_added": "127"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "117"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -94,34 +85,30 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.4"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "getMetadata": {
+      "title": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame/getMetadata",
-          "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframe-getmetadata",
-          "tags": [
-            "web-features:webrtc-encoded-transform"
-          ],
+          "spec_url": "https://w3c.github.io/mediasession/#dom-chapterinformation-title",
           "support": {
             "chrome": {
-              "version_added": "86"
+              "version_added": "127"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "117"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -131,51 +118,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.4"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "timestamp": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame/timestamp",
-          "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframe-timestamp",
-          "tags": [
-            "web-features:webrtc-encoded-transform"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "86"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "117"
-            },
-            "firefox_android": "mirror",
-            "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "15.4"
-            },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -117,6 +117,42 @@
           }
         }
       },
+      "info": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapter-info",
+          "support": {
+            "chrome": {
+              "version_added": "127",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isFallbackAdapter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter/isFallbackAdapter",

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -199,6 +199,41 @@
           }
         }
       },
+      "chapterInfo": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediametadata-chapterinfo",
+          "support": {
+            "chrome": {
+              "version_added": "127"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "title": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/title",

--- a/api/MutationEvent.json
+++ b/api/MutationEvent.json
@@ -6,7 +6,8 @@
         "spec_url": "https://w3c.github.io/uievents/#interface-mutationevent",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "1",
+            "version_removed": "127"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -45,7 +46,8 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-attrchange",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "127"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -85,7 +87,8 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-attrname",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "127"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -125,7 +128,8 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-initmutationevent",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "127"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -165,7 +169,8 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-newvalue",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "127"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -205,7 +210,8 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-prevvalue",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "127"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -245,7 +251,8 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-relatednode",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "127"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/RTCEncodedVideoFrame.json
+++ b/api/RTCEncodedVideoFrame.json
@@ -36,6 +36,40 @@
           "deprecated": false
         }
       },
+      "RTCEncodedVideoFrame": {
+        "__compat": {
+          "description": "<code>RTCEncodedVideoFrame()</code> constructor",
+          "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedvideoframe-constructor",
+          "support": {
+            "chrome": {
+              "version_added": "127"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "data": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/data",

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "127"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -51,7 +51,7 @@
             "spec_url": "https://drafts.csswg.org/css-fonts-5/#valdef-font-size-adjust-from-font",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "127"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -84,7 +84,7 @@
             "spec_url": "https://drafts.csswg.org/css-fonts-5/#valdef-font-size-adjust-none",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "127"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -117,7 +117,7 @@
             "description": "Two-value syntax",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "127"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.7 found new features shipping in Chrome 127 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 20 features are marked as shipping in Chrome 127:

- api.ChapterInformation
- api.ChapterInformation.artwork
- api.ChapterInformation.startTime
- api.ChapterInformation.title
- api.GPUAdapter.info
- api.MediaMetadata.chapterInfo
- api.MutationEvent (removal)
- api.MutationEvent.attrChange (removal)
- api.MutationEvent.attrName (removal)
- api.MutationEvent.initMutationEvent (removal)
- api.MutationEvent.newValue (removal)
- api.MutationEvent.prevValue (removal)
- api.MutationEvent.relatedNode (removal)
- api.RTCEncodedAudioFrame.RTCEncodedAudioFrame
- api.RTCEncodedVideoFrame.RTCEncodedVideoFrame
- css.properties.font-size-adjust
- css.properties.font-size-adjust.from-font
- css.properties.font-size-adjust.none
- css.properties.font-size-adjust.two-values
- html.elements.script.type.importmap.integrity

See also the 127 "Enabled by default" column on https://chromestatus.com/roadmap.

I would have expected [PointerEvent.deviceProperties](https://chromestatus.com/feature/5114132234240000) and [Snap Events](https://chromestatus.com/feature/5826089036808192) to show up as supported in collector tests but I think Chromestatus is wrong and these two aren't shipping yet.

cc @chrisdavidmills @rachelandrew 