### PR TITLE
Add Samsung Internet 26.0

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -288,6 +288,12 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "121"
+        },
+        "26.0": {
+          "release_date": "2024-07-10",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "122"
         }
       }
     }

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -285,7 +285,7 @@
         },
         "25.0": {
           "release_date": "2024-04-24",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "121"
         },


### PR DESCRIPTION
Data from https://en.wikipedia.org/wiki/Samsung_Internet

@matatk can you confirm Samsung Internet ships with Chromium 122? I thought it might be shipping a later version like 125 or so.