### PR TITLE
Enable obsolete feature linter for WebDriver category

### DIFF
--- a/lint/linter/test-obsolete.ts
+++ b/lint/linter/test-obsolete.ts
@@ -22,7 +22,7 @@ const categoriesToCheck = [
   'mathml',
   // 'svg',
   'webassembly',
-  // 'webdriver',
+  'webdriver',
   'webextensions',
 ];
 


### PR DESCRIPTION
This PR enables the obsolete feature linter for the WebDriver category. We have no obsolete features in the category, so this will ensure it remains that way.
