### PR TITLE
Add PointerEvent.persistentDeviceId spec

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -317,6 +317,7 @@
       },
       "persistentDeviceId": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-pointerevent-persistentdeviceid",
           "support": {
             "chrome": {
               "version_added": "128"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I recently added documentation for the `PointerEvent.persistentDeviceId` property (see https://github.com/mdn/content/pull/35566), but I noticed that the `spec_url` was missing from the BCD. This PR adds it.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
