### PR TITLE
Mark sandbox="allow-pointer-lock" not supported on iOS

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -898,7 +898,7 @@
                 },
                 "safari_ios": {
                   "version_added": false
-                }
+                },
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -896,7 +896,9 @@
                 "safari": {
                   "version_added": "10.1"
                 },
-                "safari_ios": "mirror",
+                "safari_ios": {
+                  "version_added": false
+                }
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },


### PR DESCRIPTION
Even if the token is parsed, it has no effect since the pointer lock API isn't supported: https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock#browser_compatibility