### PR TITLE
Firefox does not support PlatformNaclArch

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -395,9 +395,7 @@
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": {
-                "version_added": "mirror"
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -396,7 +396,7 @@
                 "version_added": false
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "mirror"
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -393,10 +393,10 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": "45"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": false
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Firefox does not support `PlatformNaclArch`. This is already correctly reflected on the `runtime.PlatformInfo` page but is not reflected on the `PlatformNaclArch` page.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
There is only a [single occurrence](https://searchfox.org/mozilla-central/search?q=PlatformNaclArch&path=&case=false&regexp=false) of `PlatformNaclArch` in the Firefox codebase which is part of an extension schema which lists it as an unsupported feature.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
