### PR TITLE
Update metadata for Expect-CT HTTP header

### DIFF
--- a/http/headers/Expect-CT.json
+++ b/http/headers/Expect-CT.json
@@ -39,7 +39,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
This PR updates and corrects the metadata (spec URLs, descriptions, statuses, etc.) for the `Expect-CT` HTTP header.

Additional Notes: Fixes #24144.
