### PR TITLE
Update Chromium data for menus Web Extensions interface

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -70,7 +70,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.ContextType",
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": [
@@ -148,7 +148,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤58",
                   "notes": "Available for use in Manifest V2 only."
                 },
                 "edge": "mirror",
@@ -177,7 +177,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤58"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -198,7 +198,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤58",
                   "notes": "Available for use in Manifest V2 only."
                 },
                 "edge": "mirror",
@@ -292,7 +292,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.ItemType",
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": [
@@ -324,7 +324,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.OnClickData",
-                "version_added": true
+                "version_added": "≤23"
               },
               "edge": "mirror",
               "firefox": [
@@ -464,7 +464,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤95"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -512,7 +512,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.create",
-                "version_added": true,
+                "version_added": "≤58",
                 "notes": "Items that don't specify 'contexts' do not inherit contexts from their parents."
               },
               "edge": "mirror",
@@ -545,7 +545,7 @@
               "description": "<code>&amp;</code> in <code>title</code> sets access key",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤69"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -664,7 +664,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.onClicked",
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": [
@@ -802,7 +802,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.remove",
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": [
@@ -834,7 +834,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.removeAll",
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": [
@@ -866,7 +866,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.update",
-                "version_added": true
+                "version_added": "≤58"
               },
               "edge": "mirror",
               "firefox": [


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `menus` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #166, #2751, #13259
