### PR TITLE
Update WebView iOS using collector results

### DIFF
--- a/api/Client.json
+++ b/api/Client.json
@@ -28,7 +28,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -64,7 +66,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -101,7 +105,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -138,7 +144,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -175,7 +183,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -212,7 +222,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Clients.json
+++ b/api/Clients.json
@@ -28,7 +28,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -64,7 +66,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -101,7 +105,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -152,7 +158,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -194,7 +202,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -240,7 +250,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -30,7 +30,9 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -68,7 +70,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -107,7 +111,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -146,7 +152,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -30,7 +30,9 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -68,7 +70,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -107,7 +111,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -146,7 +152,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Document.json
+++ b/api/Document.json
@@ -3234,7 +3234,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/api/Document.json
+++ b/api/Document.json
@@ -3196,7 +3196,9 @@
                 "version_added": "≤37"
               }
             ],
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -3716,7 +3718,9 @@
                 "version_added": "≤37"
               }
             ],
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -3833,7 +3837,9 @@
                 "version_added": "≤37"
               }
             ],
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -4039,7 +4045,9 @@
             ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -4156,7 +4164,9 @@
                 "version_added": "≤37"
               }
             ],
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Element.json
+++ b/api/Element.json
@@ -4838,7 +4838,9 @@
                 "version_added": "≤37"
               }
             ],
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -4954,7 +4956,9 @@
                 "version_added": "≤37"
               }
             ],
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -8328,7 +8332,9 @@
                 "version_added": "≤37"
               }
             ],
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -8438,7 +8444,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -155,7 +155,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -32,7 +32,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -73,7 +75,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -114,7 +118,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -28,7 +28,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -65,7 +67,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -102,7 +106,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -139,7 +145,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -176,7 +184,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -213,7 +223,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -250,7 +262,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -28,7 +28,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -65,7 +67,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -102,7 +106,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -137,7 +143,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -220,7 +228,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -295,7 +305,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -332,7 +344,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -437,7 +451,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -28,7 +28,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -271,7 +271,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -445,7 +447,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -44,7 +44,9 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -101,7 +103,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -181,7 +185,9 @@
             "webview_android": {
               "version_added": "4.4.3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -227,7 +233,9 @@
             "webview_android": {
               "version_added": "4.4.3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -304,7 +312,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -350,7 +360,9 @@
             "webview_android": {
               "version_added": "4.4.3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -396,7 +408,9 @@
             "webview_android": {
               "version_added": "4.4.3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -492,7 +506,9 @@
                 "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
               ]
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -540,7 +556,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -586,7 +604,9 @@
             "webview_android": {
               "version_added": "4.4.3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -627,7 +647,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -673,7 +695,9 @@
             "webview_android": {
               "version_added": "4.4.3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -757,7 +781,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -835,7 +861,9 @@
                 "notes": "The <code>onsourceclose</code> event handler property is not supported."
               }
             ],
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -903,7 +931,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -619,7 +619,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Badging is supported for web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -4343,7 +4346,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -4388,7 +4393,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Badging is supported for web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -125,8 +125,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -288,8 +287,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -337,8 +335,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -432,8 +429,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -523,8 +519,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -572,8 +567,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -667,8 +661,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -755,8 +748,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -845,8 +837,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -950,8 +941,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {
@@ -989,7 +979,9 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1262,8 +1254,7 @@
               "version_added": false
             },
             "webview_ios": {
-              "version_added": false,
-              "notes": "Notifications are supported in web apps saved to the home screen."
+              "version_added": false
             }
           },
           "status": {

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -71,7 +71,10 @@
             "version_added": false,
             "impl_url": "https://crbug.com/551446"
           },
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Notifications are supported in web apps saved to the home screen."
+          }
         },
         "status": {
           "experimental": false,
@@ -121,7 +124,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -281,7 +287,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -327,7 +336,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -419,7 +431,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -507,7 +522,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -553,7 +571,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -645,7 +666,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -730,7 +754,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -817,7 +844,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -919,7 +949,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -1095,7 +1128,9 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1226,7 +1261,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -39,7 +39,10 @@
             "version_added": false,
             "impl_url": "https://crbug.com/551446"
           },
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Notifications are supported in web apps saved to the home screen."
+          }
         },
         "status": {
           "experimental": false,
@@ -86,7 +89,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -31,7 +31,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Only supported on iPadOS."
+          }
         },
         "status": {
           "experimental": false,

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -255,7 +255,9 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -407,7 +409,9 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -556,7 +560,9 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -633,7 +639,9 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -741,7 +749,9 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -44,7 +44,10 @@
             "version_added": false,
             "impl_url": "https://crbug.com/421921"
           },
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Notifications are supported in web apps saved to the home screen."
+          }
         },
         "status": {
           "experimental": false,
@@ -96,7 +99,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -144,7 +150,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -40,7 +40,10 @@
             "version_added": false,
             "impl_url": "https://crbug.com/421921"
           },
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Notifications are supported in web apps saved to the home screen."
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -175,7 +181,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -306,7 +315,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -352,7 +364,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -179,7 +179,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -40,7 +40,10 @@
             "version_added": false,
             "impl_url": "https://crbug.com/421921"
           },
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Notifications are supported in web apps saved to the home screen."
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -135,7 +141,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -218,7 +227,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -266,7 +278,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -40,7 +40,10 @@
             "version_added": false,
             "impl_url": "https://crbug.com/421921"
           },
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Notifications are supported in web apps saved to the home screen."
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -130,7 +136,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -179,7 +188,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -224,7 +236,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -313,7 +328,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -364,7 +382,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/PushSubscriptionChangeEvent.json
+++ b/api/PushSubscriptionChangeEvent.json
@@ -34,7 +34,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Notifications are supported in web apps saved to the home screen."
+          }
         },
         "status": {
           "experimental": false,
@@ -74,7 +77,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": true,
@@ -115,7 +121,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -156,7 +165,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -37,7 +37,10 @@
             "version_added": false,
             "impl_url": "https://crbug.com/421921"
           },
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false,
+            "notes": "Notifications are supported in web apps saved to the home screen."
+          }
         },
         "status": {
           "experimental": false,
@@ -81,7 +84,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -124,7 +130,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -28,7 +28,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -106,7 +108,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -146,7 +150,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -183,7 +189,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -220,7 +228,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -258,7 +268,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -70,7 +70,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -28,7 +28,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -64,7 +66,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -102,7 +106,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -176,7 +182,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -221,7 +229,9 @@
             "webview_android": {
               "version_added": "40"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -259,7 +269,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -351,7 +363,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -388,7 +402,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -425,7 +441,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -326,7 +326,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -32,7 +32,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -112,7 +114,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -355,7 +359,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -506,7 +512,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -548,7 +556,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -593,7 +603,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -634,7 +646,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -858,7 +872,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -951,7 +968,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -986,7 +1005,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1027,7 +1048,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -600,7 +600,9 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -31,7 +31,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -67,7 +69,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -186,7 +190,10 @@
               "version_added": false,
               "impl_url": "https://crbug.com/551446"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -260,7 +267,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -299,7 +308,9 @@
               "version_added": "4.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -420,7 +431,10 @@
               "version_added": false,
               "impl_url": "https://crbug.com/421921"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -457,7 +471,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -501,7 +517,10 @@
               "version_added": false,
               "impl_url": "https://crbug.com/421921"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false,
+              "notes": "Notifications are supported in web apps saved to the home screen."
+            }
           },
           "status": {
             "experimental": false,
@@ -852,7 +871,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -899,7 +920,9 @@
               ]
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -937,7 +960,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -974,7 +999,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1011,7 +1038,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -52,7 +52,9 @@
             }
           ],
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -97,7 +99,9 @@
             "webview_android": {
               "version_added": "4.4.3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -200,7 +204,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -282,7 +288,9 @@
               "version_added": "3.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -405,7 +413,9 @@
               "version_added": "3.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -487,7 +497,9 @@
               "version_added": "3.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -583,7 +595,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -673,7 +687,9 @@
               "version_added": "3.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -746,7 +762,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -849,7 +867,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -931,7 +951,9 @@
               "version_added": "3.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1013,7 +1035,9 @@
               "version_added": "3.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1127,7 +1151,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -1175,7 +1201,9 @@
               "version_added": "3.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1278,7 +1306,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1381,7 +1411,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1484,7 +1516,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1566,7 +1600,9 @@
               "version_added": "3.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1662,7 +1698,9 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -33,7 +33,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -193,7 +193,9 @@
             "webview_android": {
               "version_added": "42"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -28,7 +28,9 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -62,7 +64,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -99,7 +103,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -136,7 +142,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -222,7 +230,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -286,7 +286,9 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -848,7 +848,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -82,7 +82,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -116,7 +118,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -69,7 +69,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -79,7 +79,9 @@
               "webview_android": {
                 "version_added": "2"
               },
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -114,7 +116,9 @@
               "webview_android": {
                 "version_added": "2"
               },
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -149,7 +153,9 @@
               "webview_android": {
                 "version_added": "2"
               },
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -184,7 +190,9 @@
               "webview_android": {
                 "version_added": "2"
               },
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -88,7 +88,9 @@
               "webview_android": {
                 "version_added": "37"
               },
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -106,7 +106,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -146,7 +148,9 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -193,7 +197,9 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -233,7 +239,9 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/selectors/-webkit-inner-spin-button.json
+++ b/css/selectors/-webkit-inner-spin-button.json
@@ -27,7 +27,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-meter-bar.json
+++ b/css/selectors/-webkit-meter-bar.json
@@ -29,7 +29,9 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-meter-even-less-good-value.json
+++ b/css/selectors/-webkit-meter-even-less-good-value.json
@@ -29,7 +29,9 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-meter-inner-element.json
+++ b/css/selectors/-webkit-meter-inner-element.json
@@ -27,7 +27,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-meter-optimum-value.json
+++ b/css/selectors/-webkit-meter-optimum-value.json
@@ -29,7 +29,9 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-meter-suboptimum-value.json
+++ b/css/selectors/-webkit-meter-suboptimum-value.json
@@ -29,7 +29,9 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-progress-bar.json
+++ b/css/selectors/-webkit-progress-bar.json
@@ -27,7 +27,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-progress-inner-element.json
+++ b/css/selectors/-webkit-progress-inner-element.json
@@ -27,7 +27,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-progress-value.json
+++ b/css/selectors/-webkit-progress-value.json
@@ -27,7 +27,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-search-cancel-button.json
+++ b/css/selectors/-webkit-search-cancel-button.json
@@ -31,7 +31,9 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/-webkit-search-results-button.json
+++ b/css/selectors/-webkit-search-results-button.json
@@ -31,7 +31,9 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -38,7 +38,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -524,9 +524,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": {
-                "version_added": false
-              }
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,
@@ -644,9 +642,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": {
-                "version_added": false
-              }
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,
@@ -760,9 +756,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": {
-                "version_added": false
-              }
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1053,9 +1047,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": {
-                "version_added": false
-              }
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1169,9 +1161,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": {
-                "version_added": false
-              }
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -238,7 +238,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -522,7 +524,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -640,7 +644,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -754,7 +760,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1045,7 +1053,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1159,7 +1169,9 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -32,7 +32,9 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates the BCD for the new WebView iOS browser using collector results.  This PR only updates features that are in Safari iOS but not WebView iOS (AKA, `false` values).
