### PR TITLE
createImageBitmap imageOrientation value from-image supported

### DIFF
--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -109,6 +109,78 @@
           }
         }
       },
+      "options_imageOrientation_parameter_from-image_value": {
+        "__compat": {
+          "description": "<code>options.imageOrientation</code> parameter value <code>from-image</code>",
+          "support": {
+            "chrome": {
+              "version_added": "112"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.40"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "111"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "options_imageOrientation_parameter_none_value": {
+        "__compat": {
+          "description": "<code>options.imageOrientation</code> parameter value <code>none</code>",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.40"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "options_premultiplyAlpha_parameter": {
         "__compat": {
           "description": "<code>options.premultiplyAlpha</code> parameter",

--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -107,77 +107,77 @@
             "standard_track": true,
             "deprecated": false
           }
-        }
-      },
-      "options_imageOrientation_parameter_from-image_value": {
-        "__compat": {
-          "description": "<code>options.imageOrientation</code> parameter value <code>from-image</code>",
-          "support": {
-            "chrome": {
-              "version_added": "112"
+        },
+        "from-image": {
+          "__compat": {
+            "description": "Value <code>from-image</code>",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.40"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "111"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.40"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "111"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "16"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
-        }
-      },
-      "options_imageOrientation_parameter_none_value": {
-        "__compat": {
-          "description": "<code>options.imageOrientation</code> parameter value <code>none</code>",
-          "support": {
-            "chrome": {
-              "version_added": false
+        },
+        "none": {
+          "__compat": {
+            "description": "Value <code>none</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.40"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.40"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
[`createImageBitmap()`](https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap#imageorientation) takes an `options.imageOrientation` parameter that historically had values `none` and `flipY`. The `none` parameter has been renamed to `from-image` in the spec.
The complication though is that `none` is going to be reused for a different meaning in future. This is not in the spec yet, but is in deno.

What I have done is created subfeatures for `from-image` and `none`. I could also create one for `flipY` that would match the parent - I would like to if that is OK?

`from-image` supports is FF111 from https://bugzilla.mozilla.org/show_bug.cgi?id=1809740, Chrome 112 from  https://chromiumdash.appspot.com/commit/5a0ea7914545c91610c08053dd45d5d97328378a, Safari 16 from https://bugs.webkit.org/show_bug.cgi?id=250476, Deno from first version where this appears in docs - https://deno.land/api@v1.40.0?s=ImageOrientation

`none` is only in deno, and based on that same first version, which is also the first version of the method https://deno.land/api@v1.40.0?s=ImageOrientation

Fixes #23310

Related docs work in https://github.com/mdn/content/issues/23564