### PR TITLE
SubtleCrypto ED25519 (FF129) X25519 (FF1300)

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -690,7 +690,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -808,7 +808,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "129",
                 "impl_url": "https://bugzil.la/1804788"
               },
               "firefox_android": "mirror",
@@ -934,7 +934,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1036,7 +1036,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1202,7 +1202,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -255,6 +255,55 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "x25519": {
+          "__compat": {
+            "description": "<code>X25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#x25519",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "130"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "deriveKey": {
@@ -465,6 +514,55 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "≤13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "x25519": {
+          "__compat": {
+            "description": "<code>X25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#x25519",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "130"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -716,6 +814,55 @@
               "deprecated": false
             }
           }
+        },
+        "x25519": {
+          "__compat": {
+            "description": "<code>X25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#x25519",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "130"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "generateKey": {
@@ -810,6 +957,55 @@
               "firefox": {
                 "version_added": "129",
                 "impl_url": "https://bugzil.la/1804788"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "x25519": {
+          "__compat": {
+            "description": "<code>X25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#x25519",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "130"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -935,6 +1131,55 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "129"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "x25519": {
+          "__compat": {
+            "description": "<code>X25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#x25519",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "130"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF129 supports signature algorithm Ed25519  in https://bugzilla.mozilla.org/show_bug.cgi?id=1804788 and X25519  in https://bugzilla.mozilla.org/show_bug.cgi?id=1904836

This adds FF info for Ed25519 key agreement algorithm. I also added support for X25519 in other browsers in same versions as Ed25519. This makes sense because they use the same curves and this is what the release info in those browsers indicates.

Related docs can be tracked in https://github.com/mdn/content/issues/34708 and https://github.com/mdn/content/issues/35280