### PR TITLE
Add missing api.IntersectionObserverEntry.isVisible feature

### DIFF
--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -235,11 +235,11 @@
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-isvisible",
           "support": {
             "chrome": {
-              "version_added": "≤83"
+              "version_added": "74"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤83"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -238,9 +238,7 @@
               "version_added": "74"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -230,6 +230,41 @@
           }
         }
       },
+      "isVisible": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-isvisible",
+          "support": {
+            "chrome": {
+              "version_added": "≤83"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "≤83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "rootBounds": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/rootBounds",


### PR DESCRIPTION
This PR adds the missing `isVisible` member of the `IntersectionObserverEntry` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.11.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/IntersectionObserverEntry/isVisible
