### PR TITLE
FF131 PointerEvent.PointerEvent() - azimuthAngle, altitudeAngle options

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -90,6 +90,72 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_altitudeAngle_parameter": {
+          "__compat": {
+            "description": "<code>options.altitudeAngle</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "131"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_azimuthAngle_parameter": {
+          "__compat": {
+            "description": "<code>options.azimuthAngle</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "131"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "altitudeAngle": {


### PR DESCRIPTION
FF131 Added support for [`PointerEvent.altitudeAngle`](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/altitudeAngle) and `azimuthAngle` in https://bugzilla.mozilla.org/show_bug.cgi?id=1656377

We added the features for the properties themselves in #24332. This adds the same properties for the constructor argument `options`. Note I only added the new ones, not the ones that should have been there "forever".

FYI @Elchi3 Don't know if the collector can be updated to detect these being supported.

Related docs work can be tracked in https://github.com/mdn/content/issues/35721



