### PR TITLE
Update Chromium data for webextensions.api.webNavigation.TransitionType

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -87,7 +87,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -106,7 +106,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -126,7 +126,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -145,7 +145,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -164,7 +164,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -183,7 +183,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -202,7 +202,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -222,7 +222,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -241,7 +241,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -260,7 +260,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -279,7 +279,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤70"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `TransitionType` member of the `webNavigation` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #3132
