### PR TITLE
FF130 supports oncontentvisibilityautostatechange event handler

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4086,7 +4086,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "124"
+              "version_added": "124",
+              "notes": "Version 130 added support for the <code>oncontentvisibilityautostatechange</code> event handler."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -4085,10 +4085,17 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "124",
-              "notes": "Version 130 added support for the <code>oncontentvisibilityautostatechange</code> event handler."
-            },
+            "firefox": [
+              {
+                "version_added": "130"
+              },
+              {
+                "version_added": "124",
+                "version_removed": "130",
+                "partial_implementation": true,
+                "notes": "The <code>oncontentvisibilityautostatechange</code> event handler property is not supported."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF supported the  [`contentvisibilityautostatechange` event ](https://developer.mozilla.org/en-US/docs/Web/API/Element/contentvisibilityautostatechange_event and its associated interface since FF124, but the dev team just added support for the global event handler `oncontentvisibilitychanged` in https://bugzilla.mozilla.org/show_bug.cgi?id=1898833 - an omission picked up in a test. 

What I have done here is added a note to the event record that indicates support was added for this in FF130. I am not "certain" this is the right thing to do. 
1. We don't separately document the event handler in BCD or MDN - this is the record that people would see  on the MDN page, so it looks like the right thing to update.
2. A note seems more reasonable to me than a separate version record showing `partial_implementation` between 124 and 130 - given that most people are recommended to not directly add to handler as attribute now.

Up to you though - let me know what you prefer!