### PR TITLE
Update HTTP Timing-Allow-Origin header

### DIFF
--- a/http/headers/Timing-Allow-Origin.json
+++ b/http/headers/Timing-Allow-Origin.json
@@ -10,9 +10,7 @@
               "version_added": "54"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "45"
             },

--- a/http/headers/Timing-Allow-Origin.json
+++ b/http/headers/Timing-Allow-Origin.json
@@ -7,24 +7,24 @@
           "spec_url": "https://w3c.github.io/resource-timing/#sec-timing-allow-origin",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "45"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This header has been supported with (advanced) support for https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming.