### PR TITLE
Update Safari data for api.Navigator.setAppBadge

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4248,11 +4248,17 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "17",
-              "notes": "Badging is supported for installed web apps on macOS Sonoma and higher."
+              "notes": [
+                "Badging is supported for installed web apps on macOS Sonoma and higher.",
+                "Passing <code>0</code> as an argument will clear the badge instead of displaying an unnumbered dot."
+              ]
             },
             "safari_ios": {
               "version_added": "16.4",
-              "notes": "Badging is supported for web apps saved to the home screen."
+              "notes": [
+                "Badging is supported for web apps saved to the home screen.",
+                "Passing <code>0</code> as an argument will clear the badge instead of displaying an unnumbered dot."
+              ]
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `setAppBadge` member of the `Navigator` API. This fixes #19300, which contains the supporting evidence for this change.
