### PR TITLE
Update Chromium data for offline_enabled Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/offline_enabled.json
+++ b/webextensions/manifest/offline_enabled.json
@@ -6,11 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/offline_enabled",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤72"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `offline_enabled` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #3015
