### PR TITLE
Remove css.properties.hanging-punctuation.force-end from BCD

### DIFF
--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -102,40 +102,6 @@
             }
           }
         },
-        "force-end": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-text/#valdef-hanging-punctuation-force-end",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false,
-                "notes": "The <code>force-end</code> keyword is recognized but has no effect."
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "last": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-text/#valdef-hanging-punctuation-last",


### PR DESCRIPTION
This PR removes the `force-end` member of the `hanging-punctuation` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/hanging-punctuation/force-end
