### PR TITLE
Updates for Firefox 129 beta

### DIFF
--- a/api/CSSPageDescriptors.json
+++ b/api/CSSPageDescriptors.json
@@ -1,0 +1,389 @@
+{
+  "api": {
+    "CSSPageDescriptors": {
+      "__compat": {
+        "spec_url": "https://drafts.csswg.org/cssom/#csspagedescriptors",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "129"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "margin": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-margin",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "margin-bottom": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-margin-botton",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "margin-left": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-margin-left",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "margin-right": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-margin-right",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "margin-top": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-margin-top",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "marginBottom": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-marginbotton",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "marginLeft": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-marginleft",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "marginRight": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-marginright",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "marginTop": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-margintop",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "size": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagedescriptors-size",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSPageDescriptors.json
+++ b/api/CSSPageDescriptors.json
@@ -12,9 +12,7 @@
           "firefox": {
             "version_added": "129"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -46,9 +44,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -81,9 +77,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -116,9 +110,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -151,9 +143,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -186,9 +176,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -221,9 +209,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -256,9 +242,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -291,9 +275,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -326,9 +308,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -361,9 +341,7 @@
             "firefox": {
               "version_added": "129"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/CSSStartingStyleRule.json
+++ b/api/CSSStartingStyleRule.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "129"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -540,7 +540,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -222,7 +222,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4851,6 +4851,7 @@
             "firefox": [
               {
                 "version_added": "16",
+                "version_removed": "129",
                 "notes": [
                   "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
                   "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>).",

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -165,6 +165,39 @@
           }
         }
       },
+      "contentType": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-contenttype",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "129"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "decodedBodySize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/decodedBodySize",

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -778,7 +778,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -795,7 +795,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -44,7 +44,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/TextEvent.json
+++ b/api/TextEvent.json
@@ -12,7 +12,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "129"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -46,7 +46,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -81,7 +81,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/at-rules/starting-style.json
+++ b/css/at-rules/starting-style.json
@@ -15,26 +15,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1834876",
-                "partial_implementation": true,
-                "notes": "Does not yet support animating from <code>display: none</code>"
-              },
-              {
-                "version_added": "127",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.starting-style-at-rules.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "partial_implementation": true,
-                "notes": "Does not yet support animating from <code>display: none</code>"
-              }
-            ],
+            "firefox": {
+              "version_added": "129"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1805727"
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -403,14 +403,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.float16array",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -947,14 +940,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.float16array",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Float16Array.json
+++ b/javascript/builtins/Float16Array.json
@@ -18,14 +18,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "javascript.options.experimental.float16array",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -68,14 +61,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.float16array",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1165,14 +1165,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.float16array",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -628,8 +628,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1773135"
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.1 found new features shipping in Firefox 129 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 29 features as shipping in Firefox 129:

- api.CSSPageDescriptors (https://bugzil.la/1890842)
- api.CSSPageDescriptors.margin (https://bugzil.la/1890842)
- api.CSSPageDescriptors.margin-bottom (https://bugzil.la/1890842)
- api.CSSPageDescriptors.margin-left (https://bugzil.la/1890842)
- api.CSSPageDescriptors.margin-right (https://bugzil.la/1890842)
- api.CSSPageDescriptors.margin-top (https://bugzil.la/1890842)
- api.CSSPageDescriptors.marginBottom (https://bugzil.la/1890842)
- api.CSSPageDescriptors.marginLeft (https://bugzil.la/1890842)
- api.CSSPageDescriptors.marginRight (https://bugzil.la/1890842)
- api.CSSPageDescriptors.marginTop (https://bugzil.la/1890842)
- api.CSSPageDescriptors.size (https://bugzil.la/1890842)
- api.CSSStartingStyleRule (https://bugzil.la/1900458)
- api.GeolocationCoordinates.toJSON (https://bugzil.la/1890706)
- api.GeolocationPosition.toJSON (https://bugzil.la/1890706)
- api.Navigator.vibrate (removal) (https://bugzil.la/1900037)
- api.PerformanceResourceTiming.contentType (https://bugzil.la/1800443)
- api.PerformanceResourceTiming.responseStatus (https://bugzil.la/1796785)
- api.RTCDTMFSender.canInsertDTMF (https://bugzil.la/1623193)
- api.TextEvent (https://bugzil.la/1901923)
- api.TextEvent.data (https://bugzil.la/1901923)
- api.TextEvent.initTextEvent (https://bugzil.la/1901923)
- css.at-rules.starting-style (https://bugzil.la/1900458)
- css.properties.transition-behavior (https://bugzil.la/1901645)
- javascript.builtins.DataView.getFloat16 (https://bugzil.la/1903329)
- javascript.builtins.DataView.setFloat16 (https://bugzil.la/1903329)
- javascript.builtins.Float16Array (https://bugzil.la/1903329)
- javascript.builtins.Float16Array.Float16Array (https://bugzil.la/1903329)
- javascript.builtins.Math.f16round (https://bugzil.la/1903329)
- javascript.regular_expressions.named_capturing_group.duplicate_named_capturing_groups (https://bugzil.la/1903288)

Again, I hope this PR is useful to provide updates to BCD in an easy, fast and accurate way. If you have feedback, let me know!

See also https://github.com/mdn/mdn/issues/565 and https://www.mozilla.org/en-US/firefox/129.0beta/releasenotes/