### PR TITLE
Update Opera data for EyeDropper API

### DIFF
--- a/api/EyeDropper.json
+++ b/api/EyeDropper.json
@@ -23,7 +23,9 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": "mirror",
+          "opera": {
+            "version_added": false
+          },
           "opera_android": "mirror",
           "safari": {
             "version_added": false
@@ -62,7 +64,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -97,7 +101,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -136,7 +142,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `EyeDropper` API. This fixes #16519, which contains the supporting evidence for this change.
