### PR TITLE
Update Safari data for api.Window.scrollTo.options_behavior_parameter

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5481,7 +5481,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "14",
-                "notes": "Safari does not have support for the <code>smooth</code> scroll behavior."
+                "notes": "Before version 15.4, Safari did not have support for the <code>smooth</code> scroll behavior."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `scrollTo.options_behavior_parameter` member of the `Window` API. This fixes #22889, which contains the supporting evidence for this change.
