### PR TITLE
css.at-rules.import.layer - add spec URL

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -49,6 +49,7 @@
         "layer": {
           "__compat": {
             "description": "<code>layer(&lt;layer-name&gt;)</code>",
+            "spec_url": "https://drafts.csswg.org/css-cascade-5/#ref-for-typedef-layer-name",
             "tags": [
               "web-features:cascade-layers"
             ],


### PR DESCRIPTION
### Summary

A [new page](https://github.com/mdn/content/pull/35508) is being created for the feature so the PR adds the missing spec URL
