### PR TITLE
Safari 17.6 release

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -307,16 +307,16 @@
         "17.5": {
           "release_date": "2024-05-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_5-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "618.2.12"
         },
         "17.6": {
-          "release_date": "2024-06-17",
+          "release_date": "2024-07-22",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes",
-          "status": "beta",
+          "status": "current",
           "engine": "WebKit",
-          "engine_version": "618.3.7"
+          "engine_version": "618.3.11"
         },
         "18": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -279,16 +279,16 @@
         "17.5": {
           "release_date": "2024-05-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_5-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "618.2.12"
         },
         "17.6": {
-          "release_date": "2024-06-17",
+          "release_date": "2024-07-22",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes",
-          "status": "beta",
+          "status": "current",
           "engine": "WebKit",
-          "engine_version": "618.3.7"
+          "engine_version": "618.3.11"
         },
         "18": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -167,7 +167,7 @@ const options = {
     browserName: 'Safari for Desktop',
     bcdFile: './browsers/safari.json',
     bcdBrowserName: 'safari',
-    skippedReleases: ['17.6'],
+    skippedReleases: [],
     releaseNoteJSON:
       'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
     releaseNoteURLBase: 'https://developer.apple.com',
@@ -176,7 +176,7 @@ const options = {
     browserName: 'Safari for iOS',
     bcdFile: './browsers/safari_ios.json',
     bcdBrowserName: 'safari_ios',
-    skippedReleases: ['12.1', '13.1', '14.1', '17.6'],
+    skippedReleases: ['12.1', '13.1', '14.1'],
     releaseNoteJSON:
       'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
     releaseNoteURLBase: 'https://developer.apple.com',


### PR DESCRIPTION
See https://webkit.org/blog/15739/webkit-features-in-safari-17-6/

I guess we also need to update the data for safe alignment in flex box (search for "safe_unsafe" in css/). 
This PR fixes the browser/ release data first, though.