### PR TITLE
Add the `writingsuggestions` HTML attribute to BCD

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2413,7 +2413,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1871621"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1334,6 +1334,40 @@
             "deprecated": false
           }
         }
+      },
+      "writingsuggestions": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#writing-suggestions",
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1871621"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "18"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `writingsuggestions` global HTML attribute lets developers choose where UAs should or shouldn't propose writing suggestions in text editing regions. This was added recently to BCD only as the DOM property. This PR adds the HTML attribute too.

#### Test results and supporting details

* https://chromestatus.com/feature/5153375153029120
* https://groups.google.com/a/chromium.org/g/blink-dev/c/NhWn64yxB5Q/m/1DnBEqxXAQAJ
* https://html.spec.whatwg.org/multipage/interaction.html#writing-suggestions

