### PR TITLE
update-browser-releases: Ignore Safari 17.6

### DIFF
--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -167,7 +167,7 @@ const options = {
     browserName: 'Safari for Desktop',
     bcdFile: './browsers/safari.json',
     bcdBrowserName: 'safari',
-    skippedReleases: [],
+    skippedReleases: ['17.6'],
     releaseNoteJSON:
       'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
     releaseNoteURLBase: 'https://developer.apple.com',
@@ -176,7 +176,7 @@ const options = {
     browserName: 'Safari for iOS',
     bcdFile: './browsers/safari_ios.json',
     bcdBrowserName: 'safari_ios',
-    skippedReleases: ['12.1', '13.1', '14.1'],
+    skippedReleases: ['12.1', '13.1', '14.1', '17.6'],
     releaseNoteJSON:
       'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
     releaseNoteURLBase: 'https://developer.apple.com',

--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -107,7 +107,10 @@ export const updateSafariReleases = async (options) => {
   //
   const dates: string[] = [];
   releaseData.forEach((release) => {
-    if (release.channel !== 'beta') {
+    if (
+      release.channel !== 'beta' &&
+      !options.skippedReleases.includes(release.version)
+    ) {
       dates.push(release.date);
     }
   });


### PR DESCRIPTION
This PR updates the browser release data updater to ignore Safari 17.6.

Safari 17.6 is marked as released in Apple's data, which is causing the updater script to add 17.6 as the current version.  However, this is incorrect; Safari 17.6 has not yet released.

It's possible that we may just go straight into Safari 18, so I have opted to defer to `"preview"` for any features introduced in Safari 17.6 beta.
