### PR TITLE
Update web extension compat data for Safari 18 and older releases

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -116,7 +116,7 @@
               "safari": {
                 "version_added": "15.4",
                 "partial_implementation": true,
-                "notes": "Always returns a red <code>ColorArray</code>."
+                "notes": "Always returns a <code>ColorArray</code> containing red."
               },
               "safari_ios": "mirror"
             }
@@ -772,7 +772,7 @@
               "safari_ios": {
                 "version_added": "15.4",
                 "partial_implementation": true,
-                "notes": "API exists, but the title not visible in the UI."
+                "notes": "API exists, but the title is not visible in the UI."
               }
             }
           },

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -15,7 +15,7 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": "16"
+              "version_added": "15.4"
             },
             "safari_ios": "mirror"
           }
@@ -34,7 +34,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -54,7 +54,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -74,7 +74,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -94,7 +94,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -114,7 +114,9 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4",
+                "partial_implementation": true,
+                "notes": "Always returns a red <code>ColorArray</code>."
               },
               "safari_ios": "mirror"
             }
@@ -133,7 +135,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -154,7 +156,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -173,7 +175,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -214,7 +216,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -233,7 +235,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -254,7 +256,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -273,7 +275,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -336,7 +338,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -355,7 +357,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -376,7 +378,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -394,7 +396,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -413,7 +415,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -456,7 +458,10 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4",
+                "impl_url": "https://webkit.org/b/267662",
+                "partial_implementation": true,
+                "notes": "API exists, but has no effect."
               },
               "safari_ios": "mirror"
             }
@@ -475,7 +480,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -536,7 +541,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -555,7 +560,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -575,7 +580,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -623,7 +628,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -642,7 +647,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -661,7 +666,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -681,7 +686,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -702,7 +707,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -721,7 +726,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -741,7 +746,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -762,9 +767,13 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15.4",
+                "partial_implementation": true,
+                "notes": "API exists, but the title not visible in the UI."
+              }
             }
           },
           "details_windowId_parameter": {
@@ -781,7 +790,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -801,7 +810,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -7,23 +7,29 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Available for use in Manifest V2 only."
               },
               "firefox": {
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Available for use in Manifest V2 only."
               },
               "firefox_android": {
-                "version_added": "79"
+                "version_added": "79",
+                "notes": "Available for use in Manifest V2 only."
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Available for use in Manifest V2 only."
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Available for use in Manifest V2 only."
               }
             }
           }
@@ -151,7 +157,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -199,7 +205,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -269,7 +275,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -297,9 +303,7 @@
                 "version_added": "14"
               },
               "safari_ios": {
-                "version_added": "15",
-                "partial_implementation": true,
-                "notes": "The API exists, but the title not visible in the UI."
+                "version_added": "15"
               }
             }
           },
@@ -319,7 +323,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -342,9 +346,11 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15"
+              }
             }
           },
           "details_windowId_parameter": {
@@ -363,7 +369,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -499,13 +505,15 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14",
+                "impl_url": "https://webkit.org/b/267662",
                 "partial_implementation": true,
-                "notes": "The API exists, but has no effect."
+                "notes": "API exists, but has no effect."
               },
               "safari_ios": {
                 "version_added": "15",
+                "impl_url": "https://webkit.org/b/267662",
                 "partial_implementation": true,
-                "notes": "The API exists, but has no effect."
+                "notes": "API exists, but has no effect."
               }
             }
           },
@@ -525,7 +533,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -547,7 +555,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -627,7 +635,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -649,7 +657,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -734,7 +742,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -779,11 +787,9 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "18"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                }
+                "safari_ios": "mirror"
               }
             }
           }
@@ -843,7 +849,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -865,11 +871,9 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "18"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                }
+                "safari_ios": "mirror"
               }
             }
           }
@@ -931,7 +935,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -953,11 +957,9 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "18"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                }
+                "safari_ios": "mirror"
               }
             }
           }

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -2,34 +2,58 @@
   "webextensions": {
     "api": {
       "browserAction": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction",
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "notes": "Available for use in Manifest V2 only."
+            },
+            "edge": {
+              "version_added": "14",
+              "notes": "Available for use in Manifest V2 only."
+            },
+            "firefox": {
+              "version_added": "45",
+              "notes": "Available for use in Manifest V2 only."
+            },
+            "firefox_android": {
+              "version_added": "55",
+              "notes": "Available for use in Manifest V2 only."
+            },
+            "opera": "mirror",
+            "safari": {
+              "version_added": "14",
+              "notes": "Available for use in Manifest V2 only."
+            },
+            "safari_ios": {
+              "version_added": "15",
+              "notes": "Available for use in Manifest V2 only."
+            }
+          }
+        },
         "ColorArray": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray",
             "support": {
               "chrome": {
-                "version_added": true,
-                "notes": "Available for use in Manifest V2 only."
+                "version_added": true
               },
               "edge": {
-                "version_added": "14",
-                "notes": "Available for use in Manifest V2 only."
+                "version_added": "14"
               },
               "firefox": {
-                "version_added": "45",
-                "notes": "Available for use in Manifest V2 only."
+                "version_added": "45"
               },
               "firefox_android": {
-                "version_added": "79",
-                "notes": "Available for use in Manifest V2 only."
+                "version_added": "79"
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "14",
-                "notes": "Available for use in Manifest V2 only."
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": "15",
-                "notes": "Available for use in Manifest V2 only."
+                "version_added": "15"
               }
             }
           }

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -79,12 +79,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "14",
-                  "notes": "Only supports explicit."
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": "15",
-                  "notes": "Only supports explicit."
+                  "version_added": "15"
                 }
               }
             }
@@ -193,7 +191,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/267514"
               },
               "safari_ios": "mirror"
             }
@@ -215,14 +214,26 @@
                 "version_added": "48"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "HTTPOnly cookies are not retrieved."
-              },
-              "safari_ios": {
-                "version_added": "15",
-                "notes": "HTTPOnly cookies are not retrieved."
-              }
+              "safari": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "HTTPOnly cookies are not retrieved."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": "HTTPOnly cookies are not retrieved."
+                }
+              ]
             }
           },
           "firstPartyDomain": {
@@ -283,20 +294,32 @@
                 "version_added": "48"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": [
-                  "Only the cookies in the default cookie store are retrieved.",
-                  "HTTPOnly cookies are not retrieved."
-                ]
-              },
-              "safari_ios": {
-                "version_added": "15",
-                "notes": [
-                  "Only the cookies in the default cookie store are retrieved.",
-                  "HTTPOnly cookies are not retrieved."
-                ]
-              }
+              "safari": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only the cookies in the default cookie store are retrieved.",
+                    "HTTPOnly cookies are not retrieved."
+                  ]
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only the cookies in the default cookie store are retrieved.",
+                    "HTTPOnly cookies are not retrieved."
+                  ]
+                }
+              ]
             }
           },
           "firstPartyDomain": {
@@ -354,14 +377,26 @@
                 "version_added": "48"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "Always returns the same default cookie store with ID 0."
-              },
-              "safari_ios": {
-                "version_added": "15",
-                "notes": "Always returns the same default cookie store with ID 0."
-              }
+              "safari": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "Always returns the same default cookie store with ID 0."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": "Always returns the same default cookie store with ID 0."
+                }
+              ]
             }
           }
         },
@@ -381,9 +416,11 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15"
+              }
             }
           },
           "partitionKey": {
@@ -486,12 +523,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "14",
-                "notes": "Only supports explicit."
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": "15",
-                "notes": "Only supports explicit."
+                "version_added": "15"
               }
             }
           },
@@ -510,9 +545,11 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -532,9 +569,11 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -553,9 +592,11 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -598,12 +639,32 @@
                 "notes": "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": {
-                "version_added": "15"
-              }
+              "safari": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only sets cookies in the default cookie store.",
+                    "HTTPOnly cookies are not set."
+                  ]
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only sets cookies in the default cookie store.",
+                    "HTTPOnly cookies are not set."
+                  ]
+                }
+              ]
             }
           },
           "firstPartyDomain": {
@@ -658,12 +719,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "14",
-                  "notes": "Only supports explicit."
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": "15",
-                  "notes": "Only supports explicit."
+                  "version_added": "15"
                 }
               }
             }

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -221,7 +221,7 @@
                 {
                   "version_added": "14",
                   "partial_implementation": true,
-                  "notes": "HTTPOnly cookies are not retrieved."
+                  "notes": "<code>HttpOnly</code> cookies are not retrieved."
                 }
               ],
               "safari_ios": [
@@ -231,7 +231,7 @@
                 {
                   "version_added": "15",
                   "partial_implementation": true,
-                  "notes": "HTTPOnly cookies are not retrieved."
+                  "notes": "<code>HttpOnly</code> cookies are not retrieved."
                 }
               ]
             }
@@ -303,7 +303,7 @@
                   "partial_implementation": true,
                   "notes": [
                     "Only the cookies in the default cookie store are retrieved.",
-                    "HTTPOnly cookies are not retrieved."
+                    "<code>HttpOnly</code> cookies are not retrieved."
                   ]
                 }
               ],
@@ -316,7 +316,7 @@
                   "partial_implementation": true,
                   "notes": [
                     "Only the cookies in the default cookie store are retrieved.",
-                    "HTTPOnly cookies are not retrieved."
+                    "<code>HttpOnly</code> cookies are not retrieved."
                   ]
                 }
               ]
@@ -648,7 +648,7 @@
                   "partial_implementation": true,
                   "notes": [
                     "Only sets cookies in the default cookie store.",
-                    "<code>HTTPOnly</code> cookies are not set."
+                    "<code>HttpOnly</code> cookies are not set."
                   ]
                 }
               ],
@@ -661,7 +661,7 @@
                   "partial_implementation": true,
                   "notes": [
                     "Only sets cookies in the default cookie store.",
-                    "HTTPOnly cookies are not set."
+                    "<code>HttpOnly</code> cookies are not set."
                   ]
                 }
               ]

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -648,7 +648,7 @@
                   "partial_implementation": true,
                   "notes": [
                     "Only sets cookies in the default cookie store.",
-                    "HTTPOnly cookies are not set."
+                    "<code>HTTPOnly</code> cookies are not set."
                   ]
                 }
               ],

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -443,7 +443,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "safari_ios": "mirror"
               }
@@ -992,7 +992,7 @@
               "support": {
                 "chrome": {
                   "version_added": "84",
-                  "notes": "The default value changed from true to false in Chrome 118."
+                  "notes": "The default value changed from <code>true</code> to <code>false</code> in Chrome 118."
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -1002,7 +1002,7 @@
                 "opera": "mirror",
                 "safari": {
                   "version_added": "15",
-                  "notes": "The default value changed from true to false in Safari 16.4."
+                  "notes": "The default value changed from <code>true</code> to <code>false</code> in Safari 16.4."
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -200,7 +200,7 @@
                   {
                     "version_added": "14",
                     "partial_implementation": true,
-                    "notes": "Filtering by <code>windowId</code> won't work when a tab is moved from one window to another."
+                    "notes": "Filtering by <code>windowId</code> doesn't work when a tab is moved from one window to another."
                   }
                 ],
                 "safari_ios": [
@@ -210,7 +210,7 @@
                   {
                     "version_added": "15",
                     "partial_implementation": true,
-                    "notes": "Filtering by <code>windowId</code> won't work when a tab is moved from one window to another."
+                    "notes": "Filtering by <code>windowId</code> doesn't work when a tab is moved from one window to another."
                   }
                 ]
               }

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -193,14 +193,26 @@
                   "notes": "The property is recognized, but the filter has no effect."
                 },
                 "opera": "mirror",
-                "safari": {
-                  "version_added": "14",
-                  "notes": "Filtering by <code>windowId</code> won't work when a tab is moved from one window to another."
-                },
-                "safari_ios": {
-                  "version_added": "15",
-                  "notes": "Filtering by <code>windowId</code> won't work when a tab is moved from one window to another."
-                }
+                "safari": [
+                  {
+                    "version_added": "18"
+                  },
+                  {
+                    "version_added": "14",
+                    "partial_implementation": true,
+                    "notes": "Filtering by <code>windowId</code> won't work when a tab is moved from one window to another."
+                  }
+                ],
+                "safari_ios": [
+                  {
+                    "version_added": "18"
+                  },
+                  {
+                    "version_added": "15",
+                    "partial_implementation": true,
+                    "notes": "Filtering by <code>windowId</code> won't work when a tab is moved from one window to another."
+                  }
+                ]
               }
             }
           }
@@ -222,16 +234,26 @@
                 "version_added": "48"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "partial_implementation": true,
-                "notes": "Always returns false."
-              },
-              "safari_ios": {
-                "version_added": "15",
-                "partial_implementation": true,
-                "notes": "Always returns false."
-              }
+              "safari": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "Always returns <code>false</code>."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": "Always returns <code>false</code>."
+                }
+              ]
             }
           }
         },
@@ -253,12 +275,12 @@
               "safari": {
                 "version_added": "14",
                 "partial_implementation": true,
-                "notes": "Always returns false."
+                "notes": "Always returns <code>false</code>."
               },
               "safari_ios": {
                 "version_added": "15",
                 "partial_implementation": true,
-                "notes": "Always returns false."
+                "notes": "Always returns <code>false</code>."
               }
             }
           }
@@ -278,16 +300,26 @@
               },
               "firefox_android": "mirror",
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "partial_implementation": true,
-                "notes": "Always returns true."
-              },
-              "safari_ios": {
-                "version_added": "15",
-                "partial_implementation": true,
-                "notes": "Always returns true."
-              }
+              "safari": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "Always returns <code>true</code>."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": "Always returns <code>true</code>."
+                }
+              ]
             }
           }
         },

--- a/webextensions/api/extensionTypes.json
+++ b/webextensions/api/extensionTypes.json
@@ -21,12 +21,12 @@
             "safari": {
               "version_added": "14",
               "partial_implementation": true,
-              "notes": "These features are not exposed through the 'extensionTypes' object."
+              "notes": "These features are not exposed through the <code>extensionTypes</code> object."
             },
             "safari_ios": {
               "version_added": "15",
               "partial_implementation": true,
-              "notes": "These features are not exposed through the 'extensionTypes' object."
+              "notes": "These features are not exposed through the <code>extensionTypes</code> object."
             }
           }
         },
@@ -45,7 +45,7 @@
               "safari": {
                 "version_added": "18",
                 "partial_implementation": true,
-                "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
+                "notes": "This feature is supported but not exposed through the <code>extensionTypes</code> object."
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/extensionTypes.json
+++ b/webextensions/api/extensionTypes.json
@@ -19,10 +19,14 @@
             },
             "opera": "mirror",
             "safari": {
-              "version_added": "14"
+              "version_added": "14",
+              "partial_implementation": true,
+              "notes": "These features are not exposed through the 'extensionTypes' object."
             },
             "safari_ios": {
-              "version_added": "15"
+              "version_added": "15",
+              "partial_implementation": true,
+              "notes": "These features are not exposed through the 'extensionTypes' object."
             }
           }
         },
@@ -39,7 +43,9 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18",
+                "partial_implementation": true,
+                "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
               },
               "safari_ios": "mirror"
             }
@@ -63,11 +69,9 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "14"
+                "version_added": false
               },
-              "safari_ios": {
-                "version_added": "15"
-              }
+              "safari_ios": "mirror"
             }
           },
           "rect": {

--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -44,9 +44,11 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15"
+              }
             }
           }
         },

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -100,20 +100,25 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": "Available for use in Manifest V3 or later."
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "109"
+                  "version_added": "109",
+                  "notes": "Available for use in Manifest V3 or later."
                 },
                 "firefox_android": {
                   "version_added": false
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4",
+                  "notes": "Available for use in Manifest V3 or later."
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -143,19 +148,24 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": "Available for use in Manifest V2 only."
                 },
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "53",
-                  "notes": "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                  "notes": [
+                    "Available for use in Manifest V2 only.",
+                    "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "14",
+                  "notes": "Available for use in Manifest V2 only."
                 },
                 "safari_ios": {
                   "version_added": false
@@ -188,18 +198,21 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": true,
+                  "notes": "Available for use in Manifest V2 only."
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "53"
+                  "version_added": "53",
+                  "notes": "Available for use in Manifest V2 only."
                 },
                 "firefox_android": {
                   "version_added": false
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "14",
+                  "notes": "Available for use in Manifest V2 only."
                 },
                 "safari_ios": {
                   "version_added": false
@@ -243,9 +256,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -417,9 +432,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -565,9 +582,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -586,9 +605,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -156,7 +156,7 @@
                   "version_added": "53",
                   "notes": [
                     "Available for use in Manifest V2 only.",
-                    "'The 'editable' context does not include password fields. Use the 'password' context for this."
+                    "'The <code>editable</code> context does not include password fields. Use the <code>password</code> context for this."
                   ]
                 },
                 "firefox_android": {

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -203,8 +203,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "53",
-                  "notes": "Available for use in Manifest V2 only."
+                  "version_added": "53"
                 },
                 "firefox_android": {
                   "version_added": false

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -14,12 +14,10 @@
               "notes": "Available for use in Manifest V2 only."
             },
             "firefox": {
-              "version_added": "45",
-              "notes": "Available for use in Manifest V2 only."
+              "version_added": "45"
             },
             "firefox_android": {
-              "version_added": "50",
-              "notes": "Available for use in Manifest V2 only."
+              "version_added": "50"
             },
             "opera": "mirror",
             "safari": {

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -6,23 +6,29 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Available for use in Manifest V2 only."
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Available for use in Manifest V2 only."
             },
             "firefox": {
-              "version_added": "45"
+              "version_added": "45",
+              "notes": "Available for use in Manifest V2 only."
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": "50",
+              "notes": "Available for use in Manifest V2 only."
             },
             "opera": "mirror",
             "safari": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Available for use in Manifest V2 only."
             },
             "safari_ios": {
-              "version_added": "15"
+              "version_added": "15",
+              "notes": "Available for use in Manifest V2 only."
             }
           }
         },
@@ -100,8 +106,7 @@
                 "version_added": "14"
               },
               "safari_ios": {
-                "version_added": "15",
-                "notes": "The API exists, but the title not visible in the UI."
+                "version_added": "15"
               }
             }
           }
@@ -235,9 +240,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -356,11 +363,9 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "18"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                }
+                "safari_ios": "mirror"
               }
             }
           }
@@ -407,11 +412,9 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "18"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                }
+                "safari_ios": "mirror"
               }
             }
           }
@@ -438,6 +441,7 @@
               },
               "safari_ios": {
                 "version_added": "15",
+                "partial_implementation": true,
                 "notes": "The API exists, but the title not visible in the UI."
               }
             }
@@ -458,11 +462,9 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "18"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                }
+                "safari_ios": "mirror"
               }
             }
           }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -468,7 +468,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -539,11 +539,11 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14",
-                "notes": "See the documentation on developer.apple.com about native messaging in Safari."
+                "notes": "See the <a href='https://developer.apple.com/documentation/safariservices/safari_web_extensions/messaging_between_the_app_and_javascript_in_a_safari_web_extension'>Apple Developer Documentation</a> for additional details."
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "See the documentation on developer.apple.com about native messaging in Safari."
+                "notes": "See the <a href='https://developer.apple.com/documentation/safariservices/safari_web_extensions/messaging_between_the_app_and_javascript_in_a_safari_web_extension'>Apple Developer Documentation</a> for additional details."
               }
             }
           }
@@ -737,7 +737,7 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
+                "notes": "<code>lastError</code> is not an <code>Error</code> object. Instead, it is a plain <code>Object</code> with the error text as the string value of the <code>message</code> property."
               },
               "edge": "mirror",
               "firefox": {
@@ -816,7 +816,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4",
+                "notes": "Only fired in response to connect from webpages allowed in <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable'><code>externally_connectable</code></a>."
               },
               "safari_ios": "mirror"
             }
@@ -990,24 +991,24 @@
                 {
                   "version_added": "15.4",
                   "partial_implementation": true,
-                  "notes": "Since Safari 15.4, this event is also fired in response to a message from webpages allowed in <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable'><code>externally_connectable</code></a>."
+                  "notes": "Also fired in response to a message from webpages allowed in <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable'><code>externally_connectable</code></a>."
                 },
                 {
                   "version_added": "14",
                   "partial_implementation": true,
-                  "notes": "This event is only fired in response to a message from an extension's containing app, not webpages nor other extensions."
+                  "notes": "Only fired in response to a message from an extension's containing app, not webpages nor other extensions."
                 }
               ],
               "safari_ios": [
                 {
                   "version_added": "15.4",
                   "partial_implementation": true,
-                  "notes": "Since Safari 15.4, this event is also fired in response to a message from webpages allowed in <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable'><code>externally_connectable</code></a>."
+                  "notes": "Also fired in response to a message from webpages allowed in <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable'><code>externally_connectable</code></a>."
                 },
                 {
                   "version_added": "15",
                   "partial_implementation": true,
-                  "notes": "This event is only fired in response to a message from an extension's containing app, not webpages nor other extensions."
+                  "notes": "Only fired in response to a message from an extension's containing app, not webpages nor other extensions."
                 }
               ]
             }
@@ -1307,11 +1308,11 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14",
-                "notes": "See the documentation on developer.apple.com about native messaging in Safari."
+                "notes": "See the <a href='https://developer.apple.com/documentation/safariservices/safari_web_extensions/messaging_between_the_app_and_javascript_in_a_safari_web_extension'>Apple Developer Documentation</a> for additional details."
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "See the documentation on developer.apple.com about native messaging in Safari."
+                "notes": "See the <a href='https://developer.apple.com/documentation/safariservices/safari_web_extensions/messaging_between_the_app_and_javascript_in_a_safari_web_extension'>Apple Developer Documentation</a> for additional details."
               }
             }
           }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -996,7 +996,7 @@
                 {
                   "version_added": "14",
                   "partial_implementation": true,
-                  "notes": "Only fired in response to a message from an extension's containing app, not webpages nor other extensions."
+                  "notes": "Only fired in response to a message from an extension's containing app, not webpages and other extensions."
                 }
               ],
               "safari_ios": [
@@ -1008,7 +1008,7 @@
                 {
                   "version_added": "15",
                   "partial_implementation": true,
-                  "notes": "Only fired in response to a message from an extension's containing app, not webpages nor other extensions."
+                  "notes": "Only fired in response to a message from an extension's containing app, not webpages and other extensions."
                 }
               ]
             }

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -354,7 +354,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -414,7 +414,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1862,7 +1862,7 @@
               "safari": {
                 "version_added": "14",
                 "notes": [
-                  "Will return <code>und</code> (undefined language) for macOS versions before 11.",
+                  "Returns <code>und</code> (undefined language) for macOS versions before 11.",
                   "Locale identifier will include the country code more often."
                 ]
               },
@@ -2146,11 +2146,11 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14",
-                "notes": "Also returns a the active tab in popup and background pages."
+                "notes": "Also returns the active tab in popup and background pages."
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "Also returns a the active tab in popup and background pages."
+                "notes": "Also returns the active tab in popup and background pages."
               }
             }
           }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -894,7 +894,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -915,7 +915,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -1028,7 +1028,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "16"
                 }
               }
             }
@@ -1140,10 +1140,12 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "14",
+                  "notes": "Requires host permissions for the tab, otherwise is an empty string."
                 },
                 "safari_ios": {
-                  "version_added": "15"
+                  "version_added": "15",
+                  "notes": "Requires host permissions for the tab, otherwise is an empty string."
                 }
               }
             }
@@ -1165,10 +1167,12 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "14",
+                  "notes": "Requires host permissions for the tab, otherwise is an empty string."
                 },
                 "safari_ios": {
-                  "version_added": "15"
+                  "version_added": "15",
+                  "notes": "Requires host permissions for the tab, otherwise is an empty string."
                 }
               }
             }
@@ -1674,9 +1678,11 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -1742,7 +1748,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "16"
                 }
               }
             }
@@ -1760,9 +1766,11 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -1854,7 +1862,7 @@
               "safari": {
                 "version_added": "14",
                 "notes": [
-                  "Will return <code>und</code> (undefined language) for OS lower than 11.",
+                  "Will return <code>und</code> (undefined language) for macOS versions before 11.",
                   "Locale identifier will include the country code more often."
                 ]
               },
@@ -1932,9 +1940,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -1953,10 +1963,10 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "15"
                 }
               }
             }
@@ -2135,10 +2145,12 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Also returns a the active tab in popup and background pages."
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Also returns a the active tab in popup and background pages."
               }
             }
           }
@@ -2378,7 +2390,7 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -2752,9 +2764,11 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15"
+              }
             }
           }
         },
@@ -2949,7 +2963,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "16"
                   }
                 }
               }
@@ -2996,10 +3010,12 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": "14"
+                    "version_added": "14",
+                    "notes": "Requires host permissions for the tab, otherwise is an empty string."
                   },
                   "safari_ios": {
-                    "version_added": "15"
+                    "version_added": "15",
+                    "notes": "Requires host permissions for the tab, otherwise is an empty string."
                   }
                 }
               }
@@ -3021,10 +3037,12 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": "14"
+                    "version_added": "14",
+                    "notes": "Requires host permissions for the tab, otherwise is an empty string."
                   },
                   "safari_ios": {
-                    "version_added": "15"
+                    "version_added": "15",
+                    "notes": "Requires host permissions for the tab, otherwise is an empty string."
                   }
                 }
               }
@@ -3169,12 +3187,10 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "14",
-                "notes": "Pattern matching supports <code>*</code> and <code>?</code>."
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": "15",
-                "notes": "Pattern matching supports <code>*</code> and <code>?</code>."
+                "version_added": "15"
               }
             }
           },
@@ -3814,9 +3830,11 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "14"
                   },
-                  "safari_ios": "mirror"
+                  "safari_ios": {
+                    "version_added": "15"
+                  }
                 }
               }
             }
@@ -4029,9 +4047,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -4127,7 +4147,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "16"
                 }
               }
             }

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -1322,7 +1322,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/261002"
               },
               "safari_ios": "mirror"
             }
@@ -1455,7 +1456,7 @@
                 "version_added": "14"
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": false
               }
             }
           },
@@ -1502,8 +1503,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": "15",
-                  "notes": "<code>update()</code> will not switch between side-by-side Safari on iPadOS."
+                  "version_added": false
                 }
               }
             }

--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -6,16 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action",
           "support": {
             "chrome": {
-              "version_added": "88"
+              "version_added": "88",
+              "notes": "Available for use in Manifest V3 or later."
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "109"
+              "version_added": "109",
+              "notes": "Available for use in Manifest V3 or later."
             },
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": "15.4"
+              "version_added": "15.4",
+              "notes": "Available for use in Manifest V3 or later."
             },
             "safari_ios": "mirror"
           }
@@ -84,10 +87,20 @@
               },
               "firefox_android": "mirror",
               "opera": "mirror",
-              "safari": {
-                "version_added": "15.4",
-                "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
-              },
+              "safari": [
+                {
+                  "version_added": "16.4",
+                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                },
+                {
+                  "version_added": "15.4",
+                  "partial_implementation": true,
+                  "notes": [
+                    "SVG icons are not supported.",
+                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  ]
+                }
+              ],
               "safari_ios": "mirror"
             }
           }

--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -90,14 +90,14 @@
               "safari": [
                 {
                   "version_added": "16.4",
-                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  "notes": "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                 },
                 {
                   "version_added": "15.4",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",
-                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                    "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                   ]
                 }
               ],

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -78,7 +78,7 @@
               "safari": [
                 {
                   "version_added": "14.1",
-                  "notes": "Non-persistent pages are supported, through <code>persistent: false</code>."
+                  "notes": "Available for use in Manifest V2 only."
                 },
                 {
                   "version_added": "14",
@@ -98,6 +98,25 @@
                   "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code>."
                 }
               ]
+            }
+          }
+        },
+        "preferred_environment": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "18"
+              },
+              "safari_ios": "mirror"
             }
           }
         },

--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -108,28 +108,28 @@
               "safari": [
                 {
                   "version_added": "16.4",
-                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  "notes": "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                 },
                 {
                   "version_added": "14",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",
-                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                    "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                   ]
                 }
               ],
               "safari_ios": [
                 {
                   "version_added": "16.4",
-                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  "notes": "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                 },
                 {
                   "version_added": "15.4",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",
-                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                    "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                   ]
                 }
               ]

--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -105,14 +105,34 @@
                 "version_added": "79"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
-              },
-              "safari_ios": {
-                "version_added": "15",
-                "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
-              }
+              "safari": [
+                {
+                  "version_added": "16.4",
+                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": [
+                    "SVG icons are not supported.",
+                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  ]
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "16.4",
+                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                },
+                {
+                  "version_added": "15.4",
+                  "partial_implementation": true,
+                  "notes": [
+                    "SVG icons are not supported.",
+                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  ]
+                }
+              ]
             }
           }
         },

--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -264,8 +264,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "48",
-                "notes": "Available for use in Manifest V2 only."
+                "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -208,18 +208,21 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "88"
+                "version_added": "88",
+                "notes": "Available for use in Manifest V3 or later."
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Available for use in Manifest V3 or later."
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4",
+                "notes": "Available for use in Manifest V3 or later."
               },
               "safari_ios": "mirror"
             }
@@ -229,20 +232,26 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Available for use in Manifest V2 only."
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "52"
+                "version_added": "52",
+                "notes": "Available for use in Manifest V2 only."
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14",
+                "notes": "Available for use in Manifest V2 only."
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "Available for use in Manifest V2 only."
+              }
             }
           }
         },
@@ -255,16 +264,21 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Available for use in Manifest V2 only."
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14",
+                "notes": "Available for use in Manifest V2 only."
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "Available for use in Manifest V2 only."
+              }
             }
           }
         },

--- a/webextensions/manifest/content_scripts.json
+++ b/webextensions/manifest/content_scripts.json
@@ -73,6 +73,25 @@
             }
           }
         },
+        "css_origin": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "18"
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "exclude_globs": {
           "__compat": {
             "support": {
@@ -88,7 +107,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/246492"
               },
               "safari_ios": "mirror"
             }
@@ -132,7 +152,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/246492"
               },
               "safari_ios": "mirror"
             }
@@ -177,7 +198,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/275622"
               },
               "safari_ios": "mirror"
             }
@@ -196,7 +218,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/264829"
               },
               "safari_ios": "mirror"
             }
@@ -264,7 +287,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -21,6 +21,8 @@
             "opera": "mirror",
             "safari": {
               "version_added": "15.4",
+              "impl_url": "https://webkit.org/b/269299",
+              "partial_implementation": true,
               "notes": "Safari only supports the <code>matches</code> property."
             },
             "safari_ios": "mirror"

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -847,7 +847,7 @@
                 {
                   "version_added": "14",
                   "partial_implementation": true,
-                  "notes": "Only grants a 10 MB storage quota, instead of the standard 5 MB."
+                  "notes": "Grants a 10 MB storage quota, instead of the standard 5 MB."
                 }
               ],
               "safari_ios": [
@@ -857,7 +857,7 @@
                 {
                   "version_added": "15",
                   "partial_implementation": true,
-                  "notes": "Only grants a 10 MB storage quota, instead of the standard 5 MB."
+                  "notes": "Grants a 10 MB storage quota, instead of the standard 5 MB."
                 }
               ]
             }

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -223,14 +223,14 @@
                 "version_added": "79"
               },
               "firefox": {
-                "alternative_name": "menus",
-                "version_added": "55"
+                "version_added": "55",
+                "notes": "Available as an alias to the <code>menus</code> permission."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "alternative_name": "menus",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Available as an alias to the <code>menus</code> permission."
               },
               "safari_ios": {
                 "version_added": false

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -223,11 +223,13 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "alternative_name": "menus",
+                "version_added": "55"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
+                "alternative_name": "menus",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -523,6 +525,31 @@
             }
           }
         },
+        "menus": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "alternative_name": "contextMenus",
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "alternative_name": "contextMenus",
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "nativeMessaging": {
           "__compat": {
             "support": {
@@ -728,9 +755,11 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15"
+              }
             }
           }
         },
@@ -811,10 +840,26 @@
               },
               "firefox_android": "mirror",
               "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
+              "safari": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "Only grants a 10 MB storage quota, instead of the standard 5 MB."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": "Only grants a 10 MB storage quota, instead of the standard 5 MB."
+                }
+              ]
             }
           }
         },

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -9,29 +9,41 @@
               "version_added": true,
               "notes": [
                 "Since Chrome 49, page actions are displayed on the toolbar, rather than in the address bar.",
-                "If an extension defines a page action, it is not allowed to define a browser action as well."
+                "If an extension defines a page action, it is not allowed to define a browser action as well.",
+                "Available for use in Manifest V2 only."
               ]
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Available for use in Manifest V2 only."
             },
             "firefox": {
-              "version_added": "48"
+              "version_added": "48",
+              "notes": "Available for use in Manifest V2 only."
             },
             "firefox_android": {
               "version_added": true
             },
             "opera": {
               "version_added": true,
-              "notes": "If an extension defines a page action, it is not allowed to define a browser action as well."
+              "notes": [
+                "If an extension defines a page action, it is not allowed to define a browser action as well.",
+                "Available for use in Manifest V2 only."
+              ]
             },
             "safari": {
               "version_added": "14",
-              "notes": "If an extension defines a page action, it is not allowed to define a browser action as well."
+              "notes": [
+                "If an extension defines a page action, it is not allowed to define a browser action as well.",
+                "Available for use in Manifest V2 only."
+              ]
             },
             "safari_ios": {
               "version_added": "15",
-              "notes": "If an extension defines a page action, it is not allowed to define a browser action as well."
+              "notes": [
+                "If an extension defines a page action, it is not allowed to define a browser action as well.",
+                "Available for use in Manifest V2 only."
+              ]
             }
           }
         },
@@ -79,14 +91,34 @@
                 "version_added": true
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
-              },
-              "safari_ios": {
-                "version_added": "15",
-                "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
-              }
+              "safari": [
+                {
+                  "version_added": "16.4",
+                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": [
+                    "SVG icons are not supported.",
+                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  ]
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "16.4",
+                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                },
+                {
+                  "version_added": "15.4",
+                  "partial_implementation": true,
+                  "notes": [
+                    "SVG icons are not supported.",
+                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  ]
+                }
+              ]
             }
           }
         },

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -94,28 +94,28 @@
               "safari": [
                 {
                   "version_added": "16.4",
-                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  "notes": "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                 },
                 {
                   "version_added": "14",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",
-                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                    "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                   ]
                 }
               ],
               "safari_ios": [
                 {
                   "version_added": "16.4",
-                  "notes": "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                  "notes": "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                 },
                 {
                   "version_added": "15.4",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",
-                    "Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+                    "Grayscale images are treated as template icons and processed with the system accent color and system appearance."
                   ]
                 }
               ]

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -18,8 +18,7 @@
               "notes": "Available for use in Manifest V2 only."
             },
             "firefox": {
-              "version_added": "48",
-              "notes": "Available for use in Manifest V2 only."
+              "version_added": "48"
             },
             "firefox_android": {
               "version_added": true

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -965,7 +965,7 @@
                 {
                   "version_added": "14",
                   "partial_implementation": true,
-                  "notes": "Only grants a 10 MB storage quota, instead of the standard 5 MB."
+                  "notes": "Grants a 10 MB storage quota, instead of the standard 5 MB."
                 }
               ],
               "safari_ios": [
@@ -975,7 +975,7 @@
                 {
                   "version_added": "15",
                   "partial_implementation": true,
-                  "notes": "Only grants a 10 MB storage quota, instead of the standard 5 MB."
+                  "notes": "Grants a 10 MB storage quota, instead of the standard 5 MB."
                 }
               ]
             }

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -258,16 +258,16 @@
                 "version_added": "14"
               },
               "firefox": {
-                "alternative_name": "menus",
-                "version_added": "55"
+                "version_added": "55",
+                "notes": "Available as an alias to the <code>menus</code> permission."
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": "mirror",
               "safari": {
-                "alternative_name": "menus",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Available as an alias to the <code>menus</code> permission."
               },
               "safari_ios": {
                 "version_added": false

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -258,16 +258,16 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": "55",
-                "notes": "Available as an alias to the <code>menus</code> permission."
+                "alternative_name": "menus",
+                "version_added": "55"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "14",
-                "notes": "Available as an alias to the <code>menus</code> permission."
+                "alternative_name": "menus",
+                "version_added": "14"
               },
               "safari_ios": {
                 "version_added": false
@@ -618,6 +618,7 @@
               },
               "edge": "mirror",
               "firefox": {
+                "alternative_name": "contextMenus",
                 "version_added": "53"
               },
               "firefox_android": {
@@ -625,6 +626,7 @@
               },
               "opera": "mirror",
               "safari": {
+                "alternative_name": "contextMenus",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -958,24 +960,22 @@
               },
               "safari": [
                 {
-                  "version_added": "16",
-                  "notes": "Since Safari 16, the storage quota is unlimited."
+                  "version_added": "16"
                 },
                 {
                   "version_added": "14",
                   "partial_implementation": true,
-                  "notes": "Does not grant an unlimited storage quota. Grants a 10 MB storage quota, instead of the standard 5 MB."
+                  "notes": "Only grants a 10 MB storage quota, instead of the standard 5 MB."
                 }
               ],
               "safari_ios": [
                 {
-                  "version_added": "16",
-                  "notes": "Since Safari 16, the storage quota is unlimited."
+                  "version_added": "16"
                 },
                 {
                   "version_added": "15",
                   "partial_implementation": true,
-                  "notes": "Does not grant an unlimited storage quota. Grants a 10 MB storage quota, instead of the standard 5 MB."
+                  "notes": "Only grants a 10 MB storage quota, instead of the standard 5 MB."
                 }
               ]
             }


### PR DESCRIPTION
This updates the compat data for Safari Web Extensions in Safari 18, and fixes older info for previous releases.