### PR TITLE
Update CSP block-all-mixed-content directive

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -137,7 +137,7 @@
             "support": {
               "chrome": {
                 "version_added": "44",
-                "notes": "Will be removed, see <a href='https://issues.chromium.org/issues/40260100'>bug 40260100</a>"
+                "notes": "Will be removed, see <a href='https://crbug.com/40260100'>bug 40260100</a>."
               },
               "chrome_android": "mirror",
               "edge": {

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -136,14 +136,16 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "44",
+                "notes": "Will be removed, see <a href='https://issues.chromium.org/issues/40260100'>bug 40260100</a>"
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -153,7 +155,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Firefox removal in 122: https://bugzilla.mozilla.org/show_bug.cgi?id=1806080

Chrome initial support in 44: https://groups.google.com/a/chromium.org/g/blink-dev/c/MafYMJ3zQw0/m/5VDOL9VDpAgJ, https://issues.chromium.org/issues/40398476

Chrome removal: https://issues.chromium.org/issues/40260100

Safari initial support in version 10: https://github.com/WebKit/WebKit/commit/d93030382f776750e627a2376a1c12ad47d93e94