### PR TITLE
Add scheduler.yield

### DIFF
--- a/api/Scheduler.json
+++ b/api/Scheduler.json
@@ -98,7 +98,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "130"
+              "version_added": "129"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Scheduler.json
+++ b/api/Scheduler.json
@@ -89,6 +89,43 @@
             "deprecated": false
           }
         }
+      },
+      "yield": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/scheduling-apis/#dom-scheduler-yield",
+          "tags": [
+            "web-features:scheduler"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "130"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Adds `scheduler.yield()` which is enabled by default in Chrome 129:
https://chromestatus.com/feature/6266249336586240
https://developer.chrome.com/blog/chrome-129-beta#scheduleryield

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://wpt.fyi/results/scheduler/tentative/yield?label=master&label=experimental&aligned

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
