### PR TITLE
Deprecate X-Frame-Options

### DIFF
--- a/http/headers/X-Frame-Options.json
+++ b/http/headers/X-Frame-Options.json
@@ -36,7 +36,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "ALLOW-FROM": {


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/document-lifecycle.html#x-frame-options:

> The `X-Frame-Options` HTTP response header is a legacy way of controlling whether and how a [Document](https://html.spec.whatwg.org/multipage/dom.html#document) may be loaded inside of a [child navigable](https://html.spec.whatwg.org/multipage/document-sequences.html#child-navigable). **It is obsoleted by the [frame-ancestors](https://w3c.github.io/webappsec-csp/#frame-ancestors) CSP directive**, which provides more granular control over the same situations. It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document. [[CSP]](https://html.spec.whatwg.org/multipage/references.html#refsCSP) [[RFC7034]](https://html.spec.whatwg.org/multipage/references.html#refsRFC7034)

Also from https://publications.cispa.saarland/2986/1/roth2020csp.pdf:

> in conversations with operators, several mentioned
that they relied on external resources for security headers. In
checking those resources, we found that they all list XFO as
the only defense against framing-based attacks, whereas they
advertised CSP as a means to mitigate XSS attacks [4, 5,
13, 38, 49]. Notably, even widely-used sites like securi-
tyheaders.com consider XFO the only viable option for
framing control. Neither this service nor other resources like
MDN [24] indicate that CSP can be used for this purpose.