### PR TITLE
Fix engine version for Opera Android 83

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -482,7 +482,7 @@
           "release_notes": "https://blogs.opera.com/mobile/2024/06/opera-android-version-image-generation/",
           "status": "current",
           "engine": "Blink",
-          "engine_version": "124"
+          "engine_version": "125"
         }
       }
     }

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -482,7 +482,7 @@
           "release_notes": "https://blogs.opera.com/mobile/2024/06/opera-android-version-image-generation/",
           "status": "current",
           "engine": "Blink",
-          "engine_version": "125"
+          "engine_version": "126"
         }
       }
     }


### PR DESCRIPTION
This fixes a copy-paste error when adding Opera Android 83 to the browser data, which is causing issues with updating data from the collector results.
