### PR TITLE
Fix browser data regarding Safari 18

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -319,12 +319,6 @@
           "engine_version": "618.3.11"
         },
         "18": {
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",
-          "status": "beta",
-          "engine": "WebKit",
-          "engine_version": "619.1.15"
-        },
-        "18.0": {
           "release_date": "2024-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",
           "status": "current",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -291,12 +291,6 @@
           "engine_version": "618.3.11"
         },
         "18": {
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",
-          "status": "beta",
-          "engine": "WebKit",
-          "engine_version": "619.1.15"
-        },
-        "18.0": {
           "release_date": "2024-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",
           "status": "current",

--- a/browsers/webview_ios.json
+++ b/browsers/webview_ios.json
@@ -291,12 +291,6 @@
           "engine_version": "618.3.11"
         },
         "18": {
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",
-          "status": "beta",
-          "engine": "WebKit",
-          "engine_version": "619.1.15"
-        },
-        "18.0": {
           "release_date": "2024-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes",
           "status": "current",

--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -37,7 +37,7 @@ const extractReleaseData = (str): Release | null => {
   }
   return {
     date: new Date(`${result[1]} UTC`).toISOString().substring(0, 10),
-    version: result[2],
+    version: result[2].replace(/\.0$/, ''),
     channel: result[3] ? 'beta' : 'retired',
     engineVersion: result[4].substring(2),
     releaseNote: '',


### PR DESCRIPTION
This PR fixes an issue regarding the browser data, where it added "Safari 18.0" alongside "Safari 18".  This PR fixes both the browser data and the updater script.
