### PR TITLE
WebSocket constructor support for http(s) and relative URLs

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -111,6 +111,45 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "url_parameter_http_https_relative": {
+          "__compat": {
+            "description": "<code>url</code> parameter allows <code>https</code>, <code>http</code>, and relative URLs",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "124"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17.3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "worker_support": {

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -121,7 +121,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": true
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
The WebSocket spec allows http, https, relative URLs in the constructor `url` argument from https://github.com/whatwg/websockets/pull/37.

This has been implemented in 
- FF124: https://bugzilla.mozilla.org/show_bug.cgi?id=1797449
- Chrome 125: https://chromestatus.com/feature/5848709993857024
- Webkit: https://bugs.webkit.org/show_bug.cgi?id=247149 - can't work out Safari version, but first testable in 17.3 on browserstack
- Deno - https://github.com/denoland/deno/pull/16488 but I can't work out version
- Node - no evidence.

Tested on Safari using http://wpt.live/websockets/Create-http-urls.any.worker.html

Couldn't work out versions for Deno.

@queengooborg Something you could help with?


Related docs work can be tracked in https://github.com/mdn/content/issues/26731