### PR TITLE
Ff131 text fragments

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3496,6 +3496,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fragmentDirective",
           "spec_url": "https://wicg.github.io/scroll-to-text-fragment/#dom-document-fragmentdirective",
+          "tags": [
+            "web-features:target-text"
+          ],
           "support": {
             "chrome": {
               "version_added": "86"

--- a/api/Document.json
+++ b/api/Document.json
@@ -3503,7 +3503,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "131"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3521,7 +3521,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/FragmentDirective.json
+++ b/api/FragmentDirective.json
@@ -13,7 +13,7 @@
             "version_added": "83"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "131"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/FragmentDirective.json
+++ b/api/FragmentDirective.json
@@ -34,7 +34,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/FragmentDirective.json
+++ b/api/FragmentDirective.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FragmentDirective",
         "spec_url": "https://wicg.github.io/scroll-to-text-fragment/#fragmentdirective",
+        "tags": [
+          "web-features:target-text"
+        ],
         "support": {
           "chrome": {
             "version_added": "81"

--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "131",
               "impl_url": "https://bugzil.la/1694053"
             },
             "firefox_android": "mirror",

--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -35,7 +35,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -892,7 +892,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "131",
                 "impl_url": "https://bugzil.la/1753933"
               },
               "firefox_android": "mirror",

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -884,7 +884,10 @@
         },
         "text_fragments": {
           "__compat": {
-            "description": "URL text fragments",
+            "description": "URL text fragments",,
+            "tags": [
+              "web-features:target-text"
+            ],
             "support": {
               "chrome": {
                 "version_added": "80"


### PR DESCRIPTION
FF131 supports text fragments in https://bugzilla.mozilla.org/show_bug.cgi?id=1914877

This updates the features for each of the affected interfaces.
Note, I also added `"web-features:target-text"` to some of the cases where it was missing, and marked the `FragmentDirective` and `Document.fragmentDirective` as no longer experimental.

Related docs work can be tracked in https://github.com/mdn/content/issues/35703