### PR TITLE
Add mdn_urls for Path2D

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -109,6 +109,7 @@
       },
       "arc": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/arc",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-arc-dev",
           "support": {
             "chrome": {
@@ -144,6 +145,7 @@
       },
       "arcTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/arcTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-arcto-dev",
           "support": {
             "chrome": {
@@ -179,6 +181,7 @@
       },
       "bezierCurveTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/bezierCurveTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-beziercurveto-dev",
           "support": {
             "chrome": {
@@ -214,6 +217,7 @@
       },
       "closePath": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/closePath",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-closepath-dev",
           "support": {
             "chrome": {
@@ -249,6 +253,7 @@
       },
       "ellipse": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/ellipse",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-ellipse-dev",
           "support": {
             "chrome": {
@@ -284,6 +289,7 @@
       },
       "lineTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lineTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-lineto-dev",
           "support": {
             "chrome": {
@@ -319,6 +325,7 @@
       },
       "moveTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/moveTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-moveto-dev",
           "support": {
             "chrome": {
@@ -354,6 +361,7 @@
       },
       "quadraticCurveTo": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/quadraticCurveTo",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-quadraticcurveto-dev",
           "support": {
             "chrome": {
@@ -389,6 +397,7 @@
       },
       "rect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/rect",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-rect-dev",
           "support": {
             "chrome": {
@@ -424,6 +433,7 @@
       },
       "roundRect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect-dev",
           "support": {
             "chrome": {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Path2D has all the Path members from https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D and so they are all documented under CanvasRenderingContext2D. The mdn_url linter cannot know about this, so I'm adding these mdn_urls manually.