### PR TITLE
Update Opera data for version Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/version.json
+++ b/webextensions/manifest/version.json
@@ -16,9 +16,7 @@
               "version_added": "48"
             },
             "firefox_android": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "safari": {
               "version_added": "14"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `version` Web Extensions manifest property. This sets the downstream browser(s) to mirror from their upstream counterpart.
