### PR TITLE
Fix linter for new mdn_urls

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -150,6 +150,7 @@
       },
       "bytes": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/bytes",
           "spec_url": "https://w3c.github.io/FileAPI/#dom-blob-bytes",
           "support": {
             "chrome": {

--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -2,6 +2,7 @@
   "api": {
     "CloseWatcher": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseWatcher",
         "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#closewatcher",
         "support": {
           "chrome": {
@@ -35,6 +36,7 @@
       "CloseWatcher": {
         "__compat": {
           "description": "<code>CloseWatcher()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseWatcher/CloseWatcher",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher",
           "support": {
             "chrome": {
@@ -69,6 +71,7 @@
       "cancel_event": {
         "__compat": {
           "description": "<code>cancel</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseWatcher/cancel_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#handler-closewatcher-oncancel",
           "support": {
             "chrome": {
@@ -102,6 +105,7 @@
       },
       "close": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseWatcher/close",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-close",
           "support": {
             "chrome": {
@@ -136,6 +140,7 @@
       "close_event": {
         "__compat": {
           "description": "<code>close</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseWatcher/close_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#handler-closewatcher-onclose",
           "support": {
             "chrome": {
@@ -169,6 +174,7 @@
       },
       "destroy": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseWatcher/destroy",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-destroy",
           "support": {
             "chrome": {
@@ -202,6 +208,7 @@
       },
       "requestClose": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseWatcher/requestClose",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-requestclose",
           "support": {
             "chrome": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -118,6 +118,7 @@
       },
       "anchorElement": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/anchorElement",
           "support": {
             "chrome": {
               "version_added": "preview",

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -287,6 +287,7 @@
       },
       "href": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/href",
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#dom-link-href",
           "support": {
             "chrome": {

--- a/api/NavigationActivation.json
+++ b/api/NavigationActivation.json
@@ -2,6 +2,7 @@
   "api": {
     "NavigationActivation": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationActivation",
         "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationactivation",
         "tags": [
           "web-features:navigation-activation"
@@ -38,6 +39,7 @@
       },
       "entry": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationActivation/entry",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationactivation-entry",
           "tags": [
             "web-features:navigation-activation"
@@ -75,6 +77,7 @@
       },
       "from": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationActivation/from",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationactivation-from",
           "tags": [
             "web-features:navigation-activation"
@@ -112,6 +115,7 @@
       },
       "navigationType": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationActivation/navigationType",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationactivation-navigationtype",
           "tags": [
             "web-features:navigation-activation"

--- a/api/NavigationCurrentEntryChangeEvent.json
+++ b/api/NavigationCurrentEntryChangeEvent.json
@@ -2,6 +2,7 @@
   "api": {
     "NavigationCurrentEntryChangeEvent": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationCurrentEntryChangeEvent",
         "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationcurrententrychangeevent-interface",
         "support": {
           "chrome": {

--- a/api/PageRevealEvent.json
+++ b/api/PageRevealEvent.json
@@ -2,6 +2,7 @@
   "api": {
     "PageRevealEvent": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageRevealEvent",
         "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagerevealevent-interface",
         "support": {
           "chrome": {
@@ -36,6 +37,7 @@
       "PageRevealEvent": {
         "__compat": {
           "description": "<code>PageRevealEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageRevealEvent/PageRevealEvent",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagerevealevent-interface",
           "support": {
             "chrome": {
@@ -70,6 +72,7 @@
       },
       "viewTransition": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageRevealEvent/viewTransition",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-pagerevealevent-viewtransition",
           "support": {
             "chrome": {

--- a/api/PageSwapEvent.json
+++ b/api/PageSwapEvent.json
@@ -2,6 +2,7 @@
   "api": {
     "PageSwapEvent": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageSwapEvent",
         "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pageswapevent-interface",
         "support": {
           "chrome": {
@@ -36,6 +37,7 @@
       "PageSwapEvent": {
         "__compat": {
           "description": "<code>PageSwapEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageSwapEvent/PageSwapEvent",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pageswapevent-interface",
           "support": {
             "chrome": {
@@ -70,6 +72,7 @@
       },
       "activation": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageSwapEvent/activation",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-pageswapevent-activation",
           "support": {
             "chrome": {
@@ -104,6 +107,7 @@
       },
       "viewTransition": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageSwapEvent/viewTransition",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-pageswapevent-viewtransition",
           "support": {
             "chrome": {

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -143,6 +143,7 @@
       },
       "bytes": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushMessageData/bytes",
           "spec_url": "https://w3c.github.io/push-api/#dom-pushmessagedata-bytes",
           "support": {
             "chrome": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -530,6 +530,7 @@
       },
       "bytes": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/bytes",
           "spec_url": "https://fetch.spec.whatwg.org/#dom-body-bytes",
           "support": {
             "chrome": {

--- a/api/Response.json
+++ b/api/Response.json
@@ -385,6 +385,7 @@
       },
       "bytes": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/bytes",
           "spec_url": "https://fetch.spec.whatwg.org/#dom-body-bytes",
           "support": {
             "chrome": {

--- a/api/ScrollTimeline.json
+++ b/api/ScrollTimeline.json
@@ -119,6 +119,7 @@
       },
       "source": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/source",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-scrolltimeline-source",
           "tags": [
             "web-features:scroll-driven-animations"

--- a/api/ViewTimeline.json
+++ b/api/ViewTimeline.json
@@ -119,6 +119,7 @@
       },
       "startOffset": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTimeline/startOffset",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-viewtimeline-startoffset",
           "tags": [
             "web-features:scroll-driven-animations"
@@ -157,6 +158,7 @@
       },
       "subject": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTimeline/subject",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#dom-viewtimeline-subject",
           "tags": [
             "web-features:scroll-driven-animations"

--- a/api/Window.json
+++ b/api/Window.json
@@ -3739,6 +3739,7 @@
       "pagereveal_event": {
         "__compat": {
           "description": "<code>pagereveal</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/pagereveal_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-pagereveal",
           "support": {
             "chrome": {
@@ -3813,6 +3814,7 @@
       "pageswap_event": {
         "__compat": {
           "description": "<code>pageswap</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/pageswap_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-pageswap",
           "support": {
             "chrome": {

--- a/css/properties/anchor-name.json
+++ b/css/properties/anchor-name.json
@@ -3,6 +3,7 @@
     "properties": {
       "anchor-name": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/anchor-name",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#name",
           "tags": [
             "web-features:anchor-positioning"

--- a/css/properties/contain-intrinsic-block-size.json
+++ b/css/properties/contain-intrinsic-block-size.json
@@ -3,6 +3,7 @@
     "properties": {
       "contain-intrinsic-block-size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-block-size",
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-block-size",
           "tags": [
             "web-features:contain-intrinsic-size"

--- a/css/properties/contain-intrinsic-inline-size.json
+++ b/css/properties/contain-intrinsic-inline-size.json
@@ -3,6 +3,7 @@
     "properties": {
       "contain-intrinsic-inline-size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-inline-size",
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-inline-size",
           "tags": [
             "web-features:contain-intrinsic-size"

--- a/css/properties/inset-area.json
+++ b/css/properties/inset-area.json
@@ -3,6 +3,7 @@
     "properties": {
       "inset-area": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-area",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#inset-area",
           "tags": [
             "web-features:anchor-positioning"

--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -3,6 +3,7 @@
     "properties": {
       "position-anchor": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position-anchor",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#position-anchor",
           "tags": [
             "web-features:anchor-positioning"

--- a/css/properties/position-visibility.json
+++ b/css/properties/position-visibility.json
@@ -3,6 +3,7 @@
     "properties": {
       "position-visibility": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position-visibility",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#position-visibility",
           "tags": [
             "web-features:anchor-positioning"

--- a/css/properties/text-spacing-trim.json
+++ b/css/properties/text-spacing-trim.json
@@ -3,6 +3,7 @@
     "properties": {
       "text-spacing-trim": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-spacing-trim",
           "spec_url": "https://drafts.csswg.org/css-text-4/#text-spacing-trim-property",
           "tags": [
             "web-features:text-spacing-trim"

--- a/css/types/anchor-size.json
+++ b/css/types/anchor-size.json
@@ -4,6 +4,7 @@
       "anchor-size": {
         "__compat": {
           "description": "<code>anchor-size()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/anchor-size",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn",
           "tags": [
             "web-features:anchor-positioning"

--- a/css/types/anchor.json
+++ b/css/types/anchor.json
@@ -4,6 +4,7 @@
       "anchor": {
         "__compat": {
           "description": "<code>anchor()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/anchor",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-pos",
           "tags": [
             "web-features:anchor-positioning"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -39,6 +39,7 @@
       },
       "anchor": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/anchor",
           "support": {
             "chrome": {
               "version_added": "preview",

--- a/lint/linter/test-mdn-urls.ts
+++ b/lint/linter/test-mdn-urls.ts
@@ -123,7 +123,7 @@ export const processData = (
         break;
     }
 
-    if (slugs.has(categorySlug)) {
+    if (slugs.has(categorySlug.toLowerCase())) {
       errors.push({
         ruleName: 'mdn_url_new_page',
         path,

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -141,6 +141,7 @@
         },
         "MAX_NUMBER_OF_DISABLED_STATIC_RULES": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_DISABLED_STATIC_RULES",
             "support": {
               "chrome": {
                 "version_added": false,


### PR DESCRIPTION
I was wondering why all our newly written pages don't show up with inventory updates 😄 (https://github.com/mdn/browser-compat-data/pull/23723). Turns out I introduced a little bug. This PR fixes it!