### PR TITLE
Update HTTP Keep-Alive header data

### DIFF
--- a/http/headers/Keep-Alive.json
+++ b/http/headers/Keep-Alive.json
@@ -7,14 +7,14 @@
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9112#compatibility.with.http.1.0.persistent.connections",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
I think this should be the same as the HTTP Connection header and use initial versions. They pretty much work together only
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection