### PR TITLE
webRequest.getSecurityInfo options parameter optional

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1405,6 +1405,51 @@
               },
               "safari_ios": "mirror"
             }
+          },
+          "options": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": [
+                  {
+                    "version_added": "130",
+                    "notes": "Optional"
+                  },
+                  {
+                    "version_added": "62",
+                    "notes": "Required"
+                  }
+                ],
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "requestId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "62"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "handlerBehaviorChanged": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1432,25 +1432,6 @@
                 "safari_ios": "mirror"
               }
             }
-          },
-          "requestId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "62"
-                },
-                "firefox_android": "mirror",
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
           }
         },
         "handlerBehaviorChanged": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1420,6 +1420,7 @@
                   },
                   {
                     "version_added": "62",
+                    "version_removed": "130",
                     "notes": "Required"
                   }
                 ],


### PR DESCRIPTION
#### Summary

Documents the change made in [Bug 1909474](https://bugzilla.mozilla.org/show_bug.cgi?id=1909474) webRequest.getSecurityInfo() options parameter is documented as optional but cannot be optional

#### Related issues

MDN content changes made in PR https://github.com/mdn/content/pull/35345