### PR TITLE
Add Scroll Snap events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7327,6 +7327,76 @@
           }
         }
       },
+      "scrollsnapchange_event": {
+        "__compat": {
+          "description": "<code>scrollsnapchange</code> event",
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchange",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scrollsnapchanging_event": {
+        "__compat": {
+          "description": "<code>scrollsnapchanging</code> event",
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchanging",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "securitypolicyviolation_event": {
         "__compat": {
           "description": "<code>securitypolicyviolation</code> event",

--- a/api/Element.json
+++ b/api/Element.json
@@ -9252,6 +9252,76 @@
           }
         }
       },
+      "scrollsnapchange_event": {
+        "__compat": {
+          "description": "<code>scrollsnapchange</code> event",
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchange",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scrollsnapchanging_event": {
+        "__compat": {
+          "description": "<code>scrollsnapchanging</code> event",
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchanging",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "scrollTo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollTo",

--- a/api/SnapEvent.json
+++ b/api/SnapEvent.json
@@ -1,0 +1,141 @@
+{
+  "api": {
+    "SnapEvent": {
+      "__compat": {
+        "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#snapevent-interface",
+        "support": {
+          "chrome": {
+            "version_added": "129"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "SnapEvent": {
+        "__compat": {
+          "description": "<code>SnapEvent()</code> constructor",
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#dom-snapevent-snapevent",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "snapTargetBlock": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#dom-snapevent-snaptargetblock",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "snapTargetInline": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#dom-snapevent-snaptargetinline",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Window.json
+++ b/api/Window.json
@@ -5558,6 +5558,76 @@
           }
         }
       },
+      "scrollsnapchange_event": {
+        "__compat": {
+          "description": "<code>scrollsnapchange</code> event",
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchange",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scrollsnapchanging_event": {
+        "__compat": {
+          "description": "<code>scrollsnapchanging</code> event",
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchanging",
+          "support": {
+            "chrome": {
+              "version_added": "129"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "scrollTo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scrollTo",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 129 supports scroll snap events — [`scrollsnapchange`](https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchange) and [`scrollsnapchanging`](https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchanging), which enable code being fired in response to a new scroll snap target being snapped to, and the browser identifying a change in the next snap target to be snapped to (if the gesture were to end).

See the associated [ChromeStatus entry](https://chromestatus.com/feature/5826089036808192) and the [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) blog post for more context and a guide. 

This PR adds the new events, and the `SnapEvent` event object.

Note: The spec defines the associated event handler properties as being defined on the `GlobalEventHandlers` mixin, but I've added the events to the `Element` object, as we no longer document `GlobalEventHandlers`. Let me know if you think it should sit somewhere else.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
