### PR TITLE
Firefox 130 adds HTMLVideoElement.requestVideoFrameCallback

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -635,7 +635,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "130",
               "impl_url": "https://bugzil.la/1800882"
             },
             "firefox_android": "mirror",

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -636,7 +636,9 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "impl_url": "https://bugzil.la/1800882"
+              "impl_url": "https://bugzil.la/1800882",
+              "partial_implementation": true,
+              "notes": "The <code>metadata</code> argument of the callback function does not support the following properties: <code>processingDuration</code> (<a href='https://bugzil.la/bug 1908246'>1908246</a>), <code>captureTime</code>, <code>receiveTime</code>, and <code>rtpTimestamp</code> (<a href='https://bugzil.la/bug 1908245'>1908245</a>)."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -57,7 +57,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1800882"
             },
             "firefox_android": "mirror",
@@ -635,7 +635,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "130",
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1800882"
             },
             "firefox_android": "mirror",

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -638,7 +638,7 @@
               "version_added": "preview",
               "impl_url": "https://bugzil.la/1800882",
               "partial_implementation": true,
-              "notes": "The <code>metadata</code> argument of the callback function does not support the following properties: <code>processingDuration</code> (<a href='https://bugzil.la/bug 1908246'>1908246</a>), <code>captureTime</code>, <code>receiveTime</code>, and <code>rtpTimestamp</code> (<a href='https://bugzil.la/bug 1908245'>1908245</a>)."
+              "notes": "The <code>metadata</code> argument of the callback function does not support the following properties: <code>processingDuration</code> (<a href='https://bugzil.la/1908246'>bug 1908246</a>), <code>captureTime</code>, <code>receiveTime</code>, and <code>rtpTimestamp</code> (<a href='https://bugzil.la/1908245'>bug 1908245</a>)."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1800882#c15

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Added in Firefox 130.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
