### PR TITLE
Update Chromium data for html.elements.input.type_range

### DIFF
--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -63,7 +63,7 @@
               "description": "Tick mark support",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤67"
                 },
                 "chrome_android": "mirror",
                 "edge": {
@@ -103,7 +103,7 @@
                     "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
                   },
                   {
-                    "version_added": true,
+                    "version_added": "≤67",
                     "partial_implementation": true,
                     "notes": "Vertical orientation available by setting the non-standard <code>-webkit-appearance: slider-vertical</code> style on the <code>input</code> element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
                   }


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `type_range` member of the `input` HTML element. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #2209
