### PR TITLE
Update Safari iOS data for api.Window.open

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3292,7 +3292,11 @@
             "safari": {
               "version_added": "1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "1",
+              "partial_implementation": true,
+              "notes": "This method will not function if the target is unspecified or is set to <code>_blank</code>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Window.json
+++ b/api/Window.json
@@ -3295,7 +3295,7 @@
             "safari_ios": {
               "version_added": "1",
               "partial_implementation": true,
-              "notes": "This method will not function if the target is unspecified or is set to <code>_blank</code>."
+              "notes": "This method will not function if the <code>target</code> parameter is unspecified or set to <code>_blank</code>."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `open` member of the `Window` API. This fixes #21661, which contains the supporting evidence for this change.
