### PR TITLE
WebCodecs API - FF130 desktop release

### DIFF
--- a/api/EncodedVideoChunk.json
+++ b/api/EncodedVideoChunk.json
@@ -14,11 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "preview"
+          },
           "ie": {
             "version_added": false
           },
@@ -53,11 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -92,11 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -131,11 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -170,11 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -209,11 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -248,11 +248,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VideoColorSpace.json
+++ b/api/VideoColorSpace.json
@@ -14,11 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "preview"
+          },
           "ie": {
             "version_added": false
           },
@@ -53,11 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -92,11 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -131,11 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -170,11 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -209,11 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -248,11 +248,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -14,12 +14,12 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1749045",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130",
+            "impl_url": "https://bugzil.la/1749045"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "preview"
+          },
           "ie": {
             "version_added": false
           },
@@ -54,12 +54,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -94,12 +94,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -134,12 +134,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -174,12 +174,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -214,12 +214,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -255,12 +255,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -295,12 +295,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -336,12 +336,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -376,12 +376,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -416,12 +416,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749045"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VideoEncoder.json
+++ b/api/VideoEncoder.json
@@ -14,12 +14,12 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1872733",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130",
+            "impl_url": "https://bugzil.la/1872733"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "preview"
+          },
           "ie": {
             "version_added": false
           },
@@ -54,12 +54,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -94,12 +94,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -134,12 +134,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -173,14 +173,13 @@
               "version_added": "106"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -215,12 +214,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -255,12 +254,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -295,12 +294,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -336,12 +335,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -376,12 +375,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -416,12 +415,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1872733"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -14,12 +14,12 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1749539",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130",
+            "impl_url": "https://bugzil.la/1749539"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "preview"
+          },
           "ie": {
             "version_added": false
           },
@@ -54,12 +54,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -94,12 +94,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -134,12 +134,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -174,12 +174,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -214,12 +214,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -254,12 +254,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -294,12 +294,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -334,12 +334,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -374,12 +374,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -414,12 +414,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -454,12 +454,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -494,12 +494,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -534,12 +534,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -574,12 +574,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },
@@ -614,12 +614,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130",
+              "impl_url": "https://bugzil.la/1749539"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "preview"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
WebCodecs API is supported in desktop from FF130, but is only in nightly on Android, in https://bugzilla.mozilla.org/show_bug.cgi?id=1908572

This replaces the partial/preview and puts android to "preview" (which gives a warn with `npm run test`).

Related docs work can be tracked in https://github.com/mdn/content/issues/35695