### PR TITLE
Update Chromium data for webextensions.api.cookies.Cookie.sameSite

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -67,7 +67,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤72"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -511,7 +511,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/SameSiteStatus",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": "mirror",
               "firefox": {
@@ -707,7 +707,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤72"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Cookie.sameSite` member of the `cookies` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #2918
