### PR TITLE
Enable obsolete feature linter for JavaScript category

### DIFF
--- a/lint/linter/test-obsolete.ts
+++ b/lint/linter/test-obsolete.ts
@@ -18,7 +18,7 @@ const categoriesToCheck = [
   // 'css',
   // 'html',
   // 'http',
-  // 'javascript',
+  'javascript',
   'mathml',
   // 'svg',
   'webassembly',


### PR DESCRIPTION
This PR enables the obsolete feature linter for the JavaScript category.  We have no obsolete features in the category, so this will ensure it remains that way.
