### PR TITLE
Update Safari data for css.selectors.any-link.not_match_link

### DIFF
--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -95,8 +95,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>bug 220740</a>."
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `not_match_link` member of the `any-link` CSS selector. This fixes #22794, which contains the supporting evidence for this change.

Additional Notes: https://github.com/WebKit/WebKit/commit/fd74541ad3bb9e0c9d009e2834a4164db6747e09
