### PR TITLE
Update HTTP spec_urls

### DIFF
--- a/http/headers/Accept-Encoding.json
+++ b/http/headers/Accept-Encoding.json
@@ -4,7 +4,7 @@
       "Accept-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Encoding",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-encoding",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept-encoding",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Accept-Language.json
+++ b/http/headers/Accept-Language.json
@@ -4,7 +4,7 @@
       "Accept-Language": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Language",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-language",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept-language",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Accept-Ranges.json
+++ b/http/headers/Accept-Ranges.json
@@ -4,7 +4,7 @@
       "Accept-Ranges": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Ranges",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept-ranges",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept-ranges",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Accept.json
+++ b/http/headers/Accept.json
@@ -4,7 +4,7 @@
       "Accept": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.accept",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Age.json
+++ b/http/headers/Age.json
@@ -4,7 +4,7 @@
       "Age": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Age",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.age",
+          "spec_url": "https://httpwg.org/specs/rfc9111.html#field.age",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -4,7 +4,7 @@
       "Authorization": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Authorization",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.authorization",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.authorization",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -39,7 +39,7 @@
         "Basic": {
           "__compat": {
             "description": "<code>Basic</code> authentication",
-            "spec_url": "https://www.rfc-editor.org/rfc/rfc7617#top",
+            "spec_url": "https://httpwg.org/specs/rfc7617.html#basic.authentication.scheme",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -77,7 +77,7 @@
         "Digest": {
           "__compat": {
             "description": "<code>Digest</code> authentication",
-            "spec_url": "https://www.rfc-editor.org/rfc/rfc7616#top",
+            "spec_url": "https://httpwg.org/specs/rfc7616.html#digest.access.authentication.scheme",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -177,7 +177,7 @@
         "Negotiate": {
           "__compat": {
             "description": "<code>Negotiate</code> (Kerberos) authentication",
-            "spec_url": "https://www.rfc-editor.org/rfc/rfc4120#top",
+            "spec_url": "https://www.rfc-editor.org/rfc/rfc4120#section-1",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -5,7 +5,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control",
           "spec_url": [
-            "https://www.rfc-editor.org/rfc/rfc9111#field.cache-control",
+            "https://httpwg.org/specs/rfc9111.html#field.cache-control",
             "https://httpwg.org/specs/rfc8246.html#the-immutable-cache-control-extension"
           ],
           "support": {

--- a/http/headers/Connection.json
+++ b/http/headers/Connection.json
@@ -4,7 +4,7 @@
       "Connection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Connection",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.connection",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.connection",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -4,7 +4,7 @@
       "Content-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-encoding",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-encoding",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Content-Language.json
+++ b/http/headers/Content-Language.json
@@ -4,7 +4,7 @@
       "Content-Language": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Language",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-language",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-language",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Content-Length.json
+++ b/http/headers/Content-Length.json
@@ -4,7 +4,7 @@
       "Content-Length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Length",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-length",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-length",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Content-Location.json
+++ b/http/headers/Content-Location.json
@@ -4,7 +4,7 @@
       "Content-Location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Location",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-location",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-location",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Content-Range.json
+++ b/http/headers/Content-Range.json
@@ -4,7 +4,7 @@
       "Content-Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Range",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.content-range",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-range",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Content-Type.json
+++ b/http/headers/Content-Type.json
@@ -5,8 +5,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Type",
           "spec_url": [
-            "https://www.rfc-editor.org/rfc/rfc9110#status.206",
-            "https://www.rfc-editor.org/rfc/rfc9110#field.content-type"
+            "https://httpwg.org/specs/rfc9110.html#status.206",
+            "https://httpwg.org/specs/rfc9110.html#field.content-type"
           ],
           "support": {
             "chrome": {

--- a/http/headers/Date.json
+++ b/http/headers/Date.json
@@ -4,7 +4,7 @@
       "Date": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.date",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.date",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/ETag.json
+++ b/http/headers/ETag.json
@@ -4,7 +4,7 @@
       "ETag": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/ETag",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.etag",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.etag",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Expires.json
+++ b/http/headers/Expires.json
@@ -4,7 +4,7 @@
       "Expires": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expires",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.expires",
+          "spec_url": "https://httpwg.org/specs/rfc9111.html#field.expires",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/From.json
+++ b/http/headers/From.json
@@ -4,7 +4,7 @@
       "From": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/From",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.from",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.from",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Host.json
+++ b/http/headers/Host.json
@@ -4,7 +4,7 @@
       "Host": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Host",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.host",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.host",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/If-Match.json
+++ b/http/headers/If-Match.json
@@ -4,7 +4,7 @@
       "If-Match": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Match",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-match",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-match",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/If-Modified-Since.json
+++ b/http/headers/If-Modified-Since.json
@@ -4,7 +4,7 @@
       "If-Modified-Since": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Modified-Since",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-modified-since",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-modified-since",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/If-None-Match.json
+++ b/http/headers/If-None-Match.json
@@ -4,7 +4,7 @@
       "If-None-Match": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-None-Match",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-none-match",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-none-match",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/If-Range.json
+++ b/http/headers/If-Range.json
@@ -4,7 +4,7 @@
       "If-Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Range",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-range",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-range",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/If-Unmodified-Since.json
+++ b/http/headers/If-Unmodified-Since.json
@@ -4,7 +4,7 @@
       "If-Unmodified-Since": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Unmodified-Since",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.if-unmodified-since",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-unmodified-since",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Keep-Alive.json
+++ b/http/headers/Keep-Alive.json
@@ -4,7 +4,7 @@
       "Keep-Alive": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Keep-Alive",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9112#compatibility.with.http.1.0.persistent.connections",
+          "spec_url": "https://httpwg.org/specs/rfc9112.html#compatibility.with.http.1.0.persistent.connections",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Last-Modified.json
+++ b/http/headers/Last-Modified.json
@@ -4,7 +4,7 @@
       "Last-Modified": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Last-Modified",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.last-modified",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.last-modified",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Location.json
+++ b/http/headers/Location.json
@@ -4,7 +4,7 @@
       "Location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Location",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.location",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.location",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Pragma.json
+++ b/http/headers/Pragma.json
@@ -4,7 +4,7 @@
       "Pragma": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Pragma",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.pragma",
+          "spec_url": "https://httpwg.org/specs/rfc9111.html#field.pragma",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Priority.json
+++ b/http/headers/Priority.json
@@ -4,7 +4,7 @@
       "Priority": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Priority",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9218.html#name-the-priority-http-header-fi",
+          "spec_url": "https://httpwg.org/specs/rfc9218.html#header-field",
           "support": {
             "chrome": {
               "version_added": "124"

--- a/http/headers/Proxy-Authenticate.json
+++ b/http/headers/Proxy-Authenticate.json
@@ -4,7 +4,7 @@
       "Proxy-Authenticate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Proxy-Authenticate",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.proxy-authenticate",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.proxy-authenticate",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Range.json
+++ b/http/headers/Range.json
@@ -4,7 +4,7 @@
       "Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Range",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.range",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.range",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Referer.json
+++ b/http/headers/Referer.json
@@ -4,7 +4,7 @@
       "Referer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Referer",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.referer",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.referer",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Retry-After.json
+++ b/http/headers/Retry-After.json
@@ -4,7 +4,7 @@
       "Retry-After": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Retry-After",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.retry-after",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.retry-after",
           "support": {
             "chrome": {
               "version_added": "24"

--- a/http/headers/Server.json
+++ b/http/headers/Server.json
@@ -4,7 +4,7 @@
       "Server": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Server",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.server",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.server",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/TE.json
+++ b/http/headers/TE.json
@@ -4,7 +4,7 @@
       "TE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/TE",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.te",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.te",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Trailer.json
+++ b/http/headers/Trailer.json
@@ -5,8 +5,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Trailer",
           "spec_url": [
-            "https://www.rfc-editor.org/rfc/rfc9110#field.trailer",
-            "https://www.rfc-editor.org/rfc/rfc9112#chunked.trailer.section"
+            "https://httpwg.org/specs/rfc9110.html#field.trailer",
+            "https://httpwg.org/specs/rfc9112.html#chunked.trailer.section"
           ],
           "support": {
             "chrome": {

--- a/http/headers/Transfer-Encoding.json
+++ b/http/headers/Transfer-Encoding.json
@@ -4,7 +4,7 @@
       "Transfer-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Transfer-Encoding",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9112#field.transfer-encoding",
+          "spec_url": "https://httpwg.org/specs/rfc9112.html#field.transfer-encoding",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Upgrade.json
+++ b/http/headers/Upgrade.json
@@ -5,9 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Upgrade",
           "spec_url": [
-            "https://www.rfc-editor.org/rfc/rfc9110#field.upgrade",
-            "https://www.rfc-editor.org/rfc/rfc9110#status.426",
-            "https://www.rfc-editor.org/rfc/rfc9113#informational-responses"
+            "https://httpwg.org/specs/rfc9110.html#field.upgrade",
+            "https://httpwg.org/specs/rfc9110.html#status.426",
+            "https://httpwg.org/specs/rfc9113.html#informational-responses"
           ],
           "support": {
             "chrome": {

--- a/http/headers/User-Agent.json
+++ b/http/headers/User-Agent.json
@@ -4,7 +4,7 @@
       "User-Agent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.user-agent",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.user-agent",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Vary.json
+++ b/http/headers/Vary.json
@@ -4,7 +4,7 @@
       "Vary": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Vary",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.vary",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.vary",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Via.json
+++ b/http/headers/Via.json
@@ -4,7 +4,7 @@
       "Via": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Via",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.via",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.via",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -4,7 +4,7 @@
       "WWW-Authenticate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/WWW-Authenticate",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#field.www-authenticate",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.www-authenticate",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -39,7 +39,7 @@
         "Basic": {
           "__compat": {
             "description": "<code>Basic</code> authentication",
-            "spec_url": "https://www.rfc-editor.org/rfc/rfc7617#top",
+            "spec_url": "https://httpwg.org/specs/rfc7617.html#basic.authentication.scheme",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -77,7 +77,7 @@
         "Digest": {
           "__compat": {
             "description": "<code>Digest</code> authentication",
-            "spec_url": "https://www.rfc-editor.org/rfc/rfc7616#top",
+            "spec_url": "https://httpwg.org/specs/rfc7616.html#digest.access.authentication.scheme",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -181,7 +181,7 @@
         "Negotiate": {
           "__compat": {
             "description": "<code>Negotiate</code> (Kerberos) authentication",
-            "spec_url": "https://www.rfc-editor.org/rfc/rfc4120#top",
+            "spec_url": "https://www.rfc-editor.org/rfc/rfc4120#section-1",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/http/headers/Warning.json
+++ b/http/headers/Warning.json
@@ -4,7 +4,7 @@
       "Warning": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Warning",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9111#field.warning",
+          "spec_url": "https://httpwg.org/specs/rfc9111.html#field.warning",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/methods.json
+++ b/http/methods.json
@@ -4,7 +4,7 @@
       "CONNECT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/CONNECT",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#CONNECT",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#CONNECT",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -40,7 +40,7 @@
       "DELETE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/DELETE",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#DELETE",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#DELETE",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -76,7 +76,7 @@
       "GET": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/GET",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#GET",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#GET",
           "tags": [
             "web-features:http11"
           ],
@@ -121,7 +121,7 @@
       "HEAD": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/HEAD",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#HEAD",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#HEAD",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -157,7 +157,7 @@
       "OPTIONS": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/OPTIONS",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#OPTIONS",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#OPTIONS",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -193,7 +193,7 @@
       "POST": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/POST",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#POST",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#POST",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -229,7 +229,7 @@
       "PUT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/PUT",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#PUT",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#PUT",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -4,7 +4,7 @@
       "__compat": {
         "description": "Blocks some or all insecure mixed content.",
         "mdn_url": "https://developer.mozilla.org/docs/Web/Security/Mixed_content",
-        "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+        "spec_url": "https://w3c.github.io/webappsec-mixed-content/#intro",
         "support": {
           "chrome": {
             "version_added": "≤79"
@@ -37,7 +37,7 @@
       "allow_file_urls": {
         "__compat": {
           "description": "Allow mixed content from <code>file:</code> URLs.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "spec_url": "https://w3c.github.io/webappsec-mixed-content/#intro",
           "support": {
             "chrome": {
               "version_added": "≤79"
@@ -71,7 +71,7 @@
       "allow_localhost_url": {
         "__compat": {
           "description": "Allow mixed content from localhost addresses (<code>http://localhost/</code> and <code>http://*.localhost/</code>).",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "spec_url": "https://w3c.github.io/webappsec-mixed-content/#intro",
           "support": {
             "chrome": {
               "version_added": "≤79"
@@ -105,7 +105,7 @@
       "allow_loopback_url": {
         "__compat": {
           "description": "Allow mixed content from loopback address (<code>http://127.0.0.1/</code>).",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#intro",
+          "spec_url": "https://w3c.github.io/webappsec-mixed-content/#intro",
           "support": {
             "chrome": {
               "version_added": "≤79"
@@ -139,7 +139,7 @@
       "auto_upgrade_images": {
         "__compat": {
           "description": "Upgradable image mixed content by default.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#category-upgradeable",
+          "spec_url": "https://w3c.github.io/webappsec-mixed-content/#category-upgradeable",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -177,7 +177,7 @@
       "auto_upgrade_video_audio": {
         "__compat": {
           "description": "Upgrade video and audio content by default.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#category-upgradeable",
+          "spec_url": "https://w3c.github.io/webappsec-mixed-content/#category-upgradeable",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -215,7 +215,7 @@
       "block_mixed_downloads": {
         "__compat": {
           "description": "Block mixed downloads.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#mixed-download",
+          "spec_url": "https://w3c.github.io/webappsec-mixed-content/#mixed-download",
           "support": {
             "chrome": {
               "version_added": "92"
@@ -249,7 +249,7 @@
       "blockable_mixed_content": {
         "__compat": {
           "description": "Block 'blockable' mixed content.",
-          "spec_url": "https://www.w3.org/TR/mixed-content/#category-blockable",
+          "spec_url": "https://w3c.github.io/webappsec-mixed-content/#category-blockable",
           "support": {
             "chrome": {
               "version_added": "79",

--- a/http/status.json
+++ b/http/status.json
@@ -5,7 +5,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/103",
           "spec_url": [
-            "https://www.rfc-editor.org/rfc/rfc8297#section-2",
+            "https://httpwg.org/specs/rfc8297.html#early-hints",
             "https://html.spec.whatwg.org/multipage/semantics.html#early-hints"
           ],
           "support": {
@@ -108,7 +108,7 @@
       "308": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/308",
-          "spec_url": "https://www.rfc-editor.org/rfc/rfc9110#status.308",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.308",
           "support": {
             "chrome": {
               "version_added": "36"


### PR DESCRIPTION
Prefer httpwg.org over rfc-editor.org.
Outcome of the validation in https://github.com/mdn/browser-compat-data/pull/23958