### PR TITLE
added the mdn & spec urls for api.HTMLDetailsElement.name

### DIFF
--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -40,6 +40,7 @@
       },
       "name": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement/open",
           "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-details-name",
           "tags": [
             "web-features:details-name"

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -40,6 +40,7 @@
       },
       "name": {
         "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-details-name",
           "tags": [
             "web-features:details-name"
           ],


### PR DESCRIPTION
#### Summary

- Added to the `api.HTMLDetailsElement.name`:
  - mdn_url
  - spec_url

#### Test results and supporting details

Tested in Firefox Beta 130

#### Associated PRs

- [Content PR](https://github.com/mdn/content/pull/35619)
- [Automated BCD PR](https://github.com/mdn/browser-compat-data/pull/24118)
- [Firefox Release note](https://github.com/mdn/content/pull/35447)