### PR TITLE
Update Chromium data for storage Web Extensions interface

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage",
           "support": {
             "chrome": {
-              "version_added": "≤58"
+              "version_added": "19"
             },
             "edge": {
               "version_added": "14"
@@ -34,7 +34,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": {
                 "version_added": "14"
@@ -61,7 +61,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "19"
                 },
                 "edge": {
                   "version_added": "14"
@@ -90,7 +90,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "19"
                 },
                 "edge": {
                   "version_added": "14"
@@ -145,7 +145,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "19"
                 },
                 "edge": {
                   "version_added": "14"
@@ -196,7 +196,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "19"
                 },
                 "edge": {
                   "version_added": "14"
@@ -251,7 +251,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "19"
                 },
                 "edge": {
                   "version_added": "14",
@@ -303,7 +303,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageChange",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": {
                 "version_added": "14"
@@ -329,7 +329,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/local",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": {
                 "version_added": "14"
@@ -356,7 +356,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "33"
               },
               "edge": "mirror",
               "firefox": {
@@ -385,7 +385,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/onChanged",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": {
                 "version_added": "14"
@@ -432,7 +432,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": {
                 "version_added": "15"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `storage` Web Extensions interface. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://source.chromium.org/chromium/chromium/src/+/d98f697a09b1eab58701d7d0e69275ee7f375104, https://source.chromium.org/chromium/chromium/src/+/8fdf1ef21743a36b974614fb95da02d3172fa91c
