### PR TITLE
Update Safari data for caption-side CSS property

### DIFF
--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -94,7 +94,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "≤13.1",
+                "version_removed": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -127,7 +128,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "≤13.1",
+                "version_removed": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `caption-side` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/caption-side
