### PR TITLE
Update Safari iOS data for html.elements.video.autoplay

### DIFF
--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -103,8 +103,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "10",
-                "notes": "Only available for videos that have <a href='https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html'>no sound or have the audio track disabled</a>."
+                "version_added": "10"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `autoplay` member of the `video` HTML element. This note is redundant as no browser allows autoplaying an unmuted video.
