### PR TITLE
Update Safari data for BarcodeDetector API

### DIFF
--- a/api/BarcodeDetector.json
+++ b/api/BarcodeDetector.json
@@ -41,7 +41,14 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "17",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "Shape Detection API",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -95,7 +102,14 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Shape Detection API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -149,7 +163,14 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Shape Detection API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -204,7 +225,14 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Shape Detection API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `BarcodeDetector` API. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/ce99b4d5dd33bd28ffb58899e356841cb5ed7285

Additional Notes: This fixes #22774.
