### PR TITLE
Update Chromium data for api.Performance.measure.measureOptions_parameter

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -619,7 +619,7 @@
             "description": "<code>measureOptions</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "78"
+                "version_added": "77"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `measure.measureOptions_parameter` member of the `Performance` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Performance/measure/measureOptions_parameter
