### PR TITLE
Update SourceMap HTTP header

### DIFF
--- a/http/headers/SourceMap.json
+++ b/http/headers/SourceMap.json
@@ -8,11 +8,11 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
                 "prefix": "X-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "chrome_android": "mirror",
@@ -36,18 +36,18 @@
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": true
+                "version_added": "7"
               },
               {
                 "prefix": "X-",
-                "version_added": true
+                "version_added": "6"
               }
             ],
             "safari_ios": "mirror",


### PR DESCRIPTION
I couldn't find bugs for Chrome but there is this blog post from 2012: https://developer.chrome.com/blog/sourcemaps. So, I've put version 18 as a guess.

For Safari, I found commits and I'm quite certain about these versions:
- Safari 6: https://github.com/WebKit/WebKit/commit/c07bb31c5c4cbee75a9d9db821554ab583c2390d
- Safari 7: https://github.com/WebKit/WebKit/commit/68ea517a8cd91ca04d7adae50b2817577cda1f0f