### PR TITLE
Fix MathML attr mistype: moveablelimits > movablelimits

### DIFF
--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -238,7 +238,7 @@
             }
           }
         },
-        "moveablelimits": {
+        "movablelimits": {
           "__compat": {
             "spec_url": "https://w3c.github.io/mathml-core/#dfn-movablelimits-0",
             "support": {


### PR DESCRIPTION
#### Summary

One of the `<mo>`’s attribute is called `movablelimits` [in the spec](https://w3c.github.io/mathml-core/#ref-for-dfn-movablelimits-0-1) as well as [on MDN](https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mo#movablelimits).