### PR TITLE
Hide traversed features count by default when output is piped

### DIFF
--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -261,7 +261,9 @@ if (esMain(import.meta)) {
     argv.tag,
   );
   console.log(features.join('\n'));
-  if (argv.showCount) console.log(features.length);
+  if (argv.showCount) {
+    console.log(features.length);
+  }
 }
 
 export default main;

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -222,6 +222,12 @@ if (esMain(import.meta)) {
           nargs: 1,
           default: 10,
         })
+        .option('show-count', {
+          alias: 'c',
+          describe: 'Show the count of features traversed at the end',
+          type: 'boolean',
+          default: process.stdout.isTTY,
+        })
         .example(
           'npm run traverse -- --browser=safari -n',
           'Find all features containing non-real Safari entries',
@@ -255,7 +261,7 @@ if (esMain(import.meta)) {
     argv.tag,
   );
   console.log(features.join('\n'));
-  console.log(features.length);
+  if (argv.showCount) console.log(features.length);
 }
 
 export default main;


### PR DESCRIPTION
This PR makes an update to the traverse script to introduce a `--show-count` argument, which is disabled by default if the output is being piped.  This is particularly helpful for scripting usage, such as grepping.
