### PR TITLE
Update Safari iOS data for resize CSS property

### DIFF
--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -27,7 +27,8 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": false,
+              "notes": "The value is recognized, but has no effect."
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -61,7 +62,9 @@
               "safari": {
                 "version_added": "16"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -95,7 +98,9 @@
               "safari": {
                 "version_added": "4"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "37"
@@ -129,7 +134,9 @@
               "safari": {
                 "version_added": "16"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `resize` CSS property. This fixes #23498, which contains the supporting evidence for this change.
