### PR TITLE
Update Chromium data for http.headers.Authorization.Digest.SHA-256

### DIFF
--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -114,7 +114,7 @@
               "description": "SHA2-256 digest authentication",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "117"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Digest.SHA-256` member of the `Authorization` HTTP header. This fixes #20812, which contains the supporting evidence for this change.
