### PR TITLE
Update Firefox data for api.SubtleCrypto.deriveKey.derivedKeyAlgorithm_option_pbkdf2

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -451,8 +451,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1856679'>bug 1856679</a>"
+                "version_added": "119"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `deriveKey.derivedKeyAlgorithm_option_pbkdf2` member of the `SubtleCrypto` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SubtleCrypto/deriveKey/derivedKeyAlgorithm_option_pbkdf2

Additional Notes: The conversation in the linked bug, which is now closed as RESOLVED INVALID, confirms that the collector's results are accurate.
