### PR TITLE
Update Retry-After HTTP header

### DIFF
--- a/http/headers/Retry-After.json
+++ b/http/headers/Retry-After.json
@@ -7,7 +7,7 @@
           "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.retry-after",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "24"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -19,13 +19,13 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
According to https://stackoverflow.com/questions/3764075/retry-after-http-response-header-does-it-affect-anything Chromium does something as of the end of 2012. See also https://chromiumcodereview.appspot.com/11419070. So I'm setting this to version 24 which was released early 2013.

Safari doesn't have "Retry-After" in its code base nor did I see anything on bugs.webkit.org.