### PR TITLE
Remove svg.elements.feMorphology.HTML_elements

### DIFF
--- a/svg/elements/feMorphology.json
+++ b/svg/elements/feMorphology.json
@@ -40,39 +40,6 @@
             "deprecated": false
           }
         },
-        "HTML_elements": {
-          "__compat": {
-            "description": "On HTML elements",
-            "support": {
-              "chrome": {
-                "version_added": "≤65"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "≤59"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "in": {
           "__compat": {
             "support": {


### PR DESCRIPTION
I should have proposed to delete this in https://github.com/mdn/browser-compat-data/pull/23443 already.

[SVG can be applied to HTML](https://developer.mozilla.org/en-US/docs/Web/SVG/Applying_SVG_effects_to_HTML_content) in many cases, I don't think we should be recording this here. 