### PR TITLE
Add mobile browsers to HTTP 103 data

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -25,7 +25,10 @@
             "opera": "mirror",
             "safari": {
               "version_added": "17"
-            }
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -54,7 +57,10 @@
               "safari": {
                 "version_added": "17",
                 "notes": "Supported in HTTP/2 and later only."
-              }
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -83,7 +89,10 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
I'm assuming that this is also supported in the mobile browsers.
Needed to calculate baseline for HTTP status 103.