### PR TITLE
Fix overflow CSS prop support on Edge

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -71,7 +71,9 @@
                   "version_added": "100"
                 }
               ],
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": [
                 {
                   "version_added": "3.5"

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -71,7 +71,9 @@
                   "version_added": "100"
                 }
               ],
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": [
                 {
                   "version_added": "3.5"

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -67,7 +67,9 @@
                   "version_added": "100"
                 }
               ],
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": [
                 {
                   "version_added": "1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `overflow`, `overflow-x`, and `overflow-y` CSS properties are documented in BCD as having the `auto` value supported starting from Edge 79, by using the `mirror` keyword to match Chrome.

Knowing that this property:value pair was already supported in IE, and that other values for the same property are also supported starting with Edge 12 (the first Edge ever release), I think using the `mirror` keyword was a mistake.

#### Test results and supporting details

I tested using `overflow:auto` on Edge 15, by using BrowserStack, and it worked fine. I don't have access to Edge 12, but again, knowing that this was already supported in IE. I'm almost certain this was supported in Edge 12, just like the rest of the `overflow` property.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

#23796
