### PR TITLE
Use exact version for cloneInto and exportFunction

### DIFF
--- a/webextensions/api/contentScriptGlobalScope.json
+++ b/webextensions/api/contentScriptGlobalScope.json
@@ -10,7 +10,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "30"
             },
             "firefox_android": "mirror",
             "opera": "mirror",
@@ -29,7 +29,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": true
+                "version_added": "30"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -49,7 +49,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": true
+                "version_added": "30"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
According to https://blog.mozilla.org/addons/2014/04/10/changes-to-unsafewindow-for-the-add-on-sdk/#comments, this was added in Firefox 30.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

These newly added browser support table records were added in #22767 without a version number.

#### Test results and supporting details

Not tested, but see the below blog which seems to indicate that this was added in Firefox 30:

https://blog.mozilla.org/addons/2014/04/10/changes-to-unsafewindow-for-the-add-on-sdk/

Requesting review from @Rob--W and/or @rebloor 

#### Related issues

https://github.com/openwebdocs/project/issues/206