### PR TITLE
Replace "display-outside" with individual values

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -40,6 +40,45 @@
             "deprecated": false
           }
         },
+        "block": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display/#typedef-display-outside",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "4"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "contents": {
           "__compat": {
             "support": {
@@ -102,47 +141,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          }
-        },
-        "display-outside": {
-          "__compat": {
-            "description": "<code>&lt;display-outside&gt;</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-outside",
-            "spec_url": "https://drafts.csswg.org/css-display/#typedef-display-outside",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "4"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "7"
-              },
-              "opera_android": {
-                "version_added": "10.1"
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },
@@ -302,6 +300,45 @@
                 "version_added": "6.0",
                 "notes": "Samsung Internet added this earlier than the corresponding Chrome version would indicate."
               },
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inline": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display/#typedef-display-outside",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "4"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "7"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {


### PR DESCRIPTION
This PR splits the `display-outside` subfeature of the `display` CSS property into the two individual values.  This is done for many reasons:

- The spec includes a `run-in` value for this type enum, which is not supported in any browsers.
- Splitting them out provides better machine readability.
- Splitting them out also provides better clarity.
