### PR TITLE
Mark SVG{String,Transform}List.length as standardized

### DIFF
--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -288,7 +288,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -259,6 +259,7 @@
       },
       "length": {
         "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__length",
           "support": {
             "chrome": {
               "version_added": "35"

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -377,7 +377,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -346,6 +346,7 @@
       },
       "length": {
         "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__length",
           "support": {
             "chrome": {
               "version_added": "35"


### PR DESCRIPTION
length is listed in the IDL
- https://svgwg.org/svg2-draft/types.html#InterfaceSVGStringList
- https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransformList