### PR TITLE
Update HTTP Kerberos/NTLM auth data

### DIFF
--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -180,22 +180,22 @@
             "spec_url": "https://www.rfc-editor.org/rfc/rfc4120#top",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "≤7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -213,22 +213,22 @@
             "description": "<code>NTLM</code> authentication",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "≤7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -184,22 +184,22 @@
             "spec_url": "https://www.rfc-editor.org/rfc/rfc4120#top",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "≤7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -217,22 +217,22 @@
             "description": "<code>NTLM</code> authentication",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "≤7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
From browsing around and reading various bug trackers and stackoverflow threads, these two auth methods are supported in browsers. I saw mentions of this from very early for Firefox and Chrome, slightly later for Safari (hence ≤7) and ≤11 for Internet Explorer because no idea when it was in IE. I'm happy to change this if anyone has better data or pointers.