### PR TITLE
Update HTTP Content-Disposition header

### DIFF
--- a/http/headers/Content-Disposition.json
+++ b/http/headers/Content-Disposition.json
@@ -10,14 +10,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "From version 82, if an <code>&lt;a&gt;</code> element's <code>download</code> attribute is set (for a same-origin URL) then the <code>inline</code> directive is ignored. Earlier versions did not match the specification and respected the header directive over the attribute. See <a href='https://bugzil.la/1658877'>bug 1658877</a>."
             },
             "firefox_android": "mirror",
@@ -28,7 +28,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
I think it is safe to say that this header has been supported since the initial versions of browsers.