### PR TITLE
`css.properties.image-orientation`: Safari 13 never supported it

### DIFF
--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -27,7 +27,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "13.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -62,7 +62,7 @@
                 "version_added": "13.1"
               },
               "safari_ios": {
-                "version_added": "14"
+                "version_added": "13.4"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -98,7 +98,7 @@
                 "version_added": "13.1"
               },
               "safari_ios": {
-                "version_added": "14"
+                "version_added": "13.4"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -26,7 +26,9 @@
             "safari": {
               "version_added": "13.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "14"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -59,7 +61,9 @@
               "safari": {
                 "version_added": "13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "14"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
@@ -93,7 +97,9 @@
               "safari": {
                 "version_added": "13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "14"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

iOS supported `image-orientation` later than macOS.

#### Test results and supporting details

I tried the [MDN reference page](https://developer.mozilla.org/en-US/docs/Web/CSS/image-orientation) in BrowserStack and it didn't work in Safari 13 and does in Safari 14. This squares with [caniuse](https://caniuse.com/css-image-orientation).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://github.com/web-platform-dx/web-features/pull/1833/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
