### PR TITLE
Update all browsers data for html.global_attributes.title.multi-line-support

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1233,14 +1233,14 @@
             "description": "Multi-line support",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤64"
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1248,15 +1248,11 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤11"
               },
-              "safari_ios": {
-                "version_added": null
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `title.multi-line-support` member of the `global_attributes` HTML feature. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #1089
