### PR TITLE
`font-optical-sizing` version range corrections

### DIFF
--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -47,7 +47,9 @@
                 "version_added": "79"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "17"
+              },
               "firefox": {
                 "version_added": "≤72"
               },
@@ -80,7 +82,9 @@
                 "version_added": "79"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "17"
+              },
               "firefox": {
                 "version_added": "≤72"
               },

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -51,7 +51,7 @@
                 "version_added": "17"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "62"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -86,7 +86,7 @@
                 "version_added": "17"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "62"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Both Edge and Safari have suspicious values. `none` and `auto` support are both reported to have shipped after `font-optical-sizing` itself shipped, which doesn't make sense. What would the property do without a valid value?

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I tested this manually. Edge was straight forward: the values did different things from Edge 17.

Safari was more complex. It's possible that this was implemented earlier (`CSS.supports(…)` returns true for this property from version 11) but I couldn't actually see a difference when I tested it in Safari <13.1. Given https://bugs.webkit.org/show_bug.cgi?id=197528, I think it's possible that the property didn't actually do anything before 13 or 13.1. Unfortunately, Browser Stack doesn't seem to offer Safari 13, only 13.1. I suppose it's also possible there's some other confounder (like macOS version-specific constraints). Anyway, I've at least come up with a consistent story here.

If you have ideas for more accurately reporting Safari's data, I'm all for it.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Inspired by https://github.com/web-platform-dx/web-features/pull/1630.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
