### PR TITLE
Add `background-clip: border-area`

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -112,9 +112,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -101,6 +101,44 @@
             "deprecated": false
           }
         },
+        "border-area": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-border-area",
+            "tags": [
+              "web-features:background-clip-border-area"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "border-box": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-background-clip-border-box",
@@ -224,6 +262,7 @@
         },
         "text": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text",
             "tags": [
               "web-features:background-clip-text"
             ],


### PR DESCRIPTION
Supported since STP 202: https://webkit.org/blog/15798/release-notes-for-safari-technology-preview-202/

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
