### PR TITLE
Update Safari data for api.CredentialsContainer.create.publicKey_option.extensions.largeBlob

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -301,7 +301,7 @@
                   "opera": "mirror",
                   "opera_android": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "17"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
@@ -310,7 +310,7 @@
                   }
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
                 }


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `create.publicKey_option.extensions.largeBlob` member of the `CredentialsContainer` API. This fixes #22798, which contains the supporting evidence for this change.
