### PR TITLE
Mention best practices for code examples in data issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -23,6 +23,7 @@ body:
         - Check for an [existing issue](https://github.com/mdn/browser-compat-data/issues) first. If someone else has opened an issue describing the same problem, please upvote their issue rather than creating another one.
         - Keep issues relevant to the project. Irrelevant issues will be automatically closed and marked as spam, and repeated offenses may result in exclusion from MDN Web Docs.
         - Provide as much detail as possible. The more detail you are able to provide, the better!
+        - Please make sure that any code samples provided are short, easy to read, and written in pure JavaScript. Please avoid writing code examples in TypeScript, CoffeeScript or any other JavaScript variation that requires compilation.
         - Write issues primarily in English. While translation tools are available, we will be able to provide better assistance with pre-translated content. You are more than welcome to include a version of the issue body in your preferred language alongside the English version.
 
         ---


### PR DESCRIPTION
This PR adds a line item to the data problem issue template mentioning best practices for code examples.  This was primarily inspired by a recent issue where a code example was written in TypeScript rather than JavaScript, which added an extra step when assisting the reporter.