### PR TITLE
Remove Deno and NodeJS from api.EventTarget.addEventListener.options_parameter.options_passive_parameter_default_true_touch

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -332,7 +332,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -331,18 +331,12 @@
                   "version_added": "55"
                 },
                 "chrome_android": "mirror",
-                "deno": {
-                  "version_added": false
-                },
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "61"
                 },
                 "firefox_android": "mirror",
                 "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
                   "version_added": false
                 },
                 "oculus": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Deno/NodeJS for the `addEventListener.options_parameter.options_passive_parameter_default_true_touch` member of the `EventTarget` API. Deno and NodeJS are runtimes, not browsers, so it wouldn't make much sense for these to ever have support.