### PR TITLE
Opera Android supports javascript.builtins.Intl.Collator.Collator.options_collation_parameter

### DIFF
--- a/javascript/builtins/Intl/Collator.json
+++ b/javascript/builtins/Intl/Collator.json
@@ -179,9 +179,7 @@
                   },
                   "oculus": "mirror",
                   "opera": "mirror",
-                  "opera_android": {
-                    "version_added": false
-                  },
+                  "opera_android": "mirror",
                   "safari": {
                     "version_added": "14.1"
                   },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `Collator.Collator.options_collation_parameter` member of the `Intl` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Intl/Collator/Collator/options_collation_parameter
