### PR TITLE
Update Safari data for api.ResizeObserver.observe.options_box_parameter

### DIFF
--- a/api/ResizeObserver.json
+++ b/api/ResizeObserver.json
@@ -156,7 +156,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `observe.options_box_parameter` member of the `ResizeObserver` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ResizeObserver/observe/options_box_parameter
