### PR TITLE
Update Chromium data for webextensions.api.browserAction.setBadgeBackgroundColor.string

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -590,11 +590,9 @@
               "description": "The <code>color</code> property of the <code>details</code> parameter can be set to a string.",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤63"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": true,
                   "notes": "Before Firefox 59, invalid color strings behaved as <code>null</code>."


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `setBadgeBackgroundColor.string` member of the `browserAction` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #859
