### PR TITLE
html.elements.textarea.placeholder: line breaks supported in Safari 16

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -557,7 +557,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Support for line breaks in placeholder: add missing support information for Safari.

#### Test results and supporting details

WebKit bug tracker: https://bugs.webkit.org/show_bug.cgi?id=235205 (fixed 2022-01)
Safari 16 was released in 2022-09

#### Related issues

None
