### PR TITLE
Update Chromium data for webextensions.api.windows.Window

### DIFF
--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -110,7 +110,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -135,7 +135,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -160,7 +160,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -211,7 +211,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -255,7 +255,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -280,7 +280,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -326,7 +326,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -351,7 +351,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -376,7 +376,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Window` member of the `windows` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #307
