### PR TITLE
Add missing deno data to Collator options

### DIFF
--- a/javascript/builtins/Intl/Collator.json
+++ b/javascript/builtins/Intl/Collator.json
@@ -189,6 +189,9 @@
                     "version_added": "24"
                   },
                   "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "29"
@@ -227,6 +230,9 @@
                     "version_added": "24"
                   },
                   "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "29"
@@ -265,6 +271,9 @@
                     "version_added": "24"
                   },
                   "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "29"
@@ -303,6 +312,9 @@
                     "version_added": "24"
                   },
                   "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "29"
@@ -341,6 +353,9 @@
                     "version_added": "24"
                   },
                   "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "29"


### PR DESCRIPTION
Deno was forgotten in https://github.com/mdn/browser-compat-data/pull/23686 and our linter requires deno nowadays for javascript data. This should fix the failing main branch.