### PR TITLE
Update Chromium data for tabs Web Extensions interface

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1283,7 +1283,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/WindowType",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "14"
@@ -2160,11 +2160,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getSelected",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -2186,11 +2184,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoom",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -2300,11 +2296,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/highlight",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "63"
               },
@@ -2347,7 +2341,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "≤20",
                 "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
@@ -2362,7 +2356,10 @@
                 "version_added": "54",
                 "notes": "Available for use in Manifest V2 only."
               },
-              "opera": "mirror",
+              "opera": {
+                "version_added": "15",
+                "notes": "Available for use in Manifest V2 only."
+              },
               "safari": {
                 "version_added": "14",
                 "notes": "Available for use in Manifest V2 only."
@@ -2467,11 +2464,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/move",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "46"
               },
@@ -2513,7 +2508,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onActivated",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "14"
@@ -2539,11 +2534,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onActiveChanged",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -2563,7 +2556,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onAttached",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "15"
@@ -2589,7 +2582,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onCreated",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "14"
@@ -2615,7 +2608,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onDetached",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "15"
@@ -2641,11 +2634,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlightChanged",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -2665,11 +2656,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlighted",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": [
                 {
                   "version_added": "63"
@@ -2701,11 +2690,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onMoved",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -2727,7 +2714,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "14"
@@ -2753,11 +2740,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onReplaced",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -2777,11 +2762,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onSelectionChanged",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -2801,7 +2784,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤54"
               },
               "edge": {
                 "version_added": "14"
@@ -2826,7 +2809,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2872,7 +2855,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2896,7 +2879,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2919,7 +2902,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2946,7 +2929,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2972,7 +2955,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2997,7 +2980,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3024,7 +3007,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3105,11 +3088,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onZoomChange",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -3173,7 +3154,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤19"
               },
               "edge": {
                 "version_added": "14",
@@ -3185,7 +3166,9 @@
               "firefox_android": {
                 "version_added": "54"
               },
-              "opera": "mirror",
+              "opera": {
+                "version_added": "15"
+              },
               "safari": {
                 "version_added": "14"
               },
@@ -3198,7 +3181,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤19"
                 },
                 "edge": {
                   "version_added": "14"
@@ -3209,7 +3192,9 @@
                 "firefox_android": {
                   "version_added": "54"
                 },
-                "opera": "mirror",
+                "opera": {
+                  "version_added": "15"
+                },
                 "safari": {
                   "version_added": "14"
                 },
@@ -3222,7 +3207,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3388,11 +3373,9 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "60",
                     "notes": "Treated as an alias for <code>queryInfo.active</code>."
@@ -3496,11 +3479,9 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "57"
                   },
@@ -3521,11 +3502,9 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "45"
                   },
@@ -3547,7 +3526,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3572,7 +3551,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3597,7 +3576,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3630,7 +3609,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3655,7 +3634,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3683,7 +3662,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/reload",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "17"
@@ -3709,7 +3688,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/remove",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
               "edge": {
                 "version_added": "14"
@@ -3793,7 +3772,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤41"
               },
               "edge": {
                 "version_added": "14",
@@ -3845,11 +3824,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendRequest",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -3869,11 +3846,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoom",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -3895,11 +3870,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoomSettings",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤61"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -3961,7 +3934,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "edge": {
                 "version_added": "14"
@@ -3972,7 +3945,9 @@
               "firefox_android": {
                 "version_added": "54"
               },
-              "opera": "mirror",
+              "opera": {
+                "version_added": "15"
+              },
               "safari": {
                 "version_added": "14"
               },
@@ -3986,7 +3961,7 @@
               "description": "<code>updateProperties.active</code> parameter",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
                 "edge": {
                   "version_added": "14"
@@ -4034,11 +4009,9 @@
               "description": "<code>updateProperties.highlighted</code> parameter",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "63"
                 },
@@ -4130,11 +4103,9 @@
               "description": "<code>updateProperties.pinned</code> parameter",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -4157,11 +4128,9 @@
               "description": "<code>updateProperties.selected</code> parameter",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -4181,7 +4150,7 @@
               "description": "<code>updateProperties.url</code> parameter",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
                 "edge": {
                   "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `tabs` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #512, #469, #446
