### PR TITLE
Update Firefox data for webextensions.api.webRequest.onBeforeSendHeaders.details.frameAncestors

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -3007,7 +3007,7 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": true
+                    "version_added": "58"
                   },
                   "firefox_android": "mirror",
                   "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `onBeforeSendHeaders.details.frameAncestors` member of the `webRequest` Web Extensions interface. The data comes from a bug in the web browser's bug tracker.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1305237
