### PR TITLE
Update Chromium data for BarcodeDetector API

### DIFF
--- a/api/BarcodeDetector.json
+++ b/api/BarcodeDetector.json
@@ -9,7 +9,10 @@
             {
               "version_added": "88",
               "partial_implementation": true,
-              "notes": "Supported on ChromeOS and macOS only."
+              "notes": [
+                "Supported on ChromeOS and macOS only.",
+                "Before Chrome 113, on macOS Ventura (13) and above, this interface silently failed. See <a href='https://crbug.com/40245611'>bug 40245611</a>."
+              ]
             },
             {
               "version_added": "83",
@@ -24,7 +27,10 @@
           "edge": {
             "version_added": "83",
             "partial_implementation": true,
-            "notes": "Supported on macOS only."
+            "notes": [
+              "Supported on macOS only.",
+              "Before Chrome 113, on macOS Ventura (13) and above, this interface silently failed. See <a href='https://crbug.com/40245611'>bug 40245611</a>."
+            ]
           },
           "firefox": {
             "version_added": false
@@ -37,7 +43,10 @@
           "opera": {
             "version_added": "69",
             "partial_implementation": true,
-            "notes": "Supported on macOS only."
+            "notes": [
+              "Supported on macOS only.",
+              "Before Chrome 113, on macOS Ventura (13) and above, this interface silently failed. See <a href='https://crbug.com/40245611'>bug 40245611</a>."
+            ]
           },
           "opera_android": "mirror",
           "safari": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `BarcodeDetector` API. This fixes #22907, which contains the supporting evidence for this change.
