### PR TITLE
Add calc-size() function and interpolate-size property

### DIFF
--- a/css/properties/interpolate-size.json
+++ b/css/properties/interpolate-size.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-values-5/#interpolate-size",
           "support": {
             "chrome": {
-              "version_added": "128"
+              "version_added": "129"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/interpolate-size.json
+++ b/css/properties/interpolate-size.json
@@ -1,0 +1,39 @@
+{
+  "css": {
+    "properties": {
+      "interpolate-size": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-values-5/#interpolate-size",
+          "support": {
+            "chrome": {
+              "version_added": "128"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/calc-size.json
+++ b/css/types/calc-size.json
@@ -1,0 +1,40 @@
+{
+  "css": {
+    "types": {
+      "calc-size": {
+        "__compat": {
+          "description": "<code>calc-size()</code>",
+          "spec_url": "https://drafts.csswg.org/css-values-5/#calc-size",
+          "support": {
+            "chrome": {
+              "version_added": "128"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 128 supports the [`calc-size()`](https://drafts.csswg.org/css-values-5/#calc-sizehttps://drafts.csswg.org/css-values-5/#interpolate-size) function and [`interpolate-size`]() property. See the relevant [ChromeStatus entry](https://chromestatus.com/feature/5196713071738880) for more information.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
