### PR TITLE
Safari 14 supports Cache-Control: stale-while-revalidate

### DIFF
--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -88,7 +88,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "impl_url": "https://bugzil.la/995651#c7"
+                "impl_url": "https://bugzil.la/1547587"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -134,7 +134,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
See https://github.com/WebKit/WebKit/commit/7204cf563e4ef21a7e7b2daeb32050b58c61f05e

Drive-by: Fix a bug number for Firefox.