### PR TITLE
Handle new Chromium bug tracker URLs in link shortener

### DIFF
--- a/lint/linter/test-links.test.ts
+++ b/lint/linter/test-links.test.ts
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import { processData } from './test-links.js';
 
 describe('test-links', () => {
-  it('should process Bugzilla links correctly', () => {
+  it('should process Bugzilla bug links correctly', () => {
     const rawData = 'https://bugzilla.mozilla.org/show_bug.cgi?id=12345';
     const errors = processData(rawData);
 
@@ -15,7 +15,16 @@ describe('test-links', () => {
     assert.equal(errors[0].expected, 'https://bugzil.la/12345');
   });
 
-  it('should process Chromium links correctly', () => {
+  it('should process new Chromium bug links correctly', () => {
+    const rawData = 'https://issues.chromium.org/issues/12345';
+    const errors = processData(rawData);
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].issue, 'Use shortenable URL');
+    assert.equal(errors[0].expected, 'https://crbug.com/12345');
+  });
+
+  it('should process old Chromium bug links correctly', () => {
     const rawData =
       'https://bugs.chromium.org/p/chromium/issues/detail?id=12345';
     const errors = processData(rawData);
@@ -25,7 +34,7 @@ describe('test-links', () => {
     assert.equal(errors[0].expected, 'https://crbug.com/12345');
   });
 
-  it('should process Chromium category links correctly', () => {
+  it('should process old Chromium bug links with categories correctly', () => {
     const rawData =
       'https://bugs.chromium.org/p/category/issues/detail?id=12345';
     const errors = processData(rawData);

--- a/lint/linter/test-links.ts
+++ b/lint/linter/test-links.ts
@@ -89,6 +89,17 @@ export const processData = (rawData: string): LinkError[] => {
     // use https://crbug.com/100000 instead
     errors,
     actual,
+    /https?:\/\/(issues\.chromium\.org)\/issues\/(\d+)/g,
+    (match) => ({
+      issue: 'Use shortenable URL',
+      expected: `https://crbug.com/${match[2]}`,
+    }),
+  );
+
+  processLink(
+    // use https://crbug.com/100000 instead
+    errors,
+    actual,
     /https?:\/\/(bugs\.chromium\.org|code\.google\.com)\/p\/chromium\/issues\/detail\?id=(\d+)/g,
     (match) => ({
       issue: 'Use shortenable URL',


### PR DESCRIPTION
This PR updates the link linter to handle links from the new Chromium bug tracker under `issues.chromium.org`, which all bugs have been migrated to.
