### PR TITLE
Add Safari version for X-XSS-Protection

### DIFF
--- a/http/headers/X-XSS-Protection.json
+++ b/http/headers/X-XSS-Protection.json
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true,
+              "version_added": "5",
               "version_removed": "15.4"
             },
             "safari_ios": "mirror",


### PR DESCRIPTION
Safari 5 according to this commit https://github.com/WebKit/WebKit/commit/dcbd95b99711080d37a01ac6af076bd028e1acc6