### PR TITLE
Update Chromium data for webextensions.api.devtools.network

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -233,11 +233,9 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/getHAR",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤64"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "60",
                   "notes": "The returned HAR log will be empty unless the user has previously activated the browser's network panel at least once."
@@ -284,11 +282,9 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onRequestFinished",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤64"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": [
                   {
                     "version_added": "61"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `network` member of the `devtools` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #1160, #1162
