### PR TITLE
Add Firefox version for element: details: name

### DIFF
--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -54,7 +54,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "130",
                 "impl_url": "https://bugzil.la/1856460"
               },
               "firefox_android": "mirror",


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Support for the `name` attribute on the `<details>` element was added to Firefox 130

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1856460#c17

![image](https://github.com/user-attachments/assets/80721f53-1d37-4303-86db-d188a69076d3)
![image](https://github.com/user-attachments/assets/6a3f9791-caed-46e1-bdee-1a1c96195461)



#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
