### PR TITLE
Update Safari data for http.headers.Access-Control-Allow-Methods.wildcard

### DIFF
--- a/http/headers/Access-Control-Allow-Methods.json
+++ b/http/headers/Access-Control-Allow-Methods.json
@@ -62,7 +62,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `wildcard` member of the `Access-Control-Allow-Methods` HTTP header. This fixes #11232, which contains the supporting evidence for this change.
