### PR TITLE
Updates for Firefox 131 beta

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3503,7 +3503,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "131"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3521,7 +3521,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/FragmentDirective.json
+++ b/api/FragmentDirective.json
@@ -13,7 +13,7 @@
             "version_added": "83"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "131"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -31,7 +31,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -232,7 +232,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "131"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -522,7 +522,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "131"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -232,7 +232,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "131"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -522,7 +522,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "131"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -103,7 +103,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "131"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -120,7 +120,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -137,7 +137,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "131"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -154,7 +154,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1694053"
+              "version_added": "131"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -35,7 +34,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -892,8 +892,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1753933"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -60,8 +60,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -82,7 +81,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -108,8 +107,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -130,7 +128,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -156,8 +154,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -178,7 +175,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -204,8 +201,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -226,7 +222,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -252,8 +248,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -274,7 +269,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -300,8 +295,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -322,7 +316,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -348,8 +342,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -370,7 +363,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -396,8 +389,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -418,7 +410,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -444,8 +436,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -466,7 +457,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -492,8 +483,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -514,7 +504,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -540,8 +530,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -562,7 +551,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -588,8 +577,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -610,7 +598,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -636,8 +624,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1568906"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -658,7 +645,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.2 found new features shipping in Firefox 131 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 21 features as shipping in Firefox 131 (most updates submitted in other PRs manually this time):

- api.Document.fragmentDirective
- api.FragmentDirective
- api.Permissions.permission_camera ([might be a beta thing only](https://bugzilla.mozilla.org/show_bug.cgi?id=1609427))
- api.Permissions.permission_microphone (dito)
- api.PointerEvent.altitudeAngle
- api.PointerEvent.azimuthAngle
- css.selectors.target-text
- html.elements.a.text_fragments
- javascript.builtins.Iterator.Iterator
- javascript.builtins.Iterator.drop
- javascript.builtins.Iterator.every
- javascript.builtins.Iterator.filter
- javascript.builtins.Iterator.find
- javascript.builtins.Iterator.flatMap
- javascript.builtins.Iterator.forEach
- javascript.builtins.Iterator.from
- javascript.builtins.Iterator.map
- javascript.builtins.Iterator.reduce
- javascript.builtins.Iterator.some
- javascript.builtins.Iterator.take
- javascript.builtins.Iterator.toArray

See also https://github.com/mdn/mdn/issues/574 and https://www.mozilla.org/en-US/firefox/131.0beta/releasenotes/