### PR TITLE
Update Chromium data for webextensions.api.webRequest.RequestFilter.windowId

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -252,7 +252,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤61"
                 },
                 "edge": {
                   "version_added": "14"
@@ -2038,7 +2038,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2063,7 +2063,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2109,7 +2109,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2134,7 +2134,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2178,7 +2178,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2222,7 +2222,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2247,7 +2247,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2272,7 +2272,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2297,7 +2297,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2322,7 +2322,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2347,7 +2347,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2393,7 +2393,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2418,7 +2418,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2443,7 +2443,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -2038,7 +2038,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2063,7 +2063,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2109,7 +2109,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2134,7 +2134,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2178,7 +2178,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2222,7 +2222,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2247,7 +2247,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2272,7 +2272,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2297,7 +2297,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2322,7 +2322,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2347,7 +2347,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2393,7 +2393,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2418,7 +2418,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -2443,7 +2443,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RequestFilter.windowId` member of the `webRequest` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #469
