### PR TITLE
Update Chromium data for browsingData Web Extensions interface

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData",
           "support": {
             "chrome": {
-              "version_added": "≤58"
+              "version_added": "19"
             },
             "edge": "mirror",
             "firefox": {
@@ -443,7 +443,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {
@@ -474,7 +474,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeCache",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {
@@ -505,7 +505,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeCookies",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {
@@ -533,7 +533,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeDownloads",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {
@@ -556,7 +556,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeFormData",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {
@@ -579,7 +579,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeHistory",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {
@@ -602,7 +602,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removeLocalStorage",
             "support": {
               "chrome": {
-                "version_added": "≤61"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {
@@ -649,7 +649,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removePasswords",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {
@@ -671,7 +671,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/removePluginData",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "19"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `browsingData` Web Extensions interface. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://source.chromium.org/chromium/chromium/src/+/006236a292a8dec7b134b3db35bc1d9ea7767513
