### PR TITLE
Slightly rename html.global_attributes.title.multi-line-support

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1228,7 +1228,7 @@
             "deprecated": false
           }
         },
-        "multi-line-support": {
+        "multi-line_support": {
           "__compat": {
             "description": "Multi-line support",
             "support": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1228,9 +1228,9 @@
             "deprecated": false
           }
         },
-        "multi-line_support": {
+        "multi-line_titles": {
           "__compat": {
-            "description": "Multi-line support",
+            "description": "Multi-line titles",
             "support": {
               "chrome": {
                 "version_added": true


### PR DESCRIPTION
This PR slightly renames `html.global_attributes.title.multi-line-support` to replace a hyphen with an underscore.
