### PR TITLE
Update Safari iOS data for html.elements.video.muted

### DIFF
--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -425,9 +425,7 @@
               "safari": {
                 "version_added": "5"
               },
-              "safari_ios": {
-                "version_added": null
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `muted` member of the `video` HTML element. This sets the downstream browser(s) to mirror from their upstream counterpart.
