### PR TITLE
Update Safari data for global_attributes HTML feature

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -695,7 +695,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1"
             },
             "safari_ios": {
               "version_added": "12.2",
@@ -1103,7 +1103,7 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤13.1"
             },
             "safari_ios": {
               "version_added": "9.3"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -695,7 +695,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "12.1"
             },
             "safari_ios": {
               "version_added": "12.2",
@@ -1103,7 +1103,7 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "9.3"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `global_attributes` HTML feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/global_attributes
