### PR TITLE
Update Safari iOS data for api.Gamepad.vibrationActuator

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -543,7 +543,9 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `vibrationActuator` member of the `Gamepad` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Gamepad/vibrationActuator

Additional Notes: This was confirmed via manual testing, using https://hardwaretester.com/gamepad with both a DualSense and Xbox Wireless controller.
