### PR TITLE
Remove SVG requiredFeatures attribute

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -633,40 +633,6 @@
           }
         }
       },
-      "requiredFeatures": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/requiredFeatures",
-          "spec_url": "https://www.w3.org/TR/SVG11/struct.html#RequiredFeaturesAttribute",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": null
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "systemLanguage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/systemLanguage",


### PR DESCRIPTION
Like `systemLanguage` (https://github.com/mdn/browser-compat-data/pull/23732) the `requireFeatures` attribute is not a global attribute. Instead it applies only to the (many) elements that `systemLanguage` applies to as well, so in theory I should have the same PR as `systemLanguage`.

However, 
- requiredFeatures is deprecated and not part of SVG2
- is going to be removed: https://bugs.webkit.org/show_bug.cgi?id=204125, https://issues.chromium.org/issues/40510937
- is already removed in Firefox 69 https://bugzilla.mozilla.org/show_bug.cgi?id=1295404
- it is unclear when or much this is really supported.

I think it is not worth the hassle, so I'm proposing to remove this and be done with this one.