### PR TITLE
`api.createImageBitmap.options_premultiplyAlpha_parameter`: add partial and note for `premultiplyAlpha` bug

### DIFF
--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -208,9 +208,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "15"
-            },
+            "safari": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "17",
+                "partial_implementation": true,
+                "notes": "If the source image is an <code>ImageData</code> object, then Safari does not respect the <code>premultiplyAlpha</code> option. See <a href='https://webkit.org/b/237082'>bug 237082</a>."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",

--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -216,7 +216,7 @@
                 "version_added": "15",
                 "version_removed": "17",
                 "partial_implementation": true,
-                "notes": "If the source image is an <code>ImageData</code> object, then Safari does not respect the <code>premultiplyAlpha</code> option. See <a href='https://webkit.org/b/237082'>bug 237082</a>."
+                "notes": "If the source image is an <code>ImageData</code> object, then the <code>premultiplyAlpha</code> option does nothing. See <a href='https://webkit.org/b/237082'>bug 237082</a>."
               }
             ],
             "safari_ios": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Record a bug with Safari's `createImageBitmap()` options data

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Caniuse takes this bug to make the entire feature partially implemented, so I've done the same: https://caniuse.com/createimagebitmap

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=237082
- Safari release note: https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#Canvas

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/web-platform-dx/web-features/pull/1707#discussion_r1771670454

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
