### PR TITLE
Update Firefox Android data for page_action Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -20,9 +20,7 @@
             "firefox": {
               "version_added": "48"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "opera": {
               "version_added": true,
               "notes": [
@@ -86,9 +84,7 @@
               "firefox": {
                 "version_added": "48"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": [
                 {
@@ -133,9 +129,7 @@
               "firefox": {
                 "version_added": "48"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
@@ -158,9 +152,7 @@
               "firefox": {
                 "version_added": "48"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": "14"

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -20,7 +20,9 @@
             "firefox": {
               "version_added": "48"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤57"
+            },
             "opera": {
               "version_added": true,
               "notes": [
@@ -84,7 +86,9 @@
               "firefox": {
                 "version_added": "48"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤57"
+              },
               "opera": "mirror",
               "safari": [
                 {
@@ -129,7 +133,9 @@
               "firefox": {
                 "version_added": "48"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤57"
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
@@ -152,7 +158,9 @@
               "firefox": {
                 "version_added": "48"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤57"
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `page_action` Web Extensions manifest property. This sets the downstream browser(s) to mirror from their upstream counterpart.
