### PR TITLE
Remove `@@notation` from all user-visible strings

### DIFF
--- a/api/AudioParamMap.json
+++ b/api/AudioParamMap.json
@@ -259,6 +259,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -199,6 +199,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -445,6 +445,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "51"

--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -313,6 +313,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSUnparsedValue.json
+++ b/api/CSSUnparsedValue.json
@@ -243,6 +243,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CustomStateSet.json
+++ b/api/CustomStateSet.json
@@ -341,6 +341,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -795,6 +795,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/api/EventCounts.json
+++ b/api/EventCounts.json
@@ -259,6 +259,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "85"

--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -313,6 +313,7 @@
       },
       "@@asyncIterator": {
         "__compat": {
+          "description": "[Symbol.asyncIterator]",
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-asynciterable",
           "support": {
             "chrome": {

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -652,6 +652,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "spec_url": "https://drafts.csswg.org/css-font-loading/#fontfaceset",
           "support": {
             "chrome": {

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -644,6 +644,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "50"

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -378,6 +378,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
           "tags": [
             "web-features:webgpu"

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -581,6 +581,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/api/Highlight.json
+++ b/api/Highlight.json
@@ -487,6 +487,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "tags": [
             "web-features:highlight"
           ],

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -409,6 +409,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "tags": [
             "web-features:highlight"
           ],

--- a/api/KeyboardLayoutMap.json
+++ b/api/KeyboardLayoutMap.json
@@ -268,6 +268,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "69"

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -307,6 +307,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "tags": [
             "web-features:web-midi"
           ],

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -307,6 +307,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "tags": [
             "web-features:web-midi"
           ],

--- a/api/MediaKeyStatusMap.json
+++ b/api/MediaKeyStatusMap.json
@@ -301,6 +301,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -262,7 +262,7 @@
       },
       "@@iterator": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
+          "description": "[Symbol.iterator]",
           "spec_url": "https://dom.spec.whatwg.org/#interface-nodelist",
           "support": {
             "chrome": {

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -8462,7 +8462,8 @@
       },
       "@@iterator": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport/@@iterator",
+          "description": "[Symbol.iterator]",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport/Symbol.iterator",
           "support": {
             "chrome": {
               "version_added": "58"

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -484,6 +484,7 @@
       },
       "@@asyncIterator": {
         "__compat": {
+          "description": "[Symbol.asyncIterator]",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator",
           "spec_url": "https://streams.spec.whatwg.org/#rs-asynciterator",
           "support": {

--- a/api/StylePropertyMapReadOnly.json
+++ b/api/StylePropertyMapReadOnly.json
@@ -312,6 +312,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -855,6 +855,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "spec_url": "https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams",
           "support": {
             "chrome": {

--- a/api/ViewTransitionTypeSet.json
+++ b/api/ViewTransitionTypeSet.json
@@ -322,6 +322,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "125"

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -269,6 +269,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
           "tags": [
             "web-features:webgpu"

--- a/api/WorkletSharedStorage.json
+++ b/api/WorkletSharedStorage.json
@@ -240,6 +240,7 @@
       },
       "@@asyncIterator": {
         "__compat": {
+          "description": "[Symbol.asyncIterator]",
           "support": {
             "chrome": {
               "version_added": "117"

--- a/api/XRAnchorSet.json
+++ b/api/XRAnchorSet.json
@@ -241,6 +241,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "85"

--- a/api/XRHand.json
+++ b/api/XRHand.json
@@ -257,6 +257,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/XRInputSourceArray.json
+++ b/api/XRInputSourceArray.json
@@ -227,6 +227,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
               "version_added": "79"

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2352,8 +2352,9 @@
         },
         "@@iterator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-@@iterator",
+            "description": "[Symbol.iterator]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Symbol.iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-%symbol.iterator%",
             "tags": [
               "web-features:array-iterators",
               "web-features:snapshot:ecmascript-2015"
@@ -2412,8 +2413,9 @@
         },
         "@@species": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-array-@@species",
+            "description": "[Symbol.species]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-array-%symbol.species%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],
@@ -2455,8 +2457,9 @@
         },
         "@@unscopables": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-@@unscopables",
+            "description": "[Symbol.unscopables]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Symbol.unscopables",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-%symbol.unscopables%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -560,8 +560,9 @@
         },
         "@@species": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/@@species",
-            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer-@@species",
+            "description": "[Symbol.species]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/Symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer-%symbol.species%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -45,7 +45,8 @@
         },
         "@@asyncIterator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator/@@asyncIterator",
+            "description": "[Symbol.asyncIterator]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator/Symbol.asyncIterator",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asynciteratorprototype-asynciterator",
             "tags": [
               "web-features:snapshot:ecmascript-2018"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -3040,8 +3040,9 @@
         },
         "@@toPrimitive": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive",
-            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype-@@toprimitive",
+            "description": "[Symbol.toPrimitive]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/Symbol.toPrimitive",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype-%symbol.toprimitive%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -765,8 +765,9 @@
         },
         "@@hasInstance": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/@@hasInstance",
-            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype-@@hasinstance",
+            "description": "[Symbol.hasInstance]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/Symbol.hasInstance",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype-%symbol.hasinstance%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/Intl/Segments.json
+++ b/javascript/builtins/Intl/Segments.json
@@ -83,8 +83,9 @@
           },
           "@@iterator": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/@@iterator",
-              "spec_url": "https://tc39.es/ecma402/#sec-%segmentsprototype%-@@iterator",
+              "description": "[Symbol.iterator]",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/Symbol.iterator",
+              "spec_url": "https://tc39.es/ecma402/#sec-%segmentsprototype%-%symbol.iterator%",
               "support": {
                 "chrome": {
                   "version_added": "87"

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -666,8 +666,9 @@
         },
         "@@iterator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-%iteratorprototype%-@@iterator",
+            "description": "[Symbol.iterator]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Symbol.iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-%iteratorprototype%-%symbol.iterator%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -743,8 +743,9 @@
         },
         "@@iterator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype-@@iterator",
+            "description": "[Symbol.iterator]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/Symbol.iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype-%symbol.iterator%",
             "tags": [
               "web-features:map",
               "web-features:snapshot:ecmascript-2015"
@@ -803,8 +804,9 @@
         },
         "@@species": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map-@@species",
+            "description": "[Symbol.species]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/Symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map-%symbol.species%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -600,8 +600,9 @@
         },
         "@@species": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/@@species",
-            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species",
+            "description": "[Symbol.species]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/Symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-%symbol.species%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1460,8 +1460,9 @@
         },
         "@@match": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match",
-            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@match",
+            "description": "[Symbol.match]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.match",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-%symbol.match%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],
@@ -1505,7 +1506,8 @@
         },
         "@@matchAll": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll",
+            "description": "[Symbol.matchAll]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-prototype-matchall",
             "support": {
               "chrome": {
@@ -1547,8 +1549,9 @@
         },
         "@@replace": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace",
-            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@replace",
+            "description": "[Symbol.replace]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.replace",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-%symbol.replace%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],
@@ -1590,8 +1593,9 @@
         },
         "@@search": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search",
-            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@search",
+            "description": "[Symbol.search]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.search",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-%symbol.search%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],
@@ -1635,8 +1639,9 @@
         },
         "@@species": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@species",
-            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp-@@species",
+            "description": "[Symbol.species]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp-%symbol.species%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],
@@ -1680,8 +1685,9 @@
         },
         "@@split": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split",
-            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@split",
+            "description": "[Symbol.split]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.split",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-%symbol.split%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -948,8 +948,9 @@
         },
         "@@iterator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype-@@iterator",
+            "description": "[Symbol.iterator]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/Symbol.iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype-%symbol.iterator%",
             "tags": [
               "web-features:set",
               "web-features:snapshot:ecmascript-2015"
@@ -1008,8 +1009,9 @@
         },
         "@@species": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set-@@species",
+            "description": "[Symbol.species]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/Symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set-%symbol.species%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -371,8 +371,9 @@
         },
         "@@species": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/@@species",
-            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-@@species",
+            "description": "[Symbol.species]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/Symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-%symbol.species%",
             "tags": [
               "web-features:snapshot:ecmascript-2017"
             ],

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2957,8 +2957,9 @@
         },
         "@@iterator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype-@@iterator",
+            "description": "[Symbol.iterator]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/Symbol.iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype-%symbol.iterator%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -940,8 +940,9 @@
         },
         "@@toPrimitive": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive",
-            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype-@@toprimitive",
+            "description": "[Symbol.toPrimitive]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol.toPrimitive",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype-%symbol.toprimitive%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -2121,8 +2121,9 @@
         },
         "@@iterator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype-@@iterator",
+            "description": "[Symbol.iterator]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/Symbol.iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype-%symbol.iterator%",
             "tags": [
               "web-features:typed-array-iterators",
               "web-features:snapshot:ecmascript-2015"
@@ -2181,8 +2182,9 @@
         },
         "@@species": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@species",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%-@@species",
+            "description": "[Symbol.species]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/Symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%-%symbol.species%",
             "tags": [
               "web-features:snapshot:ecmascript-2015"
             ],

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -196,7 +196,8 @@
         },
         "@@iterator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator",
+            "description": "[Symbol.iterator]",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/Symbol.iterator",
             "spec_url": [
               "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-createunmappedargumentsobject",
               "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-createmappedargumentsobject"


### PR DESCRIPTION
Part of https://github.com/mdn/mdn/issues/562. I did not touch the BCD keys in this PR, because we have two options:

1. `Array.symbol_iterator`
2. `Array.%iterator%`

I'm leaning to the first option, but I also want to get BCD maintainers' opinions in this PR. Whatever decision we reach, adding `description` is necessary because we can't reuse the key as the description.

This should be merged after https://github.com/mdn/content/pull/34824 because it's changing the MDN URLs.