### PR TITLE
Update Chromium data for webextensions.manifest.theme.colors

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -51,13 +51,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤62",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "58",
                   "notes": "Before version 59, the RGB array form was not supported for this property."
@@ -146,13 +143,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤62",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "60"
                 },
@@ -173,13 +167,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤62",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -198,13 +189,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤62",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -265,13 +253,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤62",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "63"
                 },
@@ -292,13 +277,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤62",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -317,13 +299,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤62",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -342,13 +321,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤62",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "63"
                 },
@@ -453,13 +429,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤65",
                   "notes": "The CSS color form is not supported for this property."
                 },
-                "edge": {
-                  "version_added": "79",
-                  "notes": "The CSS color form is not supported for this property."
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "59"
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `colors` member of the `theme` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #581, #1721
