### PR TITLE
Document that Safari generates randomized Ed25519 signatures

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -1388,7 +1388,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "17"
+                "version_added": "17",
+                "notes": "Generates randomized signatures as per <a href='https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/'>draft-irtf-cfrg-det-sigs-with-noise</a>, instead of deterministic signatures as per <a href='https://www.rfc-editor.org/rfc/rfc8032'>RFC 8032</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Document the fact that for the Ed25519 algorithm in Web Crypto's `crypto.subtle.sign` function, Safari generates randomized signatures as per <a href='https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/'>draft-irtf-cfrg-det-sigs-with-noise</a>, instead of deterministic signatures as per <a href='https://www.rfc-editor.org/rfc/rfc8032'>RFC 8032</a>.

There is a discussion in https://github.com/WICG/webcrypto-secure-curves/issues/28 to make this behavior legal, but as of now it isn't (although in most cases it shouldn't cause interoperability issues). Additionally, even if this becomes legal as per the Web Crypto spec, it may still be noteworthy for developers who (for some reason) require the deterministic behavior of Ed25519 as specified in RFC 8032.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This behavior can be confirmed by running

```js
const { privateKey } = await crypto.subtle.generateKey('Ed25519', false, ['sign']);
console.log(new Uint8Array(await crypto.subtle.sign('Ed25519', privateKey, new ArrayBuffer())));
console.log(new Uint8Array(await crypto.subtle.sign('Ed25519', privateKey, new ArrayBuffer())));
```

In deterministic implementations, both signatures will be identical. In randomized implementations, they'll be different. I tested desktop and mobile Safari 17 and 18 and all of them implement the randomized variant.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Relevant WebKit issue: https://bugs.webkit.org/show_bug.cgi?id=262499.
