### PR TITLE
Update Chromium data for webextensions.manifest.omnibox.keyword

### DIFF
--- a/webextensions/manifest/omnibox.json
+++ b/webextensions/manifest/omnibox.json
@@ -26,11 +26,9 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤72"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "52"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `keyword` member of the `omnibox` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #3537

Additional Notes: The key was corrected from "key" to "keyword" in #21527.
