### PR TITLE
Update Firefox data for webextensions.api.menus.ACTION_MENU_TOP_LEVEL_LIMIT

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -38,7 +38,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
-                "version_added": true
+                "version_added": "≤53"
               },
               "edge": "mirror",
               "firefox": [


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `ACTION_MENU_TOP_LEVEL_LIMIT` member of the `menus` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #166
