### PR TITLE
Update Opera data for developer Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/developer.json
+++ b/webextensions/manifest/developer.json
@@ -14,7 +14,7 @@
             },
             "firefox_android": "mirror",
             "opera": {
-              "version_added": true
+              "version_added": "≤45"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `developer` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #189

Additional Notes: Honestly, this is _probably_ wrong and it's either supported in Chrome (or was supported in Opera Presto).
