### PR TITLE
Updates for Chrome 128 beta

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -477,6 +477,40 @@
           }
         }
       },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audiocontext-onerror",
+          "support": {
+            "chrome": {
+              "version_added": "128"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getOutputTimestamp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioContext/getOutputTimestamp",

--- a/api/CaretPosition.json
+++ b/api/CaretPosition.json
@@ -6,7 +6,7 @@
         "spec_url": "https://drafts.csswg.org/cssom-view/#caret-position",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "128"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -38,7 +38,7 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-caretposition-getclientrect",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -60,7 +60,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -71,7 +71,7 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-caretposition-offset",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -93,7 +93,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -104,7 +104,7 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-caretposition-offsetnode",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -126,7 +126,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Document.json
+++ b/api/Document.json
@@ -866,7 +866,7 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-document-caretpositionfrompoint",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -1157,7 +1157,7 @@
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolindextext",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -1179,7 +1179,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -2342,7 +2342,7 @@
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindextext",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2364,7 +2364,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -4242,7 +4242,7 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -4264,7 +4264,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -346,7 +346,7 @@
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolindextext",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -368,7 +368,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1459,7 +1459,7 @@
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindextext",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -1481,7 +1481,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -564,7 +564,7 @@
             "description": "<code>\"skipad\"</code> type",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -583,7 +583,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/api/PageRevealEvent.json
+++ b/api/PageRevealEvent.json
@@ -34,6 +34,42 @@
           "deprecated": false
         }
       },
+      "PageRevealEvent": {
+        "__compat": {
+          "description": "<code>PageRevealEvent()</code> constructor",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagerevealevent-interface",
+          "support": {
+            "chrome": {
+              "version_added": "128"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "viewTransition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageRevealEvent/viewTransition",

--- a/api/PageSwapEvent.json
+++ b/api/PageSwapEvent.json
@@ -34,6 +34,42 @@
           "deprecated": false
         }
       },
+      "PageSwapEvent": {
+        "__compat": {
+          "description": "<code>PageSwapEvent()</code> constructor",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pageswapevent-interface",
+          "support": {
+            "chrome": {
+              "version_added": "128"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "activation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageSwapEvent/activation",

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -315,6 +315,38 @@
           }
         }
       },
+      "persistentDeviceId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "128"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pointerId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PointerEvent/pointerId",

--- a/css/properties/ruby-align.json
+++ b/css/properties/ruby-align.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-ruby/#ruby-align-property",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -40,7 +40,7 @@
             "spec_url": "https://drafts.csswg.org/css-ruby/#valdef-ruby-align-center",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -62,7 +62,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -73,7 +73,7 @@
             "spec_url": "https://drafts.csswg.org/css-ruby/#valdef-ruby-align-space-around",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -95,7 +95,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -106,7 +106,7 @@
             "spec_url": "https://drafts.csswg.org/css-ruby/#valdef-ruby-align-space-between",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -128,7 +128,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -139,7 +139,7 @@
             "spec_url": "https://drafts.csswg.org/css-ruby/#valdef-ruby-align-start",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -161,7 +161,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -555,6 +555,46 @@
             }
           }
         },
+        "try": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/try",
+            "spec_url": "https://tc39.es/proposal-promise-try/#sec-promise.try",
+            "support": {
+              "chrome": {
+                "version_added": "128"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "withResolvers": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers",


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.10.12 found new features shipping in Chrome 128 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 20 features as shipping in Chrome 128:

- api.CaretPosition
- api.CaretPosition.getClientRect
- api.CaretPosition.offset
- api.CaretPosition.offsetNode
- api.Document.caretPositionFromPoint
- api.Element.ariaColIndexText
- api.Element.ariaRowIndexText
- api.Element.currentCSSZoom
- api.ElementInternals.ariaColIndexText
- api.ElementInternals.ariaRowIndexText
- api.MediaSession.setActionHandler.skipad_type
- api.PageRevealEvent.PageRevealEvent
- api.PageSwapEvent.PageSwapEvent
- api.PointerEvent.persistentDeviceId
- css.properties.ruby-align
- css.properties.ruby-align.center
- css.properties.ruby-align.space-around
- css.properties.ruby-align.space-between
- css.properties.ruby-align.start
- javascript.builtins.Promise.try

See also the 128 "Enabled by default" column on https://chromestatus.com/roadmap.

cc @chrisdavidmills @rachelandrew 