### PR TITLE
CSS Style Queries: Add note about Safari not supporting these on body

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -65,7 +65,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18"
+                "version_added": "18",
+                "notes": "Does not work on body. See <a href='https://webkit.org/b/271040'>bug 271040</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -66,7 +66,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "18",
-                "notes": "Does not work on body. See <a href='https://webkit.org/b/271040'>bug 271040</a>."
+                "notes": "Does not work on <code>body</code>. See <a href='https://webkit.org/b/271040'>bug 271040</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -66,7 +66,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "18",
-                "notes": "Does not work on <code>body</code>. See <a href='https://webkit.org/b/271040'>bug 271040</a>."
+                "notes": "The document element cannot be a container. See <a href='https://webkit.org/b/271040'>bug 271040</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari has a Style Queries bug in which they don’t work on `<body>`, which is very unfortunate.

- Bug Report: https://bugs.webkit.org/show_bug.cgi?id=271040
- Repro: https://codepen.io/bramus/pen/LYKqzob 
  - The box should be green in Safari 18 / Safari Technology Preview, but it is not. Changing the `body` selector to `main` fixes the demo, confirming the bug report.