### PR TITLE
Safari 18 RC, NavigationActivation

### DIFF
--- a/api/NavigationActivation.json
+++ b/api/NavigationActivation.json
@@ -25,7 +25,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -33,7 +33,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -63,7 +63,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -71,7 +71,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -102,7 +102,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -110,7 +110,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -141,7 +141,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -149,7 +149,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The @openwebdocs [BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.3 found new features shipping in Safari 18 RC (20619.1.26.31.6). 

This PR double checks if anything has changed from the beta collector run in https://github.com/mdn/browser-compat-data/pull/23367 and I've found one difference which might be a false positive (or possibly a case of an accidental early exposure):

- api.NavigationActivation
- api.NavigationActivation.entry
- api.NavigationActivation.from
- api.NavigationActivation.navigationType

Given that `navigator.activation` is not supported, I guess that the `NavigationObject` shouldn't be there either?

Other than this, the data looks good to me and BCD should be up-to-date (from what we can tell) for the upcoming Safari 18 release.

Thoughts? @jdatapple @nt1m 