### PR TITLE
Require real values in JavaScript category for Deno

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -277,6 +277,9 @@
                   "version_added": "76"
                 },
                 "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.0"
+                },
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "70"

--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -112,6 +112,9 @@
                     }
                   ],
                   "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "54"
@@ -249,6 +252,9 @@
                       "version_added": "80"
                     },
                     "chrome_android": "mirror",
+                    "deno": {
+                      "version_added": "1.8"
+                    },
                     "edge": "mirror",
                     "firefox": {
                       "version_added": "76"
@@ -445,6 +451,9 @@
                       "version_added": "80"
                     },
                     "chrome_android": "mirror",
+                    "deno": {
+                      "version_added": "1.8"
+                    },
                     "edge": "mirror",
                     "firefox": {
                       "version_added": "76"

--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -105,6 +105,9 @@
                     }
                   ],
                   "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "54"

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -14,6 +14,15 @@
               "impl_url": "https://crbug.com/v8/11544"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.40",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-temporal"
+                }
+              ]
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false,

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -58,6 +58,9 @@
                 "version_added": "47"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -99,6 +102,9 @@
                 "version_added": "47"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -140,6 +146,9 @@
                 "version_added": "47"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -178,6 +187,9 @@
                 "version_added": "60"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "55"

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -117,6 +117,9 @@
                 "version_added": "46"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -161,6 +164,9 @@
                 "version_added": "60"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "55"

--- a/lint/linter/test-versions.ts
+++ b/lint/linter/test-versions.ts
@@ -46,7 +46,7 @@ const realValuesRequired: Record<string, string[]> = {
   html: [],
   http: [],
   svg: [],
-  javascript: [...realValuesTargetBrowsers, 'nodejs'],
+  javascript: [...realValuesTargetBrowsers, 'nodejs', 'deno'],
   mathml: realValuesTargetBrowsers,
   webassembly: realValuesTargetBrowsers,
   webdriver: realValuesTargetBrowsers,


### PR DESCRIPTION
This PR makes real values for Deno required for the JavaScript category, like NodeJS data.  Since some data for Deno was missing, this also adds the data, either by mirroring from child features or by mirroring loosely based on Chrome versions.
