### PR TITLE
Update Chromium data for content_scripts Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/content_scripts.json
+++ b/webextensions/manifest/content_scripts.json
@@ -31,7 +31,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"
@@ -54,7 +54,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"
@@ -96,7 +96,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"
@@ -118,7 +118,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"
@@ -141,7 +141,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"
@@ -163,7 +163,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"
@@ -229,7 +229,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"
@@ -252,7 +252,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `content_scripts` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #3537
