### PR TITLE
Remove CSS cursor: inherit

### DIFF
--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -648,45 +648,6 @@
             }
           }
         },
-        "inherit": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-ui/#valdef-cursor-inherit",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "95"
-              },
-              "ie": {
-                "version_added": "8"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "9"
-              },
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "1.2"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "move": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui/#valdef-cursor-move",


### PR DESCRIPTION
I think `inherit` is a global value in CSS and `cursor` is the only property that has this as a sub feature. We should remove it. 