### PR TITLE
Update Safari data for css.types.global_keywords.revert-layer

### DIFF
--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -175,14 +175,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `revert-layer` member of the `global_keywords` CSS value type. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/4ef8a3eb4931c9905b7f3f6d4d65f40e7164d20e

Additional Notes: Fixes #20453.
