### PR TITLE
Remove partial implementation status from async clipboard

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -46,7 +46,6 @@
           "support": {
             "chrome": {
               "version_added": "66",
-              "partial_implementation": true,
               "notes": [
                 "From version 86, the <code>text/html</code> MIME type is supported.",
                 "From version 85, Requires Permission-Policy <code>clipboard-read</code> permission.",
@@ -57,7 +56,6 @@
             },
             "chrome_android": {
               "version_added": "66",
-              "partial_implementation": true,
               "notes": [
                 "From version 86, the <code>text/html</code> MIME type is supported.",
                 "From version 85, Requires Permission-Policy <code>clipboard-read</code> permission.",
@@ -98,7 +96,6 @@
             },
             "webview_android": {
               "version_added": "66",
-              "partial_implementation": true,
               "notes": [
                 "From version 84, the <code>image/png</code> MIME type is supported.",
                 "From version 66, the <code>text/plain</code> MIME type is supported.",
@@ -158,7 +155,6 @@
           "support": {
             "chrome": {
               "version_added": "66",
-              "partial_implementation": true,
               "notes": [
                 "From version 85, Requires Permission-Policy <code>clipboard-read</code> permission.",
                 "Requires Permission API <code>clipboard-read</code> permission. Does not require transient activation."


### PR DESCRIPTION
This status for read() and readText() isn't clearly explained by the
notes, but seems to have been carried forward when merging compat
statements in https://github.com/mdn/browser-compat-data/pull/21667.

Since the required formats are now supported, it doesn't make sense to
continue to claim partial implementation.

https://github.com/mdn/browser-compat-data/issues/7991 would make this
clearer still.