### PR TITLE
Update Safari data for javascript.builtins.Intl.PluralRules.PluralRules.options_parameter

### DIFF
--- a/javascript/builtins/Intl/PluralRules.json
+++ b/javascript/builtins/Intl/PluralRules.json
@@ -118,7 +118,7 @@
                   "opera": "mirror",
                   "opera_android": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "15.4"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
@@ -155,14 +155,14 @@
                     "opera": "mirror",
                     "opera_android": "mirror",
                     "safari": {
-                      "version_added": false
+                      "version_added": "17.2"
                     },
                     "safari_ios": "mirror",
                     "samsunginternet_android": "mirror",
                     "webview_android": "mirror"
                   },
                   "status": {
-                    "experimental": true,
+                    "experimental": false,
                     "standard_track": true,
                     "deprecated": false
                   }
@@ -193,7 +193,7 @@
                     "opera": "mirror",
                     "opera_android": "mirror",
                     "safari": {
-                      "version_added": false
+                      "version_added": "17.2"
                     },
                     "safari_ios": "mirror",
                     "samsunginternet_android": "mirror",
@@ -231,7 +231,7 @@
                     "opera": "mirror",
                     "opera_android": "mirror",
                     "safari": {
-                      "version_added": false
+                      "version_added": "15.4"
                     },
                     "safari_ios": "mirror",
                     "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `PluralRules.PluralRules.options_parameter` member of the `Intl` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.10.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Intl/PluralRules/PluralRules/options_parameter
