### PR TITLE
Update Chromium data for storage Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/storage.json
+++ b/webextensions/manifest/storage.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤80"
             },
             "edge": {
               "version_added": "79"
@@ -30,7 +30,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤80"
               },
               "edge": {
                 "version_added": "79"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `storage` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #5575
