### PR TITLE
update-browser-releases: "current" should not become "esr" for Firefox

### DIFF
--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -133,6 +133,10 @@ export const updateFirefoxReleases = async (options) => {
     >,
   ).forEach(([key, entry]) => {
     if (key === String(esrRelease)) {
+      if (entry.status === 'current') {
+        // If the current release is also considered the ESR release, "current" status takes priority
+        return;
+      }
       result += updateBrowserEntry(
         firefoxBCD,
         options.bcdBrowserName,


### PR DESCRIPTION
This PR updates the Firefox portion of the browser updater script to ensure that the `"esr"` status is de-prioritized against `"current"`.
