### PR TITLE
Add fence and separator attributes to <mo> MathML element

### DIFF
--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -68,6 +68,40 @@
             }
           }
         },
+        "fence": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/mathml-core/#dfn-fence",
+            "support": {
+              "chrome": {
+                "version_added": "109"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "form": {
           "__compat": {
             "spec_url": "https://w3c.github.io/mathml-core/#dfn-form",
@@ -346,6 +380,40 @@
         "rspace": {
           "__compat": {
             "spec_url": "https://w3c.github.io/mathml-core/#dfn-rspace-0",
+            "support": {
+              "chrome": {
+                "version_added": "109"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "separator": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/mathml-core/#dfn-separator",
             "support": {
               "chrome": {
                 "version_added": "109"


### PR DESCRIPTION
#### Summary

Adds missing `fence` and `separator` attributes to `<mo>` MathML element

#### Test results and supporting details

- They are available [in the MathML Core spec](https://w3c.github.io/mathml-core/#dfn-mo)
- They are already [documented on MDN](https://github.com/mdn/browser-compat-data/blob/main/mathml/elements/mo.json#L71-L104)

#### Note

Only when sending the PR did I realize that for each one of them:

> There is no visual effect for this attribute

Which means there’s no way to tell if they’re supported. Unless browsers might convey them somehow to a screen reader. Now or in the future. At the same time, it’s a way to complete BCD and document the standard status of the feature.

Given all that, I used the lowest MathML implementation version of all “supporting” browsers.