### PR TITLE
Update partial implementation note for datalist

### DIFF
--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -18,11 +18,19 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "4",
-              "partial_implementation": true,
-              "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such as <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>. The <code>date</code>, <code>time</code>, <code>range</code> and <code>color</code> types are not supported."
-            },
+            "firefox": [
+              {
+                "version_added": "110",
+                "partial_implementation": true,
+                "notes": "The <code>date</code> and <code>time</code> input types are not supported."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "110",
+                "partial_implementation": true,
+                "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such as <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>. The <code>date</code>, <code>time</code>, <code>range</code> and <code>color</code> types are not supported."
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "79",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As of Firefox 110, datalist works for range and color inputs (but date and time inputs are still not supported)

#### Test results and supporting details

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist#examples

#### Related issues

