### PR TITLE
Update HTTP Link header

### DIFF
--- a/http/headers/Link.json
+++ b/http/headers/Link.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "120"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
So this is in Safari 17 per https://github.com/WebKit/WebKit/commit/eeb51f0ea0f0e1f38d9330d3113c5392b6dad50f and https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes

It is actually part of the Early Hints spec, so I think we want the same compat data as the 103 status. (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103). Updated Firefox to match that.