### PR TITLE
Update Safari data for html.global_attributes.autofocus

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1258,7 +1258,7 @@
             },
             "safari_ios": {
               "version_added": "1",
-              "notes": "If there's no hardware keyboard connected and the user has not yet interacted with the page, then calling <code>focus()<code> on an <code>&lt;input&gt;</code> element has no effect (for example, the element does not match the <code>:focus</code> selector)."
+              "notes": "If there's no hardware keyboard connected and the user has not yet interacted with the page, then calling <code>focus()</code> on an <code>&lt;input&gt;</code> element has no effect (for example, the element does not match the <code>:focus</code> selector)."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1257,7 +1257,8 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "If there's no hardware keyboard connected and the user has not yet interacted with the page, then calling <code>focus()<code> on an <code>&lt;input&gt;</code> element has no effect (for example, the element does not match the <code>:focus</code> selector)."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -195,7 +195,8 @@
               }
             ],
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4",
+              "notes": "On iOS and iPadOS devices, this attribute has no effect unless a hardware keyboard is connected."
             },
             "samsunginternet_android": "mirror",
             "webview_android": [

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -194,7 +194,9 @@
                 "notes": "Supported for the <code>&lt;button&gt;</code>, <code>&lt;input&gt;</code>, <code>&lt;select&gt;</code>, and <code>&lt;textarea&gt;</code> elements."
               }
             ],
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -196,7 +196,7 @@
             ],
             "safari_ios": {
               "version_added": "16.4",
-              "notes": "On iOS and iPadOS devices, this attribute has no effect unless a hardware keyboard is connected."
+              "notes": "If there's no hardware keyboard connected, then the <code>autofocus</code> attribute has no effect (for example, the <code>focus</code> event doesn't fire and the element does not match the <code>:focus</code> selector)."
             },
             "samsunginternet_android": "mirror",
             "webview_android": [


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `autofocus` member of the `global_attributes` HTML feature. This fixes #23457, which contains the supporting evidence for this change.
