### PR TITLE
Update Safari data for api.createImageBitmap.svgimageelement_as_source_image

### DIFF
--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -348,7 +348,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "17"
+              "version_added": "17.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `svgimageelement_as_source_image` member of the `createImageBitmap` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.11.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/createImageBitmap/svgimageelement_as_source_image

Additional Notes: The previous version number was based on commit date (https://github.com/mdn/browser-compat-data/pull/22744#discussion_r1567229731).
