### PR TITLE
Update Chromium data for webextensions.api.windows.create.createData

### DIFF
--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -743,7 +743,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -766,7 +766,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -791,7 +791,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -816,7 +816,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -866,11 +866,9 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
-                  "edge": {
-                    "version_added": "79"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "45"
                   },
@@ -910,7 +908,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -935,7 +933,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -960,7 +958,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"
@@ -986,7 +984,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "≤61"
                   },
                   "edge": {
                     "version_added": "14"

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -766,7 +766,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "≤60"
                   },
                   "edge": {
                     "version_added": "14"
@@ -908,7 +908,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "≤60"
                   },
                   "edge": {
                     "version_added": "14"
@@ -933,7 +933,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "≤60"
                   },
                   "edge": {
                     "version_added": "14"
@@ -984,7 +984,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "≤60"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1307,6 +1307,7 @@
         },
         "onBoundsChanged": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onBoundsChanged",
             "support": {
               "chrome": {
                 "version_added": "86"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `create.createData` member of the `windows` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #456
