### PR TITLE
Remove HTTP TRACE method

### DIFF
--- a/http/methods.json
+++ b/http/methods.json
@@ -261,40 +261,6 @@
             "deprecated": false
           }
         }
-      },
-      "TRACE": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/TRACE",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#TRACE",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": null
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This should have never been added IMO.

Original PR: https://github.com/mdn/browser-compat-data/pull/1700
I changed it to NULL as compromise in https://github.com/mdn/browser-compat-data/pull/3297

This also lead to a caniuse issue: https://github.com/Fyrd/caniuse/issues/5964 (I think it would be better if TRACE wasn't on caniuse either).

Fixes https://github.com/mdn/browser-compat-data/issues/1702 (for real)

Needs a content update: Other HTTP method pages also just don't use a compat table, see e.g. https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH and we should do the same for TRACE.