### PR TITLE
Data for stage 3 regexp-modifiers

### DIFF
--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -533,6 +533,47 @@
           }
         }
       },
+      "modifier": {
+        "__compat": {
+          "description": "Modifier: <code>(?ims-ims:...)</code>",
+          "spec_url": "https://arai-a.github.io/ecma262-compare/snapshot.html?pr=3221#prod-Atom",
+          "support": {
+            "chrome": {
+              "version_added": "125"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1899813"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "named_backreference": {
         "__compat": {
           "description": "Named backreference: <code>\\k&lt;name&gt;</code>",

--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -536,7 +536,7 @@
       "modifier": {
         "__compat": {
           "description": "Modifier: <code>(?ims-ims:...)</code>",
-          "spec_url": "https://arai-a.github.io/ecma262-compare/snapshot.html?pr=3221#prod-Atom",
+          "spec_url": "https://github.com/tc39/proposal-regexp-modifiers#syntax",
           "support": {
             "chrome": {
               "version_added": "125"

--- a/lint/linter/test-spec-urls.ts
+++ b/lint/linter/test-spec-urls.ts
@@ -24,7 +24,7 @@ const specsExceptions = [
   'https://github.com/tc39/proposal-regexp-legacy-features/',
 
   // Remove once tc39/ecma262#3221 is merged
-  'https://github.com/tc39/proposal-regexp-modifiers/',
+  'https://github.com/tc39/proposal-regexp-modifiers',
 
   // See https://github.com/w3c/browser-specs/issues/305
   // Features with this URL need to be checked after some time

--- a/lint/linter/test-spec-urls.ts
+++ b/lint/linter/test-spec-urls.ts
@@ -23,6 +23,9 @@ const specsExceptions = [
   // Remove if it is in the main ECMA spec
   'https://github.com/tc39/proposal-regexp-legacy-features/',
 
+  // Remove once tc39/ecma262#3221 is merged
+  'https://github.com/tc39/proposal-regexp-modifiers/',
+
   // See https://github.com/w3c/browser-specs/issues/305
   // Features with this URL need to be checked after some time
   // if they have been integrated into a real spec


### PR DESCRIPTION
This accompanies https://github.com/mdn/content/pull/34863.

I'm unsure about the spec link: tc39 proposals only have a single source of truth at stage 3, which is the PR opened against the main repo. Everyone's using the rendered diff as the point of referenece.