### PR TITLE
Mark <button> as supported in Safari 1

### DIFF
--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -28,7 +28,7 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This is to have something to pin the web-features support to: https://github.com/web-platform-dx/web-features/pull/1433

No research was done, and attributes are left as ranges since it's likely some of them are more recent.