### PR TITLE
Remove subfeatures of theme Web Extensions manifest property from BCD

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -456,27 +456,6 @@
               }
             }
           },
-          "tab_background_separator": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "62"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "tab_background_text": {
             "__compat": {
               "support": {
@@ -768,35 +747,6 @@
                 "firefox": {
                   "version_added": "67"
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
-          "toolbar_field_separator": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "59"
-                  },
-                  {
-                    "alternative_name": "toolbar_vertical_separator",
-                    "version_added": "58",
-                    "version_removed": "59",
-                    "notes": "Before version 59, the RGB array form was not supported for this property."
-                  }
-                ],
                 "firefox_android": {
                   "version_added": false
                 },


### PR DESCRIPTION
This PR removes the unsupported subfeatures of the `theme` Web Extensions manifest property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly.  Fixes #22215.
