### PR TITLE
Mirror Firefox Android for HTTP 103 status

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -17,6 +17,7 @@
             "firefox": {
               "version_added": "120"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -44,6 +45,7 @@
               "firefox": {
                 "version_added": "120"
               },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -73,6 +75,7 @@
               "firefox": {
                 "version_added": "123"
               },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
Assuming HTTP status 103 is supported in Firefox Android the same way it is supported in Firefox.

Need this data to calculate baseline.