### PR TITLE
SVG global xml:space attribute is supported in Chrome 6 and Safari 5

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -184,7 +184,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/struct.html#WhitespaceProcessingXMLSpaceAttribute",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "6"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -199,7 +199,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
See https://github.com/WebKit/WebKit/commit/5bfb9619ac7bfcf219019296630a87394d78d98c