### PR TITLE
Update Chrome/Safari versions for sandbox="allow-pointer-lock"

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -875,7 +875,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "≤49"
+                  "version_added": "23"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -890,7 +890,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "≤10.1"
+                  "version_added": "10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This was implemented in WebKit 537.6:
https://github.com/WebKit/WebKit/commit/73c18e62d7b18a7ad8c626be054f7a3845e53506
https://github.com/WebKit/WebKit/blob/73c18e62d7b18a7ad8c626be054f7a3845e53506/Source/WebCore/Configurations/Version.xcconfig

That maps to Chrome 23 and Safari 7.

Those versions need to be clamped to support for requestPointerLock(),
which is Chrome 22 and Safari 10.1. Pointer lock isn't supported on iOS.

All in all: Chrome 23 and Safari 10.1.