### PR TITLE
Update Chromium data for webextensions.manifest

### DIFF
--- a/webextensions/manifest/author.json
+++ b/webextensions/manifest/author.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/author",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤58"
             },
             "edge": {
               "version_added": "14",

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "14"
@@ -28,7 +28,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "≤72",
                 "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
@@ -54,7 +54,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "≤58",
                 "notes": "Available for use in Manifest V2 only."
               },
               "edge": {

--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "≤54",
               "notes": [
                 "Available for use in Manifest V2 only.",
                 "If an extension defines a browser action, it is not allowed to define a page action as well."
@@ -87,7 +87,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "≤58",
                 "notes": "SVG icons are not supported."
               },
               "edge": {
@@ -120,7 +120,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "14"
@@ -145,7 +145,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/manifest/chrome_settings_overrides.json
+++ b/webextensions/manifest/chrome_settings_overrides.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤58"
             },
             "edge": {
               "version_added": "79"
@@ -30,7 +30,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
               "edge": {
                 "version_added": "79"
@@ -55,7 +55,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -79,7 +79,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -102,7 +102,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -127,7 +127,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -152,7 +152,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -175,7 +175,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -198,7 +198,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -221,7 +221,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -244,7 +244,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -270,7 +270,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -295,7 +295,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -320,7 +320,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -343,7 +343,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -368,7 +368,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -393,7 +393,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -418,7 +418,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "version_added": "79"
@@ -444,7 +444,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"

--- a/webextensions/manifest/chrome_settings_overrides.json
+++ b/webextensions/manifest/chrome_settings_overrides.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": "≤58"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "55"
             },
@@ -32,9 +30,7 @@
               "chrome": {
                 "version_added": "≤59"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -57,9 +53,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -81,9 +75,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -104,9 +96,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "65"
                 },
@@ -129,9 +119,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "55"
                 },
@@ -154,9 +142,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -177,9 +163,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -200,9 +184,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -223,9 +205,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -246,9 +226,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "57",
                   "notes": "The user is asked to opt into the default search change unless it is a built-in engine."
@@ -272,9 +250,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "55"
                 },
@@ -297,9 +273,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "55"
                 },
@@ -322,9 +296,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -345,9 +317,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "55"
                 },
@@ -370,9 +340,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "64"
                 },
@@ -395,9 +363,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "64"
                 },
@@ -420,9 +386,7 @@
                 "chrome": {
                   "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "64"
                 },
@@ -446,9 +410,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/webextensions/manifest/chrome_url_overrides.json
+++ b/webextensions/manifest/chrome_url_overrides.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": "≤58"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "54"
             },
@@ -41,9 +39,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -64,9 +60,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -88,10 +82,7 @@
                 "version_added": "≤59",
                 "notes": "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome the last extension wins."
               },
-              "edge": {
-                "version_added": "79",
-                "notes": "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Edge the last extension wins."
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "54",
                 "notes": "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome the last extension wins."

--- a/webextensions/manifest/chrome_url_overrides.json
+++ b/webextensions/manifest/chrome_url_overrides.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤58"
             },
             "edge": {
               "version_added": "79"
@@ -39,7 +39,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -62,7 +62,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -85,7 +85,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "≤59",
                 "notes": "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome the last extension wins."
               },
               "edge": {

--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "79"
@@ -55,7 +55,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -82,7 +82,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -109,7 +109,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -136,7 +136,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -187,7 +187,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"

--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": "≤54"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "48"
             },
@@ -57,9 +55,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "57",
                 "notes": [
@@ -84,9 +80,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "57",
                 "notes": [
@@ -111,9 +105,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "57",
                 "notes": [
@@ -138,9 +130,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "57",
                 "notes": [
@@ -189,9 +179,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/webextensions/manifest/content_scripts.json
+++ b/webextensions/manifest/content_scripts.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "≤54",
               "notes": "Content scripts are not applied to tabs already open when the extension is loaded."
             },
             "edge": {
@@ -165,7 +165,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "≤58",
               "notes": "Until Chrome 110, the <code>object-src</code> directive was required with a secure source. From Chrome 111, the <code>object-src</code> directive is optional."
             },
             "edge": "mirror",

--- a/webextensions/manifest/default_locale.json
+++ b/webextensions/manifest/default_locale.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/default_locale",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "14"

--- a/webextensions/manifest/description.json
+++ b/webextensions/manifest/description.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/description",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "14"

--- a/webextensions/manifest/devtools_page.json
+++ b/webextensions/manifest/devtools_page.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤58"
             },
             "edge": {
               "version_added": "79"

--- a/webextensions/manifest/devtools_page.json
+++ b/webextensions/manifest/devtools_page.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": "≤58"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "54"
             },

--- a/webextensions/manifest/homepage_url.json
+++ b/webextensions/manifest/homepage_url.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": "≤54"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "48"
             },

--- a/webextensions/manifest/homepage_url.json
+++ b/webextensions/manifest/homepage_url.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "79"

--- a/webextensions/manifest/icons.json
+++ b/webextensions/manifest/icons.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": "mirror",
             "firefox": {

--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤58"
             },
             "edge": {
               "version_added": "≤18"
@@ -26,7 +26,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "17"
@@ -68,7 +68,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "17"

--- a/webextensions/manifest/name.json
+++ b/webextensions/manifest/name.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "14"

--- a/webextensions/manifest/omnibox.json
+++ b/webextensions/manifest/omnibox.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/omnibox",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤58"
             },
             "edge": {
               "version_added": "79"

--- a/webextensions/manifest/omnibox.json
+++ b/webextensions/manifest/omnibox.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": "≤58"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "52"
             },

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤58"
             },
             "edge": {
               "version_added": "79"
@@ -28,7 +28,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": {
@@ -68,7 +68,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -89,7 +89,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -152,7 +152,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -173,7 +173,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -196,7 +196,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -217,7 +217,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -240,7 +240,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -441,7 +441,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -464,7 +464,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": {
@@ -483,7 +483,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -504,7 +504,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -550,7 +550,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -571,7 +571,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -759,7 +759,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -782,7 +782,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -822,7 +822,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -845,7 +845,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -868,7 +868,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": "≤58"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "55"
             },
@@ -70,9 +68,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -91,9 +87,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -154,9 +148,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -175,9 +167,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -198,9 +188,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -219,9 +207,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -242,9 +228,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -443,9 +427,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -485,9 +467,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -506,9 +486,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "77"
               },
@@ -552,9 +530,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -573,9 +549,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -761,9 +735,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -784,9 +756,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -824,9 +794,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -847,9 +815,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -870,9 +836,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "≤54",
               "notes": [
                 "Since Chrome 49, page actions are displayed on the toolbar, rather than in the address bar.",
                 "If an extension defines a page action, it is not allowed to define a browser action as well."

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "14"
@@ -28,7 +28,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -187,7 +187,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -208,7 +208,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "79"
@@ -505,7 +505,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "14"
@@ -944,7 +944,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions",
           "support": {
             "chrome": {
-              "version_added": "≤54"
+              "version_added": "≤10"
             },
             "edge": {
               "version_added": "14"

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -30,9 +30,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "48"
               },
@@ -189,9 +187,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "54"
               },
@@ -210,9 +206,7 @@
               "chrome": {
                 "version_added": "≤58"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "51"
               },

--- a/webextensions/manifest/short_name.json
+++ b/webextensions/manifest/short_name.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "14"

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤59"
             },
             "edge": {
               "version_added": "79"
@@ -31,7 +31,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#colors",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "79"
@@ -125,7 +125,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤61",
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
@@ -571,7 +571,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤61",
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
@@ -599,7 +599,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤61",
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -8,9 +8,7 @@
             "chrome": {
               "version_added": "≤59"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "55"
             },
@@ -33,9 +31,7 @@
               "chrome": {
                 "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -128,10 +124,7 @@
                   "version_added": "≤61",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "55",
                   "notes": "Before version 59, the CSS color form was not supported for this property."
@@ -574,10 +567,7 @@
                   "version_added": "≤61",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "55",
                   "notes": "Before version 59, the CSS color form was not supported for this property."
@@ -602,10 +592,7 @@
                   "version_added": "≤61",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "57",
                   "notes": [

--- a/webextensions/manifest/version.json
+++ b/webextensions/manifest/version.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "≤54",
               "notes": "Valid Chrome versions are a subset of valid Firefox versions."
             },
             "edge": {

--- a/webextensions/manifest/web_accessible_resources.json
+++ b/webextensions/manifest/web_accessible_resources.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤54"
             },
             "edge": {
               "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `manifest` member of the `webextensions` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: 2efdf62c919f260d4c5c34b6da34ff06bbd0dbc1, #189, #216, 1077f96748d869c0406a24d1c09634b91336720a, 0b6eb2ddf938be9198c000b2ad2122b3da67ec43, #219, #244, 0b6fa92b7069e470d1c8d75f57a34ebc44ba70ee, 46f9188b7962dcac6dde3dcd93a64f2f0233f705, 29ff7e9c578526a3beac1f4b65e14a6c3fe5b58d, #481, 28b3a7726786a9d1007b8be1659c6bac24311b60
