### PR TITLE
Update Chromium data for webextensions.api.notifications.NotificationOptions

### DIFF
--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -53,11 +53,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤65"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false,
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored."
@@ -75,11 +73,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤65"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -122,11 +118,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤65"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false,
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored."
@@ -144,11 +138,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤65"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false,
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored."
@@ -192,13 +184,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤65",
                   "notes": "On macOS only the first item is shown."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "On macOS only the first item is shown."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false,
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored."
@@ -219,11 +208,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤65"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false,
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored."


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `NotificationOptions` member of the `notifications` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #1631
