### PR TITLE
Update Chromium data for webextensions.api.privacy.websites.protectedContentEnabled

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -499,11 +499,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -499,7 +499,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤60"
+                  "version_added": "≤58"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `websites.protectedContentEnabled` member of the `privacy` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #166
