### PR TITLE
Update Firefox data for events Web Extensions interface

### DIFF
--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -12,7 +12,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "≤50"
             },
             "firefox_android": "mirror",
             "opera": "mirror",
@@ -35,7 +35,7 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "≤53"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -57,7 +57,7 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -118,7 +118,7 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -160,7 +160,7 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": true
+                  "version_added": "≤59"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `events` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #166, #1686

Additional Notes: The "≤50" comes from a subfeature that's set as "50".
