### PR TITLE
Remove erroneous cookies samesite mdn_url

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -65,7 +65,6 @@
           },
           "sameSite": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/SameSiteStatus",
               "support": {
                 "chrome": {
                   "version_added": true


### PR DESCRIPTION
#### Summary

'sameSite' is a property of [cookies.Cookie](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie) and doesn't have a dedicated page. Also the link is for the entirely separate [SameSiteStatus](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/SameSiteStatus) type.