### PR TITLE
Update Edge data for forced-color-adjust CSS property

### DIFF
--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -51,7 +51,9 @@
                 "version_added": "89"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "79"
+              },
               "firefox": {
                 "version_added": "113"
               },
@@ -84,7 +86,9 @@
                 "version_added": "89"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "79"
+              },
               "firefox": {
                 "version_added": "113"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `forced-color-adjust` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/forced-color-adjust
