### PR TITLE
Mark BeforeUnloadEvent supported in Edge 12

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -12,7 +12,9 @@
           "deno": {
             "version_added": "1.24"
           },
-          "edge": "mirror",
+          "edge": {
+            "version_added": "12"
+          },
           "firefox": {
             "version_added": "1.5"
           },
@@ -60,7 +62,9 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": "1.5"
             },


### PR DESCRIPTION
Testing of Edge 15 and 18 was done in
https://github.com/openwebdocs/mdn-bcd-collector/issues/1666. Since it's
supported in IE, assume that support goes back to Edge 12 here.