### PR TITLE
Update Safari iOS data for html.elements.input.type_month

### DIFF
--- a/html/elements/input/month.json
+++ b/html/elements/input/month.json
@@ -35,7 +35,7 @@
                 "notes": "The input type is recognized, but there is no month-specific control. See <a href='https://webkit.org/b/200416'>bug 200416</a>."
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "≤11.3"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `type_month` member of the `input` HTML element. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #2204
