### PR TITLE
Update WebView Android data for html.elements.script.type.speculationrules

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -737,7 +737,9 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": true,
@@ -769,7 +771,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -804,7 +808,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -839,7 +845,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -874,7 +882,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -907,7 +917,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -940,7 +952,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -975,7 +989,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -1017,7 +1033,9 @@
                     "samsunginternet_android": {
                       "version_added": false
                     },
-                    "webview_android": "mirror"
+                    "webview_android": {
+                      "version_added": false
+                    }
                   },
                   "status": {
                     "experimental": true,
@@ -1051,7 +1069,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -1086,7 +1106,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,
@@ -1119,7 +1141,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
+                  "webview_android": {
+                    "version_added": false
+                  }
                 },
                 "status": {
                   "experimental": true,


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `type.speculationrules` member of the `script` HTML element. This fixes #23213, which contains the supporting evidence for this change.
