### PR TITLE
Updates for Firefox 130 release

### DIFF
--- a/api/AudioData.json
+++ b/api/AudioData.json
@@ -14,9 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
+            "version_added": "130"
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -31,7 +33,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -51,9 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -68,7 +72,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -88,9 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -105,7 +111,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -125,9 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -142,7 +150,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -162,9 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -179,7 +189,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -199,9 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -216,7 +228,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -236,9 +248,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -253,7 +267,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -273,9 +287,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -290,7 +306,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -310,9 +326,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -327,7 +345,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -347,9 +365,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -364,7 +384,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -384,9 +404,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -401,7 +423,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -421,9 +443,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -438,7 +462,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/AudioDecoder.json
+++ b/api/AudioDecoder.json
@@ -14,10 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1749044"
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -32,7 +33,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -52,10 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -70,7 +72,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -90,10 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -108,7 +111,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -128,10 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -146,7 +150,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -166,10 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -184,7 +189,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -204,10 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -222,7 +228,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -243,10 +249,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -261,7 +268,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -281,10 +288,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -299,7 +307,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -320,10 +328,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -338,7 +347,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -358,10 +367,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -376,7 +386,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -396,10 +406,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749044"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -414,7 +425,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -14,10 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1749046"
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -32,7 +33,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -52,10 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -70,7 +72,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -90,10 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -108,7 +111,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -128,10 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -146,7 +150,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -313,10 +317,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -331,7 +336,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -351,10 +356,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -369,7 +375,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -389,10 +395,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -407,7 +414,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -427,10 +434,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -445,7 +453,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -466,10 +474,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -484,7 +493,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -504,10 +513,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -522,7 +532,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -542,10 +552,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749046"
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -560,7 +571,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/EncodedAudioChunk.json
+++ b/api/EncodedAudioChunk.json
@@ -14,9 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
+            "version_added": "130"
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -31,7 +33,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -51,9 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -68,7 +72,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -88,9 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -105,7 +111,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -125,9 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -142,7 +150,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -162,9 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -179,7 +189,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -199,9 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -216,7 +228,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -236,9 +248,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "130"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -253,7 +267,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/EncodedVideoChunk.json
+++ b/api/EncodedVideoChunk.json
@@ -14,11 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -53,11 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -92,11 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -131,11 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -170,11 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -209,11 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -248,11 +248,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VideoColorSpace.json
+++ b/api/VideoColorSpace.json
@@ -14,11 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -53,11 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -92,11 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -131,11 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -170,11 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -209,11 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -248,11 +248,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -14,12 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1749045",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -54,12 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -94,12 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -134,12 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -174,12 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -214,12 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -255,12 +249,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -295,12 +288,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -336,12 +328,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -376,12 +367,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -416,12 +406,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749045",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VideoEncoder.json
+++ b/api/VideoEncoder.json
@@ -14,12 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1872733",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -54,12 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -94,12 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -134,12 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -175,12 +171,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -215,12 +210,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -255,12 +249,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -295,12 +288,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -336,12 +328,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -376,12 +367,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -416,12 +406,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1872733",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -14,12 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1749539",
-            "partial_implementation": true,
-            "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+            "version_added": "130"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -54,12 +53,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -94,12 +92,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -134,12 +131,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -174,12 +170,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -214,12 +209,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -254,12 +248,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -294,12 +287,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -334,12 +326,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -374,12 +365,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -414,12 +404,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -454,12 +443,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -494,12 +482,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -534,12 +521,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -574,12 +560,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -614,12 +599,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1749539",
-              "partial_implementation": true,
-              "notes": "Only supported on Linux, see <a href='https://bugzil.la/1749047'>bug 1749047</a>."
+              "version_added": "130"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.2 found new features shipping in Firefox 130 release which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

Originally we collected compat data for Firefox 130 beta, but we have seen some uplifts into the final release of 130:

With this PR, BCD considers the following additional 93 features as shipping in Firefox 130:

1. api.AudioData
2. api.AudioData.AudioData
3. api.AudioData.allocationSize
4. api.AudioData.clone
5. api.AudioData.close
6. api.AudioData.copyTo
7. api.AudioData.duration
8. api.AudioData.format
9. api.AudioData.numberOfChannels
10. api.AudioData.numberOfFrames
11. api.AudioData.sampleRate
12. api.AudioData.timestamp
13. api.AudioDecoder
14. api.AudioDecoder.AudioDecoder
15. api.AudioDecoder.close
16. api.AudioDecoder.configure
17. api.AudioDecoder.decode
18. api.AudioDecoder.decodeQueueSize
19. api.AudioDecoder.dequeue_event
20. api.AudioDecoder.flush
21. api.AudioDecoder.isConfigSupported_static
22. api.AudioDecoder.reset
23. api.AudioDecoder.state
24. api.AudioEncoder
25. api.AudioEncoder.AudioEncoder
26. api.AudioEncoder.close
27. api.AudioEncoder.configure
28. api.AudioEncoder.dequeue_event
29. api.AudioEncoder.encode
30. api.AudioEncoder.encodeQueueSize
31. api.AudioEncoder.flush
32. api.AudioEncoder.isConfigSupported_static
33. api.AudioEncoder.reset
34. api.AudioEncoder.state
35. api.EncodedAudioChunk
36. api.EncodedAudioChunk.EncodedAudioChunk
37. api.EncodedAudioChunk.byteLength
38. api.EncodedAudioChunk.copyTo
39. api.EncodedAudioChunk.duration
40. api.EncodedAudioChunk.timestamp
41. api.EncodedAudioChunk.type
42. api.EncodedVideoChunk
43. api.EncodedVideoChunk.EncodedVideoChunk
44. api.EncodedVideoChunk.byteLength
45. api.EncodedVideoChunk.copyTo
46. api.EncodedVideoChunk.duration
47. api.EncodedVideoChunk.timestamp
48. api.EncodedVideoChunk.type
49. api.VideoColorSpace
50. api.VideoColorSpace.VideoColorSpace
51. api.VideoColorSpace.fullRange
52. api.VideoColorSpace.matrix
53. api.VideoColorSpace.primaries
54. api.VideoColorSpace.toJSON
55. api.VideoColorSpace.transfer
56. api.VideoDecoder
57. api.VideoDecoder.VideoDecoder
58. api.VideoDecoder.close
59. api.VideoDecoder.configure
60. api.VideoDecoder.decode
61. api.VideoDecoder.decodeQueueSize
62. api.VideoDecoder.dequeue_event
63. api.VideoDecoder.flush
64. api.VideoDecoder.isConfigSupported_static
65. api.VideoDecoder.reset
66. api.VideoDecoder.state
67. api.VideoEncoder
68. api.VideoEncoder.VideoEncoder
69. api.VideoEncoder.close
70. api.VideoEncoder.configure
71. api.VideoEncoder.dequeue_event
72. api.VideoEncoder.encode
73. api.VideoEncoder.encodeQueueSize
74. api.VideoEncoder.flush
75. api.VideoEncoder.isConfigSupported_static
76. api.VideoEncoder.reset
77. api.VideoEncoder.state
78. api.VideoFrame
79. api.VideoFrame.VideoFrame
80. api.VideoFrame.allocationSize
81. api.VideoFrame.clone
82. api.VideoFrame.close
83. api.VideoFrame.codedHeight
84. api.VideoFrame.codedRect
85. api.VideoFrame.codedWidth
86. api.VideoFrame.colorSpace
87. api.VideoFrame.copyTo
88. api.VideoFrame.displayHeight
89. api.VideoFrame.displayWidth
90. api.VideoFrame.duration
91. api.VideoFrame.format
92. api.VideoFrame.timestamp
93. api.VideoFrame.visibleRect

See also https://github.com/mdn/mdn/issues/570 and https://www.mozilla.org/en-US/firefox/130.0beta/releasenotes/