### PR TITLE
Update spec link/status of clipboard permissions

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -287,7 +287,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -295,6 +295,7 @@
       "permission_clipboard-write": {
         "__compat": {
           "description": "<code>clipboard-write</code> permission",
+          "spec_url": "https://w3c.github.io/clipboard-apis/#dom-permissionname-clipboard-write",
           "support": {
             "chrome": {
               "version_added": "64"


### PR DESCRIPTION
The "clipboard-read" permission was removed from the spec:
https://github.com/w3c/clipboard-apis/pull/132