### PR TITLE
Traverse script: allow filtering for features without tags

### DIFF
--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -34,7 +34,7 @@ export function* iterateFeatures(
         if (obj[i].__compat) {
           if (tag) {
             const tags = obj[i].__compat?.tags;
-            if (tags && tags.includes(tag)) {
+            if ((tags && tags.includes(tag)) || (!tags && tag == 'false')) {
               yield `${identifier}${i}`;
             }
           } else {
@@ -202,7 +202,8 @@ if (esMain(import.meta)) {
         })
         .option('tag', {
           alias: 't',
-          describe: 'Filter by tag value.',
+          describe:
+            'Filter by tag value. Set to `false` to search for features with no tags.',
           type: 'string',
           nargs: 1,
           default: '',
@@ -247,6 +248,10 @@ if (esMain(import.meta)) {
         .example(
           'npm run traverse -- -t web-features:idle-detection',
           'Find all features tagged with web-features:idle-detection.',
+        )
+        .example(
+          'npm run traverse -- -t false',
+          'Find all features with no tags.',
         );
     },
   );


### PR DESCRIPTION
This PR adds the ability to filter for features without any tags.
