### PR TITLE
Update Firefox data for html.elements.link.rel.icon

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -840,7 +840,10 @@
                 },
                 "firefox": {
                   "version_added": "2",
-                  "notes": "Before Firefox 83, the <code>crossorigin</code> attribute is not supported for <code>rel=\"icon\"</code>."
+                  "notes": [
+                    "Before Firefox 83, the <code>crossorigin</code> attribute is not supported for <code>rel=\"icon\"</code>.",
+                    "The <code>media</code> attribute is not supported for <code>rel=\"icon\"</code>, see <a href='https://bugzil.la/1603885'>bug 1603885</a>."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": "4"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `rel.icon` member of the `link` HTML element. This fixes #24213, which contains the supporting evidence for this change.
