### PR TITLE
Update Chromium data for webextensions.api.commands.Command.name

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -74,7 +74,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤96"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Command.name` member of the `commands` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #12512
