### PR TITLE
Add mdn_urls for OffscreenCanvasRenderingContext2D

### DIFF
--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -38,6 +38,7 @@
       },
       "arc": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/arc",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-arc-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -74,6 +75,7 @@
       },
       "arcTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/arcTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-arcto-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -110,6 +112,7 @@
       },
       "beginPath": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/beginPath",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-beginpath-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -146,6 +149,7 @@
       },
       "bezierCurveTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/bezierCurveTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-beziercurveto-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -182,6 +186,7 @@
       },
       "canvas": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/canvas",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-canvas-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -218,6 +223,7 @@
       },
       "clearRect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/clearRect",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-clearrect-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -254,6 +260,7 @@
       },
       "clip": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/clip",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-clip-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -290,6 +297,7 @@
       },
       "closePath": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/closePath",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-closepath-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -364,6 +372,7 @@
       },
       "createConicGradient": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createConicGradient",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createconicgradient",
           "tags": [
             "web-features:canvas-createconicgradient"
@@ -400,6 +409,7 @@
       },
       "createImageData": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createImageData",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createimagedata-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -436,6 +446,7 @@
       },
       "createLinearGradient": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createLinearGradient",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createlineargradient-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -472,6 +483,7 @@
       },
       "createPattern": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createpattern-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -508,6 +520,7 @@
       },
       "createRadialGradient": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createRadialGradient",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createradialgradient-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -544,6 +557,7 @@
       },
       "direction": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/direction",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-direction-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -580,6 +594,7 @@
       },
       "drawImage": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-drawimage-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -616,6 +631,7 @@
       },
       "ellipse": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/ellipse",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-ellipse-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -652,6 +668,7 @@
       },
       "fill": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fill",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-fill-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -688,6 +705,7 @@
       },
       "fillRect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fillRect",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-fillrect-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -724,6 +742,7 @@
       },
       "fillStyle": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fillStyle",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-fillstyle-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -760,6 +779,7 @@
       },
       "fillText": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fillText",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-filltext-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -796,6 +816,7 @@
       },
       "filter": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/filter",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-filter-dev",
           "support": {
             "chrome": {
@@ -829,6 +850,7 @@
       },
       "font": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/font",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-font-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -865,6 +887,7 @@
       },
       "fontKerning": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fontKerning",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-fontkerning",
           "support": {
             "chrome": {
@@ -898,6 +921,7 @@
       },
       "fontStretch": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fontStretch",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-fontstretch",
           "support": {
             "chrome": {
@@ -931,6 +955,7 @@
       },
       "fontVariantCaps": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fontVariantCaps",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-fontvariantcaps",
           "support": {
             "chrome": {
@@ -964,6 +989,7 @@
       },
       "getImageData": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getImageData",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-getimagedata-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1000,6 +1026,7 @@
       },
       "getLineDash": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getLineDash",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-getlinedash-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1036,6 +1063,7 @@
       },
       "getTransform": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getTransform",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-gettransform-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1072,6 +1100,7 @@
       },
       "globalAlpha": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/globalAlpha",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalalpha-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1108,6 +1137,7 @@
       },
       "globalCompositeOperation": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1144,6 +1174,7 @@
       },
       "imageSmoothingEnabled": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-imagesmoothingenabled-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1180,6 +1211,7 @@
       },
       "imageSmoothingQuality": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/imageSmoothingQuality",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-imagesmoothingquality-dev",
           "support": {
             "chrome": {
@@ -1213,6 +1245,7 @@
       },
       "isContextLost": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isContextLost",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-iscontextlost",
           "tags": [
             "web-features:canvas-context-lost"
@@ -1249,6 +1282,7 @@
       },
       "isPointInPath": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isPointInPath",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-ispointinpath-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1285,6 +1319,7 @@
       },
       "isPointInStroke": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isPointInStroke",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-ispointinstroke-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1321,6 +1356,7 @@
       },
       "letterSpacing": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/letterSpacing",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-letterspacing",
           "support": {
             "chrome": {
@@ -1354,6 +1390,7 @@
       },
       "lineCap": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lineCap",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-linecap-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1390,6 +1427,7 @@
       },
       "lineDashOffset": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lineDashOffset",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-linedashoffset-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1426,6 +1464,7 @@
       },
       "lineJoin": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lineJoin",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-linejoin-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1462,6 +1501,7 @@
       },
       "lineTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lineTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-lineto-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1498,6 +1538,7 @@
       },
       "lineWidth": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lineWidth",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-linewidth-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1534,6 +1575,7 @@
       },
       "measureText": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/measureText",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-measuretext-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1570,6 +1612,7 @@
       },
       "miterLimit": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/miterLimit",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-miterlimit-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1606,6 +1649,7 @@
       },
       "moveTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/moveTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-moveto-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1642,6 +1686,7 @@
       },
       "putImageData": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/putImageData",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-putimagedata-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1678,6 +1723,7 @@
       },
       "quadraticCurveTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/quadraticCurveTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-quadraticcurveto-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1714,6 +1760,7 @@
       },
       "rect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/rect",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-rect-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1750,7 +1797,7 @@
       },
       "reset": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.reset",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/reset",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-reset",
           "tags": [
             "web-features:canvas-reset"
@@ -1787,6 +1834,7 @@
       },
       "resetTransform": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/resetTransform",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-resettransform-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1823,6 +1871,7 @@
       },
       "restore": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/restore",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-restore-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1859,6 +1908,7 @@
       },
       "rotate": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/rotate",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-rotate-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1895,6 +1945,7 @@
       },
       "roundRect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect",
           "tags": [
             "web-features:canvas-roundrect"
@@ -1931,6 +1982,7 @@
       },
       "save": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/save",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-save-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -1967,6 +2019,7 @@
       },
       "scale": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/scale",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-scale-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2003,6 +2056,7 @@
       },
       "setLineDash": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/setLineDash",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-setlinedash-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2039,6 +2093,7 @@
       },
       "setTransform": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/setTransform",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-settransform-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2075,6 +2130,7 @@
       },
       "shadowBlur": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/shadowBlur",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-shadowblur-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2111,6 +2167,7 @@
       },
       "shadowColor": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/shadowColor",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-shadowcolor-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2147,6 +2204,7 @@
       },
       "shadowOffsetX": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/shadowOffsetX",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-shadowoffsetx-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2183,6 +2241,7 @@
       },
       "shadowOffsetY": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/shadowOffsetY",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-shadowoffsety-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2219,6 +2278,7 @@
       },
       "stroke": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/stroke",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-stroke-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2255,6 +2315,7 @@
       },
       "strokeRect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/strokeRect",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-strokerect-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2291,6 +2352,7 @@
       },
       "strokeStyle": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/strokeStyle",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-strokestyle-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2327,6 +2389,7 @@
       },
       "strokeText": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/strokeText",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-stroketext-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2363,6 +2426,7 @@
       },
       "textAlign": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/textAlign",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-textalign-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2399,6 +2463,7 @@
       },
       "textBaseline": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/textBaseline",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-textbaseline-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2435,6 +2500,7 @@
       },
       "textRendering": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/textRendering",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-textrendering",
           "support": {
             "chrome": {
@@ -2468,6 +2534,7 @@
       },
       "transform": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/transform",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-transform-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2504,6 +2571,7 @@
       },
       "translate": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/translate",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-translate-dev",
           "tags": [
             "web-features:offscreen-canvas"
@@ -2540,6 +2608,7 @@
       },
       "wordSpacing": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/wordSpacing",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-wordspacing",
           "support": {
             "chrome": {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D has the same members as           https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D and so they are all documented under CanvasRenderingContext2D. The mdn_url linter cannot know about this, so I'm adding these mdn_urls manually.
