### PR TITLE
Update all browsers data for http.methods.POST

### DIFF
--- a/http/methods.json
+++ b/http/methods.json
@@ -196,14 +196,14 @@
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#POST",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -213,7 +213,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `POST` member of the `methods` HTTP feature. This method comes from the HTTP/1.0 spec, so it's highly unlikely that support was added in any browser version after the first release of browsers.
