### PR TITLE
Add missing webextensions.api.declarativeNetRequest.RuleCondition.initiatorDomains feature

### DIFF
--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -1107,6 +1107,25 @@
               }
             }
           },
+          "initiatorDomains": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "101"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "113"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "isUrlFilterCaseSensitive": {
             "__compat": {
               "support": {


### PR DESCRIPTION
This PR adds the missing `RuleCondition.initiatorDomains` member of the `declarativeNetRequest` Web Extensions interface. This fixes #23868, which contains the supporting evidence for this change.

Additional Notes: Firefox data was guesstimated using the data from `excludedInitiatorDomains`.
