### PR TITLE
Update Safari iOS data for api.HTMLElement.popover

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1998,7 +1998,11 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17",
+              "partial_implementation": true,
+              "notes": "On iOS and iPadOS, popovers are not dismissed when the user taps outside of the popover area, see <a href='https://webkit.org/b/267688'>bug 267688</a>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `popover` member of the `HTMLElement` API. This fixes #22927, which contains the supporting evidence for this change.
