### PR TITLE
Move `css.types.color.transparent` to `css.types.color.named-color.transparent`

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -916,6 +916,49 @@
                 "deprecated": false
               }
             }
+          },
+          "transparent": {
+            "__compat": {
+              "description": "<code>transparent</code> keyword",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/named-color#transparent",
+              "spec_url": "https://drafts.csswg.org/css-color/#transparent-color",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "3"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": "9"
+                },
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": "10"
+                },
+                "opera_android": {
+                  "version_added": "10.1"
+                },
+                "safari": {
+                  "version_added": "3.1"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": "37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "oklab": {
@@ -1566,49 +1609,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          }
-        },
-        "transparent": {
-          "__compat": {
-            "description": "<code>transparent</code> keyword",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/named-color#transparent",
-            "spec_url": "https://drafts.csswg.org/css-color/#transparent-color",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "3"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "9"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "10"
-              },
-              "opera_android": {
-                "version_added": "10.1"
-              },
-              "safari": {
-                "version_added": "3.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         }

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -919,7 +919,6 @@
           },
           "transparent": {
             "__compat": {
-              "description": "<code>transparent</code> keyword",
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/named-color#transparent",
               "spec_url": "https://drafts.csswg.org/css-color/#transparent-color",
               "support": {


### PR DESCRIPTION
#### Summary

According to [the spec](https://drafts.csswg.org/css-color/#transparent-color), `transparent` is a value of `<named-color>` type. I thought it a bit weird that it doesn't reside with the other `<named-color>` data.

#### Test results and supporting details

I moved the object, but did not change the underlying support information. I did drop the `description` for consistency with its sibling feature.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Discovered in the course of reviewing https://github.com/web-platform-dx/web-features/pull/1619#discussion_r1728579552