### PR TITLE
Update Edge data for PageRevealEvent API

### DIFF
--- a/api/PageRevealEvent.json
+++ b/api/PageRevealEvent.json
@@ -45,9 +45,7 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `PageRevealEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PageRevealEvent
