### PR TITLE
Add missing api.SharedWorker.SharedWorker.options_type_parameter feature

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -276,6 +276,51 @@
               "deprecated": false
             }
           }
+        },
+        "options_type_parameter": {
+          "__compat": {
+            "description": "<code>options.type</code> parameter",
+            "tags": [
+              "web-features:js-modules-shared-workers"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "80"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "deno": {
+                "version_added": "1.0",
+                "notes": "Only supports <code>module</code>"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "114"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "error_event": {


### PR DESCRIPTION
This PR adds the missing `SharedWorker.options_type_parameter` member of the `SharedWorker` API. This data is copied from the Worker API.  This fixes #13696.
