### PR TITLE
Remove css.properties.touch-action.double-tap-zoom from BCD

### DIFF
--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -50,47 +50,6 @@
             "deprecated": false
           }
         },
-        "double-tap-zoom": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-ms-",
-                  "version_added": "10"
-                }
-              ],
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "manipulation": {
           "__compat": {
             "support": {


### PR DESCRIPTION
This PR removes the `double-tap-zoom` member of the `touch-action` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/touch-action/double-tap-zoom
