### PR TITLE
Add locking mode options to FileSystemFileHandle

### DIFF
--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -73,6 +73,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "mode": {
+          "__compat": {
+            "description": "<code>mode</code> option",
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "createWritable": {
@@ -109,6 +142,41 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "mode": {
+          "__compat": {
+            "description": "<code>mode</code> option",
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 121 supports a `mode` property on the options objects that can be specified as arguments to  `FileSystemFileHandle.createSyncAccessHandle()` and `FileSystemFileHandle.createWritable()`. See the associated [ChromeStatus entry](https://chromestatus.com/feature/5172892632875008).

These features are not yet in the [FileSystem API](https://fs.spec.whatwg.org/) spec — see https://github.com/whatwg/fs/pull/151 for the relevant PR. Consequently, I have marked these additions as `"standard_track": false`, and will mark them as non-standard in the associated docs.

See also the [New Locking Scheme to Enable Multiple Readers and Writers](https://github.com/whatwg/fs/blob/main/proposals/MultipleReadersWriters.md) explainer for more information on how it works.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
