### PR TITLE
Update Firefox data for AudioEncoder API

### DIFF
--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -172,9 +172,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
+                "version_added": "130"
+              },
+              "firefox_android": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -190,7 +192,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -209,9 +211,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
+                "version_added": "130"
+              },
+              "firefox_android": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -227,7 +231,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `AudioEncoder` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/AudioEncoder
