### PR TITLE
Update Edge data for Upgrade HTTP header

### DIFF
--- a/http/headers/Upgrade.json
+++ b/http/headers/Upgrade.json
@@ -14,7 +14,9 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": "1"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `Upgrade` HTTP header. This change was requested in https://github.com/mdn/browser-compat-data/pull/23725#discussion_r1670699268.
