### PR TITLE
Update Firefox data for RTCPeerConnection API

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -672,7 +672,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "66"
+                "version_added": "37"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1168,7 +1168,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "66"
+                "version_added": "37"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1317,7 +1317,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "66"
+                "version_added": "37"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1855,7 +1855,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "66"
+                "version_added": "37"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2865,7 +2865,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "66"
+                "version_added": "37"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2975,7 +2975,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "66"
+                "version_added": "37"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `RTCPeerConnection` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCPeerConnection
