### PR TITLE
Safari doesn't support SHA-256 auth; remove SHA-512 auth

### DIFF
--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -129,40 +129,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "SHA-512": {
-            "__compat": {
-              "description": "SHA2-512 digest authentication",
-              "support": {
-                "chrome": {
                   "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": null
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -129,40 +129,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "SHA-512": {
-            "__compat": {
-              "description": "SHA2-512 digest authentication",
-              "support": {
-                "chrome": {
                   "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": null
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
For Safari, see https://github.com/WebKit/standards-positions/issues/212
SHA-512 is not supported anywhere, see discussion here: https://groups.google.com/a/chromium.org/g/blink-dev/c/cJH3JJY_tTY/m/0_uCOheRDQAJ