### PR TITLE
Remove css.properties.image-orientation.flip_and_angle from BCD

### DIFF
--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -36,40 +36,6 @@
             "deprecated": false
           }
         },
-        "flip_and_angle": {
-          "__compat": {
-            "description": "<code>flip</code> &amp; <code>&lt;angle&gt;</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "26",
-                "version_removed": "63"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "from-image": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-images/#valdef-image-orientation-from-image",


### PR DESCRIPTION
This PR removes the `flip_and_angle` member of the `image-orientation` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/image-orientation/flip_and_angle
