### PR TITLE
Add outline-color: auto keyword

### DIFF
--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -54,9 +54,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -65,9 +63,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -47,6 +47,42 @@
             "deprecated": false
           }
         },
+        "auto": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "invert": {
           "__compat": {
             "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Added auto keyword value to outline-color property. It replaced invert keyword.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Checked in the following browsers

- safari 17.0
- firefox 127
- chrome 126

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

It was updated in mdn content but compatibility table does not show `auto` is not supported anywhere
https://github.com/mdn/content/pull/29798
https://developer.mozilla.org/en-US/docs/Web/CSS/outline-color#browser_compatibility

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
