### PR TITLE
Update Safari data for accent-color CSS property

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -25,7 +25,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.4"
+              "version_added": "15.4",
+              "partial_implementation": true,
+              "notes": "Safari does not adjust the color of glyphs (such as checkmarks) on form controls to maintain contrast. See <a href='https://webkit.org/b/244233'>bug 244233</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `accent-color` CSS property. This fixes #16367, which contains the supporting evidence for this change.
