### PR TITLE
Remove SVG xml:base attribute

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -107,41 +107,6 @@
           }
         }
       },
-      "xml_base": {
-        "__compat": {
-          "description": "xml:base",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/xml:base",
-          "spec_url": "https://www.w3.org/TR/SVG11/struct.html#XMLBaseAttribute",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": null
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "xml_lang": {
         "__compat": {
           "description": "xml:lang",


### PR DESCRIPTION
Not implemented anywhere (anymore)

- Gecko https://bugzilla.mozilla.org/show_bug.cgi?id=903372 (removed in v66)
- Chromium https://groups.google.com/a/chromium.org/g/blink-dev/c/ZvArHAXyAHM/m/ftybb0waCKYJ, https://issues.chromium.org/issues/40350811 (removed in 2015)
- Safari https://bugs.webkit.org/show_bug.cgi?id=17423 (was never supported)