### PR TITLE
Update Firefox for Android web app manifest features

### DIFF
--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -17,9 +17,11 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },
@@ -34,7 +36,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -16,7 +16,7 @@
               "version_added": "88"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -16,9 +16,12 @@
               "version_added": "88"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false,
+              "notes": "The property parses, but has no effect."
+            },
             "ie": {
               "version_added": false
             },

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -12,10 +12,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/html/manifest/id.json
+++ b/html/manifest/id.json
@@ -12,9 +12,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "95"
+              "version_added": false,
+              "notes": "The property parses, but has no effect."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -12,10 +12,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/html/manifest/orientation.json
+++ b/html/manifest/orientation.json
@@ -12,9 +12,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },
@@ -35,7 +37,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -18,7 +18,10 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false,
+              "notes": "The property parses, but has no effect."
+            },
             "ie": {
               "version_added": false
             },

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -18,7 +18,10 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false,
+              "notes": "The property parses, but has no effect."
+            },
             "ie": {
               "version_added": false
             },

--- a/html/manifest/scope.json
+++ b/html/manifest/scope.json
@@ -12,9 +12,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -16,7 +16,7 @@
               "version_added": "88"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/manifest/share_target.json
+++ b/html/manifest/share_target.json
@@ -16,7 +16,10 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false,
+              "notes": "The property parses, but has no effect."
+            },
             "ie": {
               "version_added": false
             },

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -12,10 +12,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/html/manifest/start_url.json
+++ b/html/manifest/start_url.json
@@ -12,9 +12,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -12,10 +12,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Updating the state of web manifest properties that are used by Firefox for Android.

Members that are parsed by Gecko, but not used by Firefox for Android:
 - `description`
 - `dir`
 - `lang`
 - `related_applications`
 - `prefer_related_applications`
 - `share_target`

Members that are parsed by Gecko, but not used in Firefox and Firefox for Android:
 - `id`

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- Properties parsed by Gecko and Firefox for Android: https://searchfox.org/mozilla-central/rev/ece43b04e7baa4680dac46a06d5ad42b27b124f4/mobile/android/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt#64-78
- Properties parsed only by Gecko: https://searchfox.org/mozilla-central/rev/ece43b04e7baa4680dac46a06d5ad42b27b124f4/dom/manifest/ManifestProcessor.sys.mjs#118

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

#### Related Firefox for Android bugs:
- https://github.com/mozilla-mobile/fenix/issues/778
- https://github.com/mozilla-mobile/fenix/issues/772
- https://github.com/mozilla-mobile/fenix/issues/770
- https://github.com/mozilla-mobile/fenix/issues/769
- https://github.com/mozilla-mobile/fenix/issues/779
