### PR TITLE
Update Firefox data for runtime Web Extensions interface

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -965,7 +965,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": true
+                  "version_added": "≤62"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -1025,7 +1025,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": true
+                  "version_added": "≤62"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `runtime` Web Extensions interface. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #2927
