### PR TITLE
Update all browsers data for Age HTTP header

### DIFF
--- a/http/headers/Age.json
+++ b/http/headers/Age.json
@@ -7,14 +7,14 @@
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.age",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `Age` HTTP header. This was suggested to be the first version in all browsers based on https://github.com/mdn/browser-compat-data/pull/23430#discussion_r1670240424.
