### PR TITLE
TextEvent is deprecated

### DIFF
--- a/api/TextEvent.json
+++ b/api/TextEvent.json
@@ -31,7 +31,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "data": {
@@ -65,7 +65,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -100,7 +100,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
`TextEvent` is a legacy event type that was added to the spec because for compat reasons - it predates `beforeinput` and friends which should be used instead.

The spec doesn't go into that detail, but it does state that the event and event interface is obsolete: https://w3c.github.io/uievents/event-algo.html#textevent

This just adds that information.

Related docs work https://github.com/mdn/content/issues/34705