### PR TITLE
Update Chromium data for webextensions.api.windows.Window.incognito

### DIFF
--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -185,7 +185,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "edge": {
                   "alternative_name": "inPrivate",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Window.incognito` member of the `windows` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #263
