### PR TITLE
Update CSP <meta> support

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -631,7 +631,7 @@
             "description": "<code>&lt;meta&gt;</code> element support",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "25"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -648,7 +648,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
I think Firefox might be the only outlier for this one and shipped support in the meta tag later. I couldn't find anything for this being the case with the other browsers, so I'm setting the version to when CSP shipped there initially. 