### PR TITLE
Remove SVG enable-background attribute

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -1315,40 +1315,6 @@
           }
         }
       },
-      "enable-background": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/enable-background",
-          "spec_url": "https://www.w3.org/TR/SVG11/filters.html#EnableBackgroundProperty",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": null
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "fill": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/fill",


### PR DESCRIPTION
No longer in SVG 2 and not implemented anywhere.

"The only major browser that supported it (ever) was IE10/11"
https://stackoverflow.com/questions/21354116/what-exactly-does-the-enable-background-attribute-do