### PR TITLE
Remove some async clipboard web-features tags

### DIFF
--- a/api/ClipboardEvent.json
+++ b/api/ClipboardEvent.json
@@ -4,9 +4,6 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardEvent",
         "spec_url": "https://w3c.github.io/clipboard-apis/#clipboard-event-interfaces",
-        "tags": [
-          "web-features:async-clipboard"
-        ],
         "support": {
           "chrome": {
             "version_added": "41"
@@ -43,9 +40,6 @@
           "description": "<code>ClipboardEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardEvent/ClipboardEvent",
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboardevent-clipboardevent",
-          "tags": [
-            "web-features:async-clipboard"
-          ],
           "support": {
             "chrome": {
               "version_added": "58"
@@ -82,9 +76,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardEvent/clipboardData",
           "spec_url": "https://w3c.github.io/clipboard-apis/#clipboardevent-clipboarddata",
-          "tags": [
-            "web-features:async-clipboard"
-          ],
           "support": {
             "chrome": {
               "version_added": "41"

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -257,9 +257,6 @@
       "permission_clipboard-read": {
         "__compat": {
           "description": "<code>clipboard-read</code> permission",
-          "tags": [
-            "web-features:async-clipboard"
-          ],
           "support": {
             "chrome": {
               "version_added": "64"


### PR DESCRIPTION
ClipboardEvent is part of the older API:
https://w3c.github.io/clipboard-apis/#clipboard-event-api

The "clipboard-read" permission was removed from the spec:
https://github.com/w3c/clipboard-apis/pull/132