### PR TITLE
ShadowRoot.serializable, getHTML() etc add MDN urls

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5516,6 +5516,7 @@
       },
       "getHTML": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getHTML",
           "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-gethtml",
           "support": {
             "chrome": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -342,6 +342,7 @@
       },
       "getHTML": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/getHTML",
           "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-shadowroot-gethtml",
           "support": {
             "chrome": {
@@ -594,6 +595,7 @@
       },
       "serializable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/serializable",
           "spec_url": "https://dom.spec.whatwg.org/#dom-shadowroot-serializable",
           "support": {
             "chrome": {


### PR DESCRIPTION
Adds MDN urls for Shadowroot methods Shadowroot.getHTML, Shadowroot.serializable, Element.getHTML(). Follows on from work done in  #23364

Related docs work can be tracked in https://github.com/mdn/content/issues/34302