### PR TITLE
Fix mixed notations for parameter properties of `action.setIcon()`

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -653,8 +653,9 @@
               }
             }
           },
-          "imageData": {
+          "details_imageData_parameter": {
             "__compat": {
+              "description": "<code>details.imageData</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "88"

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -633,26 +633,6 @@
               "safari_ios": "mirror"
             }
           },
-          "details_windowId_parameter": {
-            "__compat": {
-              "description": "<code>details.windowId</code> parameter",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "109"
-                },
-                "firefox_android": "mirror",
-                "opera": "mirror",
-                "safari": {
-                  "version_added": "18"
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "details_imageData_parameter": {
             "__compat": {
               "description": "<code>details.imageData</code> parameter",
@@ -668,6 +648,26 @@
                 "opera": "mirror",
                 "safari": {
                   "version_added": "15.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "details_windowId_parameter": {
+            "__compat": {
+              "description": "<code>details.windowId</code> parameter",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "109"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -750,28 +750,6 @@
               }
             }
           },
-          "details_windowId_parameter": {
-            "__compat": {
-              "description": "<code>details.windowId</code> parameter",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "62"
-                },
-                "firefox_android": {
-                  "version_added": "79"
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": "18"
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "details_imageData_parameter": {
             "__compat": {
               "description": "<code>details.imageData</code> parameter",
@@ -793,6 +771,28 @@
                 "safari_ios": {
                   "version_added": "15"
                 }
+              }
+            }
+          },
+          "details_windowId_parameter": {
+            "__compat": {
+              "description": "<code>details.windowId</code> parameter",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "62"
+                },
+                "firefox_android": {
+                  "version_added": "79"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "18"
+                },
+                "safari_ios": "mirror"
               }
             }
           },

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -772,8 +772,9 @@
               }
             }
           },
-          "imageData": {
+          "details_imageData_parameter": {
             "__compat": {
+              "description": "<code>details.imageData</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "23"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The properties of the `details` parameter of `action.setIcon()` are currently specified with mixed notations. The suggested notation for such properties is `<paramName>_<propName>_parameter`. 

The `windowId` property is specified as `details_windowId_parameter`, while `imageData` is specified as a flat entry. This is inconsistent.

This PR updates the definition for `imageData` to match the (suggested) notation used by `windowId`.
