### PR TITLE
Add missing api.HTMLElement.contentEditable.plaintext-only feature

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -605,6 +605,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "plaintext-only": {
+          "__compat": {
+            "description": "<code>plaintext-only</code> as a value",
+            "support": {
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "dataset": {


### PR DESCRIPTION
This PR adds the missing `contentEditable.plaintext-only` member of the `HTMLElement` API. This fixes #21957, which contains the supporting evidence for this change.
