### PR TITLE
fix: FedCM spec_url

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -492,7 +492,7 @@
         "identity_option": {
           "__compat": {
             "description": "<code>identity</code> option",
-            "spec_url": "https://fedidcg.github.io/FedCM/#dom-credentialrequestoptions-identity",
+            "spec_url": "https://www.w3.org/TR/fedcm/#dom-credentialrequestoptions-identity",
             "support": {
               "chrome": {
                 "version_added": "108"
@@ -527,7 +527,7 @@
           "context_option": {
             "__compat": {
               "description": "<code>identity.context</code>",
-              "spec_url": "https://fedidcg.github.io/FedCM/#dom-identitycredentialrequestoptions-context",
+              "spec_url": "https://www.w3.org/TR/fedcm/#dom-identitycredentialrequestoptions-context",
               "support": {
                 "chrome": {
                   "version_added": "116"
@@ -598,7 +598,7 @@
           "loginHint": {
             "__compat": {
               "description": "<code>identity.providers.loginHint</code>",
-              "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityproviderrequestoptions-loginhint",
+              "spec_url": "https://www.w3.org/TR/fedcm/#dom-identityproviderrequestoptions-loginhint",
               "support": {
                 "chrome": {
                   "version_added": "116"

--- a/api/IdentityCredential.json
+++ b/api/IdentityCredential.json
@@ -3,7 +3,7 @@
     "IdentityCredential": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityCredential",
-        "spec_url": "https://fedidcg.github.io/FedCM/#browser-api-identity-credential-interface",
+        "spec_url": "https://www.w3.org/TR/fedcm/wser-api-identity-credential-interface",
         "support": {
           "chrome": {
             "version_added": "108"
@@ -38,7 +38,7 @@
       "disconnect_static": {
         "__compat": {
           "description": "<code>disconnect()</code> static method",
-          "spec_url": "https://fedidcg.github.io/FedCM/#dom-identitycredential-disconnect",
+          "spec_url": "https://www.w3.org/TR/fedcm/#dom-identitycredential-disconnect",
           "support": {
             "chrome": {
               "version_added": "122"
@@ -109,7 +109,7 @@
       "token": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityCredential/token",
-          "spec_url": "https://fedidcg.github.io/FedCM/#dom-identitycredential-token",
+          "spec_url": "https://www.w3.org/TR/fedcm/#dom-identitycredential-token",
           "support": {
             "chrome": {
               "version_added": "108"

--- a/api/IdentityProvider.json
+++ b/api/IdentityProvider.json
@@ -3,7 +3,7 @@
     "IdentityProvider": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider",
-        "spec_url": "https://fedidcg.github.io/FedCM/#browser-api-identity-provider-interface",
+        "spec_url": "https://www.w3.org/TR/fedcm/#browser-api-identity-provider-interface",
         "support": {
           "chrome": {
             "version_added": "116"
@@ -39,7 +39,7 @@
         "__compat": {
           "description": "<code>close()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider/close_static",
-          "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityprovider-close",
+          "spec_url": "https://www.w3.org/TR/fedcm/#dom-identityprovider-close",
           "support": {
             "chrome": {
               "version_added": "120"
@@ -76,7 +76,7 @@
         "__compat": {
           "description": "<code>getUserInfo()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider/getUserInfo_static",
-          "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityprovider-getuserinfo",
+          "spec_url": "https://www.w3.org/TR/fedcm/#dom-identityprovider-getuserinfo",
           "support": {
             "chrome": {
               "version_added": "116"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1890,7 +1890,7 @@
       "login": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/login",
-          "spec_url": "https://fedidcg.github.io/FedCM/#dom-navigator-login",
+          "spec_url": "https://www.w3.org/TR/fedcm/#dom-navigator-login",
           "support": {
             "chrome": {
               "version_added": "120"

--- a/api/NavigatorLogin.json
+++ b/api/NavigatorLogin.json
@@ -3,7 +3,7 @@
     "NavigatorLogin": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLogin",
-        "spec_url": "https://fedidcg.github.io/FedCM/#navigatorlogin",
+        "spec_url": "https://www.w3.org/TR/fedcm/#navigatorlogin",
         "support": {
           "chrome": {
             "version_added": "120"
@@ -38,7 +38,7 @@
       "setStatus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLogin/setStatus",
-          "spec_url": "https://fedidcg.github.io/FedCM/#dom-navigatorlogin-setstatus",
+          "spec_url": "https://www.w3.org/TR/fedcm/#dom-navigatorlogin-setstatus",
           "support": {
             "chrome": {
               "version_added": "120"

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -771,7 +771,7 @@
         "identity-credentials-get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/identity-credentials-get",
-            "spec_url": "https://fedidcg.github.io/FedCM/#permissions-policy-integration",
+            "spec_url": "https://www.w3.org/TR/fedcm/#permissions-policy-integration",
             "support": {
               "chrome": {
                 "version_added": "110"

--- a/http/headers/Set-Login.json
+++ b/http/headers/Set-Login.json
@@ -4,7 +4,7 @@
       "Set-Login": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Login",
-          "spec_url": "https://fedidcg.github.io/FedCM/#login-status-http",
+          "spec_url": "https://www.w3.org/TR/fedcm/#login-status-http",
           "support": {
             "chrome": {
               "version_added": "120"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The link on https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API#specifications was leading to a 404

FedCM spec advanced from CG to WG, which published a First Public Working Draft.

