### PR TITLE
feat(css): Update browser compatibility data for the CSS `calc-size()` function

### DIFF
--- a/css/types/calc-size.json
+++ b/css/types/calc-size.json
@@ -12,7 +12,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1896734"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -22,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/274177"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Add `impl_url` to Firefox and Safari.