### PR TITLE
feat(css): Add HTML `focusgroup` global attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -518,6 +518,42 @@
           }
         }
       },
+      "focusgroup": {
+        "__compat": {
+          "spec_url": "https://open-ui.org/components/focusgroup.explainer/",
+          "support": {
+            "chrome": {
+              "version_added": "104",
+              "version_removed": "107",
+              "impl_url": "https://crbug.com/40210717"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "hidden": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/hidden",


### PR DESCRIPTION
#### Summary

The HTML `focusgroup` global attribute is used to designate an element as a focus group container. This allows related focusable elements within the group to behave as a single, logical focus navigation group, _improving keyboard accessibility_. The attribute helps manage focus traversal in complex user interfaces, ensuring that navigation within grouped elements is intuitive and follows a set structure.

Spec/Explainer:
* https://open-ui.org/components/focusgroup.explainer/
* https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Focusgroup/explainer.md

Chrome:
* https://chromestatus.com/feature/5637601087193088
* https://issues.chromium.org/issues/40210717
