### PR TITLE
Update Safari data for javascript.builtins.Function.toString.toString_revision

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -749,7 +749,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `toString.toString_revision` member of the `Function` JavaScript builtin. This fixes #23517, which contains the supporting evidence for this change.
