### PR TITLE
Update all browsers data for svgglobal_attributespaint-order feature

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -511,14 +511,14 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrder",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤73"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "≤66"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -530,7 +530,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤12"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `svgglobal_attributespaint-order` feature. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #3608
