### PR TITLE
fix(css): add html standard links to media pseudo-classes

### DIFF
--- a/css/selectors/buffering.json
+++ b/css/selectors/buffering.json
@@ -6,7 +6,7 @@
           "description": "<code>:buffering</code>",
           "spec_url": [
             "https://drafts.csswg.org/selectors/#selectordef-buffering",
-            "https://html.spec.whatwg.org/#selector-buffering"
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-buffering"
           ],
           "tags": [
             "web-features:media-pseudos"

--- a/css/selectors/buffering.json
+++ b/css/selectors/buffering.json
@@ -4,7 +4,10 @@
       "buffering": {
         "__compat": {
           "description": "<code>:buffering</code>",
-          "spec_url": "https://drafts.csswg.org/selectors/#selectordef-buffering",
+          "spec_url": [
+            "https://drafts.csswg.org/selectors/#selectordef-buffering",
+            "https://html.spec.whatwg.org/#selector-buffering"
+          ],
           "tags": [
             "web-features:media-pseudos"
           ],

--- a/css/selectors/muted.json
+++ b/css/selectors/muted.json
@@ -6,7 +6,7 @@
           "description": "<code>:muted</code>",
           "spec_url": [
             "https://drafts.csswg.org/selectors/#selectordef-muted",
-            "https://html.spec.whatwg.org/#selector-muted"
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-muted"
           ],
           "tags": [
             "web-features:media-pseudos"

--- a/css/selectors/muted.json
+++ b/css/selectors/muted.json
@@ -4,7 +4,10 @@
       "muted": {
         "__compat": {
           "description": "<code>:muted</code>",
-          "spec_url": "https://drafts.csswg.org/selectors/#selectordef-muted",
+          "spec_url": [
+            "https://drafts.csswg.org/selectors/#selectordef-muted",
+            "https://html.spec.whatwg.org/#selector-muted"
+          ],
           "tags": [
             "web-features:media-pseudos"
           ],

--- a/css/selectors/paused.json
+++ b/css/selectors/paused.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:paused",
           "spec_url": [
             "https://drafts.csswg.org/selectors/#selectordef-paused",
-            "https://html.spec.whatwg.org/#selector-paused"
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-paused"
           ],
           "tags": [
             "web-features:media-pseudos"

--- a/css/selectors/paused.json
+++ b/css/selectors/paused.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "<code>:paused</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:paused",
-          "spec_url": "https://drafts.csswg.org/selectors/#selectordef-paused",
+          "spec_url": [
+            "https://drafts.csswg.org/selectors/#selectordef-paused",
+            "https://html.spec.whatwg.org/#selector-paused"
+          ],
           "tags": [
             "web-features:media-pseudos"
           ],

--- a/css/selectors/playing.json
+++ b/css/selectors/playing.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "<code>:playing</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:playing",
-          "spec_url": "https://drafts.csswg.org/selectors/#selectordef-playing",
+          "spec_url": [
+            "https://drafts.csswg.org/selectors/#selectordef-playing",
+            "https://html.spec.whatwg.org/#selector-playing"
+          ],
           "tags": [
             "web-features:media-pseudos"
           ],

--- a/css/selectors/playing.json
+++ b/css/selectors/playing.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:playing",
           "spec_url": [
             "https://drafts.csswg.org/selectors/#selectordef-playing",
-            "https://html.spec.whatwg.org/#selector-playing"
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-playing"
           ],
           "tags": [
             "web-features:media-pseudos"

--- a/css/selectors/seeking.json
+++ b/css/selectors/seeking.json
@@ -4,7 +4,10 @@
       "seeking": {
         "__compat": {
           "description": "<code>:seeking</code>",
-          "spec_url": "https://drafts.csswg.org/selectors/#selectordef-seeking",
+          "spec_url": [
+            "https://drafts.csswg.org/selectors/#selectordef-seeking",
+            "https://html.spec.whatwg.org/#selector-seeking"
+          ],
           "tags": [
             "web-features:media-pseudos"
           ],

--- a/css/selectors/seeking.json
+++ b/css/selectors/seeking.json
@@ -6,7 +6,7 @@
           "description": "<code>:seeking</code>",
           "spec_url": [
             "https://drafts.csswg.org/selectors/#selectordef-seeking",
-            "https://html.spec.whatwg.org/#selector-seeking"
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-seeking"
           ],
           "tags": [
             "web-features:media-pseudos"

--- a/css/selectors/stalled.json
+++ b/css/selectors/stalled.json
@@ -4,7 +4,10 @@
       "stalled": {
         "__compat": {
           "description": "<code>:stalled</code>",
-          "spec_url": "https://drafts.csswg.org/selectors/#selectordef-stalled",
+          "spec_url": [
+            "https://drafts.csswg.org/selectors/#selectordef-stalled",
+            "https://html.spec.whatwg.org/#selector-stalled"
+          ],
           "tags": [
             "web-features:media-pseudos"
           ],

--- a/css/selectors/stalled.json
+++ b/css/selectors/stalled.json
@@ -6,7 +6,7 @@
           "description": "<code>:stalled</code>",
           "spec_url": [
             "https://drafts.csswg.org/selectors/#selectordef-stalled",
-            "https://html.spec.whatwg.org/#selector-stalled"
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-stalled"
           ],
           "tags": [
             "web-features:media-pseudos"

--- a/css/selectors/volume-locked.json
+++ b/css/selectors/volume-locked.json
@@ -4,7 +4,10 @@
       "volume-locked": {
         "__compat": {
           "description": "<code>:volume-locked</code>",
-          "spec_url": "https://drafts.csswg.org/selectors/#selectordef-volume-locked",
+          "spec_url": [
+            "https://drafts.csswg.org/selectors/#selectordef-volume-locked",
+            "https://html.spec.whatwg.org/#selector-volume-locked"
+          ],
           "tags": [
             "web-features:media-pseudos"
           ],

--- a/css/selectors/volume-locked.json
+++ b/css/selectors/volume-locked.json
@@ -6,7 +6,7 @@
           "description": "<code>:volume-locked</code>",
           "spec_url": [
             "https://drafts.csswg.org/selectors/#selectordef-volume-locked",
-            "https://html.spec.whatwg.org/#selector-volume-locked"
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-volume-locked"
           ],
           "tags": [
             "web-features:media-pseudos"


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/31746

These media pseudo-classes have counterpart HTML standard specifications.