### PR TITLE
Update Safari data for html.elements.img.usemap.caseless_usemap

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -866,7 +866,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "≤11"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `usemap.caseless_usemap` member of the `img` HTML element. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #388
