### PR TITLE
Update Safari data for html.elements.textarea.maxlength

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -372,11 +372,10 @@
                 "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": "5"
+                "version_added": "5",
+                "notes": "Before Safari 17, newline characters counted as two characters instead of one. See <a href='https://webkit.org/b/249916'>bug 249916</a>."
               },
-              "safari_ios": {
-                "version_added": "5"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "≤37"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `maxlength` member of the `textarea` HTML element. This fixes #11988, which contains the supporting evidence for this change.
