### PR TITLE
Update Safari data for MediaController API

### DIFF
--- a/api/MediaController.json
+++ b/api/MediaController.json
@@ -19,7 +19,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "≤13.1"
+            "version_added": "6"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -51,7 +51,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -83,7 +83,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -115,7 +115,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -147,7 +147,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -179,7 +179,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -211,7 +211,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -243,7 +243,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -275,7 +275,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -307,7 +307,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -339,7 +339,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -371,7 +371,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -403,7 +403,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -435,7 +435,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -467,7 +467,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -499,7 +499,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `MediaController` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaController

Additional Notes: Safari 6 was confirmed via commit history: https://github.com/WebKit/WebKit/commit/d8366adb2edddfb3fe6271ae97a6524cccac091f.  While this commit includes IDL for many of the other features, the collector didn't confirm support before Safari 8.
