### PR TITLE
Update Chromium data for Accept-CH-Lifetime HTTP header

### DIFF
--- a/http/headers/Accept-CH-Lifetime.json
+++ b/http/headers/Accept-CH-Lifetime.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-CH-Lifetime",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Accept-CH-Lifetime` HTTP header. This fixes #14533, which contains the supporting evidence for this change.

Additional Notes: Confirmed by ChromeStatus: https://chromestatus.com/feature/5713139295322112
