### PR TITLE
Update Chrome/Safari data for svgglobal_attributestransform-origin feature

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -2907,7 +2907,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤83"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2922,7 +2922,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true,
+              "version_added": "≤13.1",
               "partial_implementation": true,
               "notes": "Does not work with <code>transform</code> SVG presentation attribute. Only works with <code>transform</code> CSS property. See <a href='https://webkit.org/b/201854'>bug 201854</a>."
             },


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `svgglobal_attributestransform-origin` feature. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #6182
