### PR TITLE
FF128 Set-Cookie partitioned in preview (CHIPS)

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -121,7 +121,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF128 supports [Cookies Having Independent Partitioned State (CHIPS)](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies) in Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1898253

This updates the subfeature.

Related docs work done in https://github.com/mdn/content/issues/33996