### PR TITLE
Update SVG presentation attributes

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -792,22 +792,24 @@
           ],
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -829,22 +831,22 @@
           ],
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -863,26 +865,34 @@
           "spec_url": "https://drafts.fxtf.org/css-masking/#clip-property",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "4",
+              "notes": "Before Internet Explorer 7, Internet Explorer incorrectly interprets <code>clip: auto</code> as <code>clip: rect(auto, auto, auto, auto)</code>."
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "7"
+            },
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "1",
+              "notes": "Safari incorrectly interprets <code>clip: auto</code> as <code>clip: rect(auto, auto, auto, auto)</code>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "37"
+            }
           },
           "status": {
             "experimental": false,
@@ -897,22 +907,24 @@
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-clip-path",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "23"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "52"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -931,22 +943,24 @@
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-clip-rule",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -965,22 +979,28 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#ColorProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "3"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1111,22 +1131,22 @@
           "spec_url": "https://drafts.fxtf.org/filter-effects/#ColorInterpolationFiltersProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1179,22 +1199,29 @@
           "spec_url": "https://drafts.csswg.org/css-ui/#cursor",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": null
+            "edge": {
+              "version_added": "12"
             },
-            "firefox_android": "mirror",
+            "firefox": {
+              "version_added": "1",
+              "notes": "Starting in Firefox 67, the maximum size allowed for custom cursors is 32x32 pixels due to cursors being misused by certain malicious sites."
+            },
+            "firefox_android": {
+              "version_added": "95"
+            },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "7"
+            },
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "1.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1216,22 +1243,28 @@
           ],
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "2"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "9.2"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1250,22 +1283,28 @@
           "spec_url": "https://svgwg.org/svg2-draft/render.html#VisibilityControl",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1287,22 +1326,22 @@
           ],
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1425,22 +1464,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#FillOpacity",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1468,13 +1509,13 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1493,22 +1534,22 @@
           "spec_url": "https://drafts.fxtf.org/filter-effects/#FilterProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤53"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "35"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1527,22 +1568,24 @@
           "spec_url": "https://drafts.fxtf.org/filter-effects/#FloodColorProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "5"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "≤11"
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1561,22 +1604,24 @@
           "spec_url": "https://drafts.fxtf.org/filter-effects/#FloodOpacityProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "5"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "≤11"
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1598,22 +1643,28 @@
           ],
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "3"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1632,22 +1683,28 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-size-prop",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1666,16 +1723,25 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-size-adjust-prop",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "127"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "3",
+                "notes": "Before Firefox 40, <code>font-size-adjust: 0</code> was incorrectly interpreted as <code>font-size-adjust: none</code> (<a href='https://bugzil.la/1144885'>bug 1144885</a>)."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "3",
+                "partial_implementation": true,
+                "notes": "Only supported on Windows."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -1700,22 +1766,25 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-stretch-prop",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "60",
+              "notes": "A <code>font-stretch</code> definition must be added to the <code>@font-face</code> before this property will function."
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "9"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1734,22 +1803,29 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-style-prop",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1",
+              "notes": "Before Firefox 44, <code>oblique</code> was not distinguished from <code>italic</code>."
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "7"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1768,22 +1844,29 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-variant-prop",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "4",
+              "notes": "Only supports the <code>small-caps</code> and <code>normal</code> keywords."
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1802,22 +1885,28 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-weight-prop",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "2"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "3"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1836,22 +1925,22 @@
           "spec_url": "https://www.w3.org/TR/SVG11/text.html#GlyphOrientationHorizontalProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1870,22 +1959,22 @@
           "spec_url": "https://www.w3.org/TR/SVG11/text.html#GlyphOrientationVerticalProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1907,26 +1996,28 @@
           ],
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "13"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "3.6"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "3"
+            }
           },
           "status": {
             "experimental": false,
@@ -1981,23 +2072,25 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "73"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "9"
+              "version_added": "4"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -2012,22 +2105,24 @@
           "spec_url": "https://drafts.fxtf.org/filter-effects/#LightingColorProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "5"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "≤11"
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2046,22 +2141,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#VertexMarkerProperties",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2080,22 +2177,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#VertexMarkerProperties",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2114,22 +2213,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#VertexMarkerProperties",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2147,27 +2248,95 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/mask",
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask",
           "support": {
-            "chrome": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1",
+                "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "120",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
+              }
+            ],
             "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": null
-            },
+            "edge": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "79",
+                "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "79",
+                "version_removed": "120",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "53"
+              },
+              {
+                "version_added": "2",
+                "version_removed": "53",
+                "partial_implementation": true,
+                "notes": "Only supports <code>mask: url(file.svg#mask_id)</code> or <code>mask: url(#mask_id)</code>, where the URL is a reference to an SVG <code>&lt;mask&gt;</code> element."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": null
-            },
+            "safari": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.1",
+                "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "3.1",
+                "version_removed": "15.4",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2",
+                "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "2",
+                "version_removed": "120",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -2185,23 +2354,43 @@
           ],
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": null
+            "edge": {
+              "version_added": "12"
             },
+            "firefox": [
+              {
+                "version_added": "1"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1",
+                "version_removed": "3.5"
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": null
+            "opera": {
+              "version_added": "9"
             },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": [
+              {
+                "version_added": "2"
+              },
+              {
+                "prefix": "-khtml-",
+                "version_added": "1.1",
+                "version_removed": "2"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -2219,22 +2408,26 @@
           "spec_url": "https://svgwg.org/svg2-draft/render.html#OverflowAndClipProperties",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "7"
+            },
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2253,26 +2446,32 @@
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProp",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "9"
+            },
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "2"
+            }
           },
           "status": {
             "experimental": false,
@@ -2287,22 +2486,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#ShapeRendering",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2385,22 +2586,22 @@
           "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2419,22 +2620,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": "3"
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2460,7 +2663,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -2486,22 +2689,22 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeDashing",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2520,22 +2723,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2554,22 +2759,22 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#LineCaps",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2588,22 +2793,22 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#LineJoin",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2622,22 +2827,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2656,22 +2863,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeOpacity",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2690,22 +2899,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeWidth",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2724,22 +2935,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2761,22 +2974,28 @@
           ],
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "3"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "3.5"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2793,22 +3012,49 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "7",
+              "notes": "Until Firefox 10, handling of <code>text-overflow</code> on blocks with inline overflow on both horizontal sides was incorrect. Before Firefox 10, if only one value was specified (such as <code>text-overflow: ellipsis;</code>), text was ellipsed on both sides of the block, instead of only the end edge based on the block's text direction."
             },
             "firefox_android": "mirror",
-            "ie": {
-              "version_added": null
-            },
+            "ie": [
+              {
+                "version_added": "6"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "8"
+              }
+            ],
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "9",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10.1",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
-              "version_added": null
+              "version_added": "1.3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2827,26 +3073,46 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#TextRendering",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "4",
+              "notes": [
+                "This property is only supported on Windows and Linux.",
+                "Initial versions had bugs on Windows and Linux that broke font substitution, small-caps, letter-spacing or caused text to overlap. See <a href='https://crbug.com/114719'>bug 114719</a>, <a href='https://crbug.com/51973'>bug 51973</a>, <a href='https://crbug.com/55458'>bug 55458</a>, <a href='https://crbug.com/149548'>bug 149548</a>."
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": "1",
+              "notes": [
+                "This property is only supported on Windows and Linux.",
+                "The <code>optimizeSpeed</code> option has no effect on Firefox 4 because the standard code for text rendering is already fast and there is not a faster code path at this time. See <a href='https://bugzil.la/595688'>bug 595688</a> for details."
+              ]
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "46"
+            },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "5"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "notes": "This property is only supported on Windows and Linux. Samsung Internet is not on Windows or Linux."
+            },
+            "webview_android": {
+              "version_added": "3",
+              "notes": "From version 3 to 4.3, there is a serious bug where <code>text-rendering: optimizeLegibility</code> causes custom web fonts to not render. This was fixed in version 4.4."
+            }
           },
           "status": {
             "experimental": false,
@@ -2863,27 +3129,121 @@
             "https://svgwg.org/svg2-draft/coords.html#TransformProperty"
           ],
           "support": {
-            "chrome": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
             "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": null
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "16"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "≤40",
+                "version_removed": "preview"
+              }
+            ],
             "firefox_android": "mirror",
-            "ie": {
-              "version_added": null
-            },
+            "ie": [
+              {
+                "version_added": "10",
+                "notes": "Internet Explorer does not support the global values <code>initial</code> and <code>unset</code>."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "11"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "9",
+                "notes": "Internet Explorer 5.5 or later supports a proprietary <a href='https://msdn.microsoft.com/en-us/library/ms533014(VS.85,loband).aspx'>Matrix Filter</a> which can be used to achieve a similar effect."
+              }
+            ],
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": "mirror",
+            "opera": [
+              {
+                "version_added": "23"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "10.5",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
+              },
+              {
+                "prefix": "-o-",
+                "version_added": "11",
+                "version_removed": "14"
+              }
+            ],
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              }
+            ],
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2",
+                "notes": "Android 2.3 has a bug where input forms will \"jump\" when typing, if any container element has a <code>-webkit-transform</code>."
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -2937,22 +3297,28 @@
           "spec_url": "https://drafts.csswg.org/css-writing-modes/#unicode-bidi",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "2"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "9.2"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1.3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2971,22 +3337,24 @@
           "spec_url": "https://svgwg.org/svg2-draft/coords.html#VectorEffects",
           "support": {
             "chrome": {
-              "version_added": "12"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
-              "version_added": "15"
+              "version_added": "≤72"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5.1"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -3005,22 +3373,33 @@
           "spec_url": "https://svgwg.org/svg2-draft/render.html#VisibilityControl",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "4",
+              "notes": [
+                "Internet Explorer doesn't support <code>visibility: initial</code>.",
+                "Internet Explorer doesn't support <code>visibility: unset</code>.",
+                "Up to Internet Explorer 7, descendants of <code>hidden</code> elements will still be invisible even if they have <code>visibility</code> set to <code>visible</code>."
+              ]
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -3037,22 +3416,28 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -3078,23 +3463,23 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "73"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "3.5"
+            },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5.1"
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -3111,27 +3496,64 @@
             "https://svgwg.org/svg2-draft/text.html#WritingModeProperty"
           ],
           "support": {
-            "chrome": {
-              "version_added": null
-            },
+            "chrome": [
+              {
+                "version_added": "48"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "8"
+              }
+            ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "41",
+              "notes": "Firefox 42 added support for bidirectional and RTL scripts in vertical modes."
             },
             "firefox_android": "mirror",
-            "ie": {
-              "version_added": null
-            },
+            "ie": [
+              {
+                "version_added": "9",
+                "notes": "Internet Explorer's implementation differs from the specification."
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "9",
+                "notes": "Internet Explorer's implementation differs from the specification."
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": null
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5.1"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": [
+              {
+                "version_added": "48"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
#### Summary

SVG presentation attributes can be used on all SVG elements and they are also CSS properties. We have compat data for all them in the css.properties.* tree already. This PR uses the compat data from the css.properties.* tree in svg.global_attributes.* as well. (A lot of them are ranged values but I think that's better than the null values we have now)

#### Test results and supporting details

None, I'm assuming support is the same. We have always update the data later if we see discrepancies between SVG attribute and CSS property.

#### Related issues

https://github.com/mdn/browser-compat-data/issues/9462