### PR TITLE
Add declarativeNetRequest.RuleCondition.domainType details

### DIFF
--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -4,7 +4,6 @@
       "calc-constant": {
         "__compat": {
           "description": "<code>&lt;calc-constant&gt;</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc-keyword",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-constants",
           "tags": [
             "web-features:calc-constants"

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -910,6 +910,25 @@
               }
             }
           },
+          "domainType": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "84"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "128"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "15"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "excludedDomains": {
             "__compat": {
               "support": {


### PR DESCRIPTION
#### Summary

Add missing `declarativeNetRequest.RuleCondition.domainType` data, including "update" to reflect Firefox implementation in [Bug 1797408](https://bugzilla.mozilla.org/show_bug.cgi?id=1797408) [DNR] Implement domainType (firstParty / thirdParty) condition

#### Related issues

Related MDN content in PR TBC
