### PR TITLE
Safari 18.0 adds support for writingsuggestions HTML attribute

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2422,14 +2422,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This replaces https://github.com/mdn/browser-compat-data/pull/23613 

#### Summary

Safari 18.0 adds support for `writingsuggestions` HTML attribute

#### Test results and supporting details

https://webkit.org/blog/15443/news-from-wwdc24-webkit-in-safari-18-beta/#html
(there's a test in the article) 