### PR TITLE
Update Firefox data for webextensions.manifest.commands._execute_action

### DIFF
--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -201,7 +201,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": true,
+                "version_added": "91",
                 "notes": "Available for use in Manifest V3 or later."
               },
               "firefox_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `_execute_action` member of the `commands` Web Extensions manifest property. The data comes from a bug in the web browser's bug tracker.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1706398
