### PR TITLE
Update IE data for input HTML element

### DIFF
--- a/html/elements/input/button.json
+++ b/html/elements/input/button.json
@@ -20,7 +20,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/html/elements/input/checkbox.json
+++ b/html/elements/input/checkbox.json
@@ -20,7 +20,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/html/elements/input/file.json
+++ b/html/elements/input/file.json
@@ -23,7 +23,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": {

--- a/html/elements/input/hidden.json
+++ b/html/elements/input/hidden.json
@@ -20,7 +20,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": {

--- a/html/elements/input/image.json
+++ b/html/elements/input/image.json
@@ -20,7 +20,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/html/elements/input/radio.json
+++ b/html/elements/input/radio.json
@@ -20,7 +20,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -21,7 +21,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -21,7 +21,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/html/elements/input/text.json
+++ b/html/elements/input/text.json
@@ -20,7 +20,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Internet Explorer for the `input` HTML element. This sets IE to "≤11" to replace all `true` values with ranged versions.  (Apparently, this was missed in the last migration.)
