### PR TITLE
Update Opera data for webextensions.api.notifications.TemplateType

### DIFF
--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -301,10 +301,7 @@
                 "version_added": "48",
                 "notes": "Only the 'basic' type is supported."
               },
-              "opera": {
-                "version_added": true,
-                "notes": "Only the 'basic' type is supported."
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `TemplateType` member of the `notifications` Web Extensions interface. This sets the downstream browser(s) to mirror from their upstream counterpart.
