### PR TITLE
Update Opera data for webextensions.api.devtools.panels.ExtensionSidebarPane

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -490,9 +490,7 @@
                   "firefox_android": {
                     "version_added": false
                   },
-                  "opera": {
-                    "version_added": true
-                  },
+                  "opera": "mirror",
                   "safari": {
                     "version_added": false
                   },
@@ -535,9 +533,7 @@
                   "firefox_android": {
                     "version_added": false
                   },
-                  "opera": {
-                    "version_added": true
-                  },
+                  "opera": "mirror",
                   "safari": {
                     "version_added": false
                   },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `panels.ExtensionSidebarPane` member of the `devtools` Web Extensions interface. This sets the downstream browser(s) to mirror from their upstream counterpart.
