### PR TITLE
Update Chromium data for permissions Web Extensions interface

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -6,11 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤59"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "55"
             },
@@ -31,11 +29,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -57,11 +53,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/contains",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -83,11 +77,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/getAll",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -109,11 +101,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onAdded",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "77"
               },
@@ -133,11 +123,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "77"
               },
@@ -157,11 +145,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/remove",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },
@@ -185,11 +171,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤59"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55",
                 "notes": [


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `permissions` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #220, #226
