### PR TITLE
Update Chrome Android data for theme_color HTML manifest property

### DIFF
--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -21,12 +21,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": null
             },
@@ -34,9 +30,7 @@
               "version_added": "15"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `theme_color` HTML manifest property. This sets the downstream browser(s) to mirror from their upstream counterpart.
