### PR TITLE
Update Firefox support for HTTP Origin header

### DIFF
--- a/http/headers/Origin.json
+++ b/http/headers/Origin.json
@@ -22,7 +22,7 @@
                 "version_added": "70"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "partial_implementation": true,
                 "notes": "Not sent with <code>POST</code> requests until Firefox 58, see <a href='https://bugzil.la/446344'>bug 446344</a>."
               }


### PR DESCRIPTION
I forgot this one in https://github.com/mdn/browser-compat-data/pull/23756