### PR TITLE
Remove html.elements.{area,object}.tabindex & Update html.global_attributes.tabindex

### DIFF
--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -619,41 +619,6 @@
             }
           }
         },
-        "tabindex": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "≤11"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "target": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-target",

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -448,41 +448,6 @@
             }
           }
         },
-        "tabindex": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "≤11"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "type": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-type",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1100,7 +1100,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

this can be a follow up to https://github.com/mdn/browser-compat-data/pull/7310 and part of the https://github.com/mdn/browser-compat-data/issues/21810

the attribute is defined on the global_attributes itself and should not defined on detailed html elements again

1. Remove html.elements.{area,object}.tabindex (most data are the same, except for the firefox one, assume the global one (and HTML interface one) is correct)
2. Update html.global_attributes.tabindex (opera: data taken from the same property of HTMLElement)

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
