### PR TITLE
Add new Compute Pressure WebDriver commands

### DIFF
--- a/webdriver/commands/CreateVirtualPressureSource.json
+++ b/webdriver/commands/CreateVirtualPressureSource.json
@@ -1,0 +1,40 @@
+{
+  "webdriver": {
+    "commands": {
+      "CreateVirtualPressureSource": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/compute-pressure/#create-virtual-pressure-source",
+          "support": {
+            "chrome": {
+              "version_added": "129",
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/DeleteVirtualPressureSource.json
+++ b/webdriver/commands/DeleteVirtualPressureSource.json
@@ -1,0 +1,40 @@
+{
+  "webdriver": {
+    "commands": {
+      "DeleteVirtualPressureSource": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/compute-pressure/#delete-virtual-pressure-source",
+          "support": {
+            "chrome": {
+              "version_added": "129",
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webdriver/commands/UpdateVirtualPressureSource.json
+++ b/webdriver/commands/UpdateVirtualPressureSource.json
@@ -1,0 +1,40 @@
+{
+  "webdriver": {
+    "commands": {
+      "UpdateVirtualPressureSource": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/compute-pressure/#update-virtual-pressure-source",
+          "support": {
+            "chrome": {
+              "version_added": "129",
+              "notes": "To enable Chromium support, include <code>{\"goog:chromeOptions\": {\"w3c\": true}}</code> in the <a href=https://developer.mozilla.org/docs/Web/WebDriver/Capabilities>capabilities</a>."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Chromium 129 ships with 3 new Compute Pressure WebDriver commands.
- CreateVirtualPressureSource
- DeleteVirtualPressureSource
- UpdateVirtualPressureSource

https://chromestatus.com/feature/5130657352384512

cc @kenchris