### PR TITLE
Update metadata for css.properties.width.stretch

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -390,7 +390,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects the metadata (spec URLs, descriptions, statuses, etc.) for the `stretch` member of the `width` CSS property.

Additional Notes: Fixes #24190.
