### PR TITLE
Remove web-features tag from deprecated Bluetooth writeValue() method

### DIFF
--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -470,9 +470,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/writeValue",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue",
-          "tags": [
-            "web-features:web-bluetooth"
-          ],
           "support": {
             "chrome": {
               "version_added": "56"


### PR DESCRIPTION
Its inclusion causes a warning in web-features dist file generation. We
cannot deal with deprecated BCD keys yet because by definition
deprecated features cannot be Baseline.

This is the only deprecated BCD key currently tagged for web-features.