### PR TITLE
FF131 CSSPositionTryRule/TryDescriptors - behind pref

### DIFF
--- a/api/CSSPositionTryDescriptors.json
+++ b/api/CSSPositionTryDescriptors.json
@@ -14,8 +14,15 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1838746"
+            "version_added": "131",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "layout.css.anchor-positioning.enabled",
+                "value_to_set": "true"
+              }
+            ],
+            "impl_url": "https://bugzil.la/1909346"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,8 +58,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -89,8 +103,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -127,8 +148,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -165,8 +193,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -203,8 +238,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -241,8 +283,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -279,8 +328,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -317,8 +373,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -355,8 +418,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -393,8 +463,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -431,8 +508,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -469,8 +553,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -507,8 +598,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -545,8 +643,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -583,8 +688,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -621,8 +733,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -659,8 +778,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -697,8 +823,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -735,8 +868,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -773,8 +913,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -811,8 +958,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -849,8 +1003,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -887,8 +1048,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -925,8 +1093,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -963,8 +1138,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1001,8 +1183,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1039,8 +1228,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1077,8 +1273,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1115,8 +1318,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1153,8 +1363,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1191,8 +1408,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1229,8 +1453,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1267,8 +1498,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1305,8 +1543,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1343,8 +1588,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1381,8 +1633,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1419,8 +1678,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1457,8 +1723,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1495,8 +1768,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1533,8 +1813,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1571,8 +1858,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1609,8 +1903,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1647,8 +1948,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1685,8 +1993,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1723,8 +2038,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1761,8 +2083,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1799,8 +2128,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1837,8 +2173,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1875,8 +2218,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1913,8 +2263,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1951,8 +2308,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1989,8 +2353,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2027,8 +2398,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2065,8 +2443,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2103,8 +2488,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2141,8 +2533,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2179,8 +2578,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2217,8 +2623,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2255,8 +2668,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2293,8 +2713,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2331,8 +2758,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2369,8 +2803,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2407,8 +2848,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2445,8 +2893,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2489,8 +2944,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2527,8 +2989,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2571,8 +3040,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2609,8 +3085,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2647,8 +3130,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2685,8 +3175,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/CSSPositionTryRule.json
+++ b/api/CSSPositionTryRule.json
@@ -14,8 +14,15 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1838746"
+            "version_added": "131",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "layout.css.anchor-positioning.enabled",
+                "value_to_set": "true"
+              }
+            ],
+            "impl_url": "https://bugzil.la/1909346"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,8 +58,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -89,8 +103,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "131",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.anchor-positioning.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1909346"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF131 implements [`CSSPositionTryRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPositionTryRule) and [`CSSPositionTryDescriptors`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPositionTryDescriptors) behind a preference `layout.css.anchor-positioning.enabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=1909346

This updates the relevant feature.

Related docs work can be tracked in https://github.com/mdn/content/issues/35699