### PR TITLE
Update Firefox data for html.elements.th.rowspan.rowspan_zero

### DIFF
--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -362,7 +362,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": true
+                  "version_added": "≤55"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `rowspan.rowspan_zero` member of the `th` HTML element. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #325
