### PR TITLE
Remove obsolete referrer CSP directive

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -733,41 +733,6 @@
             }
           }
         },
-        "referrer": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/referrer",
-            "support": {
-              "chrome": {
-                "version_added": "33",
-                "version_removed": "56"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "37",
-                "version_removed": "62"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "report-sample": {
           "__compat": {
             "description": "<code>report-sample</code> source value",


### PR DESCRIPTION
Gone for more than two years from all browsers.