### PR TITLE
Update Chromium data for html.manifest

### DIFF
--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -25,9 +25,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": true
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": null
             },

--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -36,9 +36,7 @@
               "notes": "Does not support <code>fullscreen</code> or <code>minimal-ui</code>."
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -35,9 +35,7 @@
               "notes": "Only used when no <code>apple-touch-icon</code> is present with <code>\"purpose\": \"any\"</code> or no <code>\"purpose\"</code> key."
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -34,9 +34,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -34,9 +34,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `manifest` member of the `html` HTML manifest property. This sets the downstream browser(s) to mirror from their upstream counterpart.
