### PR TITLE
Update Safari data for html.global_attributes.contenteditable.plaintext-only

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -311,7 +311,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `contenteditable.plaintext-only` member of the `global_attributes` HTML feature. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #6117
