### PR TITLE
Mark sandbox="allow-downloads" support in Safari

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -753,7 +753,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "17"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
It landed in the WebKit main branch here:
https://github.com/WebKit/WebKit/commit/f8f6da20d5073dc5050556c3f4e1c6f8007b2b13

However, Originally-landed-as point to this commit:
https://github.com/WebKit/WebKit/commit/9d46b7777bca2b36c82f040065e3d7953f8f782d https://github.com/WebKit/WebKit/blob/9d46b7777bca2b36c82f040065e3d7953f8f782d/Configurations/Version.xcconfig

Going by the date (2023-07-13) and WebKit version (616.1.24) Safari 17 is the most likely correct version.

It's not mentioned in the release notes, and no testing was done to confirm support.