### PR TITLE
Update Chromium data for ReadableStreamDefaultController API

### DIFF
--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -6,7 +6,7 @@
         "spec_url": "https://streams.spec.whatwg.org/#rs-default-controller-class",
         "support": {
           "chrome": {
-            "version_added": "≤80"
+            "version_added": "52"
           },
           "chrome_android": "mirror",
           "deno": [
@@ -64,7 +64,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-close①",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -105,7 +105,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-desired-size②",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -146,7 +146,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-enqueue①",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -187,7 +187,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#rs-default-controller-error",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ReadableStreamDefaultController` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ReadableStreamDefaultController
