### PR TITLE
Update Chromium data for webextensions.api.windows.WindowType

### DIFF
--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -601,11 +601,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -624,11 +622,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -647,11 +643,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -743,7 +737,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -766,7 +760,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -791,7 +785,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -816,7 +810,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -866,11 +860,9 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "45"
                   },
@@ -910,7 +902,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -935,7 +927,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -960,7 +952,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -986,7 +978,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1112,11 +1104,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1463,11 +1453,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1486,7 +1474,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -1511,7 +1499,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -1536,11 +1524,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1561,7 +1547,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"
@@ -1607,11 +1593,9 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1632,7 +1616,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤60"
                 },
                 "edge": {
                   "version_added": "14"

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -737,7 +737,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -760,7 +760,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -785,7 +785,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -810,7 +810,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -860,9 +860,11 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
-                  "edge": "mirror",
+                  "edge": {
+                    "version_added": "79"
+                  },
                   "firefox": {
                     "version_added": "45"
                   },
@@ -902,7 +904,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -927,7 +929,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -952,7 +954,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -978,7 +980,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": true
                   },
                   "edge": {
                     "version_added": "14"
@@ -1104,9 +1106,11 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤59"
+                  "version_added": true
                 },
-                "edge": "mirror",
+                "edge": {
+                  "version_added": "79"
+                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1453,9 +1457,11 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤59"
+                  "version_added": true
                 },
-                "edge": "mirror",
+                "edge": {
+                  "version_added": "79"
+                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1474,7 +1480,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤60"
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": "14"
@@ -1499,7 +1505,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤60"
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": "14"
@@ -1524,9 +1530,11 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤59"
+                  "version_added": true
                 },
-                "edge": "mirror",
+                "edge": {
+                  "version_added": "79"
+                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1547,7 +1555,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤60"
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": "14"
@@ -1593,9 +1601,11 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤59"
+                  "version_added": true
                 },
-                "edge": "mirror",
+                "edge": {
+                  "version_added": "79"
+                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1616,7 +1626,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤60"
+                  "version_added": true
                 },
                 "edge": {
                   "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WindowType` member of the `windows` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #262
