### PR TITLE
Remove css.properties.ruby-position.inter-character from BCD

### DIFF
--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -91,40 +91,6 @@
               "deprecated": false
             }
           }
-        },
-        "inter-character": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/1258284"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1055672"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `inter-character` member of the `ruby-position` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/ruby-position/inter-character
