### PR TITLE
Update Chromium data for webextensions.api.browsingData.DataTypeSet

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData",
           "support": {
             "chrome": {
-              "version_added": "≤58"
+              "version_added": "≤30"
             },
             "edge": "mirror",
             "firefox": {
@@ -26,7 +26,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/DataTypeSet",
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -53,7 +53,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -80,7 +80,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -107,7 +107,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -126,7 +126,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -153,7 +153,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -180,7 +180,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -201,7 +201,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -222,7 +222,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -243,7 +243,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -264,7 +264,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -283,7 +283,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "30"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DataTypeSet` member of the `browsingData` Web Extensions interface. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://source.chromium.org/chromium/chromium/src/+/c606b46a266fcef9370b02a2db8f08c8bc57fbcf
