### PR TITLE
Update Safari data for Access-Control-Allow-Headers HTTP header

### DIFF
--- a/http/headers/Access-Control-Allow-Headers.json
+++ b/http/headers/Access-Control-Allow-Headers.json
@@ -102,7 +102,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `Access-Control-Allow-Headers` HTTP header. This fixes #11232, which contains the supporting evidence for this change.
