### PR TITLE
Remove css.at-rules.document.regexp from BCD

### DIFF
--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -43,40 +43,6 @@
             "standard_track": false,
             "deprecated": true
           }
-        },
-        "regexp": {
-          "__compat": {
-            "description": "<code>regexp()</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "6",
-                "version_removed": "61"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `regexp` member of the `document` CSS at-rule from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly.
