### PR TITLE
Update align-content.json — the 'safe' keyword in Flexbox was added in Safari 17.6. 

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -272,7 +272,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "18"
+                  "version_added": "17.6"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
Support for the 'safe' keyword in Flexbox was added in Safari 17.6. 
https://webkit.org/blog/15739/webkit-features-in-safari-17-6/

It was listed as "Safari 18" in MDN BCD because support was first announced in Safari 18 beta, in June. But then we shipped support in July in Safari 17.6. That's the first public release. 