### PR TITLE
Remove html.elements.link.methods from BCD

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -497,41 +497,6 @@
             }
           }
         },
-        "methods": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "4"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "referrerpolicy": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-referrerpolicy",


### PR DESCRIPTION
This PR removes the `methods` member of the `link` HTML element from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.11.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/link/methods
