### PR TITLE
Remove plugin-types CSP directive

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -697,48 +697,6 @@
             }
           }
         },
-        "plugin-types": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types",
-            "support": {
-              "chrome": {
-                "version_added": "40",
-                "version_removed": "90"
-              },
-              "chrome_android": {
-                "version_added": true,
-                "version_removed": "90"
-              },
-              "edge": {
-                "version_added": "15",
-                "version_removed": "90"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "9.3"
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "prefetch-src": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src",


### PR DESCRIPTION
Gone from Safari for a long time, too.

https://bugs.webkit.org/show_bug.cgi?id=220724 
https://wpt.fyi/results/content-security-policy/plugin-types?label=master&label=experimental&aligned