### PR TITLE
Update metadata for css.properties.display.none

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -747,6 +747,7 @@
         },
         "none": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display/#valdef-display-none",
             "support": {
               "chrome": {
                 "version_added": "1",


### PR DESCRIPTION
This PR updates and corrects the metadata (spec URLs, descriptions, statuses, etc.) for the `none` member of the `display` CSS property.
