### PR TITLE
Update Chromium data for Alt-Svc HTTP header

### DIFF
--- a/http/headers/Alt-Svc.json
+++ b/http/headers/Alt-Svc.json
@@ -7,12 +7,10 @@
           "spec_url": "https://httpwg.org/specs/rfc7838.html#alt-svc",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "52"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤79"
-            },
+            "edge": "mirror",
             "firefox": [
               {
                 "version_added": "38"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Alt-Svc` HTTP header. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://chromiumdash.appspot.com/commit/decead7175be5101f9dbef0fdc387d8a544d299b
