### PR TITLE
Replace propName_value notation by paramName_propName_parameter notation in `tabs.update()`

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3981,9 +3981,9 @@
               }
             }
           },
-          "active_value": {
+          "updateProperties_active_parameter": {
             "__compat": {
-              "description": "<code>active</code> value",
+              "description": "<code>updateProperties.active</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -4007,9 +4007,9 @@
               }
             }
           },
-          "autoDiscardable_value": {
+          "updateProperties_autoDiscardable_parameter": {
             "__compat": {
-              "description": "<code>autoDiscardable</code> value",
+              "description": "<code>updateProperties.autoDiscardable</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "54"
@@ -4029,9 +4029,9 @@
               }
             }
           },
-          "highlighted_value": {
+          "updateProperties_highlighted_parameter": {
             "__compat": {
-              "description": "<code>highlighted</code> value",
+              "description": "<code>updateProperties.highlighted</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -4055,9 +4055,9 @@
               }
             }
           },
-          "loadReplace_value": {
+          "updateProperties_loadReplace_parameter": {
             "__compat": {
-              "description": "<code>loadReplace</code> value",
+              "description": "<code>updateProperties.loadReplace</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -4077,9 +4077,9 @@
               }
             }
           },
-          "muted_value": {
+          "updateProperties_muted_parameter": {
             "__compat": {
-              "description": "<code>muted</code> value",
+              "description": "<code>updateProperties.muted</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "45"
@@ -4101,9 +4101,9 @@
               }
             }
           },
-          "openerTabId_value": {
+          "updateProperties_openerTabId_parameter": {
             "__compat": {
-              "description": "<code>openerTabId</code> value",
+              "description": "<code>updateProperties.openerTabId</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "18"
@@ -4125,9 +4125,9 @@
               }
             }
           },
-          "pinned_value": {
+          "updateProperties_pinned_parameter": {
             "__compat": {
-              "description": "<code>pinned</code> value",
+              "description": "<code>updateProperties.pinned</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -4152,9 +4152,9 @@
               }
             }
           },
-          "selected_value": {
+          "updateProperties_selected_parameter": {
             "__compat": {
-              "description": "<code>selected</code> value",
+              "description": "<code>updateProperties.selected</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -4176,9 +4176,9 @@
               }
             }
           },
-          "url_value": {
+          "updateProperties_url_parameter": {
             "__compat": {
-              "description": "<code>url</code> value",
+              "description": "<code>updateProperties.url</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": true


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The definition for `tabs.updated()` uses a notation which is not used anywhere else in BCD (to my knowledge). The notation is not documented in https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#parameters-and-parameter-object-features 

This PR changes the entry for `tabs.update()` to use the suggested `<paramName>_<propName>_parameter` notation.