### PR TITLE
Update Firefox data for optional_permissions Web Extensions manifest

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -684,7 +684,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": true
+                "version_added": "63"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox for the `optional_permissions` Web Extensions manifest property for search with the intent of replacing `true` values with exact values to eliminate `true` values from BCD.

Commit: https://hg.mozilla.org/mozilla-central/rev/a659bb692003
Commit Date: August 2, 2018
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1477271
Target Milestone: mozilla63