### PR TITLE
Clarify notes about clipboard permissions

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -46,7 +46,7 @@
           "support": {
             "chrome": {
               "version_added": "66",
-              "notes": "From version 85, the <code>Permissions-Policy clipboard-read</code> header is required."
+              "notes": "The user must grant the <code>clipboard-read</code> permission."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -55,7 +55,7 @@
               "notes": [
                 "This method must be called within user gesture event handlers.",
                 "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require a user interaction and does not display a paste prompt.",
-                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is surpressed."
+                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is suppressed."
               ]
             },
             "firefox_android": "mirror",
@@ -124,7 +124,7 @@
           "support": {
             "chrome": {
               "version_added": "66",
-              "notes": "From version 85, the <code>Permissions-Policy clipboard-read</code> header is required."
+              "notes": "The user must grant the <code>clipboard-read</code> permission."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -133,7 +133,7 @@
               "notes": [
                 "This method must be called within user gesture event handlers.",
                 "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require a user interaction and does not display a paste prompt.",
-                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is surpressed."
+                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is suppressed."
               ]
             },
             "firefox_android": "mirror",
@@ -267,8 +267,8 @@
             "chrome": {
               "version_added": "66",
               "notes": [
-                "From version 107, this method must be called within user gesture event handlers, or the page must include the <code>Permissions-Policy clipboard-write</code> header.",
-                "From version 85, the <code>Permissions-Policy clipboard-write</code> header is required."
+                "From version 107, this method must be called within user gesture event handlers, or the user must grant the <code>clipboard-write</code> permission.",
+                "Before version 107, the user must grant the <code>clipboard-write</code> permission."
               ]
             },
             "chrome_android": "mirror",
@@ -280,7 +280,7 @@
               "notes": [
                 "This method must be called within user gesture event handlers.",
                 "Web extensions require the <code>clipboardWrite</code> permission in manifest to read data. With this permission, the extension does not require a user interaction and does not display a paste prompt.",
-                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is surpressed."
+                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is suppressed."
               ]
             },
             "firefox_android": "mirror",
@@ -315,8 +315,8 @@
             "chrome": {
               "version_added": "66",
               "notes": [
-                "From version 107, this method must be called within user gesture event handlers, or the page must include the <code>Permissions-Policy clipboard-write</code> header.",
-                "From version 85, the <code>Permissions-Policy clipboard-write</code> header is required."
+                "From version 107, this method must be called within user gesture event handlers, or the user must grant the <code>clipboard-write</code> permission.",
+                "Before version 107, the user must grant the <code>clipboard-write</code> permission."
               ]
             },
             "chrome_android": "mirror",
@@ -326,7 +326,7 @@
               "notes": [
                 "This method must be called within user gesture event handlers.",
                 "Web extensions require the <code>clipboardRead</code> permission in manifest to read data. With this permission, the extension does not require a user interaction and does not display a paste prompt.",
-                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is surpressed."
+                "A paste prompt is displayed when the clipboard is read. If the clipboard contains same-origin content, the prompt is suppressed."
               ]
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
The notes about version 85 appear to be about this change:
https://chromestatus.com/feature/5767075295395840

However, there is no requirement to use the feature policy or permission
policy, that is only used to constrain a page more than the default,
typically to disallow requesting a permission at all.

It was confirmed that the two permissions go back to Chrome 66, by
testing `navigator.permissions.query({name: "clipboard-read"})` and
"clipboard-write" in DevTools in Chrome 66.

The only remaining noteworthy thing is the behavior around user
activation. The existing claims in the notes weren't double checked,
just carried forward while updating permissions language.

Drive-by: fix surpressed typo in Firefox notes