### PR TITLE
Remove `api.MouseEvent.region`

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -880,47 +880,6 @@
           }
         }
       },
-      "region": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/region",
-          "support": {
-            "chrome": {
-              "version_added": "51",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "32",
-              "version_removed": "104"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "relatedTarget": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/relatedTarget",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This seems to be a non-feature.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I could find no reference to it in a current spec, no open Chromium bugs relating to it, and failed to find evidence of it under inspection in Chrome with the flag turned on.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

The docs were removed from MDN in 2022: https://github.com/mdn/content/pull/17743.

The data for this property probably ought to have been removed alongside https://github.com/mdn/browser-compat-data/pull/8442.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
