### PR TITLE
Remove css.properties.-moz-orient.auto from BCD

### DIFF
--- a/css/properties/-moz-orient.json
+++ b/css/properties/-moz-orient.json
@@ -33,41 +33,6 @@
             "deprecated": false
           }
         },
-        "auto": {
-          "__compat": {
-            "description": "<code>auto</code> value",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "21",
-                "version_removed": "40",
-                "notes": "The <code>auto</code> value was equivalent to <code>horizontal</code>."
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "block": {
           "__compat": {
             "description": "<code>block</code> value",


### PR DESCRIPTION
This PR removes the `auto` member of the `-moz-orient` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/-moz-orient/auto
