### PR TITLE
Chrome/Safari only partially support list-item counter

### DIFF
--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -49,7 +49,9 @@
             "spec_url": "https://drafts.csswg.org/css-lists-3/#valdef-counter-increment-list-item",
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "≤83",
+                "partial_implementation": true,
+                "notes": "The <code>list-item</code> counter is <em>not</em> used when generating the default marker string on list items; see <a href='https://issues.chromium.org/issues/338233131'>bug 338233131</a>."
               },
               "chrome_android": "mirror",
               "edge": {
@@ -68,7 +70,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤13.1",
+                "partial_implementation": true,
+                "notes": "The <code>list-item</code> counter is <em>not</em> used correctly when generating content, as it is <em>not</em> fully implemented; see <a href='https://bugs.webkit.org/show_bug.cgi?id=260436'>bug 260436</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -51,7 +51,7 @@
               "chrome": {
                 "version_added": "≤83",
                 "partial_implementation": true,
-                "notes": "The <code>list-item</code> counter is <em>not</em> used when generating the default marker string on list items; see <a href='https://crbug.com/338233131'>bug 338233131</a>."
+                "notes": "Overriding the initial value of the implicit <code>list-item</code> counter has <em>no</em> effect when the default marker string for list items (<code>::marker</code>) is generated; see <a href='https://crbug.com/338233131'>bug 338233131</a>."
               },
               "chrome_android": "mirror",
               "edge": {
@@ -72,7 +72,7 @@
               "safari": {
                 "version_added": "≤13.1",
                 "partial_implementation": true,
-                "notes": "The <code>list-item</code> counter is <em>not</em> used correctly when generating content, as it is <em>not</em> fully implemented; see <a href='https://webkit.org/b/260436'>bug 260436</a>."
+                "notes": "Overriding the initial value of the implicit <code>list-item</code> counter results in incorrect values for the <code>counter()</code> function used to generate content, as it is <em>not</em> fully implemented; see <a href='https://webkit.org/b/260436'>bug 260436</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -51,7 +51,7 @@
               "chrome": {
                 "version_added": "≤83",
                 "partial_implementation": true,
-                "notes": "The <code>list-item</code> counter is <em>not</em> used when generating the default marker string on list items; see <a href='https://issues.chromium.org/issues/338233131'>bug 338233131</a>."
+                "notes": "The <code>list-item</code> counter is <em>not</em> used when generating the default marker string on list items; see <a href='https://crbug.com/338233131'>bug 338233131</a>."
               },
               "chrome_android": "mirror",
               "edge": {
@@ -72,7 +72,7 @@
               "safari": {
                 "version_added": "≤13.1",
                 "partial_implementation": true,
-                "notes": "The <code>list-item</code> counter is <em>not</em> used correctly when generating content, as it is <em>not</em> fully implemented; see <a href='https://bugs.webkit.org/show_bug.cgi?id=260436'>bug 260436</a>."
+                "notes": "The <code>list-item</code> counter is <em>not</em> used correctly when generating content, as it is <em>not</em> fully implemented; see <a href='https://webkit.org/b/260436'>bug 260436</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Add incomplete support (partial_implementation + notes) for the special `list-item` counter for the `counter-reset` CSS property in Chrome and Safari.

I'm currently unable to test it explicitly for Edge.  
I also haven't found time to test behaviors for the other `counter-*` properties.

#### Test results and supporting details

- [Chrome bug entry](https://issues.chromium.org/issues/338233131)
- [Safari bug entry](https://bugs.webkit.org/show_bug.cgi?id=260436)

#### Related issues

Fixes #23070 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
