### PR TITLE
SVG href is not a global attribute

### DIFF
--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -74,6 +74,7 @@
         },
         "href": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementHrefAttribute",
             "support": {
               "chrome": {
                 "version_added": "50"

--- a/svg/elements/animate.json
+++ b/svg/elements/animate.json
@@ -174,6 +174,41 @@
             }
           }
         },
+        "href": {
+          "__compat": {
+            "spec_url": "https://svgwg.org/specs/animations/#HrefAttribute",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "repeatCount": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/repeatCount",

--- a/svg/elements/animateMotion.json
+++ b/svg/elements/animateMotion.json
@@ -72,6 +72,41 @@
             }
           }
         },
+        "href": {
+          "__compat": {
+            "spec_url": "https://svgwg.org/specs/animations/#HrefAttribute",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "keyPoints": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/keyPoints",

--- a/svg/elements/animateTransform.json
+++ b/svg/elements/animateTransform.json
@@ -108,6 +108,41 @@
             }
           }
         },
+        "href": {
+          "__compat": {
+            "spec_url": "https://svgwg.org/specs/animations/#HrefAttribute",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "to": {
           "__compat": {
             "support": {

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -76,6 +76,7 @@
         },
         "href": {
           "__compat": {
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feimage-href",
             "support": {
               "chrome": {
                 "version_added": "5"

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -142,6 +142,41 @@
             }
           }
         },
+        "href": {
+          "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/embedded.html#ImageElementHrefAttribute",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "≤11"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "preserveAspectRatio": {
           "__compat": {
             "support": {

--- a/svg/elements/linearGradient.json
+++ b/svg/elements/linearGradient.json
@@ -112,6 +112,41 @@
             }
           }
         },
+        "href": {
+          "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementHrefAttribute",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "≤11"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "spreadMethod": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/spreadMethod",

--- a/svg/elements/mpath.json
+++ b/svg/elements/mpath.json
@@ -36,6 +36,41 @@
             "deprecated": false
           }
         },
+        "href": {
+          "__compat": {
+            "spec_url": "https://svgwg.org/specs/animations/#MPathElementHrefAttribute",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "xlink_href": {
           "__compat": {
             "description": "<code>xlink:href</code>",

--- a/svg/elements/pattern.json
+++ b/svg/elements/pattern.json
@@ -76,6 +76,7 @@
         },
         "href": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementHrefAttribute",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -87,7 +88,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/svg/elements/radialGradient.json
+++ b/svg/elements/radialGradient.json
@@ -274,24 +274,27 @@
         },
         "href": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementHrefAttribute",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "1.5"
+                "version_added": "51"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "12.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -106,6 +106,41 @@
             }
           }
         },
+        "href": {
+          "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/interact.html#ScriptElementHrefAttribute",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "≤11"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "type": {
           "__compat": {
             "support": {

--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -42,6 +42,41 @@
             "deprecated": false
           }
         },
+        "href": {
+          "__compat": {
+            "spec_url": "https://svgwg.org/specs/animations/#HrefAttribute",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "51"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "to": {
           "__compat": {
             "support": {

--- a/svg/elements/textPath.json
+++ b/svg/elements/textPath.json
@@ -39,6 +39,7 @@
         },
         "href": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElementHrefAttribute",
             "support": {
               "chrome": {
                 "version_added": "50",

--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -161,6 +161,7 @@
         },
         "href": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute",
             "support": {
               "chrome": {
                 "version_added": "50"

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -215,6 +215,7 @@
       "xlink_actuate": {
         "__compat": {
           "description": "<code>xlink:actuate</code>",
+          "spec_url": "https://www.w3.org/TR/SVG11/linking.html#XLinkActuateAttribute",
           "support": {
             "chrome": {
               "version_added": null
@@ -283,6 +284,7 @@
       "xlink_role": {
         "__compat": {
           "description": "<code>xlink:role</code>",
+          "spec_url": "https://www.w3.org/TR/SVG11/linking.html#XLinkRoleAttribute",
           "support": {
             "chrome": {
               "version_added": null
@@ -442,55 +444,6 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "10"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "href": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/href",
-          "spec_url": [
-            "https://drafts.fxtf.org/filter-effects/#element-attrdef-feimage-href",
-            "https://svgwg.org/specs/animations/#DiscardElementHrefAttribute",
-            "https://svgwg.org/specs/animations/#HrefAttribute",
-            "https://svgwg.org/specs/animations/#MPathElementHrefAttribute",
-            "https://svgwg.org/svg2-draft/embedded.html#ImageElementHrefAttribute",
-            "https://svgwg.org/svg2-draft/linking.html#AElementHrefAttribute",
-            "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementHrefAttribute",
-            "https://svgwg.org/svg2-draft/pservers.html#PatternElementHrefAttribute",
-            "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementHrefAttribute",
-            "https://svgwg.org/svg2-draft/interact.html#ScriptElementHrefAttribute",
-            "https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute",
-            "https://svgwg.org/svg2-draft/text.html#TextPathElementHrefAttribute"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "50"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "51"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": "≤11"
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "12.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

The SVG `href` attribute is not a global attribute, it can only be used for certain elements. Remove it from global attribute data and add it to the elements where it is still missing.

#### Test results and supporting details

None.

#### Related issues

- https://github.com/mdn/browser-compat-data/issues/9462
- https://github.com/openwebdocs/mdn-bcd-collector/pull/1474