### PR TITLE
Remove css.properties.outline-color.invert from BCD

### DIFF
--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -46,45 +46,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "invert": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "3"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "8"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "7",
-                "version_removed": "15"
-              },
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `invert` member of the `outline-color` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/outline-color/invert
