### PR TITLE
update-browser-releases: ensure "esr" is set when "current" -> "esr"

### DIFF
--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -133,7 +133,7 @@ export const updateFirefoxReleases = async (options) => {
     >,
   ).forEach(([key, entry]) => {
     if (key === String(esrRelease)) {
-      if (entry.status === 'current') {
+      if (key === String(stableRelease)) {
         // If the current release is also considered the ESR release, "current" status takes priority
         return;
       }


### PR DESCRIPTION
This is a follow-up to #23928, which updates the logic to look at what _will_ be set as the current browser release, rather than what is already set as the current release, so "current" can eventually become "esr".
