### PR TITLE
Update Firefox data for html.global_attributes.spellcheck

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1087,7 +1087,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "≤72"
             },
             "firefox_android": {
               "version_added": "57"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `spellcheck` member of the `global_attributes` HTML feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/global_attributes/spellcheck
