### PR TITLE
Firefox 124 added `white-space-collapse: preserve-spaces`

### DIFF
--- a/css/properties/white-space-collapse.json
+++ b/css/properties/white-space-collapse.json
@@ -165,6 +165,39 @@
               "deprecated": false
             }
           }
+        },
+        "preserve-spaces": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-white-space-collapse-preserve-spaces",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "124"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds the missing `preserve-spaces` member of the `white-space-collapse` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/white-space-collapse/preserve-spaces
