### PR TITLE
Update Opera data for html.elements.script.referrerpolicy

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -365,9 +365,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "14"
               },
@@ -400,12 +398,8 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -439,12 +433,8 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -478,12 +468,8 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": false
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `referrerpolicy` member of the `script` HTML element. This sets the downstream browser(s) to mirror from their upstream counterpart.
