### PR TITLE
Add MDN URLs for chapterInfo features

### DIFF
--- a/api/ChapterInformation.json
+++ b/api/ChapterInformation.json
@@ -2,6 +2,7 @@
   "api": {
     "ChapterInformation": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChapterInformation",
         "spec_url": "https://w3c.github.io/mediasession/#chapterinformation",
         "support": {
           "chrome": {
@@ -34,6 +35,7 @@
       },
       "artwork": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChapterInformation/artwork",
           "spec_url": "https://w3c.github.io/mediasession/#dom-chapterinformation-artwork",
           "support": {
             "chrome": {
@@ -67,6 +69,7 @@
       },
       "startTime": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChapterInformation/startTime",
           "spec_url": "https://w3c.github.io/mediasession/#dom-chapterinformation-starttime",
           "support": {
             "chrome": {
@@ -100,6 +103,7 @@
       },
       "title": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChapterInformation/title",
           "spec_url": "https://w3c.github.io/mediasession/#dom-chapterinformation-title",
           "support": {
             "chrome": {

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -201,6 +201,7 @@
       },
       "chapterInfo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/chapterInfo",
           "spec_url": "https://w3c.github.io/mediasession/#dom-mediametadata-chapterinfo",
           "support": {
             "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In https://github.com/mdn/content/pull/34400, I add documentation for the Media Session API `MediaMetadata` `chapterInfo` functionality.

I saw that the BCD for these features was already added, but there were no MDN URLs. This PR adds the missing MDN URLs.

One small point — the spec URLs look correct, but in the local page previews, the "No specification found" box pops up. I'm not sure what the problem is.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
