### PR TITLE
Update CSS `hyphens: auto` language support

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -564,7 +564,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "130"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1861,7 +1861,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "130"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Update hyphens.json to indicate that Czech/Slovak hyphenation patterns are added in Firefox 130.

#### Related issues

See https://bugzilla.mozilla.org/show_bug.cgi?id=1908931 for the Firefox bug where this change landed.
