### PR TITLE
Update Opera data for page_action Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -23,13 +23,7 @@
             "firefox_android": {
               "version_added": true
             },
-            "opera": {
-              "version_added": true,
-              "notes": [
-                "If an extension defines a page action, it is not allowed to define a browser action as well.",
-                "Available for use in Manifest V2 only."
-              ]
-            },
+            "opera": "mirror",
             "safari": {
               "version_added": "14",
               "notes": [


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `page_action` Web Extensions manifest property. This sets the downstream browser(s) to mirror from their upstream counterpart.
