### PR TITLE
Enable obsolete feature linter for HTML category

### DIFF
--- a/lint/linter/test-obsolete.ts
+++ b/lint/linter/test-obsolete.ts
@@ -16,7 +16,7 @@ const { browsers } = bcd;
 const categoriesToCheck = [
   'api',
   // 'css',
-  // 'html',
+  'html',
   // 'http',
   'javascript',
   'mathml',
@@ -149,14 +149,9 @@ export default {
       processData(logger, data);
     }
   },
-  // XXX Exceptions disabled while the corresponding categories are ignored
-  // exceptions: [
-  // 'http.headers.Cache-Control.stale-if-error',
-  // 'http.headers.Feature-Policy.layout-animations',
-  // 'http.headers.Feature-Policy.legacy-image-formats',
-  // 'http.headers.Feature-Policy.oversized-images',
-  // 'http.headers.Feature-Policy.unoptimized-images',
-  // 'http.headers.Feature-Policy.unsized-media',
-  // 'svg.elements.view.zoomAndPan',
-  // ],
+  exceptions: [
+    'html.elements.track.kind.descriptions',
+    // The following exceptions are disabled while their categories are ignored:
+    // 'http.headers.Cache-Control.stale-if-error',
+  ],
 } as Linter;


### PR DESCRIPTION
This PR enables the obsolete feature linter for the HTML category.  A part of this PR is to add an exception to a certain feature, as requested in https://github.com/mdn/browser-compat-data/pull/23699#pullrequestreview-2163196786.  (Note: this PR takes the opportunity to clean up the disabled exceptions, as all but one were removed and/or marked as supported.)

Note: this PR will FAIL until #23696, #23697 and #23698 have been merged.
