### PR TITLE
Update Chromium data for optional_permissions Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -718,7 +718,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -125,7 +125,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤81"
               },
               "edge": "mirror",
               "firefox": {
@@ -348,7 +348,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤65"
               },
               "edge": "mirror",
               "firefox": {
@@ -368,7 +368,7 @@
             "description": "<code>downloads.open</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤65"
               },
               "edge": "mirror",
               "firefox": {
@@ -532,7 +532,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤92"
               },
               "edge": "mirror",
               "firefox": {
@@ -614,7 +614,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤80"
               },
               "edge": {
                 "version_added": "79"
@@ -699,7 +699,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤81"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions",
           "support": {
             "chrome": {
-              "version_added": "≤58"
+              "version_added": "18"
             },
             "edge": "mirror",
             "firefox": {
@@ -66,7 +66,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -85,7 +85,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -146,7 +146,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -165,7 +165,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -186,7 +186,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -205,7 +205,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -228,7 +228,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -427,7 +427,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -467,7 +467,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -486,7 +486,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -555,7 +555,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -574,7 +574,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -762,7 +762,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -837,7 +837,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -858,7 +858,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -879,7 +879,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -26,7 +26,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "21"
+                "version_added": "26"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -368,7 +368,7 @@
             "description": "<code>downloads.open</code>",
             "support": {
               "chrome": {
-                "version_added": "≤65"
+                "version_added": "30"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -26,7 +26,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "21"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -678,7 +678,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "86"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -47,7 +47,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "21"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -800,7 +800,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -348,7 +348,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤65"
+                "version_added": "22"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -614,11 +614,9 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "19"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "75"
               },

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -47,7 +47,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "21"
+                "version_added": "22"
               },
               "edge": "mirror",
               "firefox": {
@@ -348,7 +348,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "22"
+                "version_added": "31"
               },
               "edge": "mirror",
               "firefox": {
@@ -368,7 +368,7 @@
             "description": "<code>downloads.open</code>",
             "support": {
               "chrome": {
-                "version_added": "30"
+                "version_added": "31"
               },
               "edge": "mirror",
               "firefox": {
@@ -532,7 +532,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "27"
+                "version_added": "29"
               },
               "edge": "mirror",
               "firefox": {
@@ -678,7 +678,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "86"
+                "version_added": "87"
               },
               "edge": "mirror",
               "firefox": {
@@ -697,7 +697,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "31"
+                "version_added": "37"
               },
               "edge": "mirror",
               "firefox": {
@@ -718,7 +718,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "19"
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {
@@ -781,7 +781,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "20"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -125,7 +125,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤81"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -532,7 +532,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤92"
+                "version_added": "27"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -697,7 +697,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤81"
+                "version_added": "31"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -448,7 +448,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "29"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -781,7 +781,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "20"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `optional_permissions` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

This PR uses the source code and commit history of Chrome to add specific version numbers, rather than just ranges.  Details for each feature and the commit the version number chosen is available in the commit messages for this PR.