### PR TITLE
Updates for Chrome 129 beta

### DIFF
--- a/api/CSSPositionTryDescriptors.json
+++ b/api/CSSPositionTryDescriptors.json
@@ -2477,10 +2477,15 @@
             "web-features:anchor-positioning"
           ],
           "support": {
-            "chrome": {
-              "alternative_name": "inset-area",
-              "version_added": "125"
-            },
+            "chrome": [
+              {
+                "version_added": "129"
+              },
+              {
+                "alternative_name": "inset-area",
+                "version_added": "125"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -2554,10 +2559,15 @@
             "web-features:anchor-positioning"
           ],
           "support": {
-            "chrome": {
-              "alternative_name": "insetArea",
-              "version_added": "125"
-            },
+            "chrome": [
+              {
+                "version_added": "129"
+              },
+              {
+                "alternative_name": "insetArea",
+                "version_added": "125"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -266,7 +266,7 @@
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-parsecreationoptionsfromjson",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "129"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -285,10 +285,12 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -301,7 +303,7 @@
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-parserequestoptionsfromjson",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "129"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -320,10 +322,12 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -437,7 +441,7 @@
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-tojson",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "129"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -456,10 +460,12 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -113,8 +113,7 @@
             "description": "<code>Blob</code> value",
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/webrtc/2276"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/interpolate-size.json
+++ b/css/properties/interpolate-size.json
@@ -1,0 +1,111 @@
+{
+  "css": {
+    "properties": {
+      "interpolate-size": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-values-5/#interpolate-size",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "allow-keywords": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-values-5/#valdef-interpolate-size-allow-keywords",
+            "support": {
+              "chrome": {
+                "version_added": "129"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "numeric-only": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-values-5/#valdef-interpolate-size-numeric-only",
+            "support": {
+              "chrome": {
+                "version_added": "129"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/position-area.json
+++ b/css/properties/position-area.json
@@ -9,10 +9,15 @@
             "web-features:anchor-positioning"
           ],
           "support": {
-            "chrome": {
-              "alternative_name": "inset-area",
-              "version_added": "125"
-            },
+            "chrome": [
+              {
+                "version_added": "129"
+              },
+              {
+                "alternative_name": "inset-area",
+                "version_added": "125"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -47,7 +52,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -84,7 +89,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -121,7 +126,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -158,7 +163,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -195,7 +200,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -232,7 +237,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -269,7 +274,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -306,7 +311,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -343,7 +348,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -380,7 +385,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -417,7 +422,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -454,7 +459,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -491,7 +496,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -528,7 +533,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -565,7 +570,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -602,7 +607,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -639,7 +644,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -676,7 +681,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -713,7 +718,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -750,7 +755,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -787,7 +792,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -824,7 +829,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -861,7 +866,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -898,7 +903,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -935,7 +940,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -972,7 +977,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1009,7 +1014,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1046,7 +1051,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1083,7 +1088,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1120,7 +1125,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1157,7 +1162,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1194,7 +1199,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1231,7 +1236,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1268,7 +1273,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1305,7 +1310,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/position-try-fallbacks.json
+++ b/css/properties/position-try-fallbacks.json
@@ -53,7 +53,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -90,7 +90,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -127,7 +127,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -164,7 +164,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "125"
+                "version_added": "128"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/types/calc-size.json
+++ b/css/types/calc-size.json
@@ -1,0 +1,40 @@
+{
+  "css": {
+    "types": {
+      "calc-size": {
+        "__compat": {
+          "description": "<code>calc-size()</code>",
+          "spec_url": "https://drafts.csswg.org/css-values-5/#calc-size",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/Intl/DurationFormat.json
+++ b/javascript/builtins/Intl/DurationFormat.json
@@ -8,7 +8,7 @@
             "spec_url": "https://tc39.es/proposal-intl-duration-format/#durationformat-objects",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "129"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -36,7 +36,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -48,7 +48,7 @@
               "spec_url": "https://tc39.es/proposal-intl-duration-format/#sec-intl-durationformat-constructor",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "129"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -76,7 +76,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -88,7 +88,7 @@
               "spec_url": "https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.format",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "129"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -116,7 +116,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -128,7 +128,7 @@
               "spec_url": "https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "129"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -156,7 +156,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -168,7 +168,7 @@
               "spec_url": "https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.resolvedOptions",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "129"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -196,7 +196,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -208,7 +208,7 @@
               "spec_url": "https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.supportedLocalesOf",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "129"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -236,7 +236,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.02 found new features shipping in Chrome 129 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 52 features as shipping in Chrome 129:

- api.CSSPositionTryDescriptors.position-area
- api.CSSPositionTryDescriptors.positionArea
- api.PublicKeyCredential.parseCreationOptionsFromJSON_static
- api.PublicKeyCredential.parseRequestOptionsFromJSON_static
- api.PublicKeyCredential.toJSON
- api.RTCDataChannel.binaryType.blob_value
- css.properties.interpolate-size
- css.properties.interpolate-size.allow-keywords
- css.properties.interpolate-size.numeric-only
- css.properties.position-area
- css.properties.position-area.block-end
- css.properties.position-area.block-start
- css.properties.position-area.bottom
- css.properties.position-area.center
- css.properties.position-area.end
- css.properties.position-area.inline-end
- css.properties.position-area.inline-start
- css.properties.position-area.left
- css.properties.position-area.none
- css.properties.position-area.right
- css.properties.position-area.self-end
- css.properties.position-area.self-start
- css.properties.position-area.span-all
- css.properties.position-area.span-block-end
- css.properties.position-area.span-block-start
- css.properties.position-area.span-bottom
- css.properties.position-area.span-end
- css.properties.position-area.span-inline-end
- css.properties.position-area.span-inline-start
- css.properties.position-area.span-start
- css.properties.position-area.span-top
- css.properties.position-area.span-x-end
- css.properties.position-area.span-x-start
- css.properties.position-area.span-y-end
- css.properties.position-area.span-y-start
- css.properties.position-area.start
- css.properties.position-area.top
- css.properties.position-area.x-end
- css.properties.position-area.x-self-end
- css.properties.position-area.x-self-start
- css.properties.position-area.x-start
- css.properties.position-area.y-end
- css.properties.position-area.y-self-end
- css.properties.position-area.y-self-start
- css.properties.position-area.y-start
- css.types.calc-size
- javascript.builtins.Intl.DurationFormat
- javascript.builtins.Intl.DurationFormat.DurationFormat
- javascript.builtins.Intl.DurationFormat.format
- javascript.builtins.Intl.DurationFormat.formatToParts
- javascript.builtins.Intl.DurationFormat.resolvedOptions

See also the 129 "Enabled by default" column on https://chromestatus.com/roadmap.

Notes on features mentioned on chromestatus not listed here:
- scheduler.yield: I don't see it supported in 129, maybe it slipped to 130.
- Snap Events: The collector[ doesn't support global events](https://github.com/openwebdocs/mdn-bcd-collector/issues/1111) right now. Need to submit this manually.
- Computer Pressure WebDriver extensions: The collector doesn't support WebDriver features ([yet](https://github.com/openwebdocs/mdn-bcd-collector/issues/1762)). I opened https://github.com/mdn/browser-compat-data/pull/24211 for this.

cc @chrisdavidmills @rachelandrew 