### PR TITLE
Add Samsung Internet 26.0

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -285,9 +285,15 @@
         },
         "25.0": {
           "release_date": "2024-04-24",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "121"
+        },
+        "26.0": {
+          "release_date": "2024-06-07",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "122"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Add Samsung Internet 26.0. Blink Engine is 122.
Samsung Internet 27.0 is in Beta and seems to be Blink 125. I almost added it to the list as a “beta” but since Samsung Internet has no predictable release dates, this probably would break things?

#### Test results and supporting details

Manually tested on my phone. Couldn’t find any release notes, so no official release date. So release date is taken from its first appearance in Play Store.

#### Related issues


