### PR TITLE
Update Firefox data for Directory API

### DIFF
--- a/api/Directory.json
+++ b/api/Directory.json
@@ -9,7 +9,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "≤72"
+            "version_added": "30"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -40,7 +40,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "48"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -72,7 +72,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "42"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -104,7 +104,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "30"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -136,7 +136,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "42"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `Directory` API. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://hg.mozilla.org/mozilla-central/rev/b1c0310cdac10003943ca8f1f176bed8c85c1609, https://hg.mozilla.org/mozilla-central/rev/c050de3408c8992a07299c7da8bd8006d48f8073, https://hg.mozilla.org/mozilla-central/rev/bd1aca23aba6cc93019b9756f27b8079132f627f
