### PR TITLE
Add three missing MathML elements

### DIFF
--- a/mathml/elements/annotation-xml.json
+++ b/mathml/elements/annotation-xml.json
@@ -1,0 +1,40 @@
+{
+  "mathml": {
+    "elements": {
+      "annotation-xml": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/semantics",
+          "spec_url": "https://w3c.github.io/mathml-core/#semantics-and-presentation",
+          "support": {
+            "chrome": {
+              "version_added": "109"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/mathml/elements/annotation.json
+++ b/mathml/elements/annotation.json
@@ -1,0 +1,40 @@
+{
+  "mathml": {
+    "elements": {
+      "annotation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/semantics",
+          "spec_url": "https://w3c.github.io/mathml-core/#semantics-and-presentation",
+          "support": {
+            "chrome": {
+              "version_added": "109"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/mathml/elements/mprescripts.json
+++ b/mathml/elements/mprescripts.json
@@ -1,0 +1,40 @@
+{
+  "mathml": {
+    "elements": {
+      "mprescripts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mmultiscripts",
+          "spec_url": "https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts",
+          "support": {
+            "chrome": {
+              "version_added": "109"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A while ago we added support for automatically collecting compat data for MathML (https://github.com/openwebdocs/mdn-bcd-collector/issues/503).

I recently fixed a bug with that compat data collection and so our tooling proposes to add these three missing MathML elements for completeness! The MDN docs are for these are inline on the https://developer.mozilla.org/en-US/docs/Web/MathML/Element/semantics and https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mmultiscripts pages and I think that's fine, but having all elements in BCD makes sense to me.

cc @pepelsbey and @fred-wang for review.