### PR TITLE
Update related apps manifest members

### DIFF
--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -16,7 +16,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -28,7 +28,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -16,7 +16,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Looks like `related_applications` and `prefer_related_application` are single engine features according to https://github.com/w3c/manifest/issues/877 so I think we should mark firefox and safari as false.