### PR TITLE
Clipboard API: clean up notes and create subfeatures for MIME types

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -46,36 +46,18 @@
           "support": {
             "chrome": {
               "version_added": "66",
-              "partial_implementation": true,
-              "notes": [
-                "From version 86, the <code>text/html</code> MIME type is supported.",
-                "From version 85, Requires Permission-Policy <code>clipboard-read</code> permission.",
-                "From version 76, the <code>image/png</code> MIME type is supported.",
-                "From version 66, the <code>text/plain</code> MIME type is supported.",
-                "Requires Permission API <code>clipboard-read</code> permission. Does not require transient activation."
-              ]
+              "notes": "From version 85, the <code>Permissions-Policy clipboard-read</code> header is required."
             },
-            "chrome_android": {
-              "version_added": "66",
-              "partial_implementation": true,
-              "notes": [
-                "From version 86, the <code>text/html</code> MIME type is supported.",
-                "From version 85, Requires Permission-Policy <code>clipboard-read</code> permission.",
-                "From version 84, the <code>image/png</code> MIME type is supported.",
-                "From version 66, the <code>text/plain</code> MIME type is supported.",
-                "Requires Permission API <code>clipboard-read</code> permission. Does not require transient activation."
-              ]
-            },
+            "chrome_android": "mirror",
             "edge": {
-              "version_added": "79"
+              "version_added": "mirror"
             },
             "firefox": {
               "version_added": "127",
               "notes": [
-                "The <code>text/plain</code>, <code>text/html</code> and <code>image/png</code> MIME types are supported.",
-                "The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content.",
-                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require transient activation or paste prompt.",
-                "Requires transient activation."
+                "This method must be called within user gesture event handlers.",
+                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require a user interaction and does not display a paste prompt.",
+                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is surpressed."
               ]
             },
             "firefox_android": "mirror",
@@ -83,28 +65,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "63"
-            },
-            "opera_android": {
-              "version_added": "54"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "13.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "66",
-              "partial_implementation": true,
-              "notes": [
-                "From version 84, the <code>image/png</code> MIME type is supported.",
-                "From version 66, the <code>text/plain</code> MIME type is supported.",
-                "Requires Permission API <code>clipboard-read</code> permission. Does not require transient activation."
-              ]
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -158,21 +126,116 @@
           "support": {
             "chrome": {
               "version_added": "66",
-              "partial_implementation": true,
-              "notes": [
-                "From version 85, Requires Permission-Policy <code>clipboard-read</code> permission.",
-                "Requires Permission API <code>clipboard-read</code> permission. Does not require transient activation."
-              ]
+              "notes": "From version 85, the <code>Permissions-Policy clipboard-read</code> header is required."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "125",
               "notes": [
-                "From version 122 The paste-prompt on clipboard read is suppressed if the clipboard contains same-origin content",
-                "From version 122, Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With permission the extension does not require transient activation or paste prompt",
-                "Requires transient activation."
+                "This method must be called within user gesture event handlers.",
+                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require a user interaction and does not display a paste prompt.",
+                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is surpressed."
               ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type_image-png": {
+        "__compat": {
+          "description": "Supports <code>image/png</code> MIME type",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "127"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type_text-html": {
+        "__compat": {
+          "description": "Supports <code>text/html</code> MIME type",
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "127"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type_text-plain": {
+        "__compat": {
+          "description": "Supports <code>text/plain</code> MIME type",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "127"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -206,30 +269,20 @@
             "chrome": {
               "version_added": "66",
               "notes": [
-                "From version 107, requires Permission API <code>clipboard-write</code> permission (or transient activation when permission is not granted).",
-                "From version 85, Requires Permission-Policy <code>clipboard-write</code> permission.",
-                "From version 76, the <code>image/png</code> MIME type is supported.",
-                "From version 66, no permissons or gesture required to write to clipboard."
+                "From version 107, this method must be called within user gesture event handlers, or the page must include the <code>Permissions-Policy clipboard-write</code> header.",
+                "From version 85, the <code>Permissions-Policy clipboard-write</code> header is required."
               ]
             },
-            "chrome_android": {
-              "version_added": "66",
-              "notes": [
-                "From version 107, requires Permission API <code>clipboard-write</code> permission (or transient activation when permission is not granted).",
-                "From version 85, Requires Permission-Policy <code>clipboard-write</code> permission.",
-                "From version 84, the <code>image/png</code> MIME type is supported.",
-                "From version 66, no permissons or gesture required to write to clipboard."
-              ]
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "79"
             },
             "firefox": {
               "version_added": "127",
               "notes": [
-                "The <code>text/plain</code>, <code>text/html</code> and <code>image/png</code> MIME types are supported.",
-                "Web extensions with the <code>clipboardWrite</code> permission in their manifest do not require transient activation.",
-                "Requires transient activation. The Permissions API <code>clipboard-write</code> permission is not used."
+                "This method must be called within user gesture event handlers.",
+                "Web extensions require the <code>clipboardWrite</code> permission in manifest to read data. With this permission, the extension does not require a user interaction and does not display a paste prompt.",
+                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is surpressed."
               ]
             },
             "firefox_android": "mirror",
@@ -237,19 +290,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "63"
-            },
-            "opera_android": {
-              "version_added": "54"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "13.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -270,9 +317,8 @@
             "chrome": {
               "version_added": "66",
               "notes": [
-                "From version 107, requires Permission API <code>clipboard-write</code> permission (or transient activation when permission is not granted).",
-                "From version 85, Requires Permission-Policy <code>clipboard-write</code> permission.",
-                "From version 66, no permissons or gesture required to write to clipboard."
+                "From version 107, this method must be called within user gesture event handlers, or the page must include the <code>Permissions-Policy clipboard-write</code> header.",
+                "From version 85, the <code>Permissions-Policy clipboard-write</code> header is required."
               ]
             },
             "chrome_android": "mirror",
@@ -280,8 +326,9 @@
             "firefox": {
               "version_added": "63",
               "notes": [
-                "From version 122, Web extensions with the <code>clipboardWrite</code> permission in manifest do not require transient activation.",
-                "Requires transient activation."
+                "This method must be called within user gesture event handlers.",
+                "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require a user interaction and does not display a paste prompt.",
+                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is surpressed."
               ]
             },
             "firefox_android": "mirror",
@@ -293,7 +340,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "13.1",
-              "notes": "Must be called within user gesture event handlers such as <code>pointerdown</code> or <code>pointerup</code>."
+              "notes": "This method must be called within user gesture event handlers."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -49,9 +49,7 @@
               "notes": "From version 85, the <code>Permissions-Policy clipboard-read</code> header is required."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "mirror"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "127",
               "notes": [


### PR DESCRIPTION
This PR performs two things related to the Clipboard API:

- Cleans up the notes for the read and write methods
  - The notes didn't fully follow conventional note style, and used a term that's not well known ("transient activation")
  - Additionally, this sets numerous Chromium browsers to mirror from upstream, with the notes being the only difference from existing data
- Adds subfeatures for the various MIME types that the `read` and `write` methods could accept
  - This data came straight from the notes themselves

This fixes #7991.
