### PR TITLE
Adds MAX_NUMBER_OF_DISABLED_STATIC_RULES

### DIFF
--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -139,6 +139,25 @@
             }
           }
         },
+        "MAX_NUMBER_OF_DISABLED_STATIC_RULES": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "128"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES",

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -143,7 +143,8 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "Although this property is not exposed, the limit is enforced and applies to disable static rules across all rulesets."
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
### Summary

Adds browser compatibility data for the `declarativeNetRequest` type `MAX_NUMBER_OF_DISABLED_STATIC_RULES` addressing the dev–doc-needed request from [Bug 1896628](https://bugzilla.mozilla.org/show_bug.cgi?id=1896628)[DNR] Enforce a limit to the maximum number of static rules disabled individually.

Version information for Chrome and Safari based on [comments](https://github.com/w3c/webextensions/issues/162#issuecomment-2109966158) on Declarative Net Request proposal: disable individual static rules #162 and the Chrome documentation.

Related content change in PR TBC