### PR TITLE
Update html.elements.input.size

### DIFF
--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -1195,21 +1195,28 @@
               "chrome": {
                 "version_added": "1"
               },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
               },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "5.5"
               },
+              "oculus": "mirror",
               "opera": {
                 "version_added": "≤12.1"
               },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "1"
-              }
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
The mobile browsers were missing completely for this one. Adding them by mirroring. I did test if the [code example](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) works in iOS Safari and it does. Not 100% sure about the others.