### PR TITLE
Chromium doesn't support webextensions.manifest.action.theme_icons

### DIFF
--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -150,7 +150,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "88"
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `theme_icons` member of the `action` Web Extensions manifest property. This fixes #23151, which contains the supporting evidence for this change.
