### PR TITLE
Navigator.cookiesEnabled - Safari 18 fix

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -777,9 +777,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "18"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "18",
+                "partial_implementation": true,
+                "notes": "Returns <code>true</code> even if the browser is set to block cookies if <code>navigator.cookieEnabled</code> is invoked inside a third-party <code>iframe</code>)"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
[Safari 18](https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes) fixes a long standing bug where `Navigator.cookiesEnabled` could return `true` in some conditions where cookies are blocked. 

> Fixed navigator.cookieEnabled to return false when cookies are blocked. (121284878)

I fixed this by calling the old implementation partial and adding a new feature.

This is related to https://github.com/mdn/content/pull/35725

