### PR TITLE
Update for Deno v1.45

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -157,6 +157,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.45"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "128"

--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -317,9 +317,16 @@
         "1.44": {
           "release_date": "2024-05-30",
           "release_notes": "https://deno.com/blog/v1.44",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "12.6"
+        },
+        "1.45": {
+          "release_date": "2024-07-11",
+          "release_notes": "https://deno.com/blog/v1.45",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "12.7"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Updates `Blob.bytes` compat table to mention Deno v1.45 which ships with it

#### Test results and supporting details

https://github.com/denoland/deno/pull/24148
https://deno.com/blog/v1.45

#### Related issues

n/a