### PR TITLE
FF131 Set-Cookie partitioned cookies

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -121,7 +121,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "131"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -140,7 +140,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF131 supports partitioned cookies (CHIPS) by default in https://bugzilla.mozilla.org/show_bug.cgi?id=1908160.

This updates the release feature.

Related docs work can be tracked in https://github.com/mdn/content/issues/35722