### PR TITLE
Update Chromium data for webextensions.api.webRequest.RequestFilter.urls

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -202,7 +202,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
                 "edge": {
                   "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RequestFilter.urls` member of the `webRequest` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #389
