### PR TITLE
Correct data error for ruby-align

### DIFF
--- a/css/properties/ruby-align.json
+++ b/css/properties/ruby-align.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari Technology Preview does not support `ruby-align`. Not sure how that got added. Changing "preview" to false.

Here's a test: https://software.hixie.ch/utilities/js/live-dom-viewer/?%3Cstyle%3E%40supports%20(ruby-align%3A%20center)%20%7B%20html%20%7B%20background%3A%20green%3B%20%7D%20%7D%3C%2Fstyle%3E
