### PR TITLE
`vibrationActuator` is now part of the Gamepad API spec

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -553,7 +553,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -524,6 +524,7 @@
       "vibrationActuator": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/vibrationActuator",
+          "spec_url": "https://w3c.github.io/gamepad/#dom-gamepad-vibrationactuator",
           "support": {
             "chrome": {
               "version_added": "68"


### PR DESCRIPTION
#### Summary

`vibrationActuator` was added as part of https://github.com/w3c/gamepad/pull/190 and can now be found at https://w3c.github.io/gamepad/#gamepad-interface
