### PR TITLE
Update Safari data for -webkit-details-marker CSS selector

### DIFF
--- a/css/selectors/-webkit-details-marker.json
+++ b/css/selectors/-webkit-details-marker.json
@@ -27,7 +27,8 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `-webkit-details-marker` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/-webkit-details-marker
