### PR TITLE
Update Chromium data for menclose MathML element

### DIFF
--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/menclose",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "109"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `menclose` MathML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/mathml/elements/menclose
