### PR TITLE
Deduplicate `css.types.basic-shape.path` and descendants

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -200,37 +200,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/path",
             "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-path",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "88",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>clip-path</code> and <code>offset-path</code> properties."
-                },
-                {
-                  "version_added": "56",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>offset-path</code> property."
-                },
-                {
-                  "version_added": "52",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>d</code> SVG presentation attribute."
-                }
-              ],
+              "chrome": {
+                "version_added": "52"
+              },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "97",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>clip-path</code> and <code>offset-path</code> CSS properties. Not supported on the <code>shape-outside</code> CSS property."
-                },
-                {
-                  "version_added": "72",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties."
-                }
-              ],
+              "firefox": {
+                "version_added": "72"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -240,33 +217,20 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "16",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>offset-path</code> and <code>clip-path</code> properties."
-                },
-                {
-                  "version_added": "13.1",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>clip-path</code> property."
+                  "version_added": "13.1"
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "10.1",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>clip-path</code> property."
+                  "version_added": "10.1"
                 }
               ],
               "safari_ios": [
                 {
-                  "version_added": "13",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>clip-path</code> property."
+                  "version_added": "13"
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "10.3",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>clip-path</code> property."
+                  "version_added": "10.3"
                 }
               ],
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

`css.types.basic-shape.path` is shown as partially implemented in all browsers, but this information is a summation of the descendant features. This PR undoes this flattening, showing `path()` support commencing with the first of the subfeatures.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Since this is duplicate information, the source is BCD itself (i.e., `css.types.basic-shape.path.{clip-path,d,offset-path,shape-outside}`), though I'm just deleting data rather than introducing new facts.

The existing structure of this data—with subfeatures reiterating a partial implementation of the parent—makes actually consuming this data in web-features impossible. Because the parent feature is shown as not implemented and compute-baseline follows a feature's ancestry (e.g., to know if a feature is behind its parent's prefix), the descendants are _also_ treated as partially implemented. Since there's a way to know which contexts are supported—the features dedicated to those facts—I think we shouldn't show partially implemented on the top-most `path()` feature.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

https://github.com/web-platform-dx/web-features/pull/1799/
