### PR TITLE
Update Opera data for webextensions.api.privacy.services

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -193,9 +193,7 @@
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": true
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -214,9 +212,7 @@
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": true
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -256,9 +252,7 @@
                   "version_added": "56"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": true
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -298,9 +292,7 @@
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": true
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `services` member of the `privacy` Web Extensions interface. This sets the downstream browser(s) to mirror from their upstream counterpart.
