### PR TITLE
Update Chromium data for webextensions.api.extension.getViews.windowId

### DIFF
--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -178,7 +178,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤93"
                 },
                 "edge": {
                   "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `getViews.windowId` member of the `extension` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #12246
