### PR TITLE
Update Chromium data for options_page Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/options_page.json
+++ b/webextensions/manifest/options_page.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤65"
             },
             "edge": {
               "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `options_page` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #1267
