### PR TITLE
Update Firefox data for dictionaries Web Extensions manifest property

### DIFF
--- a/webextensions/manifest/dictionaries.json
+++ b/webextensions/manifest/dictionaries.json
@@ -10,7 +10,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "61"
             },
             "firefox_android": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `dictionaries` Web Extensions manifest property. The data comes from a bug in the web browser's bug tracker.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1410214
