### PR TITLE
CSS `stroke` property spec URL

### DIFF
--- a/css/properties/stroke.json
+++ b/css/properties/stroke.json
@@ -4,7 +4,7 @@
       "stroke": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke",
-          "spec_url": "https://drafts.fxtf.org/fill-stroke-3/#stroke-shorthand",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint",
           "support": {
             "chrome": {
               "version_added": "≤80"


### PR DESCRIPTION
The property is supported as defined in this https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint spec, not as a shorthand as defined in the not-updated-since-2017 drafts.fxtf.org spec