### PR TITLE
Safari 18 supports bytes() method

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -169,14 +169,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -162,7 +162,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -169,7 +169,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Request.json
+++ b/api/Request.json
@@ -552,7 +552,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Response.json
+++ b/api/Response.json
@@ -407,7 +407,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Not sure how I missed this in https://github.com/mdn/browser-compat-data/pull/23367 but Safari 18 supports the new bytes() methods https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes

Tested in Version 18.0 (20619.1.20.11.1)