### PR TITLE
Update Chromium data for browserAction Web Extensions interface

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -40,7 +40,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "20"
               },
               "edge": {
                 "version_added": "14"
@@ -144,7 +144,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeBackgroundColor",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "20"
               },
               "edge": {
                 "version_added": "14"
@@ -196,7 +196,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeText",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "20"
               },
               "edge": {
                 "version_added": "14"
@@ -266,7 +266,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getPopup",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "20"
               },
               "edge": "mirror",
               "firefox": {
@@ -312,7 +312,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getTitle",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "20"
               },
               "edge": {
                 "version_added": "15"
@@ -509,7 +509,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "20"
               },
               "edge": {
                 "version_added": "14"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `browserAction` Web Extensions interface. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://source.chromium.org/chromium/chromium/src/+/e28a937b1cb87e62afefb5918512ce8b9dfc49d5
