### PR TITLE
added version_added and flags for reg_exp modifiers in firefox

### DIFF
--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -548,7 +548,14 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "javascript.options.experimental.regexp_modifiers",
+                  "value_to_set": "true"
+                }
+              ],
               "impl_url": "https://bugzil.la/1899813"
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

- `javascript.regular_expressions.modifier` for Firefox
  - Added version_added 
  - added flag

#### Test results and supporting details

- tested in Firefox Nightly 131.0a1 (2024-08-28) with [this codepen](https://codepen.io/CodeRedDigital/pen/GRbEOLE?editors=0011)

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/35622)