### PR TITLE
Update Opera data for webextensions.api.i18n.getUILanguage

### DIFF
--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -155,9 +155,7 @@
               "firefox_android": {
                 "version_added": "48"
               },
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": "14"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `getUILanguage` member of the `i18n` Web Extensions interface. This sets the downstream browser(s) to mirror from their upstream counterpart.
