### PR TITLE
Remove html.elements.input.x-moz-errormessage from BCD

### DIFF
--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -1340,40 +1340,6 @@
               "deprecated": true
             }
           }
-        },
-        "x-moz-errormessage": {
-          "__compat": {
-            "description": "<code>x-moz-errormessage</code> attribute",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": true,
-                "version_removed": "66"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `x-moz-errormessage` member of the `input` HTML element from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.7).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/input/x-moz-errormessage

Additional Notes: There is a message about this attribute in the content, but it simply states that it used to exist and was removed, so it doesn't need to be deleted.
