### PR TITLE
Correct data for CSS filter on SVG elements

### DIFF
--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -93,7 +93,7 @@
             "description": "On SVG elements",
             "support": {
               "chrome": {
-                "version_added": "≤53"
+                "version_added": "89"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -108,7 +108,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤10.1"
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/246106"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This was most recently researched and updated here:
https://github.com/mdn/browser-compat-data/issues/18917
https://github.com/mdn/browser-compat-data/pull/21569

These two tests were run in Chrome 88, 89, Edge 18, and Safari 17.5:
https://codepen.io/estelle/pen/rNZNqaK
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12923

The filter works in Chrome 89, but not in Chrome 88, Edge 18, or Safari
17.5.

Chrome 89 is confirmed by these additional sources:
https://stackoverflow.com/questions/32567156/why-dont-css-filters-work-on-svg-elements-in-chrome
https://crbug.com/40134524#comment79

Lack of support in Safari is confirmed by these sources:
https://stackoverflow.com/questions/76919922/css-filters-on-svg-elements-not-applied-in-safari
https://bugs.webkit.org/show_bug.cgi?id=246106

The WebKit bug is linked.