### PR TITLE
Update Safari data for alternate stylesheets

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -743,7 +743,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
"Other browsers like Chrome and Safari don’t do anything with the alternative stylesheets."

https://adactio.com/journal/19365