### PR TITLE
Update browser versions for sandbox="allow-popups"

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -913,11 +913,11 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-popups",
               "support": {
                 "chrome": {
-                  "version_added": "5"
+                  "version_added": "17"
                 },
                 "chrome_android": "mirror",
                 "edge": {
-                  "version_added": "≤18"
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "28"
@@ -926,13 +926,13 @@
                   "version_added": "27"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "≤10.1"
+                  "version_added": "6"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This was implemented in WebKit 535.8:
https://github.com/WebKit/WebKit/commit/78f87065d871ddf0bb9d4c77310f62ae6375df47
https://github.com/WebKit/WebKit/blob/78f87065d871ddf0bb9d4c77310f62ae6375df47/Source/WebCore/Configurations/Version.xcconfig

That maps to Chrome 17 and Safari 6.

The commit message mentions support in IE10, which is confirmed by this
proposal from the time:
https://www.w3.org/html/wg/wiki/ChangeProposals/sandbox_allow_popups

Thus it must have been in Edge 12 as well.