### PR TITLE
Ff130 csp report to

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -11,7 +11,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "130",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.reporting.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "ie": {

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -780,7 +780,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "130",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.reporting.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/http/headers/Report-To.json
+++ b/http/headers/Report-To.json
@@ -10,7 +10,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "130",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.reporting.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/Reporting-Endpoints.json
+++ b/http/headers/Reporting-Endpoints.json
@@ -1,11 +1,13 @@
 {
   "http": {
     "headers": {
-      "Report-To": {
+      "Reporting-Endpoints": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Reporting-Endpoints",
+          "spec_url": "https://w3c.github.io/reporting/#header-field-registration",
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": "96"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -38,9 +40,9 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
FF130 supports the CSP [`report-to`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) directive in https://bugzilla.mozilla.org/show_bug.cgi?id=1391243 behind a preference.

- [x]  [`report-to`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
- [x] [CSPViolationReportBody](https://developer.mozilla.org/en-US/docs/Web/API/CSPViolationReportBody)

in https://bugzilla.mozilla.org/show_bug.cgi?id=1860588:

- [x] `Report-To` header
- [x] [Reporting-Endpoints](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Reporting-Endpoints) header 

There is also some Reporting API stuff that is quite related to document. I'll do that separately.

I'm confirming this in  https://bugzilla.mozilla.org/show_bug.cgi?id=1391243#c11 and some related stuff, but what I have here should be correct based on the IDL and info in bugs.

Related docs work can be tracked in https://github.com/mdn/content/issues/35279