### PR TITLE
chore(css): Add `spec_url` to deprecated device-related `@media` features

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -329,7 +329,10 @@
           "__compat": {
             "description": "<code>device-aspect-ratio</code> media feature",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-aspect-ratio",
-            "spec_url": "https://drafts.csswg.org/mediaqueries/#device-aspect-ratio",
+            "spec_url": [
+              "https://drafts.csswg.org/mediaqueries/#device-aspect-ratio",
+              "https://drafts.csswg.org/mediaqueries-4/#mf-deprecated"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -375,7 +378,10 @@
           "__compat": {
             "description": "<code>device-height</code> media feature",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-height",
-            "spec_url": "https://drafts.csswg.org/mediaqueries/#device-height",
+            "spec_url": [
+              "https://drafts.csswg.org/mediaqueries/#device-height",
+              "https://drafts.csswg.org/mediaqueries-4/#mf-deprecated"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -461,7 +467,10 @@
           "__compat": {
             "description": "<code>device-width</code> media feature",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-width",
-            "spec_url": "https://drafts.csswg.org/mediaqueries/#device-width",
+            "spec_url": [
+              "https://drafts.csswg.org/mediaqueries/#device-width",
+              "https://drafts.csswg.org/mediaqueries-4/#mf-deprecated"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -355,7 +355,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-aspect-ratio",
             "spec_url": [
               "https://drafts.csswg.org/mediaqueries/#device-aspect-ratio",
-              "https://drafts.csswg.org/mediaqueries-4/#mf-deprecated"
+              "https://drafts.csswg.org/mediaqueries-4/#device-aspect-ratio"
             ],
             "support": {
               "chrome": {
@@ -404,7 +404,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-height",
             "spec_url": [
               "https://drafts.csswg.org/mediaqueries/#device-height",
-              "https://drafts.csswg.org/mediaqueries-4/#mf-deprecated"
+              "https://drafts.csswg.org/mediaqueries-4/#device-height"
             ],
             "support": {
               "chrome": {
@@ -493,7 +493,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-width",
             "spec_url": [
               "https://drafts.csswg.org/mediaqueries/#device-width",
-              "https://drafts.csswg.org/mediaqueries-4/#mf-deprecated"
+              "https://drafts.csswg.org/mediaqueries-4/#device-width"
             ],
             "support": {
               "chrome": {


### PR DESCRIPTION
According to the 2018 "[Media Queries Level 4 specification draft](https://drafts.csswg.org/mediaqueries-4/#mf-deprecated)", the `device-width`, `device-height` and `device-aspect-ratio` media features are deprecated. They are kept for backward compatibility, but should be avoided.
