### PR TITLE
Update Edge data for api.Navigator.share

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -445,7 +445,7 @@
                 "version_added": "93"
               },
               {
-                "version_added": "89",
+                "version_added": "81",
                 "version_removed": "93",
                 "partial_implementation": true,
                 "notes": "Only supported on Windows."
@@ -496,7 +496,9 @@
               "chrome_android": {
                 "version_added": "76"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "81"
+              },
               "firefox": {
                 "version_added": false
               },
@@ -536,13 +538,13 @@
               "chrome_android": {
                 "version_added": "76"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "96"
+              "edge": {
+                "version_added": "81"
               },
-              "firefox_android": {
+              "firefox": {
                 "version_added": false
               },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -4281,7 +4283,7 @@
                 "version_added": "93"
               },
               {
-                "version_added": "89",
+                "version_added": "81",
                 "version_removed": "93",
                 "partial_implementation": true,
                 "notes": "Only supported on Windows."
@@ -4334,7 +4336,9 @@
               "chrome_android": {
                 "version_added": "76"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "81"
+              },
               "firefox": {
                 "version_added": false
               },
@@ -4374,7 +4378,9 @@
               "chrome_android": {
                 "version_added": "76"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "81"
+              },
               "firefox": {
                 "version_added": "71"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `share` member of the `Navigator` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.11.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Navigator/share
