### PR TITLE
Update Chromium data for webextensions.manifest.background.scripts

### DIFF
--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -124,7 +124,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "≤72",
                 "notes": "Available for use in Manifest V2 only."
               },
               "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `scripts` member of the `background` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #3537
