### PR TITLE
Safari 18.0 adds support for `writingsuggestions` HTML attribute

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2422,7 +2422,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.0"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2422,7 +2422,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.0"
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari 18.0 adds support for `writingsuggestions` HTML attribute

#### Test results and supporting details

https://webkit.org/blog/15443/news-from-wwdc24-webkit-in-safari-18-beta/#html
(there's a test in the article) 