### PR TITLE
Add missing features for IntersectionObserver API

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -114,6 +114,41 @@
           }
         }
       },
+      "delay": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-delay",
+          "support": {
+            "chrome": {
+              "version_added": "≤83"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "≤83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "disconnect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/disconnect",
@@ -378,6 +413,41 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "trackVisibility": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-trackvisibility",
+          "support": {
+            "chrome": {
+              "version_added": "≤83"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "≤83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -122,9 +122,7 @@
               "version_added": "74"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -426,9 +424,7 @@
               "version_added": "74"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -119,11 +119,11 @@
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-delay",
           "support": {
             "chrome": {
-              "version_added": "≤83"
+              "version_added": "74"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤83"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -423,11 +423,11 @@
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-trackvisibility",
           "support": {
             "chrome": {
-              "version_added": "≤83"
+              "version_added": "74"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤83"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds the missing features of the `IntersectionObserver` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.11.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/IntersectionObserver
