### PR TITLE
Remove >> and >>> descendant syntax

### DIFF
--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -8,8 +8,7 @@
           "spec_url": "https://drafts.csswg.org/selectors/#descendant-combinators",
           "support": {
             "chrome": {
-              "version_added": "1",
-              "notes": "Since Chrome 61, <code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -40,40 +39,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "two_greater_than_syntax": {
-          "__compat": {
-            "description": "<code>A &gt;&gt; B</code> syntax",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10",
-                "version_removed": "11.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
           }
         }
       }


### PR DESCRIPTION
Safari's `A >> B` syntax is gone for a long time and for Chrome, it looks like `A >>> B` is gone, too.
See https://groups.google.com/a/chromium.org/g/blink-dev/c/HX5Y8Ykr5Ns/m/2R_xIkOvCgAJ 