### PR TITLE
Update WebView data for api.Navigator.userAgentData

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4707,7 +4707,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false,
+              "version_added": "119",
               "impl_url": "https://crbug.com/921655"
             }
           },
@@ -4742,7 +4742,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "119"
               }
             },
             "status": {


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `userAgentData` member of the `Navigator` API. This fixes #22125, which contains the supporting evidence for this change.
