### PR TITLE
Remove html.elements.iframe.external_protocol_urls_blocked

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -307,39 +307,6 @@
             }
           }
         },
-        "external_protocol_urls_blocked": {
-          "__compat": {
-            "description": "External protocol URLs blocked",
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "67"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": null
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "frameborder": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#attr-iframe-frameborder",


### PR DESCRIPTION
Originally added in 2019 in https://github.com/mdn/browser-compat-data/pull/4089.

I think we can remove this now. The `sandbox="allow-top-navigation-to-custom-protocols"` feature seems like the standardized and more relevant feature in this file.