### PR TITLE
Add mdn_urls for CSSPositionTryDescriptors

### DIFF
--- a/api/CSSPositionTryDescriptors.json
+++ b/api/CSSPositionTryDescriptors.json
@@ -39,6 +39,7 @@
       },
       "align-self": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-align-self",
           "tags": [
             "web-features:anchor-positioning"
@@ -76,6 +77,7 @@
       },
       "alignSelf": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-alignself",
           "tags": [
             "web-features:anchor-positioning"
@@ -113,6 +115,7 @@
       },
       "block-size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-block-size",
           "tags": [
             "web-features:anchor-positioning"
@@ -150,6 +153,7 @@
       },
       "blockSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-blocksize",
           "tags": [
             "web-features:anchor-positioning"
@@ -187,6 +191,7 @@
       },
       "bottom": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-bottom",
           "tags": [
             "web-features:anchor-positioning"
@@ -224,6 +229,7 @@
       },
       "height": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-height",
           "tags": [
             "web-features:anchor-positioning"
@@ -261,6 +267,7 @@
       },
       "inline-size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inline-size",
           "tags": [
             "web-features:anchor-positioning"
@@ -298,6 +305,7 @@
       },
       "inlineSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inlinesize",
           "tags": [
             "web-features:anchor-positioning"
@@ -335,6 +343,7 @@
       },
       "inset": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inset",
           "tags": [
             "web-features:anchor-positioning"
@@ -372,6 +381,7 @@
       },
       "inset-area": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inset-area",
           "tags": [
             "web-features:anchor-positioning"
@@ -409,6 +419,7 @@
       },
       "inset-block": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inset-block",
           "tags": [
             "web-features:anchor-positioning"
@@ -446,6 +457,7 @@
       },
       "inset-block-end": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inset-block-end",
           "tags": [
             "web-features:anchor-positioning"
@@ -483,6 +495,7 @@
       },
       "inset-block-start": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inset-block-start",
           "tags": [
             "web-features:anchor-positioning"
@@ -520,6 +533,7 @@
       },
       "inset-inline": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inset-inline",
           "tags": [
             "web-features:anchor-positioning"
@@ -557,6 +571,7 @@
       },
       "inset-inline-end": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inset-inline-end",
           "tags": [
             "web-features:anchor-positioning"
@@ -594,6 +609,7 @@
       },
       "inset-inline-start": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-inset-inline-start",
           "tags": [
             "web-features:anchor-positioning"
@@ -631,6 +647,7 @@
       },
       "insetArea": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-insetarea",
           "tags": [
             "web-features:anchor-positioning"
@@ -668,6 +685,7 @@
       },
       "insetBlock": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-insetblock",
           "tags": [
             "web-features:anchor-positioning"
@@ -705,6 +723,7 @@
       },
       "insetBlockEnd": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-insetblockend",
           "tags": [
             "web-features:anchor-positioning"
@@ -742,6 +761,7 @@
       },
       "insetBlockStart": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-insetblockstart",
           "tags": [
             "web-features:anchor-positioning"
@@ -779,6 +799,7 @@
       },
       "insetInline": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-insetinline",
           "tags": [
             "web-features:anchor-positioning"
@@ -816,6 +837,7 @@
       },
       "insetInlineEnd": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-insetinlineend",
           "tags": [
             "web-features:anchor-positioning"
@@ -853,6 +875,7 @@
       },
       "insetInlineStart": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-insetinlinestart",
           "tags": [
             "web-features:anchor-positioning"
@@ -890,6 +913,7 @@
       },
       "justify-self": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-justify-self",
           "tags": [
             "web-features:anchor-positioning"
@@ -927,6 +951,7 @@
       },
       "justifySelf": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-justifyself",
           "tags": [
             "web-features:anchor-positioning"
@@ -964,6 +989,7 @@
       },
       "left": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-left",
           "tags": [
             "web-features:anchor-positioning"
@@ -1001,6 +1027,7 @@
       },
       "margin": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin",
           "tags": [
             "web-features:anchor-positioning"
@@ -1038,6 +1065,7 @@
       },
       "margin-block": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-block",
           "tags": [
             "web-features:anchor-positioning"
@@ -1075,6 +1103,7 @@
       },
       "margin-block-end": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-block-end",
           "tags": [
             "web-features:anchor-positioning"
@@ -1112,6 +1141,7 @@
       },
       "margin-block-start": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-block-start",
           "tags": [
             "web-features:anchor-positioning"
@@ -1149,6 +1179,7 @@
       },
       "margin-bottom": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-bottom",
           "tags": [
             "web-features:anchor-positioning"
@@ -1186,6 +1217,7 @@
       },
       "margin-inline": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-inline",
           "tags": [
             "web-features:anchor-positioning"
@@ -1223,6 +1255,7 @@
       },
       "margin-inline-end": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-inline-end",
           "tags": [
             "web-features:anchor-positioning"
@@ -1260,6 +1293,7 @@
       },
       "margin-inline-start": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-inline-start",
           "tags": [
             "web-features:anchor-positioning"
@@ -1297,6 +1331,7 @@
       },
       "margin-left": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-left",
           "tags": [
             "web-features:anchor-positioning"
@@ -1334,6 +1369,7 @@
       },
       "margin-right": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-right",
           "tags": [
             "web-features:anchor-positioning"
@@ -1371,6 +1407,7 @@
       },
       "margin-top": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margin-top",
           "tags": [
             "web-features:anchor-positioning"
@@ -1408,6 +1445,7 @@
       },
       "marginBlock": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-marginblock",
           "tags": [
             "web-features:anchor-positioning"
@@ -1445,6 +1483,7 @@
       },
       "marginBlockEnd": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-marginblockend",
           "tags": [
             "web-features:anchor-positioning"
@@ -1482,6 +1521,7 @@
       },
       "marginBlockStart": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-marginblockstart",
           "tags": [
             "web-features:anchor-positioning"
@@ -1519,6 +1559,7 @@
       },
       "marginBottom": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-marginbottom",
           "tags": [
             "web-features:anchor-positioning"
@@ -1556,6 +1597,7 @@
       },
       "marginInline": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margininline",
           "tags": [
             "web-features:anchor-positioning"
@@ -1593,6 +1635,7 @@
       },
       "marginInlineEnd": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margininlineend",
           "tags": [
             "web-features:anchor-positioning"
@@ -1630,6 +1673,7 @@
       },
       "marginInlineStart": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margininlinestart",
           "tags": [
             "web-features:anchor-positioning"
@@ -1667,6 +1711,7 @@
       },
       "marginLeft": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-marginleft",
           "tags": [
             "web-features:anchor-positioning"
@@ -1704,6 +1749,7 @@
       },
       "marginRight": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-marginright",
           "tags": [
             "web-features:anchor-positioning"
@@ -1741,6 +1787,7 @@
       },
       "marginTop": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-margintop",
           "tags": [
             "web-features:anchor-positioning"
@@ -1778,6 +1825,7 @@
       },
       "max-block-size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-max-block-size",
           "tags": [
             "web-features:anchor-positioning"
@@ -1815,6 +1863,7 @@
       },
       "max-height": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-max-height",
           "tags": [
             "web-features:anchor-positioning"
@@ -1852,6 +1901,7 @@
       },
       "max-inline-size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-max-inline-size",
           "tags": [
             "web-features:anchor-positioning"
@@ -1889,6 +1939,7 @@
       },
       "max-width": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-max-width",
           "tags": [
             "web-features:anchor-positioning"
@@ -1926,6 +1977,7 @@
       },
       "maxBlockSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-maxblocksize",
           "tags": [
             "web-features:anchor-positioning"
@@ -1963,6 +2015,7 @@
       },
       "maxHeight": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-maxheight",
           "tags": [
             "web-features:anchor-positioning"
@@ -2000,6 +2053,7 @@
       },
       "maxInlineSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-maxinlinesize",
           "tags": [
             "web-features:anchor-positioning"
@@ -2037,6 +2091,7 @@
       },
       "maxWidth": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-maxwidth",
           "tags": [
             "web-features:anchor-positioning"
@@ -2074,6 +2129,7 @@
       },
       "min-block-size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-min-block-size",
           "tags": [
             "web-features:anchor-positioning"
@@ -2111,6 +2167,7 @@
       },
       "min-height": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-min-height",
           "tags": [
             "web-features:anchor-positioning"
@@ -2148,6 +2205,7 @@
       },
       "min-inline-size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-min-inline-size",
           "tags": [
             "web-features:anchor-positioning"
@@ -2185,6 +2243,7 @@
       },
       "min-width": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-min-width",
           "tags": [
             "web-features:anchor-positioning"
@@ -2222,6 +2281,7 @@
       },
       "minBlockSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-minblocksize",
           "tags": [
             "web-features:anchor-positioning"
@@ -2259,6 +2319,7 @@
       },
       "minHeight": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-minheight",
           "tags": [
             "web-features:anchor-positioning"
@@ -2296,6 +2357,7 @@
       },
       "minInlineSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-mininlinesize",
           "tags": [
             "web-features:anchor-positioning"
@@ -2333,6 +2395,7 @@
       },
       "minWidth": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-minwidth",
           "tags": [
             "web-features:anchor-positioning"
@@ -2370,6 +2433,7 @@
       },
       "place-self": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-place-self",
           "tags": [
             "web-features:anchor-positioning"
@@ -2407,6 +2471,7 @@
       },
       "placeSelf": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-placeself",
           "tags": [
             "web-features:anchor-positioning"
@@ -2444,6 +2509,7 @@
       },
       "position-anchor": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-position-anchor",
           "tags": [
             "web-features:anchor-positioning"
@@ -2481,6 +2547,7 @@
       },
       "positionAnchor": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-positionanchor",
           "tags": [
             "web-features:anchor-positioning"
@@ -2518,6 +2585,7 @@
       },
       "right": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-right",
           "tags": [
             "web-features:anchor-positioning"
@@ -2555,6 +2623,7 @@
       },
       "top": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-top",
           "tags": [
             "web-features:anchor-positioning"
@@ -2592,6 +2661,7 @@
       },
       "width": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties",
           "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#dom-csspositiontrydescriptors-width",
           "tags": [
             "web-features:anchor-positioning"


### PR DESCRIPTION
The mdn_url linter cannot know that there won't be no subpages here. Adding the mdn_urls manually pointing to https://developer.mozilla.org/en-US/docs/Web/API/CSSPositionTryDescriptors#instance_properties