### PR TITLE
Mark OfflineAudioContext resume() not really supported in Firefox

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -224,7 +224,9 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "40",
+              "partial_implementation": true,
+              "notes": "The method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://bugzil.la/1265406'>bug 1265406</a>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
It always rejects:
https://github.com/mozilla/gecko-dev/blob/bb682ab37e12bf256f4180693568bf1325aab2be/dom/media/webaudio/AudioContext.cpp#L1062-L1066

This was first determined by simple testing in Firefox DevTools:

```js
ctx = new OfflineAudioContext(1, 480000, 48000);
ctx.resume();
```