### PR TITLE
Update Chromium data for webextensions.manifest.manifest_version.v2

### DIFF
--- a/webextensions/manifest/manifest_version.json
+++ b/webextensions/manifest/manifest_version.json
@@ -29,7 +29,7 @@
             "description": "Version 2",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤21"
               },
               "edge": {
                 "version_added": "14"
@@ -38,7 +38,9 @@
                 "version_added": "48"
               },
               "firefox_android": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "15"
+              },
               "safari": {
                 "version_added": "14"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `v2` member of the `manifest_version` Web Extensions manifest property. This version range was added based upon the removal version for Manifest v1 (see #3536).
