### PR TITLE
Update Chromium data for webextensions.api.privacy.network

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -81,11 +81,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "54"
                 },
@@ -121,11 +119,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "54",
                   "notes": "Starting in Firefox 70, a value of <code>disable_non_proxied_udp</code> requires a proxy if one is configured, but allows connections to go through if no proxy is set up. Previously, in this mode WebRTC could only be used if a proxy was configured and TURN over TCP was available; this behavior is now exposed as <code>proxy_only</code>."


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `network` member of the `privacy` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #364
