### PR TITLE
Update Safari support for `css.types.resolution`

### DIFF
--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -36,8 +36,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/78087"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -88,7 +87,7 @@
                 }
               ],
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -140,7 +139,7 @@
                 }
               ],
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -180,7 +179,7 @@
                 "version_added": "12.1"
               },
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -214,7 +213,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Follows up the incomplete update to Safari's support for `resolution` media queries in https://github.com/mdn/browser-compat-data/pull/18706

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Test case: https://codepen.io/fvsch/pen/Jqavor

Release notes: https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes

Resolved bug: https://bugs.webkit.org/show_bug.cgi?id=78087

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes https://github.com/mdn/browser-compat-data/issues/20635

Discovered via https://github.com/web-platform-dx/web-features/pull/1673