### PR TITLE
Chromium doesn't support font-variant-position

### DIFF
--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -7,7 +7,8 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-variant-position-prop",
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": false,
+              "notes": "The propery is recognized, but has no effect."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -39,7 +40,8 @@
             "spec_url": "https://drafts.csswg.org/css-fonts/#font-variant-position-normal-value",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": false,
+                "notes": "The propery is recognized, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -72,7 +74,8 @@
             "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-variant-position-sub",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": false,
+                "notes": "The propery is recognized, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -105,7 +108,8 @@
             "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-variant-position-super",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": false,
+                "notes": "The propery is recognized, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `font-variant-position` CSS property. This fixes #24136, which contains the supporting evidence for this change.
