### PR TITLE
Mirror Chromium downstream when downstream is null

### DIFF
--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -129,9 +129,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "5.1"
               },

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1079,9 +1079,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "11.1"
                 },
@@ -1123,9 +1121,7 @@
                   },
                   "oculus": "mirror",
                   "opera": "mirror",
-                  "opera_android": {
-                    "version_added": null
-                  },
+                  "opera_android": "mirror",
                   "safari": {
                     "version_added": "11.1"
                   },
@@ -1168,9 +1164,7 @@
                   },
                   "oculus": "mirror",
                   "opera": "mirror",
-                  "opera_android": {
-                    "version_added": null
-                  },
+                  "opera_android": "mirror",
                   "safari": {
                     "version_added": "11.1"
                   },
@@ -1213,9 +1207,7 @@
                   },
                   "oculus": "mirror",
                   "opera": "mirror",
-                  "opera_android": {
-                    "version_added": null
-                  },
+                  "opera_android": "mirror",
                   "safari": {
                     "version_added": "11.1"
                   },
@@ -1258,9 +1250,7 @@
                   },
                   "oculus": "mirror",
                   "opera": "mirror",
-                  "opera_android": {
-                    "version_added": null
-                  },
+                  "opera_android": "mirror",
                   "safari": {
                     "version_added": "11.1"
                   },
@@ -1303,9 +1293,7 @@
                   },
                   "oculus": "mirror",
                   "opera": "mirror",
-                  "opera_android": {
-                    "version_added": null
-                  },
+                  "opera_android": "mirror",
                   "safari": {
                     "version_added": "11.1"
                   },
@@ -1340,9 +1328,7 @@
                   },
                   "oculus": "mirror",
                   "opera": "mirror",
-                  "opera_android": {
-                    "version_added": null
-                  },
+                  "opera_android": "mirror",
                   "safari": {
                     "version_added": "11.1"
                   },

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -397,13 +397,8 @@
                   "notes": "Browsers initially supported an <a href='https://wiki.whatwg.org/wiki/Meta_referrer'>early draft</a> of the specification which can only use a meta tag and is only compatible with the <code>origin</code> value from the new spec."
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "15",
-                  "notes": "Until Opera 46, <code>content</code> values weren't constrained to the values listed in the spec."
-                },
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "11.1"
                 },
@@ -411,10 +406,7 @@
                   "version_added": "12"
                 },
                 "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "37",
-                  "notes": "Until Chrome 46, <code>content</code> values weren't constrained to the values listed in the spec."
-                }
+                "webview_android": "mirror"
               },
               "status": {
                 "experimental": false,

--- a/html/elements/portal.json
+++ b/html/elements/portal.json
@@ -50,7 +50,8 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror"
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -290,9 +290,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "11.1"
               },

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -525,9 +525,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": false
                 },

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -490,6 +490,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "13.1"
             },

--- a/http/headers/Accept-CH.json
+++ b/http/headers/Accept-CH.json
@@ -92,9 +92,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },

--- a/http/headers/Device-Memory.json
+++ b/http/headers/Device-Memory.json
@@ -23,9 +23,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },

--- a/http/status.json
+++ b/http/status.json
@@ -23,6 +23,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "17"
             },
@@ -54,6 +55,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "17",
                 "notes": "Supported in HTTP/2 and later only."
@@ -87,6 +89,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR sets downstream browsers (such as Opera Android) to mirror from upstream when the downstream browser is `null`.
