### PR TITLE
Update Safari data for Authorization HTTP header

### DIFF
--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `Authorization` HTTP header. This mirrors Chrome down to Safari.
