### PR TITLE
Update Chrome Android data for api.ClipboardItem.supports_static

### DIFF
--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -181,9 +181,7 @@
             "chrome": {
               "version_added": "121"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "127"
@@ -216,9 +214,7 @@
               "chrome": {
                 "version_added": "121"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -252,9 +248,7 @@
               "chrome": {
                 "version_added": "121"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `supports` static method of the `ClipboardItem` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ClipboardItem/supports_static

Additional Notes: The subfeatures aren't tested with the collector, but they're likely set to `false` for the same reason the parent was: lack of collector results for Chrome Android.
