### PR TITLE
`css.at-rules.counter-style.speak-as` is supported in Chrome

### DIFF
--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -269,7 +269,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 91 is shown as shipping `api.CSSCounterStyleRule.speakAs`, but the data for `css.at-rules.counter-style.speak-as` says unsupported. This discrepancy looked weird and, upon closer investigation, turned out to be wrong.

#### Test results and supporting details

I used the manual test (checking the accessibility inspector) and automated test below, in Browserstack.

Tests:

- https://wpt.live/css/css-counter-styles/counter-style-at-rule/speak-as-manual.html
- https://wpt.live/css/css-counter-styles/counter-style-at-rule/speak-as-syntax.html

Also this https://issues.chromium.org/issues/40164365 (unclear why it's still open though).

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
https://github.com/web-platform-dx/web-features/pull/1400/files#r1680603901