### PR TITLE
Change `inset-area()` to `inset-area` in `position-try-fallbacks`

### DIFF
--- a/css/properties/position-try-fallbacks.json
+++ b/css/properties/position-try-fallbacks.json
@@ -157,15 +157,22 @@
         },
         "inset-area": {
           "__compat": {
-            "description": "<code>inset-area()</code> function",
+            "description": "<code>inset-area</code> values",
             "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#propdef-inset-area",
             "tags": [
               "web-features:anchor-positioning"
             ],
             "support": {
-              "chrome": {
-                "version_added": "125"
-              },
+              "chrome": [
+                {
+                  "version_added": "128"
+                },
+                {
+                  "version_added": "125",
+                  "version_removed": "128",
+                  "notes": "<code>inset-area</code> values had to be wrapped inside an <code>inset-area()</code> function."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As of Chrome 128, the `inset-area()` function has been removed. Moving forward, `inset-area` values are just included directly in the `position-try-fallbacks` list as fallback options.

I wasn't sure of the best way to represent this; please let me know what you think.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
