### PR TITLE
Mark <wbr> supported in Edge 12 (most likely)

### DIFF
--- a/html/elements/wbr.json
+++ b/html/elements/wbr.json
@@ -10,7 +10,9 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge":{
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/wbr.json
+++ b/html/elements/wbr.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge":{
+            "edge": {
               "version_added": "12"
             },
             "firefox": {


### PR DESCRIPTION
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12893 was tested in Edge 15 and IE 11.

It works in Edge 15, but not IE 11.

Not knowing for sure where from Edge 12-15 this was introduced, Edge 12 is the most reasonable guess.