### PR TITLE
Rename html.elements.img.usemap.caseless_usemap -> case_sensitive

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -844,7 +844,7 @@
               "deprecated": false
             }
           },
-          "caseless_usemap": {
+          "case_sensitive": {
             "__compat": {
               "description": "Content is case-sensitive",
               "support": {


### PR DESCRIPTION
This PR renames a subfeature of the `usemap` attribute of the `img` tag for clarity.  The original name was `caseless_usemap`, but this doesn't make sense based on its description, so it has been renamed to `case_sensitive`.
