### PR TITLE
Update Chromium data for webextensions.api.storage.StorageArea.onChanged

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -176,16 +176,12 @@
                 "chrome": {
                   "version_added": "73"
                 },
-                "edge": {
-                  "version_added": true
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "101"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": true
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": "14"
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `StorageArea.onChanged` member of the `storage` Web Extensions interface. This sets the downstream browser(s) to mirror from their upstream counterpart.
