### PR TITLE
Update Firefox data for css.at-rules.font-face.src.tech_keyword

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -961,21 +961,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "preview"
-                  },
-                  {
-                    "version_added": "105",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.font-tech.enabled",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox": {
+                  "version_added": "107"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `src.tech_keyword` member of the `font-face` CSS at-rule. This fixes #23614, which contains the supporting evidence for this change.
