### PR TITLE
Update Edge versions for <time>

### DIFF
--- a/html/elements/time.json
+++ b/html/elements/time.json
@@ -11,7 +11,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "22"
@@ -62,7 +62,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "22"


### PR DESCRIPTION
The HTMLTimeElement data was set to 14 based on testing that included Edge 13, so 14 is likely to be correct:

https://github.com/mdn/browser-compat-data/pull/3310 https://github.com/mdn/browser-compat-data/pull/7246

Also, the test for the API creates an element, so it cannot be a dangling interface, support for the element is implied: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLTimeElement