### PR TITLE
Firefox Android doesn't support "direct" and "enterprise" attestation values for CredentialsContainer.create()

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -109,6 +109,218 @@
               "deprecated": false
             }
           },
+          "attestation": {
+            "__compat": {
+              "description": "<code>attestation</code> option",
+              "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredentialcreationoptions-attestation",
+              "support": {
+                "chrome": {
+                  "version_added": "67"
+                },
+                "chrome_android": {
+                  "version_added": "70"
+                },
+                "edge": {
+                  "version_added": "18"
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "13"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "direct": {
+              "__compat": {
+                "description": "<code>direct</code> attestation conveyance preference",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions#direct",
+                "spec_url": "https://w3c.github.io/webauthn/#dom-attestationconveyancepreference-direct",
+                "support": {
+                  "chrome": {
+                    "version_added": "67"
+                  },
+                  "chrome_android": {
+                    "version_added": "70"
+                  },
+                  "edge": {
+                    "version_added": "18"
+                  },
+                  "firefox": {
+                    "version_added": "60"
+                  },
+                  "firefox_android": {
+                    "version_added": false,
+                    "partial_implementation": true,
+                    "notes": "<code>credentialCreationData.attestationConveyancePreferenceOption</code> value \"direct\" is not supported. See https://bugzil.la/1550164"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "13"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "enterprise": {
+              "__compat": {
+                "description": "<code>enterprise</code> attestation conveyance preference",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions#enterprise",
+                "spec_url": "https://w3c.github.io/webauthn/#dom-attestationconveyancepreference-enterprise",
+                "support": {
+                  "chrome": {
+                    "version_added": "67"
+                  },
+                  "chrome_android": {
+                    "version_added": "70"
+                  },
+                  "edge": {
+                    "version_added": "18"
+                  },
+                  "firefox": {
+                    "version_added": "60"
+                  },
+                  "firefox_android": {
+                    "version_added": false,
+                    "partial_implementation": true,
+                    "notes": "<code>credentialCreationData.attestationConveyancePreferenceOption</code> value \"direct\" is not supported. See https://bugzil.la/1550164"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "13"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "indirect": {
+              "__compat": {
+                "description": "<code>indirect</code> attestation conveyance preference",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions#indirect",
+                "spec_url": "https://w3c.github.io/webauthn/#dom-attestationconveyancepreference-indirect",
+                "support": {
+                  "chrome": {
+                    "version_added": "67"
+                  },
+                  "chrome_android": {
+                    "version_added": "70"
+                  },
+                  "edge": {
+                    "version_added": "18"
+                  },
+                  "firefox": {
+                    "version_added": "60"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "13"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "none": {
+              "__compat": {
+                "description": "<code>none</code> attestation conveyance preference",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions#none",
+                "spec_url": "https://w3c.github.io/webauthn/#dom-attestationconveyancepreference-none",
+                "support": {
+                  "chrome": {
+                    "version_added": "67"
+                  },
+                  "chrome_android": {
+                    "version_added": "70"
+                  },
+                  "edge": {
+                    "version_added": "18"
+                  },
+                  "firefox": {
+                    "version_added": "60"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "13"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
           "extensions": {
             "__compat": {
               "description": "<code>create()</code> extensions",

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -50,11 +50,7 @@
             "firefox": {
               "version_added": "60"
             },
-            "firefox_android": {
-              "version_added": "60",
-              "partial_implementation": true,
-              "notes": "<code>credentialCreationData.attestationConveyancePreferenceOption</code> values \"direct\" and \"enterprise\" are not supported."
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -50,7 +50,11 @@
             "firefox": {
               "version_added": "60"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "60",
+              "partial_implementation": true,
+              "notes": "<code>credentialCreationData.attestationConveyancePreferenceOption</code> values \"direct\" and \"enterprise\" are not supported."
+            },
             "ie": {
               "version_added": false
             },

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -150,7 +150,6 @@
             },
             "direct": {
               "__compat": {
-                "description": "<code>direct</code> attestation conveyance preference",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions#direct",
                 "spec_url": "https://w3c.github.io/webauthn/#dom-attestationconveyancepreference-direct",
                 "support": {
@@ -195,7 +194,6 @@
             },
             "enterprise": {
               "__compat": {
-                "description": "<code>enterprise</code> attestation conveyance preference",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions#enterprise",
                 "spec_url": "https://w3c.github.io/webauthn/#dom-attestationconveyancepreference-enterprise",
                 "support": {
@@ -240,7 +238,6 @@
             },
             "indirect": {
               "__compat": {
-                "description": "<code>indirect</code> attestation conveyance preference",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions#indirect",
                 "spec_url": "https://w3c.github.io/webauthn/#dom-attestationconveyancepreference-indirect",
                 "support": {
@@ -281,7 +278,6 @@
             },
             "none": {
               "__compat": {
-                "description": "<code>none</code> attestation conveyance preference",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredentialCreationOptions#none",
                 "spec_url": "https://w3c.github.io/webauthn/#dom-attestationconveyancepreference-none",
                 "support": {

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -214,7 +214,7 @@
                   "firefox_android": {
                     "version_added": false,
                     "partial_implementation": true,
-                    "notes": "<code>credentialCreationData.attestationConveyancePreferenceOption</code> value \"direct\" is not supported. See https://bugzil.la/1550164"
+                    "notes": "<code>credentialCreationData.attestationConveyancePreferenceOption</code> value \"enterprise\" is not supported. See https://bugzil.la/1550164"
                   },
                   "ie": {
                     "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox on mobile does not support the "direct" or "enterprise" options for [`credentialCreationData.attestationConveyancePreferenceOption`](https://www.w3.org/TR/webauthn-2/#credentialcreationdata-attestationconveyancepreferenceoption).
This PR updates the data to reflect this.

#### Supporting details

Here's the issue which explains that firefox on mobile has not yet implemented a dialog which would satisfy their _self-imposed_ privacy requirement for direct attestations, and therefore do not currently support a "direct" or "enterprise" attestation option:
https://bugzilla.mozilla.org/show_bug.cgi?id=1550164

