### PR TITLE
Only allow real versions and non-obsolete features in svg/

### DIFF
--- a/lint/linter/test-obsolete.ts
+++ b/lint/linter/test-obsolete.ts
@@ -20,7 +20,7 @@ const categoriesToCheck = [
   // 'http',
   'javascript',
   'mathml',
-  // 'svg',
+  'svg',
   'webassembly',
   'webdriver',
   'webextensions',

--- a/lint/linter/test-versions.ts
+++ b/lint/linter/test-versions.ts
@@ -45,7 +45,7 @@ const realValuesRequired: Record<string, string[]> = {
   css: realValuesTargetBrowsers,
   html: [],
   http: [],
-  svg: [],
+  svg: realValuesTargetBrowsers,
   javascript: [...realValuesTargetBrowsers, 'nodejs', 'deno'],
   mathml: realValuesTargetBrowsers,
   webassembly: realValuesTargetBrowsers,


### PR DESCRIPTION
We've fixed everything up in SVG so let's not regress this. Disallow `true` and `null` values and disallow obsolete features.