### PR TITLE
Opera Android supports javascript.grammar.numeric_separators

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -426,9 +426,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "13"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `numeric_separators` member of the `grammar` JavaScript feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/grammar/numeric_separators
