### PR TITLE
Fix property order after adding a description

### DIFF
--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -42,7 +42,6 @@ const load = async (...files: string[]): Promise<void> => {
 
     if (fsStats.isFile()) {
       if (path.extname(file) === '.json' && !file.endsWith('.schema.json')) {
-        fixPropertyOrder(file);
         if (!file.includes('/browsers/')) {
           fixBrowserOrder(file);
           fixFeatureOrder(file);
@@ -53,6 +52,7 @@ const load = async (...files: string[]): Promise<void> => {
           fixStatus(file);
           fixMirror(file);
         }
+        fixPropertyOrder(file);
       }
     } else {
       const subFiles = (await fs.readdir(file)).map((subfile) =>


### PR DESCRIPTION
Thanks to the recent PRs that allow us to fix descriptions automatically, we can now add descriptions automatically when running `npm run fix`. The OWD collector uses this when adding new features (`npm run add-new-bcd` in the collector)

However, the descriptions are added at the end of the support block, so I think we should run `fixPropertyOrder` at the end of the fixing process instead of the beginning to avoid this from happening.