### PR TITLE
Update Chromium data for html.global_attributes.nonce

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -897,7 +897,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤61"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -897,7 +897,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce",
           "support": {
             "chrome": {
-              "version_added": "≤61"
+              "version_added": "61"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `nonce` member of the `global_attributes` HTML feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/global_attributes/nonce
