### PR TITLE
Add missing http.status.408 feature

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -669,6 +669,40 @@
           }
         }
       },
+      "408": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/408",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.408",
+          "support": {
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "409": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/409",


### PR DESCRIPTION
This PR adds the missing `408` member of the `status` HTTP feature. This fixes #8016, which contains the supporting evidence for this change.
