### PR TITLE
Updates for Firefox 130 beta

### DIFF
--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "130"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -3058,7 +3058,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "127"
+              "version_added": "127",
+              "version_removed": "130",
+              "partial_implementation": true,
+              "notes": "Accidental early exposure with no functionality."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -2300,7 +2300,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "127"
+              "version_added": "127",
+              "version_removed": "130",
+              "partial_implementation": true,
+              "notes": "Accidental early exposure with no functionality."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.1 found new features shipping in Firefox 130 beta which was released last week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 12 features as shipping in Firefox 130 (most updates submitted in other PRs manually this time):

- api.HTMLDetailsElement.name
  - https://github.com/mdn/content/issues/35283
- api.SubtleCrypto.deriveBits.x25519
  - https://github.com/mdn/content/issues/34708 (and below)
- api.SubtleCrypto.deriveKey.x25519
- api.SubtleCrypto.exportKey.x25519
- api.SubtleCrypto.generateKey.x25519
- api.SubtleCrypto.importKey.x25519
- api.WebGL2RenderingContext.drawingBufferColorSpace (removal, see https://bugzilla.mozilla.org/show_bug.cgi?id=1909559)
  - https://github.com/mdn/content/issues/35422 
- api.WebGLRenderingContext.drawingBufferColorSpace (ditto)
  - https://github.com/mdn/content/issues/35422
- css.properties.hyphens.language_czech 
  - https://github.com/mdn/content/issues/35425
- css.properties.hyphens.language_slovak 
  - https://github.com/mdn/content/issues/35425
- html.elements.details.name
- webextensions.api.webRequest.getSecurityInfo.options

See also https://github.com/mdn/mdn/issues/570 and https://www.mozilla.org/en-US/firefox/130.0beta/releasenotes/