### PR TITLE
Update Safari data for font-variant-emoji CSS property

### DIFF
--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -29,7 +29,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.5",
+              "flags": [
+                {
+                  "name": "CSS font-variant-emoji property",
+                  "type": "preference",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `font-variant-emoji` CSS property. This fixes #23216, which contains the supporting evidence for this change.

Additional Notes: The version number may not be entirely accurate, but since flag data really only matters for the current version, I figure that it's not too important to track down.
