### PR TITLE
Mirroring: fix a bug when Safari Desktop is a range

### DIFF
--- a/scripts/build/mirror.ts
+++ b/scripts/build/mirror.ts
@@ -72,7 +72,7 @@ export const getMatchingBrowserVersion = (
       return (range ? '≤' : '') + v;
     }
     if (sourceVersion.replace('≤', '') in browserData.releases) {
-      return (range ? '≤' : '') + sourceVersion;
+      return sourceVersion;
     }
     throw new Error(`Cannot find iOS version matching Safari ${sourceVersion}`);
   }


### PR DESCRIPTION
This PR fixes a small bug where the range denominator (`≤`) is accidentally added twice when mirroring from Safari Desktop to Safari iOS on certain versions.  This unblocks #23377.
