### PR TITLE
Remove html.elements.track.kind.descriptions from BCD

### DIFF
--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -117,42 +117,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "descriptions": {
-            "__compat": {
-              "description": "<code>kind='descriptions'</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/1447858"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1871143"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/266724"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         },
         "label": {


### PR DESCRIPTION
This PR removes the `kind.descriptions` member of the `track` HTML element from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.11.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/track/kind/descriptions
