### PR TITLE
Update Edge support for <data>

### DIFF
--- a/html/elements/data.json
+++ b/html/elements/data.json
@@ -11,7 +11,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "22"


### PR DESCRIPTION
Changing it to Edge 14 matches HTMLDataElement, and is the only difference between element and API for any browser.

It's not impossible that the element was recognized in some way before Edge 14, but there's no reason to suspect it and do further research.