### PR TITLE
Update Safari data for AudioContext API

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -111,7 +111,8 @@
             ],
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "14.1",
+                "notes": "New audio contexts are suspended until the <code>resume()</code> method is called via user action, such as the <code>click</code> event."
               },
               {
                 "prefix": "webkit",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `AudioContext` API. This fixes #16009, which contains the supporting evidence for this change.
