### PR TITLE
FF129 MediaCapabilities.decodingInfo() - encrypted content

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -81,6 +81,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "configuration_keySystemConfiguration_parameter": {
+          "__compat": {
+            "description": "<code>configuration.keySystemConfiguration</code> parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#keysystemconfiguration",
+            "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingconfiguration-keysystemconfiguration",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "129"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "encodingInfo": {

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -111,7 +111,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -89,7 +89,7 @@
             "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingconfiguration-keysystemconfiguration",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "80"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
FF129 Adds support for using [`MediaCapabilities.decodingInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/decodingInfo) with encoded media in https://bugzilla.mozilla.org/show_bug.cgi?id=1898344

The spec is a bit messy, but what it means is that 
- the `configuration` object passed to the `decodingInfo()` method has a new property called `keySystemConfiguration`.
- The returned promise resolves to include the property `keySystemAccess` which is a `MediaKeySystemAccess` you can use to get keys and decode the content for playback. 
  
What I have done is added a subfeature under `decodingInfo()`  for the `keySystemConfiguration` parameter. I haven't added another subfeature for the  `keySystemAccess` in the returned object - should I add that too, even though it would be identical?

Or is to have just one entry but name it something like  `encrypted_media`?

Related docs work can be tracked in https://github.com/mdn/content/issues/34696

> **Note:** The spec has another value   `configuration` in the return object, but that is not implemented by anyone.
