### PR TITLE
Update fetchpriority support

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -488,7 +488,8 @@
                   "name": "network.fetchpriority.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1797715"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -481,7 +481,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "127",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.fetchpriority.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -280,7 +280,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "127",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.fetchpriority.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -287,7 +287,8 @@
                   "name": "network.fetchpriority.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1797715"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -352,7 +352,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "127",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.fetchpriority.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -359,7 +359,8 @@
                   "name": "network.fetchpriority.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1797715"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -346,16 +346,21 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "127",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.fetchpriority.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "17.2"

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -353,7 +353,8 @@
                     "name": "network.fetchpriority.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1797715"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -269,9 +269,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "17.2"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -262,7 +262,15 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "127",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.fetchpriority.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1797715"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -267,7 +267,8 @@
                     "name": "network.fetchpriority.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1797715"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -260,16 +260,21 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "127",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.fetchpriority.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "17.2"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Opera was always the same as Chrome but looks like some updates were missed in #16933
This is the first result from a caniuse search so is confusing: https://caniuse.com/?search=fetchpriority

Firefox has had this behind a flag, I think since 127 (https://forums.mozillazine.org/viewtopic.php?t=3122117).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Firefox:
https://bugzilla.mozilla.org/show_bug.cgi?id=1797715

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/7393187e-4b9e-4466-a869-7042a6f87eba">

Opera:
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/e9d2a14b-7194-4b78-b915-2c5adc464cb9">


#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
