### PR TITLE
Update Firefox data for webextensions.api.browserAction.setBadgeBackgroundColor.string

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -595,7 +595,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": true,
+                  "version_added": "≤57",
                   "notes": "Before Firefox 59, invalid color strings behaved as <code>null</code>."
                 },
                 "firefox_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `setBadgeBackgroundColor.string` member of the `browserAction` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #859
