### PR TITLE
FF129 CSSPageRule.style derives from CSSPageDescriptors

### DIFF
--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -124,9 +124,9 @@
             "deprecated": false
           }
         },
-        "CSSPageDescriptors": {
+        "type_CSSPageDescriptors": {
           "__compat": {
-            "description": "Derives from <a href='https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors'><code>CSSPageDescriptors</code></a> (not <a href='https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration'><code>CSSStyleDeclaration</code></a>",
+            "description": "Type changed to <a href='https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors'><code>CSSPageDescriptors</code></a>",
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -123,6 +123,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "CSSPageDescriptors": {
+          "__compat": {
+            "description": "Derives from <a href='https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors'><code>CSSPageDescriptors</code></a> (not <a href='https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration'><code>CSSStyleDeclaration</code></a>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "129"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
FF129 Adds support for [`CSSPageRule.style`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPageRule/style) being a [`CSSPageDescriptors`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPageDescriptors) (as per current spec) rather than a [`CSSStyleDeclaration`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration).

As far as I can tell there isn't really any compatibility issue with this right now, because `CSSStyleDeclaration` has getters and setters to set the same properties. However there could well be in future, because `CSSPageDescriptors` is likely to evolve separately. Right now the only benefit I can see is that it is possible to identify the Web object that corresponds to the `@page` CSS because it has a different type.

This follows on from #23730

Related docs work can be tracked in https://github.com/mdn/content/issues/34702