### PR TITLE
Update IE data for svg.elements.textPath.textLength

### DIFF
--- a/svg/elements/textPath.json
+++ b/svg/elements/textPath.json
@@ -226,7 +226,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": true
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for IE for the `textLength` member of the `textPath` SVG element. Apparently, this one was missed in the mass conversion of IE=`true` > `≤11`.
