### PR TITLE
FF46 makes push and notifications permission aliases

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -597,7 +597,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "46"
+              "version_added": "46",
+              "notes": "An alias for the `push` permission (returns the same value)."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -702,7 +703,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "46"
+              "version_added": "46",
+              "notes": "An alias for the `notifications` permission (returns the same value)."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -598,7 +598,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "46",
-              "notes": "An alias for the `push` permission (returns the same value)."
+              "notes": "Alias for the `push` permission (returns the same value)."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -704,7 +704,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "46",
-              "notes": "An alias for the `notifications` permission (returns the same value)."
+              "notes": "Alias for the `notifications` permission (returns the same value)."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
The docs for `Permissions.query()` had the following string, which I am removing:

> [!NOTE]
> As of Firefox 44, the permissions for [Notifications](/en-US/docs/Web/API/Notifications_API) and [Push](/en-US/docs/Web/API/Push_API) have been merged. If permission is granted (e.g. by the user, in the relevant permissions dialog), `navigator.permissions.query()` will return `true` for both `notifications` and `push`.

Moved this info into the BCD under the respective permissions, with a note that they are aliases. The first version is 46 and not 44, so the docs were wrong "at best".

Related docs work in https://github.com/mdn/content/issues/35765