### PR TITLE
Chrome and Safari ship duplicate named capture groups

### DIFF
--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -619,8 +619,7 @@
             "description": "Duplicate names in different disjunction alternatives are allowed",
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13173"
+                "version_added": "125"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -642,14 +641,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Chrome 125: https://chromestatus.com/feature/5149208388829184
Safari 17: https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes, https://bugs.webkit.org/show_bug.cgi?id=252553