### PR TITLE
Add display_override manifest member tabbed value

### DIFF
--- a/html/manifest/display_override.json
+++ b/html/manifest/display_override.json
@@ -20,9 +20,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -36,6 +34,41 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "tabbed": {
+          "__compat": {
+            "spec_url": "https://wicg.github.io/manifest-incubations/#dfn-tabbed",
+            "support": {
+              "chrome": {
+                "version_added": "126"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 126 supports the [`display_override`](https://developer.mozilla.org/en-US/docs/Web/Manifest/display_override) manifest member's [`tabbed`](https://wicg.github.io/manifest-incubations/#dfn-tabbed) value (see the [ChromeStatus emtry](https://chromestatus.com/feature/5128143454076928)).

This PR adds a separate data point for it.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
