### PR TITLE
Update Firefox support for `display` manifest

### DIFF
--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "47"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This is an addendum to https://github.com/mdn/browser-compat-data/pull/23661 to update the `display` member support in Firefox desktop.

#### Related PRs

https://github.com/openwebdocs/project/issues/206#issuecomment-2222830282
