### PR TITLE
Update Chromium data for ReadableStreamDefaultReader API

### DIFF
--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -6,7 +6,7 @@
         "spec_url": "https://streams.spec.whatwg.org/#default-reader-class",
         "support": {
           "chrome": {
-            "version_added": "78"
+            "version_added": "43"
           },
           "chrome_android": "mirror",
           "deno": [
@@ -106,7 +106,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-generic-reader-cancel②",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -147,7 +147,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-generic-reader-closed②",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -188,7 +188,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-default-reader-read①",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -229,7 +229,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-default-reader-release-lock②",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ReadableStreamDefaultReader` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ReadableStreamDefaultReader
