### PR TITLE
Update Chrome/Safari data for html.elements.meta.http-equiv

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -295,7 +295,7 @@
                 "deprecated": false
               }
             }
-          },
+          }
         },
         "name": {
           "__compat": {

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -157,7 +157,7 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-content-language",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "chrome_android": "mirror",
                 "edge": {
@@ -174,7 +174,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -192,7 +192,7 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-content-security-policy",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "chrome_android": "mirror",
                 "edge": {
@@ -209,7 +209,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -227,7 +227,7 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-content-type",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "chrome_android": "mirror",
                 "edge": {
@@ -244,7 +244,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -301,7 +301,7 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-set-cookie",
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤59",
                   "version_removed": "65"
                 },
                 "chrome_android": "mirror",
@@ -321,7 +321,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -296,44 +296,6 @@
               }
             }
           },
-          "set-cookie": {
-            "__compat": {
-              "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-keyword-set-cookie",
-              "support": {
-                "chrome": {
-                  "version_added": "≤59",
-                  "version_removed": "65"
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "12",
-                  "version_removed": "79"
-                },
-                "firefox": {
-                  "version_added": "1",
-                  "version_removed": "68"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": "≤11"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "≤10.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": true
-              }
-            }
-          }
         },
         "name": {
           "__compat": {


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `http-equiv` member of the `meta` HTML element. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: f14e41f437083c77954e8bcf481998d3c77a851a
