### PR TITLE
Update Firefox data for javascript.statements.import.service_worker_support

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1584,7 +1584,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1360870"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1584,7 +1584,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "114"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `import.service_worker_support` member of the `statements` JavaScript feature. This fixes #23554 and fixes #23160, which contains the supporting evidence for this change.

Additional Notes: It is worth noting that this feature, and a subfeature of `ServiceWorker` indicating ECMAScript module support, were both added in #19835. It has been confirmed that ECMAScript modules aren't supported in Service Workers in Firefox yet.
