### PR TITLE
Update Safari iOS data for perspective CSS property

### DIFF
--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -60,7 +60,8 @@
             ],
             "safari_ios": [
               {
-                "version_added": "9"
+                "version_added": "9",
+                "notes": "In iOS 13, the <code>perspective</code> property did not function properly. The issues were fixed in iOS 14."
               },
               {
                 "prefix": "-webkit-",


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `perspective` CSS property. This fixes #6637, which contains the supporting evidence for this change.
