### PR TITLE
Update Chromium data for webextensions.manifest.incognito.spanning

### DIFF
--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -47,7 +47,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "≤18"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `spanning` member of the `incognito` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #3535
