### PR TITLE
Update Chrome Android data for GPU API

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -118,7 +118,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -172,7 +172,7 @@
                 "notes": "Currently supported on dual GPU macOS devices only."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "edge": "mirror",
               "firefox": {
@@ -213,7 +213,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -126,7 +126,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "127"
             },
             "edge": "mirror",
             "firefox": {
@@ -166,7 +166,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -213,7 +213,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -272,7 +272,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -331,7 +331,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -369,7 +369,7 @@
                 "version_added": "116"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "deno": [
                 {

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -118,7 +118,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": "1.39",
@@ -171,7 +171,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": "1.39",
@@ -224,7 +224,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": "1.39",

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -189,7 +189,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -248,7 +248,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -307,7 +307,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -366,7 +366,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -425,7 +425,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -484,7 +484,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": {
             "version_added": false
@@ -59,7 +59,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -109,7 +109,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -156,7 +156,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -203,7 +203,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -189,7 +189,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -248,7 +248,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -307,7 +307,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -366,7 +366,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -425,7 +425,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -484,7 +484,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -543,7 +543,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -602,7 +602,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -661,7 +661,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -720,7 +720,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -779,7 +779,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": {
             "version_added": false
@@ -59,7 +59,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": {
             "version_added": false
@@ -59,7 +59,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -106,7 +106,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -153,7 +153,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -200,7 +200,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -247,7 +247,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -294,7 +294,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -194,7 +194,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -253,7 +253,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -312,7 +312,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -371,7 +371,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -430,7 +430,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -489,7 +489,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -548,7 +548,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -603,7 +603,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -189,7 +189,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -248,7 +248,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -307,7 +307,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -366,7 +366,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -425,7 +425,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -484,7 +484,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -539,7 +539,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -598,7 +598,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -657,7 +657,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -716,7 +716,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -775,7 +775,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -834,7 +834,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -893,7 +893,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -952,7 +952,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1011,7 +1011,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -1052,7 +1052,7 @@
                 "version_added": "116"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "deno": {
                 "version_added": false
@@ -1096,7 +1096,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1155,7 +1155,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1214,7 +1214,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1273,7 +1273,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1332,7 +1332,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1391,7 +1391,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1451,7 +1451,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -67,7 +67,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": {
             "version_added": false
@@ -55,7 +55,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUInternalError.json
+++ b/api/GPUInternalError.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": {
             "version_added": false
@@ -56,7 +56,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -72,7 +72,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": {
             "version_added": false
@@ -56,7 +56,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -93,7 +93,7 @@
                 "version_added": "113"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "deno": {
                 "version_added": false
@@ -137,7 +137,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -189,7 +189,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -248,7 +248,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -124,7 +124,7 @@
                 "version_added": "116"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "deno": [
                 {
@@ -180,7 +180,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -239,7 +239,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -294,7 +294,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -353,7 +353,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -412,7 +412,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPURenderBundle.json
+++ b/api/GPURenderBundle.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -67,7 +67,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -189,7 +189,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -241,7 +241,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -305,7 +305,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -364,7 +364,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -423,7 +423,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -478,7 +478,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -537,7 +537,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -596,7 +596,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -655,7 +655,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -714,7 +714,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -773,7 +773,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -827,7 +827,7 @@
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "deno": [
                 {

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -126,7 +126,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -185,7 +185,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -244,7 +244,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -308,7 +308,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -372,7 +372,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -431,7 +431,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -486,7 +486,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -545,7 +545,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -604,7 +604,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -663,7 +663,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -722,7 +722,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -781,7 +781,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -840,7 +840,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -899,7 +899,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -958,7 +958,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1017,7 +1017,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1076,7 +1076,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1135,7 +1135,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1189,7 +1189,7 @@
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "deno": [
                 {
@@ -1245,7 +1245,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1300,7 +1300,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -118,7 +118,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -69,7 +69,7 @@
               "version_added": "113"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -122,7 +122,7 @@
               "version_added": "113"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -175,7 +175,7 @@
               "version_added": "113"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -228,7 +228,7 @@
               "version_added": "113"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -281,7 +281,7 @@
               "version_added": "113"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -334,7 +334,7 @@
               "version_added": "113"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -387,7 +387,7 @@
               "version_added": "113"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -70,7 +70,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -127,7 +127,7 @@
               "version_added": "120"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -169,7 +169,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -227,7 +227,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -281,7 +281,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -323,7 +323,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -365,7 +365,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -419,7 +419,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -473,7 +473,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -527,7 +527,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -581,7 +581,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -635,7 +635,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -689,7 +689,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -743,7 +743,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -797,7 +797,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -851,7 +851,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -893,7 +893,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -947,7 +947,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1001,7 +1001,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1055,7 +1055,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1109,7 +1109,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1163,7 +1163,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1217,7 +1217,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1271,7 +1271,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1325,7 +1325,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1379,7 +1379,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1433,7 +1433,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1487,7 +1487,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1541,7 +1541,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1595,7 +1595,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1649,7 +1649,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -1703,7 +1703,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -130,7 +130,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -189,7 +189,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -248,7 +248,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -307,7 +307,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -366,7 +366,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -425,7 +425,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -484,7 +484,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -543,7 +543,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -602,7 +602,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {
@@ -661,7 +661,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -71,7 +71,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": {
             "version_added": false
@@ -60,7 +60,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false
@@ -107,7 +107,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": {
               "version_added": false

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "deno": [
             {
@@ -72,7 +72,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `GPU` API. This fixes #22159, which contains the supporting evidence for this change.

Additional Notes: While the collector currently doesn't have results for Android browsers, the data was confired in the collector by manually running the tests on Chrome Android via BrowserStack.
