### PR TITLE
Add mdn_urls for GPUSupportedLimits properties

### DIFF
--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -60,6 +60,7 @@
       },
       "maxBindGroups": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroups",
           "tags": [
             "web-features:webgpu"
@@ -118,6 +119,7 @@
       },
       "maxBindGroupsPlusVertexBuffers": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroupsplusvertexbuffers",
           "tags": [
             "web-features:webgpu"
@@ -159,6 +161,7 @@
       },
       "maxBindingsPerBindGroup": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindingsperbindgroup",
           "tags": [
             "web-features:webgpu"
@@ -217,6 +220,7 @@
       },
       "maxBufferSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbuffersize",
           "tags": [
             "web-features:webgpu"
@@ -271,6 +275,7 @@
       },
       "maxColorAttachmentBytesPerSample": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcolorattachmentbytespersample",
           "tags": [
             "web-features:webgpu"
@@ -313,6 +318,7 @@
       },
       "maxColorAttachments": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcolorattachments",
           "tags": [
             "web-features:webgpu"
@@ -355,6 +361,7 @@
       },
       "maxComputeInvocationsPerWorkgroup": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeinvocationsperworkgroup",
           "tags": [
             "web-features:webgpu"
@@ -409,6 +416,7 @@
       },
       "maxComputeWorkgroupSizeX": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizex",
           "tags": [
             "web-features:webgpu"
@@ -463,6 +471,7 @@
       },
       "maxComputeWorkgroupSizeY": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizey",
           "tags": [
             "web-features:webgpu"
@@ -517,6 +526,7 @@
       },
       "maxComputeWorkgroupSizeZ": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizez",
           "tags": [
             "web-features:webgpu"
@@ -571,6 +581,7 @@
       },
       "maxComputeWorkgroupsPerDimension": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsperdimension",
           "tags": [
             "web-features:webgpu"
@@ -625,6 +636,7 @@
       },
       "maxComputeWorkgroupStorageSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupstoragesize",
           "tags": [
             "web-features:webgpu"
@@ -679,6 +691,7 @@
       },
       "maxDynamicStorageBuffersPerPipelineLayout": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxdynamicstoragebuffersperpipelinelayout",
           "tags": [
             "web-features:webgpu"
@@ -733,6 +746,7 @@
       },
       "maxDynamicUniformBuffersPerPipelineLayout": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxdynamicuniformbuffersperpipelinelayout",
           "tags": [
             "web-features:webgpu"
@@ -787,6 +801,7 @@
       },
       "maxInterStageShaderComponents": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadercomponents",
           "tags": [
             "web-features:webgpu"
@@ -841,6 +856,7 @@
       },
       "maxInterStageShaderVariables": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadervariables",
           "tags": [
             "web-features:webgpu"
@@ -883,6 +899,7 @@
       },
       "maxSampledTexturesPerShaderStage": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxsampledtexturespershaderstage",
           "tags": [
             "web-features:webgpu"
@@ -937,6 +954,7 @@
       },
       "maxSamplersPerShaderStage": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxsamplerspershaderstage",
           "tags": [
             "web-features:webgpu"
@@ -991,6 +1009,7 @@
       },
       "maxStorageBufferBindingSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferbindingsize",
           "tags": [
             "web-features:webgpu"
@@ -1045,6 +1064,7 @@
       },
       "maxStorageBuffersPerShaderStage": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferspershaderstage",
           "tags": [
             "web-features:webgpu"
@@ -1099,6 +1119,7 @@
       },
       "maxStorageTexturesPerShaderStage": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturespershaderstage",
           "tags": [
             "web-features:webgpu"
@@ -1153,6 +1174,7 @@
       },
       "maxTextureArrayLayers": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturearraylayers",
           "tags": [
             "web-features:webgpu"
@@ -1207,6 +1229,7 @@
       },
       "maxTextureDimension1D": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension1d",
           "tags": [
             "web-features:webgpu"
@@ -1261,6 +1284,7 @@
       },
       "maxTextureDimension2D": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension2d",
           "tags": [
             "web-features:webgpu"
@@ -1315,6 +1339,7 @@
       },
       "maxTextureDimension3D": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension3d",
           "tags": [
             "web-features:webgpu"
@@ -1369,6 +1394,7 @@
       },
       "maxUniformBufferBindingSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferbindingsize",
           "tags": [
             "web-features:webgpu"
@@ -1423,6 +1449,7 @@
       },
       "maxUniformBuffersPerShaderStage": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferspershaderstage",
           "tags": [
             "web-features:webgpu"
@@ -1477,6 +1504,7 @@
       },
       "maxVertexAttributes": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexattributes",
           "tags": [
             "web-features:webgpu"
@@ -1531,6 +1559,7 @@
       },
       "maxVertexBufferArrayStride": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexbufferarraystride",
           "tags": [
             "web-features:webgpu"
@@ -1585,6 +1614,7 @@
       },
       "maxVertexBuffers": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexbuffers",
           "tags": [
             "web-features:webgpu"
@@ -1639,6 +1669,7 @@
       },
       "minStorageBufferOffsetAlignment": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minstoragebufferoffsetalignment",
           "tags": [
             "web-features:webgpu"
@@ -1693,6 +1724,7 @@
       },
       "minUniformBufferOffsetAlignment": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minuniformbufferoffsetalignment",
           "tags": [
             "web-features:webgpu"


### PR DESCRIPTION
The https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits MDN page is not quite conventional as it doesn't create sub pages for all its properties. And that makes sense: the instance properties are more like constants and so they are just documented inline on the page. Our mdn_url linter doesn't know about this, so I'm adding the URLs manually.