### PR TITLE
Update Safari data for ImageCapture API

### DIFF
--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -28,7 +28,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "17.4",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "Image Capture API",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -69,7 +76,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Image Capture API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -103,7 +117,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Image Capture API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -141,7 +162,14 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "17.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Image Capture API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -224,7 +252,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Image Capture API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -266,7 +301,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Image Capture API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `ImageCapture` API. This fixes #23727, which contains the supporting evidence for this change.
