### PR TITLE
Update WebView data for MIDI API

### DIFF
--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -71,9 +71,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -31,9 +31,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false
-          }
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": false,
@@ -73,9 +71,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -115,9 +111,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -31,9 +31,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false
-          }
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": false,
@@ -113,9 +111,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirrro"
           },
           "status": {
             "experimental": false,

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -111,7 +111,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirrro"
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `MIDI` APIs. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/MIDIInput
https://mdn-bcd-collector.gooborg.com/tests/api/MIDIMessageEvent
https://mdn-bcd-collector.gooborg.com/tests/api/MIDIOutput
