### PR TITLE
Update CSP manifest-src

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -560,12 +560,10 @@
             "spec_url": "https://w3c.github.io/webappsec-csp/#directive-manifest-src",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "40"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "41"
               },
@@ -577,7 +575,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari 11 comes from https://github.com/WebKit/WebKit/commit/ce7a29eceb9193024e3e8ffff394bb743227c880

Chrome 40 comes from the date of https://codereview.chromium.org/570563003/
Chromestatus is wrong https://chromestatus.com/feature/5679927315660800