### PR TITLE
Update Chromium data for page_action Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -72,7 +72,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "≤54",
                 "notes": "SVG icons are not supported."
               },
               "edge": {
@@ -125,7 +125,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤54"
               },
               "edge": {
                 "version_added": "14"
@@ -150,7 +150,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤54"
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -72,7 +72,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤54",
+                "version_added": "≤72",
                 "notes": "SVG icons are not supported."
               },
               "edge": {
@@ -125,7 +125,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤54"
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"
@@ -150,7 +150,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤54"
+                "version_added": "≤72"
               },
               "edge": {
                 "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `page_action` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #3537
