### PR TITLE
fix(css): update container spec URLs

### DIFF
--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -3,7 +3,7 @@
     "CSSContainerRule": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule",
-        "spec_url": "https://drafts.csswg.org/css-contain-3/#the-csscontainerrule-interface",
+        "spec_url": "https://drafts.csswg.org/css-conditional-5/#the-csscontainerrule-interface",
         "tags": [
           "web-features:container-queries"
         ],
@@ -39,7 +39,7 @@
       "containerName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerName",
-          "spec_url": "https://drafts.csswg.org/css-contain-3/#dom-csscontainerrule-containername",
+          "spec_url": "https://drafts.csswg.org/css-conditional-5/#dom-csscontainerrule-containername",
           "tags": [
             "web-features:container-queries"
           ],
@@ -76,7 +76,7 @@
       "containerQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerQuery",
-          "spec_url": "https://drafts.csswg.org/css-contain-3/#dom-csscontainerrule-containerquery",
+          "spec_url": "https://drafts.csswg.org/css-conditional-5/#dom-csscontainerrule-containerquery",
           "tags": [
             "web-features:container-queries"
           ],

--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>@container</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@container",
-          "spec_url": "https://drafts.csswg.org/css-contain-3/#container-rule",
+          "spec_url": "https://drafts.csswg.org/css-conditional-5/#container-rule",
           "tags": [
             "web-features:container-queries"
           ],
@@ -42,7 +42,7 @@
           "__compat": {
             "description": "Style queries for custom properties",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@container",
-            "spec_url": "https://drafts.csswg.org/css-contain-3/#style-container",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#style-container",
             "tags": [
               "web-features:container-style-queries"
             ],

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -73,7 +73,7 @@
         "inline-size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain#inline-size",
-            "spec_url": "https://drafts.csswg.org/css-contain/#valdef-contain-inline-size",
+            "spec_url": "https://drafts.csswg.org/css-contain-2/#valdef-contain-inline-size",
             "tags": [
               "web-features:contain-inline-size"
             ],

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -73,7 +73,7 @@
         "inline-size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain#inline-size",
-            "spec_url": "https://drafts.csswg.org/css-contain-3/#valdef-contain-inline-size",
+            "spec_url": "https://drafts.csswg.org/css-contain/#valdef-contain-inline-size",
             "tags": [
               "web-features:contain-inline-size"
             ],

--- a/css/properties/container-name.json
+++ b/css/properties/container-name.json
@@ -4,7 +4,7 @@
       "container-name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container-name",
-          "spec_url": "https://drafts.csswg.org/css-contain-3/#container-name",
+          "spec_url": "https://drafts.csswg.org/css-conditional-5/#container-name",
           "tags": [
             "web-features:container-queries"
           ],
@@ -39,7 +39,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-contain-3/#valdef-container-name-none",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-name-none",
             "tags": [
               "web-features:container-queries"
             ],

--- a/css/properties/container-type.json
+++ b/css/properties/container-type.json
@@ -4,7 +4,7 @@
       "container-type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container-type",
-          "spec_url": "https://drafts.csswg.org/css-contain-3/#container-type",
+          "spec_url": "https://drafts.csswg.org/css-conditional-5/#container-type",
           "tags": [
             "web-features:container-queries"
           ],
@@ -39,7 +39,7 @@
         },
         "inline-size": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-contain-3/#valdef-container-type-inline-size",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-type-inline-size",
             "tags": [
               "web-features:container-queries"
             ],
@@ -75,7 +75,7 @@
         },
         "normal": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-contain-3/#valdef-container-type-normal",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-type-normal",
             "tags": [
               "web-features:container-queries"
             ],
@@ -111,7 +111,7 @@
         },
         "size": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-contain-3/#valdef-container-type-size",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-type-size",
             "tags": [
               "web-features:container-queries"
             ],

--- a/css/properties/container.json
+++ b/css/properties/container.json
@@ -4,7 +4,7 @@
       "container": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container",
-          "spec_url": "https://drafts.csswg.org/css-contain-3/#container-shorthand",
+          "spec_url": "https://drafts.csswg.org/css-conditional-5/#container-shorthand",
           "tags": [
             "web-features:container-queries"
           ],


### PR DESCRIPTION
The contents of `css-contain-3` specification [have been moved](https://drafts.csswg.org/css-contain-3/#changes-2022-08) to `css-conditional-5` . 

Refs
- https://github.com/w3c/csswg-drafts/pull/10447
- https://github.com/w3c/csswg-drafts/issues/10433#issuecomment-2165558965