### PR TITLE
Update Deno data for api.EventTarget.addEventListener.options_parameter.options_passive_parameter_default_true_wheel

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -365,7 +365,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `addEventListener.options_parameter.options_passive_parameter_default_true_wheel` member of the `EventTarget` API. Deno doesn't have its own mouse support as far as I can tell, so this just sets the feature to `false`.

Additional Notes: This PR removes one of the remaining `null` values in BCD.
