### PR TITLE
Mark <rp> and <rt> supported in Edge 12

### DIFF
--- a/html/elements/rp.json
+++ b/html/elements/rp.json
@@ -10,7 +10,9 @@
               "version_added": "5"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": "38"
             },

--- a/html/elements/rt.json
+++ b/html/elements/rt.json
@@ -10,7 +10,9 @@
               "version_added": "5"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": "38"
             },


### PR DESCRIPTION
They were supported in IE 5, and almost certainly weren't removed in
Edge 12-18.

https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12892 was
tested in Edge 15 to confirm it renderes as expected.