### PR TITLE
Remove api.FetchEvent.replacesClientId from BCD

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -239,44 +239,6 @@
           }
         }
       },
-      "replacesClientId": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/replacesClientId",
-          "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-replacesClientId",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "alternative_name": "targetClientId",
-              "version_added": "11.1",
-              "version_removed": "16",
-              "impl_url": "https://webkit.org/b/226638"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "request": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/request",


### PR DESCRIPTION
This PR removes the `replacesClientId` member of the `FetchEvent` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FetchEvent/replacesClientId
