### PR TITLE
FF131 Document.caretPositionFromPoint() has new option

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -895,6 +895,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_parameter": {
+          "__compat": {
+            "description": "<code>options</code> parameter",
+            "tags": [
+              "web-features:document-caretpositionfrompoint"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "128"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "131"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "caretRangeFromPoint": {


### PR DESCRIPTION
FF131 adds support for "new shadow dom behaviour" in [`Document/caretPositionFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/caretPositionFromPoint) in https://bugzilla.mozilla.org/show_bug.cgi?id=1914596

Essentially this means a new option, called `options` has been added the the api, along with `x`, `y`. The option allows a caller to supply a list of shadow roots, which allows the caret position to be resolved (or not, if not supplied). 
Chrome implemented this in their first release (128), but FF implemented the API in FF20, so this is a compatibility difference. I've added the option as a method subfeature.

Related docs work can be tracked in https://github.com/mdn/content/issues/35702