### PR TITLE
Set Safari 17.6 to beta

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -307,16 +307,9 @@
         "17.5": {
           "release_date": "2024-05-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_5-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "618.2.12"
-        },
-        "17.6": {
-          "release_date": "2024-06-17",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "618.3.7"
+          "engine_version": "618.2.12"
         },
         "18": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -311,6 +311,13 @@
           "engine": "WebKit",
           "engine_version": "618.2.12"
         },
+        "17.6": {
+          "release_date": "2024-06-17",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes",
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "618.3.7"
+        },
         "18": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",
           "status": "beta",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -279,16 +279,9 @@
         "17.5": {
           "release_date": "2024-05-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_5-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "618.2.12"
-        },
-        "17.6": {
-          "release_date": "2024-06-17",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "618.3.7"
+          "engine_version": "618.2.12"
         },
         "18": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -283,6 +283,13 @@
           "engine": "WebKit",
           "engine_version": "618.2.12"
         },
+        "17.6": {
+          "release_date": "2024-06-17",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes",
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "618.3.7"
+        },
         "18": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",
           "status": "beta",


### PR DESCRIPTION
This PR sets Safari 17.6 to beta.  This was added by the auto updater script for browser data and marked as the current browser, but it has never been released and the release notes mark it as a beta version.