### PR TITLE
Add missing css.properties.display.none.option_is_hidden feature

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -787,6 +787,39 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "option_is_hidden": {
+            "__compat": {
+              "description": "Setting <code>display: none</code> on an <code>&lt;option&gt;</code> element hides it from the dropdown",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
           }
         },
         "ruby": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -790,7 +790,7 @@
           },
           "option_is_hidden": {
             "__compat": {
-              "description": "Setting <code>display: none</code> on an <code>&lt;option&gt;</code> element hides it from the dropdown",
+              "description": "Setting <code>display: none</code> on an <code>&lt;option&gt;</code> element hides it from the dropdown.",
               "support": {
                 "chrome": {
                   "version_added": "1"


### PR DESCRIPTION
This PR adds the missing `none.option_is_hidden` member of the `display` CSS property. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code:

```html
<style id="test-style">
	#hidden {
		display: none;
	}
</style>
<select>
	<option>One</option>
	<option id="hidden">Two</option>
	<option>Three</option>
</select>
```

Additional Notes: This fixes #24247.
