### PR TITLE
Mark Chrome's implementation of KeyboardEvent.repeat as buggy

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1083,7 +1083,9 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-repeat",
           "support": {
             "chrome": {
-              "version_added": "32"
+              "version_added": "32",
+              "partial_implementation": true,
+              "notes": "On Windows and Linux, if multiple keys are held down, a <code>keydown</code> event for the most recently pressed key will trigger with <code>repeat</code> incorrectly set to <code>false</code>. See <a href='https://crbug.com/40940886'>bug 40940886</a>."
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update the `KeyboardEvent.repeat` data for Chrome since as described in https://github.com/mdn/browser-compat-data/issues/23432 (and https://issues.chromium.org/issues/40940886) the implementation is broken, and can't really be used.

This needs to be updated, so web devs don't waste time on an implementation that cannot work due to well known browser bugs.

#### Test results and supporting details

As described in the linked issue (and upstream bug), I've created a JSFiddle that shows the issue:



1. See this simple JSFiddle: https://jsfiddle.net/ys6o5tfg/5/
2. Press and hold: ArrowLeft, ArrowUp, ArrowRight (in this order)
3. Release ArrowLeft (while keeping ArrowUp and ArrowRight pressed)
4. See that KEYDOWN ArrowRight is printed in the div (i.e. a keydown event with repeat = false is emitted for ArrowRight)



<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #23432
