### PR TITLE
Update Chromium data for api.Request.cache.only-if-cached

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -640,7 +640,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "64"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `cache.only-if-cached` member of the `Request` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Request/cache/only-if-cached
