### PR TITLE
Add subfeature for CSP form-action blocked redirects

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -412,7 +412,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "≤11.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -412,7 +412,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -391,6 +391,39 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "blocks_redirects": {
+            "__compat": {
+              "description": "Redirects are blocked after a form submission",
+              "support": {
+                "chrome": {
+                  "version_added": "≤63"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
           }
         },
         "frame-ancestors": {


### PR DESCRIPTION
This PR migrates the note from https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action to a BCD subfeature.  Fixes #6132.
