### PR TITLE
Update Chromium data for WEBGL_compressed_texture_pvrtc API

### DIFF
--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -6,7 +6,7 @@
         "spec_url": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "128"
           },
           "chrome_android": {
             "version_added": "28"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_compressed_texture_pvrtc` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WEBGL_compressed_texture_pvrtc
