### PR TITLE
Update Chromium data for theme Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -866,7 +866,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#images",
             "support": {
               "chrome": {
-                "version_added": "≤68"
+                "version_added": "≤67"
               },
               "edge": "mirror",
               "firefox": {
@@ -934,7 +934,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#properties",
             "support": {
               "chrome": {
-                "version_added": "≤68"
+                "version_added": "≤67"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -866,18 +866,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#images",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤68"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55",
                 "notes": "Before Firefox 60, this property was required."
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "opera": {
                 "version_added": false
               },
@@ -912,16 +908,14 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤76"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "55"
                 },
                 "firefox_android": {
-                  "version_added": true,
+                  "version_added": "55",
                   "notes": "This property is required."
                 },
                 "opera": {
@@ -940,11 +934,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#properties",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤68"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "55"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `theme` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #2194, #4615

Additional Notes: Firefox Android is also set to mirror in this PR.
