### PR TITLE
FF127 WebVTT Cue text supports all character references

### DIFF
--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -468,6 +468,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "all_html_character_references": {
+          "__compat": {
+            "description": "All HTML character references allowed.",
+            "support": {
+              "chrome": {
+                "version_added": "≤80"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "127"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17.5"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "vertical": {


### PR DESCRIPTION
FF127 supports all HTML character references in WebVTT cues in  https://bugzilla.mozilla.org/show_bug.cgi?id=1395924 (from a small subset that were formerly supported in the spec a long time ago).

Safari 17.5 supports all reference according to https://wpt.live/webvtt/parsing/cue-text-parsing/tests/entities.html (on latest iPhone). Safari 17.3 does not, so I have marked as 17.5 support.

Chrome 80 supports all char references but any earlier the tests fail.

I have marked this in VTTCue.text entry. It might also go in the constructor, which can also take the text, but I decided not to - will if you think it needed. This also applies to the WebVTT file format, but that has no BCD entry.

Related docs work tracked in https://github.com/mdn/content/issues/33589