### PR TITLE
Update Chrome/Safari data for mixed-content HTTP feature

### DIFF
--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -40,7 +40,7 @@
           "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤79"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -268,7 +268,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤9.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `mixed-content` HTTP feature. This PR was intended to be a part of the true->ranged project with ranges based upon the commit the feature was added in, but the feature was first added to BCD this year (#23220), so this gives the roughest guess based upon all the sibling data.
