### PR TITLE
Update Firefox data for html.elements.input.type_tel

### DIFF
--- a/html/elements/input/tel.json
+++ b/html/elements/input/tel.json
@@ -19,7 +19,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/input/tel.json
+++ b/html/elements/input/tel.json
@@ -19,7 +19,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤61"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `type_tel` member of the `input` HTML element. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #2226
