### PR TITLE
Update Safari iOS data for api.RTCDataChannel.transferable

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -932,9 +932,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `transferable` member of the `RTCDataChannel` API. This fixes #21989, which contains the supporting evidence for this change.
