### PR TITLE
Update Chromium data for css.types.global_keywords.revert-layer

### DIFF
--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -160,7 +160,7 @@
             "spec_url": "https://drafts.csswg.org/css-cascade-5/#revert-layer",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "99"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -182,7 +182,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `revert-layer` member of the `global_keywords` CSS value type. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code: https://wpt.live/css/css-cascade/revert-layer-001.html

Additional Notes: Fixes #16336.
