### PR TITLE
Update Chromium data for version_name Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/version_name.json
+++ b/webextensions/manifest/version_name.json
@@ -6,11 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤65"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `version_name` Web Extensions manifest property. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: #1380
