### PR TITLE
Update Chromium data for webextensions.api.devtools.panels

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -431,11 +431,9 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "54"
                   },

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -342,11 +342,9 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/createSidebarPane",
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "57"
                   },
@@ -366,11 +364,9 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/onSelectionChanged",
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "56"
                   },
@@ -391,11 +387,9 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "54"
                   },
@@ -465,11 +459,9 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onHidden",
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "57",
                     "notes": "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>."
@@ -490,11 +482,9 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onShown",
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "57",
                     "notes": "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>."
@@ -515,13 +505,10 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setExpression",
                 "support": {
                   "chrome": {
-                    "version_added": true,
+                    "version_added": "≤61",
                     "notes": "The expression must evaluate to a JavaScript object or a DOM node, or nothing is shown in the sidebar."
                   },
-                  "edge": {
-                    "version_added": "79",
-                    "notes": "The expression must evaluate to a JavaScript object or a DOM node, or nothing is shown in the sidebar."
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "57",
                     "notes": "Before Firefox 60, the expression must evaluate to an object that can be serialized to JSON, or nothing was shown in the sidebar. In particular, JavaScript cyclic objects and DOM nodes were not supported. See <a href='https://bugzil.la/1403130'>bug 1403130</a>."
@@ -563,13 +550,10 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setObject",
                 "support": {
                   "chrome": {
-                    "version_added": true,
+                    "version_added": "≤61",
                     "notes": "If the <code>jsonObject</code> parameter is a string, it is not displayed."
                   },
-                  "edge": {
-                    "version_added": "79",
-                    "notes": "If the <code>jsonObject</code> parameter is a string, it is not displayed."
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "57",
                     "notes": "If the <code>jsonObject</code> is a string, then <code>rootTitle</code> must also be given, or <code>jsonObject</code> will not be displayed. See <a href='https://bugzil.la/1412310'>bug 1412310</a>."
@@ -714,11 +698,9 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/elements",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "56"
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `panels` member of the `devtools` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #360, #460
