### PR TITLE
Update Chromium data for match_patterns Web Extensions feature

### DIFF
--- a/webextensions/match_patterns.json
+++ b/webextensions/match_patterns.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Match_patterns",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "≤65"
           },
           "edge": {
             "version_added": "14"
@@ -29,7 +29,7 @@
             "description": "Wildcard <code>*</code> scheme",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤65"
               },
               "edge": {
                 "version_added": "14"
@@ -72,7 +72,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤65"
               },
               "edge": {
                 "version_added": "14"
@@ -95,7 +95,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤65"
               },
               "edge": {
                 "version_added": "14"
@@ -156,7 +156,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤65"
               },
               "edge": {
                 "version_added": "14"
@@ -177,7 +177,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤65"
               },
               "edge": {
                 "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `match_patterns` Web Extensions feature. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #2135
