### PR TITLE
Mark <br> supported in Safari 1

### DIFF
--- a/html/elements/br.json
+++ b/html/elements/br.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This can be assumed confidently without testing.