### PR TITLE
FF128 <base> target forbids tab, newline, <

### DIFF
--- a/api/HTMLBaseElement.json
+++ b/api/HTMLBaseElement.json
@@ -114,6 +114,41 @@
               "deprecated": false
             }
           }
+        },
+        "forbid_tab_newline_lessthan_urls": {
+          "__compat": {
+            "description": "tab, newline, and &lt; are not allowed (dangling markup prevention)",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "128",
+                "impl_url": "https://bugzil.la/1835157"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16",
+                "impl_url": "https://webkit.org/b/257349"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "target": {

--- a/api/HTMLBaseElement.json
+++ b/api/HTMLBaseElement.json
@@ -115,7 +115,7 @@
             }
           }
         },
-        "forbid_tab_newline_lessthan_urls": {
+        "forbid_special_characters": {
           "__compat": {
             "description": "tab, newline, and &lt; are not allowed (dangling markup prevention)",
             "support": {


### PR DESCRIPTION
FF128 adds support for blocking urls in the [`target`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#target) attribute of the `<base>` element that have newline, tab or `<` char in https://bugzilla.mozilla.org/show_bug.cgi?id=1835157 (This is to prevent dangling markdown attacks).

This is in chrome 61 (https://chromestatus.com/feature/5735596811091968) and Safari 16 (https://bugs.webkit.org/show_bug.cgi?id=257349)

Related docs work can be tracked in [#33995](https://github.com/mdn/content/issues/33995)