### PR TITLE
Only allow real versions and non-obsolete features in http/

### DIFF
--- a/lint/linter/test-obsolete.ts
+++ b/lint/linter/test-obsolete.ts
@@ -17,7 +17,7 @@ const categoriesToCheck = [
   'api',
   // 'css',
   'html',
-  // 'http',
+  'http',
   'javascript',
   'mathml',
   'svg',
@@ -151,7 +151,8 @@ export default {
   },
   exceptions: [
     'html.elements.track.kind.descriptions',
-    // The following exceptions are disabled while their categories are ignored:
-    // 'http.headers.Cache-Control.stale-if-error',
+    'http.headers.Cache-Control.stale-if-error',
+    'http.headers.Permissions-Policy.battery',
+    'http.headers.X-XSS-Protection',
   ],
 } as Linter;

--- a/lint/linter/test-versions.ts
+++ b/lint/linter/test-versions.ts
@@ -44,7 +44,7 @@ const realValuesRequired: Record<string, string[]> = {
   api: realValuesTargetBrowsers,
   css: realValuesTargetBrowsers,
   html: [],
-  http: [],
+  http: realValuesTargetBrowsers,
   svg: realValuesTargetBrowsers,
   javascript: [...realValuesTargetBrowsers, 'nodejs', 'deno'],
   mathml: realValuesTargetBrowsers,


### PR DESCRIPTION
We've fixed everything up in HTTP so let's not regress this. Disallow `true` and `null` values and disallow obsolete features.

I think it is okay to have these two as exceptions, but I have no strong feelings. 
'http.headers.Cache-Control.stale-if-error'
'http.headers.Permissions-Policy.battery' 

'http.headers.X-XSS-Protection' Still quite known and used, so I feel like it is important to keep this for a while still.

This PR will pass after https://github.com/mdn/browser-compat-data/pull/23819 is merged.