### PR TITLE
SVG support was introduced in WebView Android 3

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -1808,11 +1808,11 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2",
+                "version_added": "3",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               },
               {
-                "version_added": "2",
+                "version_added": "3",
                 "version_removed": "120",
                 "partial_implementation": true,
                 "notes": "While the property is recognized, values applied to it don't have any effect."
@@ -1951,7 +1951,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "2"
+              "version_added": "3"
             }
           },
           "status": {
@@ -2658,8 +2658,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2",
-                "notes": "Android 2.3 has a bug where input forms will \"jump\" when typing, if any container element has a <code>-webkit-transform</code>."
+                "version_added": "3"
               }
             ]
           },


### PR DESCRIPTION
This PR fixes #10790.

Note: a note explaining Android 2.3's behavior was removed.  It appears that the data was copied from the CSS property.
