### PR TITLE
Updated Safari support for Web App Manifests

### DIFF
--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -29,9 +29,7 @@
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -30,9 +30,7 @@
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": null

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -28,10 +28,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -28,7 +28,9 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "17",
+              "partial_implementation": true,
+              "notes": "Does not support <code>fullscreen</code> or <code>minimal-ui</code>."
             },
             "safari_ios": {
               "version_added": "11.3",

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -28,7 +28,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "17",
+              "notes": "Only used when no <code>apple-touch-icon</code> is present with <code>\"purpose\": \"any\"</code> or no <code>\"purpose\"</code> key."
             },
             "safari_ios": {
               "version_added": "15.4",

--- a/html/manifest/id.json
+++ b/html/manifest/id.json
@@ -22,9 +22,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -28,7 +28,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "11.3"

--- a/html/manifest/orientation.json
+++ b/html/manifest/orientation.json
@@ -26,7 +26,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/html/manifest/orientation.json
+++ b/html/manifest/orientation.json
@@ -28,9 +28,7 @@
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": null

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -30,9 +30,7 @@
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": null
             },

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -28,7 +28,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/html/manifest/scope.json
+++ b/html/manifest/scope.json
@@ -26,7 +26,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "11.3"

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -28,7 +28,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false,

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -28,7 +28,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "11.3"

--- a/html/manifest/start_url.json
+++ b/html/manifest/start_url.json
@@ -26,7 +26,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "11.3"

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -28,7 +28,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "15"


### PR DESCRIPTION
Modified Safari support data for the following Web App Manifest members. Based on release notes and internal review:

`name`, `short_name`, `start_url`, `scope`
- Supported [since iOS 11.3](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html#//apple_ref/doc/uid/TP40014305-CH14-SW1). Support [added for macOS in Safari 17.0.](https://developer.apple.com/videos/play/wwdc2023/10120/)
- rdar://27661063

`display`
- Partially implemented [since iOS 11.3](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html#//apple_ref/doc/uid/TP40014305-CH14-SW1). Support [added for macOS in Safari 17.0.](https://developer.apple.com/videos/play/wwdc2023/10120/)
- rdar://35837993

`theme_color`
- Supported [since iOS 15.0](https://webkit.org/blog/11989/new-webkit-features-in-safari-15/). Support [added for macOS in Safari 17.0.](https://developer.apple.com/videos/play/wwdc2023/10120/)
- rdar://77062361

`icons`
- Supported [since iOS 15.4](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes). Support [added for macOS in Safari 17.0.](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes)
- rdar://84311306

`id`
- Supported [since iOS 16.4](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes). Support [added for macOS in Safari 17.0.](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes)
- rdar://83656112

`background_color`, `description`, `orientation`
- Members are parsed by WebKit, but not used by Safari.
- rdar://107035193
- rdar://107370833

`related_applications`, `screenshots`
- Neither of these manifest members are parsed by WebKit.
- rdar://74982806