### PR TITLE
Firefox 36+ applies object-position to iframes

### DIFF
--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -61,6 +61,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "applies_to_iframe_elements": {
+          "__compat": {
+            "description": "Applies to <code>&lt;iframe&gt;</code> elements",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "36"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds the missing `applies_to_iframe_elements` member of the `object-position` CSS property. This fixes #23586, which contains the supporting evidence for this change.

Additional Notes: The test code was copied and adapted to a local server, then manually run on Firefox 36 and old Chrome/Safari versions to confirm support.
