### PR TITLE
Update Chrome/Safari versions for sandbox="allow-top-navigation"

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1120,7 +1120,7 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-top-navigation",
               "support": {
                 "chrome": {
-                  "version_added": "≤49"
+                  "version_added": "6"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -1135,7 +1135,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "≤10.1"
+                  "version_added": "5"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This was implemented in WebKit 533.3:
https://github.com/WebKit/WebKit/commit/f4228dc0076684651c8b54680db4d1d7b964a321
https://github.com/WebKit/WebKit/blob/f4228dc0076684651c8b54680db4d1d7b964a321/WebCore/Configurations/Version.xcconfig

That maps to Chrome 5 or 6, Safari 5, and iOS 4.2.

Chrome 5 or 6 is ambiguous because the engine version is 533 with no
minor version. Chrome 6 is 534.3, so it was definitely in Chrome 6.

Unlike other sandbox data, mirroring can be used for iOS, as Safari 5
does map to iOS 4.2.