### PR TITLE
Update data about import attributes

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -457,6 +457,27 @@
         "18.17.0": {
           "release_date": "2023-07-18",
           "release_notes": "https://nodejs.org/en/blog/release/v18.17.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.2"
+        },
+        "18.18.0": {
+          "release_date": "2023-09-18",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.18.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.2"
+        },
+        "18.19.0": {
+          "release_date": "2023-11-29",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.19.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.2"
+        },
+        "18.20.0": {
+          "release_date": "2024-03-26",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.20.0/",
           "status": "esr",
           "engine": "V8",
           "engine_version": "10.2"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1312,7 +1312,8 @@
             "description": "Import attributes with <code>assert</code> syntax (formerly import assertions)",
             "support": {
               "chrome": {
-                "version_added": "91"
+                "version_added": "91",
+                "version_removed": "126"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -1355,7 +1356,8 @@
               "description": "<code>assert {type: 'css'}</code>",
               "support": {
                 "chrome": {
-                  "version_added": "93"
+                  "version_added": "93",
+                  "version_removed": "126"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -1400,7 +1402,8 @@
               "description": "<code>assert {type: 'json'}</code>",
               "support": {
                 "chrome": {
-                  "version_added": "91"
+                  "version_added": "91",
+                  "version_removed": "126"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -1466,9 +1469,15 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "20.10.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "20.10.0"
+                },
+                {
+                  "version_added": "18.20.0",
+                  "version_removed": "19.0.0"
+                }
+              ],
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1547,9 +1556,15 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": "20.10.0"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "20.10.0"
+                  },
+                  {
+                    "version_added": "18.20.0",
+                    "version_removed": "19.0.0"
+                  }
+                ],
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

- Update data about import attributes support (both `with` and `assert` syntax)

#### Test results and supporting details

- Node.js support for import attributes: https://nodejs.org/api/esm.html#import-attributes (see "Switch from Import Assertions to Import Attributes" entry in the History table)
- chromestatus entry for removing `assert`: https://chromestatus.com/feature/4689167795879936

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
