### PR TITLE
Update Chromium data for webextensions.api.browserAction.onClicked.tab

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -448,7 +448,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤78"
                 },
                 "edge": {
                   "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `onClicked.tab` member of the `browserAction` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #5285
