### PR TITLE
Update Chromium data for api.MediaRecorder.error_event

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -228,9 +228,7 @@
           "spec_url": "https://w3c.github.io/mediacapture-record/#dom-mediarecorder-onerror",
           "support": {
             "chrome": {
-              "version_added": "49",
-              "partial_implementation": true,
-              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
+              "version_added": "49"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -228,7 +228,9 @@
           "spec_url": "https://w3c.github.io/mediacapture-record/#dom-mediarecorder-onerror",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": "49",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/ErrorEvent'><code>ErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `error_event` member of the `MediaRecorder` API. This fixes #21687, which contains the supporting evidence for this change.
