### PR TITLE
Update Firefox data for css.properties.text-transform.math-auto

### DIFF
--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -297,7 +297,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "117"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -314,7 +314,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `math-auto` member of the `text-transform` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-transform/math-auto
