### PR TITLE
Add spec_urls to wasm features

### DIFF
--- a/webassembly/BigInt-to-i64-integration.json
+++ b/webassembly/BigInt-to-i64-integration.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "BigInt-to-i64-integration": {
       "__compat": {
+        "spec_url": "https://webassembly.github.io/spec/js-api/#ref-for-syntax-numtype①⓪",
         "support": {
           "chrome": {
             "version_added": "85"

--- a/webassembly/mutable-globals.json
+++ b/webassembly/mutable-globals.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "mutable-globals": {
       "__compat": {
+        "spec_url": "https://webassembly.github.io/spec/js-api/index.html#dom-globaldescriptor-mutable",
         "support": {
           "chrome": {
             "version_added": "≤80"


### PR DESCRIPTION
Two WebAssembly features had no spec_urls