### PR TITLE
Update Chromium data for Clipboard API

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -46,7 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "66",
+              "version_added": "76",
               "notes": "The user must grant the <code>clipboard-read</code> permission."
             },
             "chrome_android": "mirror",
@@ -246,7 +246,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "76"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -284,7 +284,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "66",
+              "version_added": "76",
               "notes": [
                 "From version 107, this method must be called within user gesture event handlers, or the user must grant the <code>clipboard-write</code> permission.",
                 "Before version 107, the user must grant the <code>clipboard-write</code> permission."


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Clipboard` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Clipboard

Additional Notes: This effectively reverts #6302. The changes made in that PR were incorrect, and the supporting links in the description of the PR confirm it. (One says `readText` and `writeText` were introduced in 66, the other says `read` and `write` in 76, which our PR confirms.)
