### PR TITLE
Update metadata for PaymentResponse API

### DIFF
--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -212,6 +212,7 @@
         "__compat": {
           "description": "<code>payerdetailchange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerdetailchange_event",
+          "spec_url": "https://www.w3.org/TR/payment-request/#dfn-payerdetailchange",
           "support": {
             "chrome": {
               "version_added": "78"
@@ -255,14 +256,15 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
       "payerEmail": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerEmail",
+          "spec_url": "https://www.w3.org/TR/payment-request/#payeremail-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -306,14 +308,15 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
       "payerName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerName",
+          "spec_url": "https://www.w3.org/TR/payment-request/#payername-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -357,14 +360,15 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
       "payerPhone": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerPhone",
+          "spec_url": "https://www.w3.org/TR/payment-request/#payerphone-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -408,8 +412,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -524,6 +528,7 @@
       "shippingAddress": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/shippingAddress",
+          "spec_url": "https://www.w3.org/TR/payment-request/#shippingaddress-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -567,14 +572,15 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
       "shippingOption": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/shippingOption",
+          "spec_url": "https://www.w3.org/TR/payment-request/#shippingoption-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -618,8 +624,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -212,7 +212,7 @@
         "__compat": {
           "description": "<code>payerdetailchange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerdetailchange_event",
-          "spec_url": "https://www.w3.org/TR/payment-request/#dfn-payerdetailchange",
+          "spec_url": "https://w3c.github.io/payment-request/#dfn-payerdetailchange",
           "support": {
             "chrome": {
               "version_added": "78"
@@ -264,7 +264,7 @@
       "payerEmail": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerEmail",
-          "spec_url": "https://www.w3.org/TR/payment-request/#payeremail-attribute",
+          "spec_url": "https://w3c.github.io/payment-request/#payeremail-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -316,7 +316,7 @@
       "payerName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerName",
-          "spec_url": "https://www.w3.org/TR/payment-request/#payername-attribute",
+          "spec_url": "https://w3c.github.io/payment-request/#payername-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -368,7 +368,7 @@
       "payerPhone": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerPhone",
-          "spec_url": "https://www.w3.org/TR/payment-request/#payerphone-attribute",
+          "spec_url": "https://w3c.github.io/payment-request/#payerphone-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -528,7 +528,7 @@
       "shippingAddress": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/shippingAddress",
-          "spec_url": "https://www.w3.org/TR/payment-request/#shippingaddress-attribute",
+          "spec_url": "https://w3c.github.io/payment-request/#shippingaddress-attribute",
           "support": {
             "chrome": {
               "version_added": "60"
@@ -580,7 +580,7 @@
       "shippingOption": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/shippingOption",
-          "spec_url": "https://www.w3.org/TR/payment-request/#shippingoption-attribute",
+          "spec_url": "https://w3c.github.io/payment-request/#shippingoption-attribute",
           "support": {
             "chrome": {
               "version_added": "60"


### PR DESCRIPTION
This PR updates and corrects the metadata (spec URLs, descriptions, statuses, etc.) for the `PaymentResponse` API.

Additional Notes: This fixes #24205.
