### PR TITLE
Update Safari iOS data for webextensions.api.cookies.set.partitionKey

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -699,7 +699,8 @@
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `set.partitionKey` member of the `cookies` Web Extensions interface. This sets the downstream browser(s) to mirror from their upstream counterpart.
