### PR TITLE
Fix all JS data that show up in web-docs-backlog

### DIFF
--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -100,6 +100,8 @@
             "IntlLegacyConstructedSymbol": {
               "__compat": {
                 "description": "Supports normative optional <code>ChainDateTimeFormat</code> behavior",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#return_value",
+                "spec_url": "https://tc39.es/ecma402/#sec-chaindatetimeformat",
                 "support": {
                   "chrome": [
                     {

--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -93,6 +93,8 @@
             "IntlLegacyConstructedSymbol": {
               "__compat": {
                 "description": "Supports normative optional <code>ChainNumberFormat</code> behavior",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#return_value",
+                "spec_url": "https://tc39.es/ecma402/#sec-chainnumberformat",
                 "support": {
                   "chrome": [
                     {

--- a/javascript/builtins/Intl/RelativeTimeFormat.json
+++ b/javascript/builtins/Intl/RelativeTimeFormat.json
@@ -369,44 +369,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            },
-            "numberingSystem": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "73"
-                  },
-                  "chrome_android": "mirror",
-                  "deno": {
-                    "version_added": "1.8"
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "70"
-                  },
-                  "firefox_android": "mirror",
-                  "ie": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "12.0.0"
-                  },
-                  "oculus": "mirror",
-                  "opera": "mirror",
-                  "opera_android": "mirror",
-                  "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": "mirror",
-                  "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
             }
           },
           "supportedLocalesOf": {

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1030,7 +1030,7 @@
           },
           "escaping": {
             "__compat": {
-              "description": "Escaping",
+              "description": "Line breaks and slashes are escaped",
               "support": {
                 "chrome": {
                   "version_added": "73"
@@ -1334,7 +1334,7 @@
           },
           "escaping": {
             "__compat": {
-              "description": "Escaping",
+              "description": "Line breaks and slashes are escaped",
               "support": {
                 "chrome": {
                   "version_added": "73"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2287,8 +2287,10 @@
               "deprecated": false
             }
           },
-          "locale": {
+          "locales_parameter": {
             "__compat": {
+              "description": "<code>locales</code> parameter",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase#locales",
               "support": {
                 "chrome": {
                   "version_added": "58"
@@ -2394,8 +2396,10 @@
               "deprecated": false
             }
           },
-          "locale": {
+          "locales_parameter": {
             "__compat": {
+              "description": "<code>locales</code> parameter",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase#locales",
               "support": {
                 "chrome": {
                   "version_added": "58"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

These data show up because the description is a single word without space. I fixed them by either adding `mdn_url` or changing the description

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
