### PR TITLE
Note which browsers only support 103 Early Hints over HTTP/2 or above

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -10,7 +10,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "103"
+              "version_added": "103",
+              "notes": "Supported in HTTP/2 and later only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -25,7 +26,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "17"
+              "version_added": "17",
+              "notes": "Supported in HTTP/2 and later only."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -57,8 +59,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "17",
-                "notes": "Supported in HTTP/2 and later only."
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome and Safari only support 103 Early Hints over HTTP/2 or above.
Firefox supports it over HTTP/1.1 as well [though say they might change that](https://github.com/whatwg/fetch/issues/1698#issuecomment-1704907061) - CC: @valenting in case any update here.

This used to be clearly defined in BCD data, but was updated in #21083 and the note about Chrome was removed, and now it only shows a note for Safari under `rel=preconnect`:

<img width="809" alt="Screenshot of current MDN data showing Safari restricting this to HTTP/2 for preconnect" src="https://github.com/user-attachments/assets/71e3cb9b-9138-4771-a7f4-e3dbd2e091e1">

This is incorrect to me. Chrome has similar restrictions to Safari (for both preconnect and preload), and Safari restricts all of 103, and not just preconnects (though admittedly that is the only type Safari supports so they are kind of equivalent).

So I think this restriction should be under the main 103 entry (rather than just `rel=preconnect`) and should be the same for Chrome and Safari. Alternatively we can list this restriction under all three entries but that seems a little excessive to me.

Note: I work on Chrome and maintain [our docs on this](https://developer.chrome.com/docs/web-platform/early-hints).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

This is not covered by [WPT that only covers HTTP/2 tests](https://wpt.fyi/results/loading/early-hints?label=experimental&label=master&aligned) but is easy enough to test with a simple HTTP/1 node server like this that returns a preload:

```js
const net = require('net');

const hostname = '127.0.0.1';
const port = 3000;

const server = net.createServer((socket) => {
  socket.on('data', (data) => {
    const request = data.toString();

    const requestLines = request.split('\r\n');

    const requestLine = requestLines[0];
    const [method, url, protocol] = requestLine.split(' ');

    let response;
    if (method === 'GET' && url === '/') {
      response = `HTTP/1.1 103 Early Hints\r\nLink: </assets/css/common.css>;rel=preload;as=style\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nWelcome to the homepage!\n`;
    } else {
      response = `HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\n\r\n404 Not Found\n`;
    }

    // Write the response to the socket
    socket.write(response);

    // End the connection
    socket.end();
  });

  socket.on('error', (err) => {
    console.error(`Socket error: ${err.message}`);
  });
});

server.listen(port, hostname, () => {
  console.log(`Server running at http://${hostname}:${port}/`);
});

server.on('error', (err) => {
  console.error(`Server error: ${err.message}`);
});
```

Chrome shows no preload of the CSS file:

<img width="1381" alt="image" src="https://github.com/user-attachments/assets/c1c9365a-7fdc-470a-9d86-2a4658cc98d4">

Neither does Safari (though it doiesn't even support `preload` early hint so this isn't a great test I admit, but more difficult to show `preconnect`—and ultimately we're not changing Safari's support here, only Chrome's):

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/2c9f5b96-2af9-40de-8b09-488e11a6bcae">

But Firefox does:

<img width="974" alt="image" src="https://github.com/user-attachments/assets/7e41d9ba-eadc-4977-9a9a-029238c4dc25">

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Partial reversion of #21083

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
