### PR TITLE
Update Chromium data for webextensions.api.runtime.lastError

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -753,7 +753,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError",
             "support": {
               "chrome": {
-                "version_added": "≤56",
+                "version_added": "≤58",
                 "notes": "<code>lastError</code> is not an <code>Error</code> object. Instead, it is a plain <code>Object</code> with the error text as the string value of the <code>message</code> property."
               },
               "edge": "mirror",

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -753,7 +753,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "≤56",
                 "notes": "<code>lastError</code> is not an <code>Error</code> object. Instead, it is a plain <code>Object</code> with the error text as the string value of the <code>message</code> property."
               },
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `lastError` member of the `runtime` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #166
