### PR TITLE
Rename network quality client hints and update data

### DIFF
--- a/http/headers/Downlink.json
+++ b/http/headers/Downlink.json
@@ -1,32 +1,32 @@
 {
   "http": {
     "headers": {
-      "rtt": {
+      "Downlink": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/RTT",
-          "spec_url": "https://wicg.github.io/netinfo/#rtt-request-header-field",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Downlink",
+          "spec_url": "https://wicg.github.io/netinfo/#downlink-request-header-field",
           "support": {
             "chrome": {
               "version_added": "67",
-              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤79",
-              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/ECT.json
+++ b/http/headers/ECT.json
@@ -1,32 +1,30 @@
 {
   "http": {
     "headers": {
-      "downlink": {
+      "ECT": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Downlink",
-          "spec_url": "https://wicg.github.io/netinfo/#downlink-request-header-field",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/ECT",
+          "spec_url": "https://wicg.github.io/netinfo/#ect-request-header-field",
           "support": {
             "chrome": {
-              "version_added": "67",
-              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
+              "version_added": "67"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤79",
-              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
+              "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/RTT.json
+++ b/http/headers/RTT.json
@@ -1,30 +1,32 @@
 {
   "http": {
     "headers": {
-      "ect": {
+      "RTT": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/ECT",
-          "spec_url": "https://wicg.github.io/netinfo/#ect-request-header-field",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/RTT",
+          "spec_url": "https://wicg.github.io/netinfo/#rtt-request-header-field",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "67",
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤79"
+              "version_added": "≤79",
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
These three headers had the wrong casings. Also, it doesn't look like this is supported in Firefox or Safari (or IE).