### PR TITLE
Update Chrome/Safari data for html.elements.object.classid

### DIFF
--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -111,7 +111,7 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#attr-object-classid",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -128,7 +128,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -111,7 +111,7 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#attr-object-classid",
             "support": {
               "chrome": {
-                "version_added": "≤59"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -128,7 +128,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤10.1"
+                "version_added": "3"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `classid` member of the `object` HTML element. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: 3dfd3b0d5e09f8f66d2eef2af939e820bcb1fca3
