### PR TITLE
Update Chromium data for types Web Extensions interface

### DIFF
--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types",
           "support": {
             "chrome": {
-              "version_added": "≤56"
+              "version_added": "≤58"
             },
             "edge": "mirror",
             "firefox": {
@@ -25,7 +25,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting",
             "support": {
               "chrome": {
-                "version_added": "≤56"
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": {
@@ -44,7 +44,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange",
               "support": {
                 "chrome": {
-                  "version_added": "≤56"
+                  "version_added": "≤58"
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -6,11 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤56"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "54"
             },
@@ -27,11 +25,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤56"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "54"
               },
@@ -48,11 +44,9 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤56"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "72"
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `types` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #166
