### PR TITLE
Storage Updates

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -152,7 +152,10 @@
                 },
                 "firefox": {
                   "version_added": "78",
-                  "notes": "Only supported by the <code>sync</code> storage area."
+                  "notes": [
+                    "Supported by the <code>sync</code> and, from Firefox 131, <code>session</code> storage areas.",
+                    "Not implemented in <code>local</code>, see <a href='https://bugzil.la/138583'>bug 138583</a>"
+                  ]
                 },
                 "firefox_android": {
                   "version_added": false
@@ -349,6 +352,207 @@
                 "version_added": "15"
               }
             }
+          },
+          "clear": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
+            "empty_key": {
+              "__compat": {
+                "description": "Supports empty key",
+                "support": {
+                  "chrome": {
+                    "version_added": "≤105"
+                  },
+                  "edge": {
+                    "version_added": "14"
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
+          },
+          "getBytesInUse": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "78"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged",
+              "support": {
+                "chrome": {
+                  "version_added": "73"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "101"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
+            "empty_key": {
+              "__compat": {
+                "description": "Supports empty key",
+                "support": {
+                  "chrome": {
+                    "version_added": "≤105"
+                  },
+                  "edge": {
+                    "version_added": "14"
+                  },
+                  "firefox": {
+                    "version_added": "45"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
+          },
+          "set": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14",
+                  "notes": "storage is limited to 1MB per value."
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
           }
         },
         "managed": {
@@ -377,6 +581,196 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
+            }
+          },
+          "clear": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
+            "empty_key": {
+              "__compat": {
+                "description": "Supports empty key",
+                "support": {
+                  "chrome": {
+                    "version_added": "≤105"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
+          },
+          "getBytesInUse": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged",
+              "support": {
+                "chrome": {
+                  "version_added": "73"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "101"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
+            "empty_key": {
+              "__compat": {
+                "description": "Supports empty key",
+                "support": {
+                  "chrome": {
+                    "version_added": "≤105"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "57"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
+          },
+          "set": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
             }
           }
         },
@@ -425,6 +819,205 @@
               },
               "safari_ios": "mirror"
             }
+          },
+          "QUOTA_BYTES": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "131"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "clear": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "115"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "115"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror"
+              }
+            },
+            "empty_key": {
+              "__compat": {
+                "description": "Supports empty key",
+                "support": {
+                  "chrome": {
+                    "version_added": "≤105"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "115"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
+          },
+          "getBytesInUse": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "131"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "115"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "115"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror"
+              }
+            },
+            "empty_key": {
+              "__compat": {
+                "description": "Supports empty key",
+                "support": {
+                  "chrome": {
+                    "version_added": "≤105"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "115"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
+          },
+          "set": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "115"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "setAccessLevel": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/setAccessLevel",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "115"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "sync": {
@@ -463,6 +1056,220 @@
                   "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
                   "Safari 15 and 15.1 erroneously store sync items in the <code>local</code> storage area. If unable to locate sync items, check for sync items in the <code>local</code> storage area and do a one-time migration to the <code>sync</code> storage area."
                 ]
+              }
+            }
+          },
+          "clear": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "15"
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "15"
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
+            "empty_key": {
+              "__compat": {
+                "description": "Supports empty key",
+                "support": {
+                  "chrome": {
+                    "version_added": "≤105"
+                  },
+                  "edge": {
+                    "version_added": "15"
+                  },
+                  "firefox": {
+                    "version_added": "53"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
+          },
+          "getBytesInUse": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "15"
+                },
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1385832"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "onChanged": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged",
+              "support": {
+                "chrome": {
+                  "version_added": "73"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "101"
+                },
+                "firefox_android": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "remove": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "15"
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
+            "empty_key": {
+              "__compat": {
+                "description": "Supports empty key",
+                "support": {
+                  "chrome": {
+                    "version_added": "≤105"
+                  },
+                  "edge": {
+                    "version_added": "15"
+                  },
+                  "firefox": {
+                    "version_added": "53"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
+          },
+          "set": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "15",
+                  "notes": "storage is limited to 1MB per value."
+                },
+                "firefox": {
+                  "version_added": "53"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           }


### PR DESCRIPTION
#### Summary

This change:

- Address is the compatibility updates needed for [Bug 1908925](https://bugzilla.mozilla.org/show_bug.cgi?id=1908925)
"storage.session quota is not enforced" to cover the implementation of `storage.session.getBytesInUse` and `storage.session.QUOTA_BYTES`
- for clarity, exemplified the Storage area method types etc. under each storage area.

#### Related issues

Related content changes for [Bug 1908925](https://bugzilla.mozilla.org/show_bug.cgi?id=1908925) or in https://github.com/mdn/content/pull/35629