### PR TITLE
Update Opera data for html.global_attributes.spellcheck

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1095,9 +1095,7 @@
               "version_added": "11"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "opera_android": {
               "version_added": "37"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `spellcheck` member of the `global_attributes` HTML feature. This sets the downstream browser(s) to mirror from their upstream counterpart.
