### PR TITLE
Update Temporal data

### DIFF
--- a/javascript/builtins/Temporal/Calendar.json
+++ b/javascript/builtins/Temporal/Calendar.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "Calendar": {
           "__compat": {
-            "description": "Temporal.Calendar interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-calendar-objects",
             "tags": [
               "web-features:temporal"
@@ -55,7 +54,7 @@
           },
           "Calendar": {
             "__compat": {
-              "description": "Temporal.Calendar constructor",
+              "description": "<code>Calendar()</code> constructor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-calendar-constructor",
               "tags": [
                 "web-features:temporal"
@@ -107,7 +106,6 @@
           },
           "dateAdd": {
             "__compat": {
-              "description": "Temporal.Calendar.dateAdd()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dateadd",
               "tags": [
                 "web-features:temporal"
@@ -159,7 +157,6 @@
           },
           "dateFromFields": {
             "__compat": {
-              "description": "Temporal.Calendar.dateFromFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.datefromfields",
               "tags": [
                 "web-features:temporal"
@@ -211,7 +208,6 @@
           },
           "dateUntil": {
             "__compat": {
-              "description": "Temporal.Calendar.dateUntil()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dateuntil",
               "tags": [
                 "web-features:temporal"
@@ -263,7 +259,6 @@
           },
           "day": {
             "__compat": {
-              "description": "Temporal.Calendar.day()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.day",
               "tags": [
                 "web-features:temporal"
@@ -315,7 +310,6 @@
           },
           "dayOfWeek": {
             "__compat": {
-              "description": "Temporal.Calendar.dayOfWeek()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dayofweek",
               "tags": [
                 "web-features:temporal"
@@ -367,7 +361,6 @@
           },
           "dayOfYear": {
             "__compat": {
-              "description": "Temporal.Calendar.dayOfYear()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.dayofyear",
               "tags": [
                 "web-features:temporal"
@@ -419,7 +412,6 @@
           },
           "daysInMonth": {
             "__compat": {
-              "description": "Temporal.Calendar.daysInMonth()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinmonth",
               "tags": [
                 "web-features:temporal"
@@ -471,7 +463,6 @@
           },
           "daysInWeek": {
             "__compat": {
-              "description": "Temporal.Calendar.daysInWeek()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinweek",
               "tags": [
                 "web-features:temporal"
@@ -523,7 +514,6 @@
           },
           "daysInYear": {
             "__compat": {
-              "description": "Temporal.Calendar.daysInYear()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.daysinyear",
               "tags": [
                 "web-features:temporal"
@@ -575,7 +565,6 @@
           },
           "era": {
             "__compat": {
-              "description": "Temporal.Calendar.era()",
               "tags": [
                 "web-features:temporal"
               ],
@@ -626,7 +615,6 @@
           },
           "eraYear": {
             "__compat": {
-              "description": "Temporal.Calendar.eraYear()",
               "tags": [
                 "web-features:temporal"
               ],
@@ -677,7 +665,6 @@
           },
           "fields": {
             "__compat": {
-              "description": "Temporal.Calendar.fields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.fields",
               "tags": [
                 "web-features:temporal"
@@ -729,7 +716,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.Calendar.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.from",
               "tags": [
                 "web-features:temporal"
@@ -781,7 +767,6 @@
           },
           "id": {
             "__compat": {
-              "description": "Temporal.Calendar.id",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.calendar.prototype.id",
               "tags": [
                 "web-features:temporal"
@@ -833,7 +818,6 @@
           },
           "inLeapYear": {
             "__compat": {
-              "description": "Temporal.Calendar.inLeapYear()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.inleapyear",
               "tags": [
                 "web-features:temporal"
@@ -885,7 +869,6 @@
           },
           "mergeFields": {
             "__compat": {
-              "description": "Temporal.Calendar.mergeFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.mergefields",
               "tags": [
                 "web-features:temporal"
@@ -937,7 +920,6 @@
           },
           "month": {
             "__compat": {
-              "description": "Temporal.Calendar.month()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.month",
               "tags": [
                 "web-features:temporal"
@@ -989,7 +971,6 @@
           },
           "monthCode": {
             "__compat": {
-              "description": "Temporal.Calendar.monthCode()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthcode",
               "tags": [
                 "web-features:temporal"
@@ -1041,7 +1022,6 @@
           },
           "monthDayFromFields": {
             "__compat": {
-              "description": "Temporal.Calendar.monthDayFromFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthdayfromfields",
               "tags": [
                 "web-features:temporal"
@@ -1093,7 +1073,6 @@
           },
           "monthsInYear": {
             "__compat": {
-              "description": "Temporal.Calendar.monthsInYear()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthsinyear",
               "tags": [
                 "web-features:temporal"
@@ -1145,7 +1124,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.Calendar.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -1197,7 +1175,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.Calendar.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -1249,7 +1226,6 @@
           },
           "weekOfYear": {
             "__compat": {
-              "description": "Temporal.Calendar.weekOfYear()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.weekofyear",
               "tags": [
                 "web-features:temporal"
@@ -1301,7 +1277,6 @@
           },
           "year": {
             "__compat": {
-              "description": "Temporal.Calendar.year()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.year",
               "tags": [
                 "web-features:temporal"
@@ -1353,7 +1328,6 @@
           },
           "yearMonthFromFields": {
             "__compat": {
-              "description": "Temporal.Calendar.yearMonthFromFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.yearmonthfromfields",
               "tags": [
                 "web-features:temporal"

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "Duration": {
           "__compat": {
-            "description": "Temporal.Duration interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-duration-objects",
             "tags": [
               "web-features:temporal"
@@ -55,7 +54,7 @@
           },
           "Duration": {
             "__compat": {
-              "description": "Temporal.Duration constructor",
+              "description": "<code>Duration()</code> constructor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-duration-constructor",
               "tags": [
                 "web-features:temporal"
@@ -107,7 +106,6 @@
           },
           "abs": {
             "__compat": {
-              "description": "Temporal.Duration.abs()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.abs",
               "tags": [
                 "web-features:temporal"
@@ -159,7 +157,6 @@
           },
           "add": {
             "__compat": {
-              "description": "Temporal.Duration.add()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.add",
               "tags": [
                 "web-features:temporal"
@@ -211,7 +208,6 @@
           },
           "blank": {
             "__compat": {
-              "description": "Temporal.Duration.blank",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.blank",
               "tags": [
                 "web-features:temporal"
@@ -263,7 +259,6 @@
           },
           "compare": {
             "__compat": {
-              "description": "Temporal.Duration.compare()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.compare",
               "tags": [
                 "web-features:temporal"
@@ -315,7 +310,6 @@
           },
           "days": {
             "__compat": {
-              "description": "Temporal.Duration.days",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.days",
               "tags": [
                 "web-features:temporal"
@@ -367,7 +361,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.Duration.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.from",
               "tags": [
                 "web-features:temporal"
@@ -419,7 +412,6 @@
           },
           "hours": {
             "__compat": {
-              "description": "Temporal.Duration.hours",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.hours",
               "tags": [
                 "web-features:temporal"
@@ -471,7 +463,6 @@
           },
           "microseconds": {
             "__compat": {
-              "description": "Temporal.Duration.microseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.microseconds",
               "tags": [
                 "web-features:temporal"
@@ -523,7 +514,6 @@
           },
           "milliseconds": {
             "__compat": {
-              "description": "Temporal.Duration.milliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.milliseconds",
               "tags": [
                 "web-features:temporal"
@@ -575,7 +565,6 @@
           },
           "minutes": {
             "__compat": {
-              "description": "Temporal.Duration.minutes",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.minutes",
               "tags": [
                 "web-features:temporal"
@@ -627,7 +616,6 @@
           },
           "months": {
             "__compat": {
-              "description": "Temporal.Duration.months",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.months",
               "tags": [
                 "web-features:temporal"
@@ -679,7 +667,6 @@
           },
           "nanoseconds": {
             "__compat": {
-              "description": "Temporal.Duration.nanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.nanoseconds",
               "tags": [
                 "web-features:temporal"
@@ -731,7 +718,6 @@
           },
           "negated": {
             "__compat": {
-              "description": "Temporal.Duration.negated()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.negated",
               "tags": [
                 "web-features:temporal"
@@ -783,7 +769,6 @@
           },
           "round": {
             "__compat": {
-              "description": "Temporal.Duration.round()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round",
               "tags": [
                 "web-features:temporal"
@@ -835,7 +820,6 @@
           },
           "seconds": {
             "__compat": {
-              "description": "Temporal.Duration.seconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.seconds",
               "tags": [
                 "web-features:temporal"
@@ -887,7 +871,6 @@
           },
           "sign": {
             "__compat": {
-              "description": "Temporal.Duration.sign",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.sign",
               "tags": [
                 "web-features:temporal"
@@ -939,7 +922,6 @@
           },
           "subtract": {
             "__compat": {
-              "description": "Temporal.Duration.subtract()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract",
               "tags": [
                 "web-features:temporal"
@@ -991,7 +973,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.Duration.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -1043,7 +1024,6 @@
           },
           "toLocaleString": {
             "__compat": {
-              "description": "Temporal.Duration.toLocaleString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tolocalestring",
               "tags": [
                 "web-features:temporal"
@@ -1095,7 +1075,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.Duration.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -1147,7 +1126,6 @@
           },
           "total": {
             "__compat": {
-              "description": "Temporal.Duration.total()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total",
               "tags": [
                 "web-features:temporal"
@@ -1199,7 +1177,6 @@
           },
           "valueOf": {
             "__compat": {
-              "description": "Temporal.Duration.valueOf()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof",
               "tags": [
                 "web-features:temporal"
@@ -1251,7 +1228,6 @@
           },
           "weeks": {
             "__compat": {
-              "description": "Temporal.Duration.weeks",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.weeks",
               "tags": [
                 "web-features:temporal"
@@ -1303,7 +1279,6 @@
           },
           "with": {
             "__compat": {
-              "description": "Temporal.Duration.with()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.with",
               "tags": [
                 "web-features:temporal"
@@ -1355,7 +1330,6 @@
           },
           "years": {
             "__compat": {
-              "description": "Temporal.Duration.years",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.years",
               "tags": [
                 "web-features:temporal"

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "Instant": {
           "__compat": {
-            "description": "Temporal.Instant interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-objects",
             "tags": [
               "web-features:temporal"
@@ -55,8 +54,8 @@
           },
           "Instant": {
             "__compat": {
-              "description": "Temporal.Instant constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-objects",
+              "description": "<code>Instant()</code> constructor",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-constructor",
               "tags": [
                 "web-features:temporal"
               ],
@@ -107,7 +106,6 @@
           },
           "add": {
             "__compat": {
-              "description": "Temporal.Instant.add()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.add",
               "tags": [
                 "web-features:temporal"
@@ -159,7 +157,6 @@
           },
           "compare": {
             "__compat": {
-              "description": "Temporal.Instant.compare()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.compare",
               "tags": [
                 "web-features:temporal"
@@ -209,61 +206,8 @@
               }
             }
           },
-          "epochMicroseconds": {
-            "__compat": {
-              "description": "Temporal.Instant.epochMicroseconds",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmicroseconds",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "preview",
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "epochMilliseconds": {
             "__compat": {
-              "description": "Temporal.Instant.epochMilliseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmilliseconds",
               "tags": [
                 "web-features:temporal"
@@ -315,60 +259,7 @@
           },
           "epochNanoseconds": {
             "__compat": {
-              "description": "Temporal.Instant.epochNanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "preview",
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "epochSeconds": {
-            "__compat": {
-              "description": "Temporal.Instant.epochSeconds",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
               "tags": [
                 "web-features:temporal"
               ],
@@ -419,7 +310,6 @@
           },
           "equals": {
             "__compat": {
-              "description": "Temporal.Instant.equals()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals",
               "tags": [
                 "web-features:temporal"
@@ -471,60 +361,7 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.Instant.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.from",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "preview",
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "fromEpochMicroseconds": {
-            "__compat": {
-              "description": "Temporal.Instant.fromEpochMicroseconds()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochseconds",
               "tags": [
                 "web-features:temporal"
               ],
@@ -575,7 +412,6 @@
           },
           "fromEpochMilliseconds": {
             "__compat": {
-              "description": "Temporal.Instant.fromEpochMilliseconds()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochmilliseconds",
               "tags": [
                 "web-features:temporal"
@@ -627,60 +463,7 @@
           },
           "fromEpochNanoseconds": {
             "__compat": {
-              "description": "Temporal.Instant.fromEpochNanoseconds()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochnanoseconds",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "preview",
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "fromEpochSeconds": {
-            "__compat": {
-              "description": "Temporal.Instant.fromEpochSeconds()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochseconds",
               "tags": [
                 "web-features:temporal"
               ],
@@ -731,7 +514,6 @@
           },
           "round": {
             "__compat": {
-              "description": "Temporal.Instant.round()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round",
               "tags": [
                 "web-features:temporal"
@@ -783,7 +565,6 @@
           },
           "since": {
             "__compat": {
-              "description": "Temporal.Instant.since()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.since",
               "tags": [
                 "web-features:temporal"
@@ -835,7 +616,6 @@
           },
           "subtract": {
             "__compat": {
-              "description": "Temporal.Instant.subtract()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.subtract",
               "tags": [
                 "web-features:temporal"
@@ -887,7 +667,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.Instant.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -939,7 +718,6 @@
           },
           "toLocaleString": {
             "__compat": {
-              "description": "Temporal.Instant.toLocaleString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tolocalestring",
               "tags": [
                 "web-features:temporal"
@@ -991,7 +769,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.Instant.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -1041,61 +818,8 @@
               }
             }
           },
-          "toZonedDateTime": {
-            "__compat": {
-              "description": "Temporal.Instant.toZonedDateTime()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetime",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "toZonedDateTimeISO": {
             "__compat": {
-              "description": "Temporal.Instant.toZonedDateTimeISO()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso",
               "tags": [
                 "web-features:temporal"
@@ -1147,7 +871,6 @@
           },
           "until": {
             "__compat": {
-              "description": "Temporal.Instant.until()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.until",
               "tags": [
                 "web-features:temporal"
@@ -1199,7 +922,6 @@
           },
           "valueOf": {
             "__compat": {
-              "description": "Temporal.Instant.valueOf()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof",
               "tags": [
                 "web-features:temporal"

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "Now": {
           "__compat": {
-            "description": "Temporal.Now interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-now-object",
             "tags": [
               "web-features:temporal"
@@ -55,60 +54,7 @@
           },
           "instant": {
             "__compat": {
-              "description": "Temporal.Now.instant()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.instant",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "plainDate": {
-            "__compat": {
-              "description": "Temporal.Now.plainDate()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindate",
               "tags": [
                 "web-features:temporal"
               ],
@@ -159,60 +105,7 @@
           },
           "plainDateISO": {
             "__compat": {
-              "description": "Temporal.Now.plainDateISO()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindateiso",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "plainDateTime": {
-            "__compat": {
-              "description": "Temporal.Now.plainDateTime()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetime",
               "tags": [
                 "web-features:temporal"
               ],
@@ -263,7 +156,6 @@
           },
           "plainDateTimeISO": {
             "__compat": {
-              "description": "Temporal.Now.plainDateTimeISO()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso",
               "tags": [
                 "web-features:temporal"
@@ -313,10 +205,9 @@
               }
             }
           },
-          "timeZone": {
+          "plainTimeISO": {
             "__compat": {
-              "description": "Temporal.Now.timeZone()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.timezone",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaintimeiso",
               "tags": [
                 "web-features:temporal"
               ],
@@ -365,10 +256,9 @@
               }
             }
           },
-          "zonedDateTime": {
+          "timeZoneID": {
             "__compat": {
-              "description": "Temporal.Now.zonedDateTime()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetime",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.timezoneid",
               "tags": [
                 "web-features:temporal"
               ],
@@ -419,7 +309,6 @@
           },
           "zonedDateTimeISO": {
             "__compat": {
-              "description": "Temporal.Now.zonedDateTimeISO()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetimeiso",
               "tags": [
                 "web-features:temporal"

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "PlainDate": {
           "__compat": {
-            "description": "Temporal.PlainDate interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindate-objects",
             "tags": [
               "web-features:temporal"
@@ -55,7 +54,7 @@
           },
           "PlainDate": {
             "__compat": {
-              "description": "Temporal.PlainDate constructor",
+              "description": "<code>PlainDate()</code> constructor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindate-constructor",
               "tags": [
                 "web-features:temporal"
@@ -107,7 +106,6 @@
           },
           "add": {
             "__compat": {
-              "description": "Temporal.PlainDate.add()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add",
               "tags": [
                 "web-features:temporal"
@@ -157,10 +155,9 @@
               }
             }
           },
-          "calendar": {
+          "calendarId": {
             "__compat": {
-              "description": "Temporal.PlainDate.calendar",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.calendar",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.calendarid",
               "tags": [
                 "web-features:temporal"
               ],
@@ -211,7 +208,6 @@
           },
           "compare": {
             "__compat": {
-              "description": "Temporal.PlainDate.compare()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare",
               "tags": [
                 "web-features:temporal"
@@ -263,7 +259,6 @@
           },
           "day": {
             "__compat": {
-              "description": "Temporal.PlainDate.day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.day",
               "tags": [
                 "web-features:temporal"
@@ -315,7 +310,6 @@
           },
           "dayOfWeek": {
             "__compat": {
-              "description": "Temporal.PlainDate.dayOfWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofweek",
               "tags": [
                 "web-features:temporal"
@@ -367,7 +361,6 @@
           },
           "dayOfYear": {
             "__compat": {
-              "description": "Temporal.PlainDate.dayOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofyear",
               "tags": [
                 "web-features:temporal"
@@ -419,7 +412,6 @@
           },
           "daysInMonth": {
             "__compat": {
-              "description": "Temporal.PlainDate.daysInMonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinmonth",
               "tags": [
                 "web-features:temporal"
@@ -471,7 +463,6 @@
           },
           "daysInWeek": {
             "__compat": {
-              "description": "Temporal.PlainDate.daysInWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinweek",
               "tags": [
                 "web-features:temporal"
@@ -523,7 +514,6 @@
           },
           "daysInYear": {
             "__compat": {
-              "description": "Temporal.PlainDate.daysInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinyear",
               "tags": [
                 "web-features:temporal"
@@ -575,7 +565,6 @@
           },
           "equals": {
             "__compat": {
-              "description": "Temporal.PlainDate.equals()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals",
               "tags": [
                 "web-features:temporal"
@@ -627,7 +616,6 @@
           },
           "era": {
             "__compat": {
-              "description": "Temporal.PlainDate.era",
               "tags": [
                 "web-features:temporal"
               ],
@@ -678,7 +666,6 @@
           },
           "eraYear": {
             "__compat": {
-              "description": "Temporal.PlainDate.eraYear",
               "tags": [
                 "web-features:temporal"
               ],
@@ -729,7 +716,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.PlainDate.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from",
               "tags": [
                 "web-features:temporal"
@@ -781,7 +767,6 @@
           },
           "getISOFields": {
             "__compat": {
-              "description": "Temporal.PlainDate.getISOFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.getisofields",
               "tags": [
                 "web-features:temporal"
@@ -833,7 +818,6 @@
           },
           "inLeapYear": {
             "__compat": {
-              "description": "Temporal.PlainDate.inLeapYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.inleapyear",
               "tags": [
                 "web-features:temporal"
@@ -885,7 +869,6 @@
           },
           "month": {
             "__compat": {
-              "description": "Temporal.PlainDate.month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.month",
               "tags": [
                 "web-features:temporal"
@@ -937,8 +920,7 @@
           },
           "monthCode": {
             "__compat": {
-              "description": "Temporal.PlainDate.monthCode",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthCode",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthcode",
               "tags": [
                 "web-features:temporal"
               ],
@@ -989,7 +971,6 @@
           },
           "monthsInYear": {
             "__compat": {
-              "description": "Temporal.PlainDate.monthsInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthsinyear",
               "tags": [
                 "web-features:temporal"
@@ -1041,7 +1022,6 @@
           },
           "since": {
             "__compat": {
-              "description": "Temporal.PlainDate.since()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since",
               "tags": [
                 "web-features:temporal"
@@ -1093,7 +1073,6 @@
           },
           "subtract": {
             "__compat": {
-              "description": "Temporal.PlainDate.subtract()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.subtract",
               "tags": [
                 "web-features:temporal"
@@ -1145,7 +1124,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.PlainDate.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -1197,7 +1175,6 @@
           },
           "toLocaleString": {
             "__compat": {
-              "description": "Temporal.PlainDate.toLocaleString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tolocalestring",
               "tags": [
                 "web-features:temporal"
@@ -1249,7 +1226,6 @@
           },
           "toPlainDateTime": {
             "__compat": {
-              "description": "Temporal.PlainDate.toPlainDateTime()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplaindatetime",
               "tags": [
                 "web-features:temporal"
@@ -1301,7 +1277,6 @@
           },
           "toPlainMonthDay": {
             "__compat": {
-              "description": "Temporal.PlainDate.toPlainMonthDay()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday",
               "tags": [
                 "web-features:temporal"
@@ -1353,7 +1328,6 @@
           },
           "toPlainYearMonth": {
             "__compat": {
-              "description": "Temporal.PlainDate.toPlainYearMonth()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainyearmonth",
               "tags": [
                 "web-features:temporal"
@@ -1405,7 +1379,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.PlainDate.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -1457,7 +1430,6 @@
           },
           "toZonedDateTime": {
             "__compat": {
-              "description": "Temporal.PlainDate.toZonedDateTime()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tozoneddatetime",
               "tags": [
                 "web-features:temporal"
@@ -1509,7 +1481,6 @@
           },
           "until": {
             "__compat": {
-              "description": "Temporal.PlainDate.until()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until",
               "tags": [
                 "web-features:temporal"
@@ -1561,7 +1532,6 @@
           },
           "valueOf": {
             "__compat": {
-              "description": "Temporal.PlainDate.valueOf()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof",
               "tags": [
                 "web-features:temporal"
@@ -1613,7 +1583,6 @@
           },
           "weekOfYear": {
             "__compat": {
-              "description": "Temporal.PlainDate.weekOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.weekofyear",
               "tags": [
                 "web-features:temporal"
@@ -1665,7 +1634,6 @@
           },
           "with": {
             "__compat": {
-              "description": "Temporal.PlainDate.with()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.with",
               "tags": [
                 "web-features:temporal"
@@ -1717,7 +1685,6 @@
           },
           "withCalendar": {
             "__compat": {
-              "description": "Temporal.PlainDate.withCalendar()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.withcalendar",
               "tags": [
                 "web-features:temporal"
@@ -1769,8 +1736,58 @@
           },
           "year": {
             "__compat": {
-              "description": "Temporal.PlainDate.year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/v8/11544"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.40",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--unstable-temporal"
+                    }
+                  ]
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "yearOfWeek": {
+            "__compat": {
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.yearofweek",
               "tags": [
                 "web-features:temporal"
               ],

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "PlainDateTime": {
           "__compat": {
-            "description": "Temporal.PlainDateTime interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-objects",
             "tags": [
               "web-features:temporal"
@@ -55,7 +54,7 @@
           },
           "PlainDateTime": {
             "__compat": {
-              "description": "Temporal.PlainDateTime constructor",
+              "description": "<code>PlainDateTime()</code> constructor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-constructor",
               "tags": [
                 "web-features:temporal"
@@ -107,7 +106,6 @@
           },
           "add": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.add()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.add",
               "tags": [
                 "web-features:temporal"
@@ -157,10 +155,9 @@
               }
             }
           },
-          "calendar": {
+          "calendarId": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.calendar",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.calendar",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.calendarid",
               "tags": [
                 "web-features:temporal"
               ],
@@ -211,7 +208,6 @@
           },
           "compare": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.compare()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare",
               "tags": [
                 "web-features:temporal"
@@ -263,7 +259,6 @@
           },
           "day": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.day",
               "tags": [
                 "web-features:temporal"
@@ -315,7 +310,6 @@
           },
           "dayOfWeek": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.dayOfWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofweek",
               "tags": [
                 "web-features:temporal"
@@ -367,7 +361,6 @@
           },
           "dayOfYear": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.dayOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofyear",
               "tags": [
                 "web-features:temporal"
@@ -419,7 +412,6 @@
           },
           "daysInMonth": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.daysInMonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinmonth",
               "tags": [
                 "web-features:temporal"
@@ -471,7 +463,6 @@
           },
           "daysInWeek": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.daysInWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinweek",
               "tags": [
                 "web-features:temporal"
@@ -523,7 +514,6 @@
           },
           "daysInYear": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.daysInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinyear",
               "tags": [
                 "web-features:temporal"
@@ -575,7 +565,6 @@
           },
           "equals": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.equals()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals",
               "tags": [
                 "web-features:temporal"
@@ -627,7 +616,6 @@
           },
           "era": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.era",
               "tags": [
                 "web-features:temporal"
               ],
@@ -678,7 +666,6 @@
           },
           "eraYear": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.eraYear",
               "tags": [
                 "web-features:temporal"
               ],
@@ -729,7 +716,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from",
               "tags": [
                 "web-features:temporal"
@@ -781,7 +767,6 @@
           },
           "getISOFields": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.getISOFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.getisofields",
               "tags": [
                 "web-features:temporal"
@@ -833,7 +818,6 @@
           },
           "hour": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.hour",
               "tags": [
                 "web-features:temporal"
@@ -885,7 +869,6 @@
           },
           "inLeapYear": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.inLeapYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.inleapyear",
               "tags": [
                 "web-features:temporal"
@@ -937,7 +920,6 @@
           },
           "microsecond": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.microsecond",
               "tags": [
                 "web-features:temporal"
@@ -989,7 +971,6 @@
           },
           "millisecond": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.millisecond",
               "tags": [
                 "web-features:temporal"
@@ -1041,7 +1022,6 @@
           },
           "minute": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.minute",
               "tags": [
                 "web-features:temporal"
@@ -1093,7 +1073,6 @@
           },
           "month": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.month",
               "tags": [
                 "web-features:temporal"
@@ -1145,7 +1124,6 @@
           },
           "monthCode": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.monthCode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthcode",
               "tags": [
                 "web-features:temporal"
@@ -1197,7 +1175,6 @@
           },
           "monthsInYear": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.monthsInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthsinyear",
               "tags": [
                 "web-features:temporal"
@@ -1249,7 +1226,6 @@
           },
           "nanosecond": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.nanosecond",
               "tags": [
                 "web-features:temporal"
@@ -1301,7 +1277,6 @@
           },
           "round": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.round()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round",
               "tags": [
                 "web-features:temporal"
@@ -1353,7 +1328,6 @@
           },
           "second": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.second",
               "tags": [
                 "web-features:temporal"
@@ -1405,7 +1379,6 @@
           },
           "since": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.since()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since",
               "tags": [
                 "web-features:temporal"
@@ -1457,7 +1430,6 @@
           },
           "subtract": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.subtract()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.subtract",
               "tags": [
                 "web-features:temporal"
@@ -1509,7 +1481,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -1561,7 +1532,6 @@
           },
           "toLocaleString": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.toLocaleString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tolocalestring",
               "tags": [
                 "web-features:temporal"
@@ -1613,60 +1583,7 @@
           },
           "toPlainDate": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.toPlainDate()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindate",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "toPlainMonthDay": {
-            "__compat": {
-              "description": "Temporal.PlainDateTime.toPlainMonthDay()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplainmonthday",
               "tags": [
                 "web-features:temporal"
               ],
@@ -1717,60 +1634,7 @@
           },
           "toPlainTime": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.toPlainTime()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaintime",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "toPlainYearMonth": {
-            "__compat": {
-              "description": "Temporal.PlainDateTime.toPlainYearMonth()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplainyearmonth",
               "tags": [
                 "web-features:temporal"
               ],
@@ -1821,7 +1685,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -1873,7 +1736,6 @@
           },
           "toZonedDateTime": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.toZonedDateTime()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime",
               "tags": [
                 "web-features:temporal"
@@ -1925,7 +1787,6 @@
           },
           "until": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.until()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.until",
               "tags": [
                 "web-features:temporal"
@@ -1977,7 +1838,6 @@
           },
           "valueOf": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.valueOf()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof",
               "tags": [
                 "web-features:temporal"
@@ -2029,7 +1889,6 @@
           },
           "weekOfYear": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.weekOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.weekofyear",
               "tags": [
                 "web-features:temporal"
@@ -2081,7 +1940,6 @@
           },
           "with": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.with()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with",
               "tags": [
                 "web-features:temporal"
@@ -2133,60 +1991,7 @@
           },
           "withCalendar": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.withCalendar()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "withPlainDate": {
-            "__compat": {
-              "description": "Temporal.PlainDateTime.withPlainDate()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate",
               "tags": [
                 "web-features:temporal"
               ],
@@ -2237,7 +2042,6 @@
           },
           "withPlainTime": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.withPlainTime()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime",
               "tags": [
                 "web-features:temporal"
@@ -2289,8 +2093,58 @@
           },
           "year": {
             "__compat": {
-              "description": "Temporal.PlainDateTime.year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/v8/11544"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.40",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--unstable-temporal"
+                    }
+                  ]
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "yearOfWeek": {
+            "__compat": {
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.yearofweek",
               "tags": [
                 "web-features:temporal"
               ],

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "PlainMonthDay": {
           "__compat": {
-            "description": "Temporal.PlainMonthDay interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-objects",
             "tags": [
               "web-features:temporal"
@@ -55,7 +54,7 @@
           },
           "PlainMonthDay": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay constructor",
+              "description": "<code>PlainMonthDay()</code> constructor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-constructor",
               "tags": [
                 "web-features:temporal"
@@ -105,10 +104,9 @@
               }
             }
           },
-          "calendar": {
+          "calendarId": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.calendar",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendar",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendarid",
               "tags": [
                 "web-features:temporal"
               ],
@@ -159,7 +157,6 @@
           },
           "day": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.day",
               "tags": [
                 "web-features:temporal"
@@ -211,7 +208,6 @@
           },
           "equals": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.equals()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals",
               "tags": [
                 "web-features:temporal"
@@ -263,7 +259,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from",
               "tags": [
                 "web-features:temporal"
@@ -315,7 +310,6 @@
           },
           "getISOFields": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.getISOFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.getisofields",
               "tags": [
                 "web-features:temporal"
@@ -367,7 +361,6 @@
           },
           "monthCode": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.monthCode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.monthcode",
               "tags": [
                 "web-features:temporal"
@@ -419,7 +412,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -471,7 +463,6 @@
           },
           "toLocaleString": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.toLocaleString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tolocalestring",
               "tags": [
                 "web-features:temporal"
@@ -523,7 +514,6 @@
           },
           "toPlainDate": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.toPlainDate()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate",
               "tags": [
                 "web-features:temporal"
@@ -575,7 +565,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -627,7 +616,6 @@
           },
           "valueOf": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.valueOf()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof",
               "tags": [
                 "web-features:temporal"
@@ -679,7 +667,6 @@
           },
           "with": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.with()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with",
               "tags": [
                 "web-features:temporal"

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "PlainTime": {
           "__compat": {
-            "description": "Temporal.PlainTime interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaintime-objects",
             "tags": [
               "web-features:temporal"
@@ -55,7 +54,7 @@
           },
           "PlainTime": {
             "__compat": {
-              "description": "Temporal.PlainTime constructor",
+              "description": "<code>PlainTime()</code> constructor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-constructor",
               "tags": [
                 "web-features:temporal"
@@ -107,60 +106,7 @@
           },
           "add": {
             "__compat": {
-              "description": "Temporal.PlainTime.add()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.add",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "preview",
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "calendar": {
-            "__compat": {
-              "description": "Temporal.PlainTime.calendar",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.calendar",
               "tags": [
                 "web-features:temporal"
               ],
@@ -211,7 +157,7 @@
           },
           "compare": {
             "__compat": {
-              "description": "Temporal.PlainTime.compare()",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.compare",
               "tags": [
                 "web-features:temporal"
               ],
@@ -262,7 +208,6 @@
           },
           "equals": {
             "__compat": {
-              "description": "Temporal.PlainTime.equals()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.equals",
               "tags": [
                 "web-features:temporal"
@@ -314,7 +259,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.PlainTime.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.from",
               "tags": [
                 "web-features:temporal"
@@ -366,7 +310,6 @@
           },
           "getISOFields": {
             "__compat": {
-              "description": "Temporal.PlainTime.getISOFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.getisofields",
               "tags": [
                 "web-features:temporal"
@@ -418,7 +361,6 @@
           },
           "hour": {
             "__compat": {
-              "description": "Temporal.PlainTime.hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.hour",
               "tags": [
                 "web-features:temporal"
@@ -470,7 +412,6 @@
           },
           "microsecond": {
             "__compat": {
-              "description": "Temporal.PlainTime.microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.microsecond",
               "tags": [
                 "web-features:temporal"
@@ -522,7 +463,6 @@
           },
           "millisecond": {
             "__compat": {
-              "description": "Temporal.PlainTime.millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.millisecond",
               "tags": [
                 "web-features:temporal"
@@ -574,7 +514,6 @@
           },
           "minute": {
             "__compat": {
-              "description": "Temporal.PlainTime.minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.minute",
               "tags": [
                 "web-features:temporal"
@@ -626,7 +565,6 @@
           },
           "nanosecond": {
             "__compat": {
-              "description": "Temporal.PlainTime.nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.nanosecond",
               "tags": [
                 "web-features:temporal"
@@ -678,7 +616,6 @@
           },
           "round": {
             "__compat": {
-              "description": "Temporal.PlainTime.round()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round",
               "tags": [
                 "web-features:temporal"
@@ -730,7 +667,6 @@
           },
           "second": {
             "__compat": {
-              "description": "Temporal.PlainTime.second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.second",
               "tags": [
                 "web-features:temporal"
@@ -782,7 +718,6 @@
           },
           "since": {
             "__compat": {
-              "description": "Temporal.PlainTime.since()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since",
               "tags": [
                 "web-features:temporal"
@@ -834,7 +769,6 @@
           },
           "subtract": {
             "__compat": {
-              "description": "Temporal.PlainTime.subtract()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.subtract",
               "tags": [
                 "web-features:temporal"
@@ -886,7 +820,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.PlainTime.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -938,60 +871,7 @@
           },
           "toLocaleString": {
             "__compat": {
-              "description": "Temporal.PlainTime.toLocaleString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tolocalestring",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "toPlainDateTime": {
-            "__compat": {
-              "description": "Temporal.PlainTime.toPlainDateTime()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.toplaindatetime",
               "tags": [
                 "web-features:temporal"
               ],
@@ -1042,7 +922,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.PlainTime.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -1092,61 +971,8 @@
               }
             }
           },
-          "toZonedDateTime": {
-            "__compat": {
-              "description": "Temporal.PlainTime.toZonedDateTime()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tozoneddatetime",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "until": {
             "__compat": {
-              "description": "Temporal.PlainTime.until()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.until",
               "tags": [
                 "web-features:temporal"
@@ -1198,7 +1024,6 @@
           },
           "valueOf": {
             "__compat": {
-              "description": "Temporal.PlainTime.valueOf()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof",
               "tags": [
                 "web-features:temporal"
@@ -1250,7 +1075,6 @@
           },
           "with": {
             "__compat": {
-              "description": "Temporal.PlainTime.with()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.with",
               "tags": [
                 "web-features:temporal"

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "PlainYearMonth": {
           "__compat": {
-            "description": "Temporal.PlainYearMonth interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects",
             "tags": [
               "web-features:temporal"
@@ -55,7 +54,7 @@
           },
           "PlainYearMonth": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth constructor",
+              "description": "<code>PlainYearMonth()</code> constructor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor",
               "tags": [
                 "web-features:temporal"
@@ -107,7 +106,6 @@
           },
           "add": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.add()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.add",
               "tags": [
                 "web-features:temporal"
@@ -157,10 +155,9 @@
               }
             }
           },
-          "calendar": {
+          "calendarId": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.calendar",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.calendar",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.calendarid",
               "tags": [
                 "web-features:temporal"
               ],
@@ -211,7 +208,6 @@
           },
           "compare": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.compare()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare",
               "tags": [
                 "web-features:temporal"
@@ -263,7 +259,6 @@
           },
           "daysInMonth": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.daysInMonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinmonth",
               "tags": [
                 "web-features:temporal"
@@ -315,7 +310,6 @@
           },
           "daysInYear": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.daysInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinyear",
               "tags": [
                 "web-features:temporal"
@@ -367,7 +361,6 @@
           },
           "equals": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.equals()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals",
               "tags": [
                 "web-features:temporal"
@@ -419,7 +412,7 @@
           },
           "era": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.era",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.era",
               "tags": [
                 "web-features:temporal"
               ],
@@ -470,7 +463,7 @@
           },
           "eraYear": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.eraYear",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.erayear",
               "tags": [
                 "web-features:temporal"
               ],
@@ -521,7 +514,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.from",
               "tags": [
                 "web-features:temporal"
@@ -573,7 +565,6 @@
           },
           "getISOFields": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.getISOFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.getisofields",
               "tags": [
                 "web-features:temporal"
@@ -625,7 +616,6 @@
           },
           "inLeapYear": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.inLeapYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.inleapyear",
               "tags": [
                 "web-features:temporal"
@@ -677,8 +667,7 @@
           },
           "month": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.month",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthCode",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.month",
               "tags": [
                 "web-features:temporal"
               ],
@@ -729,8 +718,7 @@
           },
           "monthCode": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.monthCode",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthCode",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthcode",
               "tags": [
                 "web-features:temporal"
               ],
@@ -781,7 +769,6 @@
           },
           "monthsInYear": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.monthsInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthsinyear",
               "tags": [
                 "web-features:temporal"
@@ -833,7 +820,6 @@
           },
           "since": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.since()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since",
               "tags": [
                 "web-features:temporal"
@@ -885,7 +871,6 @@
           },
           "subtract": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.subtract()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.subtract",
               "tags": [
                 "web-features:temporal"
@@ -937,7 +922,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -989,7 +973,6 @@
           },
           "toLocaleString": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.toLocaleString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tolocalestring",
               "tags": [
                 "web-features:temporal"
@@ -1041,7 +1024,6 @@
           },
           "toPlainDate": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.toPlainDate()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate",
               "tags": [
                 "web-features:temporal"
@@ -1093,7 +1075,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -1145,7 +1126,6 @@
           },
           "until": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.until()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.until",
               "tags": [
                 "web-features:temporal"
@@ -1197,7 +1177,6 @@
           },
           "valueOf": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.valueOf()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof",
               "tags": [
                 "web-features:temporal"
@@ -1249,7 +1228,6 @@
           },
           "with": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.with()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with",
               "tags": [
                 "web-features:temporal"
@@ -1301,7 +1279,6 @@
           },
           "year": {
             "__compat": {
-              "description": "Temporal.PlainYearMonth.year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.year",
               "tags": [
                 "web-features:temporal"

--- a/javascript/builtins/Temporal/TimeZone.json
+++ b/javascript/builtins/Temporal/TimeZone.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "TimeZone": {
           "__compat": {
-            "description": "Temporal.TimeZone interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-timezone-objects",
             "tags": [
               "web-features:temporal"
@@ -55,7 +54,7 @@
           },
           "TimeZone": {
             "__compat": {
-              "description": "Temporal.TimeZone constructor",
+              "description": "<code>TimeZone()</code> constructor",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-timezone-constructor",
               "tags": [
                 "web-features:temporal"
@@ -107,7 +106,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.TimeZone.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.from",
               "tags": [
                 "web-features:temporal"
@@ -159,60 +157,7 @@
           },
           "getInstantFor": {
             "__compat": {
-              "description": "Temporal.TimeZone.getInstantFor()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getinstantfor",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "getNextTransition": {
-            "__compat": {
-              "description": "Temporal.TimeZone.getNextTransition()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getnexttransition",
               "tags": [
                 "web-features:temporal"
               ],
@@ -263,7 +208,6 @@
           },
           "getOffsetNanosecondsFor": {
             "__compat": {
-              "description": "Temporal.TimeZone.getOffsetNanosecondsFor()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getoffsetnanosecondsfor",
               "tags": [
                 "web-features:temporal"
@@ -315,7 +259,6 @@
           },
           "getOffsetStringFor": {
             "__compat": {
-              "description": "Temporal.TimeZone.getOffsetStringFor()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getoffsetstringfor",
               "tags": [
                 "web-features:temporal"
@@ -367,7 +310,6 @@
           },
           "getPlainDateTimeFor": {
             "__compat": {
-              "description": "Temporal.TimeZone.getPlainDateTimeFor()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getplaindatetimefor",
               "tags": [
                 "web-features:temporal"
@@ -419,60 +361,7 @@
           },
           "getPossibleInstantsFor": {
             "__compat": {
-              "description": "Temporal.TimeZone.getPossibleInstantsFor()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getpossibleinstantsfor",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "getPreviousTransition": {
-            "__compat": {
-              "description": "Temporal.TimeZone.getPreviousTransition()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getprevioustransition",
               "tags": [
                 "web-features:temporal"
               ],
@@ -523,7 +412,6 @@
           },
           "id": {
             "__compat": {
-              "description": "Temporal.TimeZone.id",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.timezone.prototype.id",
               "tags": [
                 "web-features:temporal"
@@ -575,7 +463,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.TimeZone.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -627,7 +514,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.TimeZone.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.tostring",
               "tags": [
                 "web-features:temporal"

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -4,7 +4,6 @@
       "Temporal": {
         "ZonedDateTime": {
           "__compat": {
-            "description": "Temporal.ZonedDateTime interface",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects",
             "tags": [
               "web-features:temporal"
@@ -55,8 +54,8 @@
           },
           "ZonedDateTime": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects",
+              "description": "<code>ZonedDateTime()</code> constructor",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-constructor",
               "tags": [
                 "web-features:temporal"
               ],
@@ -107,7 +106,6 @@
           },
           "add": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.add()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.add",
               "tags": [
                 "web-features:temporal"
@@ -157,10 +155,9 @@
               }
             }
           },
-          "calendar": {
+          "calendarId": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.calendar",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.calendar",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.calendarid",
               "tags": [
                 "web-features:temporal"
               ],
@@ -211,7 +208,6 @@
           },
           "compare": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.compare()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare",
               "tags": [
                 "web-features:temporal"
@@ -263,7 +259,6 @@
           },
           "day": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.day",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.day",
               "tags": [
                 "web-features:temporal"
@@ -315,7 +310,6 @@
           },
           "dayOfWeek": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.dayOfWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofweek",
               "tags": [
                 "web-features:temporal"
@@ -367,7 +361,6 @@
           },
           "dayOfYear": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.dayOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofyear",
               "tags": [
                 "web-features:temporal"
@@ -419,7 +412,6 @@
           },
           "daysInMonth": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.daysInMonth",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinmonth",
               "tags": [
                 "web-features:temporal"
@@ -471,7 +463,6 @@
           },
           "daysInWeek": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.daysInWeek",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinweek",
               "tags": [
                 "web-features:temporal"
@@ -523,60 +514,7 @@
           },
           "daysInYear": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.daysInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinyear",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "epochMicroseconds": {
-            "__compat": {
-              "description": "Temporal.ZonedDateTime.epochMicroseconds",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmicroseconds",
               "tags": [
                 "web-features:temporal"
               ],
@@ -627,8 +565,7 @@
           },
           "epochMilliseconds": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.epochMilliseconds",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmilliseconds",
               "tags": [
                 "web-features:temporal"
               ],
@@ -679,60 +616,7 @@
           },
           "epochNanoseconds": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.epochNanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "epochSeconds": {
-            "__compat": {
-              "description": "Temporal.ZonedDateTime.epochSeconds",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochseconds",
               "tags": [
                 "web-features:temporal"
               ],
@@ -783,7 +667,6 @@
           },
           "equals": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.equals()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.equals",
               "tags": [
                 "web-features:temporal"
@@ -835,7 +718,7 @@
           },
           "era": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.era",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.era",
               "tags": [
                 "web-features:temporal"
               ],
@@ -886,7 +769,7 @@
           },
           "eraYear": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.eraYear",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.erayear",
               "tags": [
                 "web-features:temporal"
               ],
@@ -937,7 +820,6 @@
           },
           "from": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.from()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from",
               "tags": [
                 "web-features:temporal"
@@ -989,8 +871,58 @@
           },
           "getISOFields": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.getISOFields()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.getisofields",
+              "tags": [
+                "web-features:temporal"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/v8/11544"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.40",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--unstable-temporal"
+                    }
+                  ]
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "getTimeZoneTransition": {
+            "__compat": {
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.gettimezonetransition",
               "tags": [
                 "web-features:temporal"
               ],
@@ -1041,7 +973,6 @@
           },
           "hour": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.hour",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hour",
               "tags": [
                 "web-features:temporal"
@@ -1093,7 +1024,6 @@
           },
           "hoursInDay": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.hoursInDay",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hoursinday",
               "tags": [
                 "web-features:temporal"
@@ -1145,7 +1075,6 @@
           },
           "inLeapYear": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.inLeapYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.inleapyear",
               "tags": [
                 "web-features:temporal"
@@ -1197,7 +1126,6 @@
           },
           "microsecond": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.microsecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.microsecond",
               "tags": [
                 "web-features:temporal"
@@ -1249,7 +1177,6 @@
           },
           "millisecond": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.millisecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.millisecond",
               "tags": [
                 "web-features:temporal"
@@ -1301,7 +1228,6 @@
           },
           "minute": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.minute",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.minute",
               "tags": [
                 "web-features:temporal"
@@ -1353,7 +1279,6 @@
           },
           "month": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.month",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.month",
               "tags": [
                 "web-features:temporal"
@@ -1405,7 +1330,6 @@
           },
           "monthCode": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.monthCode",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthcode",
               "tags": [
                 "web-features:temporal"
@@ -1457,7 +1381,6 @@
           },
           "monthsInYear": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.monthsInYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthsinyear",
               "tags": [
                 "web-features:temporal"
@@ -1509,7 +1432,6 @@
           },
           "nanosecond": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.nanosecond",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.nanosecond",
               "tags": [
                 "web-features:temporal"
@@ -1561,7 +1483,6 @@
           },
           "offset": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.offset",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offset",
               "tags": [
                 "web-features:temporal"
@@ -1613,7 +1534,6 @@
           },
           "offsetNanoseconds": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.offsetNanoseconds",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offsetnanoseconds",
               "tags": [
                 "web-features:temporal"
@@ -1665,7 +1585,6 @@
           },
           "round": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.round()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round",
               "tags": [
                 "web-features:temporal"
@@ -1717,7 +1636,6 @@
           },
           "second": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.second",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.second",
               "tags": [
                 "web-features:temporal"
@@ -1769,7 +1687,6 @@
           },
           "since": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.since()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.since",
               "tags": [
                 "web-features:temporal"
@@ -1821,7 +1738,7 @@
           },
           "startOfDay": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.startOfDay",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.startofday",
               "tags": [
                 "web-features:temporal"
               ],
@@ -1872,7 +1789,6 @@
           },
           "subtract": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.subtract()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.subtract",
               "tags": [
                 "web-features:temporal"
@@ -1922,10 +1838,9 @@
               }
             }
           },
-          "timeZone": {
+          "timeZoneId": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.timeZone",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.timezone",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.timezoneid",
               "tags": [
                 "web-features:temporal"
               ],
@@ -1976,7 +1891,6 @@
           },
           "toInstant": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.toInstant()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toinstant",
               "tags": [
                 "web-features:temporal"
@@ -2028,7 +1942,6 @@
           },
           "toJSON": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.toJSON()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tojson",
               "tags": [
                 "web-features:temporal"
@@ -2080,7 +1993,6 @@
           },
           "toLocaleString": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.toLocaleString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tolocalestring",
               "tags": [
                 "web-features:temporal"
@@ -2132,7 +2044,6 @@
           },
           "toPlainDate": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.toPlainDate()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaindate",
               "tags": [
                 "web-features:temporal"
@@ -2184,60 +2095,7 @@
           },
           "toPlainDateTime": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.toPlainDateTime()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaindatetime",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "toPlainMonthDay": {
-            "__compat": {
-              "description": "Temporal.ZonedDateTime.toPlainMonthDay()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplainmonthday",
               "tags": [
                 "web-features:temporal"
               ],
@@ -2288,60 +2146,7 @@
           },
           "toPlainTime": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.toPlainTime()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaintime",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "toPlainYearMonth": {
-            "__compat": {
-              "description": "Temporal.ZonedDateTime.toPlainYearMonth()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplainyearmonth",
               "tags": [
                 "web-features:temporal"
               ],
@@ -2392,7 +2197,6 @@
           },
           "toString": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.toString()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tostring",
               "tags": [
                 "web-features:temporal"
@@ -2444,7 +2248,6 @@
           },
           "until": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.until()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.until",
               "tags": [
                 "web-features:temporal"
@@ -2496,7 +2299,6 @@
           },
           "valueOf": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.valueOf()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.valueof",
               "tags": [
                 "web-features:temporal"
@@ -2548,7 +2350,6 @@
           },
           "weekOfYear": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.weekOfYear",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.weekofyear",
               "tags": [
                 "web-features:temporal"
@@ -2600,7 +2401,6 @@
           },
           "with": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.with()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.with",
               "tags": [
                 "web-features:temporal"
@@ -2652,60 +2452,7 @@
           },
           "withCalendar": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.withCalendar()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withcalendar",
-              "tags": [
-                "web-features:temporal"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/v8/11544"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.40",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--unstable-temporal"
-                    }
-                  ]
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1519167"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/223166"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "withPlainDate": {
-            "__compat": {
-              "description": "Temporal.ZonedDateTime.withPlainDate()",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaindate",
               "tags": [
                 "web-features:temporal"
               ],
@@ -2756,7 +2503,6 @@
           },
           "withPlainTime": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.withPlainTime()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaintime",
               "tags": [
                 "web-features:temporal"
@@ -2808,7 +2554,6 @@
           },
           "withTimeZone": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.withTimeZone()",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withtimezone",
               "tags": [
                 "web-features:temporal"
@@ -2860,8 +2605,58 @@
           },
           "year": {
             "__compat": {
-              "description": "Temporal.ZonedDateTime.year",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.year",
+              "tags": [
+                "web-features:temporal"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/v8/11544"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.40",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--unstable-temporal"
+                    }
+                  ]
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1519167"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/223166"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "yearOfWeek": {
+            "__compat": {
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.yearofweek",
               "tags": [
                 "web-features:temporal"
               ],


### PR DESCRIPTION
This PR updates Temporal compat data.

- Remove descriptions as it is more conventional to not have them
- Update constructor descriptions to match BCD conventions
- Fix some typos in spec_url fragments
- Rename calendar properties to calendarId
- Rename timezone properties to timezoneId
- Remove properties per https://github.com/tc39/proposal-temporal/pull/2895
- Add yearOfWeek properties
- Remove TimeZone.p.getNextTransition and TimeZone.p.getPreviousTransition
- Add ZonedDateTime.p.getTimeZoneTransition

(Looks more removals will come: https://github.com/tc39/proposal-temporal/pull/2925 but thanks to the spec_url validation I'm doing in https://github.com/mdn/browser-compat-data/pull/23958 we'll be able to keep track of this going forward.)