### PR TITLE
Update Opera data for html.elements.video.muted

### DIFF
--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -418,9 +418,7 @@
                 "version_added": "10"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "5"


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `muted` member of the `video` HTML element. This sets the downstream browser(s) to mirror from their upstream counterpart.
