### PR TITLE
`css.types.image.gradient`: Remove `-ms-` prefix

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -188,7 +188,6 @@
               ],
               "chrome_android": "mirror",
               "edge": {
-                "prefix": "-ms-",
                 "version_added": "12"
               },
               "firefox": {


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Edge never appears to have never supported a prefix for any `<gradient>` CSS value type.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

An abstract type having a prefix doesn't make any sense. Nevertheless, I tested gradients on Edge 18 and 15 and found that prefixes had no effect for `conic-gradient()` or `linear-conic-gradient()` and neither was supported in any case. The other gradients were supported without prefixes.

I believe this be a case of a prefix being wrongly reported, then copied, from IE data.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered in the course of calculating aggregated statuses in web-features https://github.com/web-platform-dx/web-features/pull/1231/files#r1660916516

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
