### PR TITLE
Use version number for sync support for Firefox for Android

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -442,7 +442,7 @@
                 "notes": "Before version 79, storage quota limits are not enforced."
               },
               "firefox_android": {
-                "version_added": true,
+                "version_added": "53",
                 "notes": "Data isn't synchronized with the user's Mozilla account. See <a href='https://bugzil.la/1625257'>bug 1625257</a>."
               },
               "opera": {


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1253740#c471, with that code "chrome.storage.sync will be present on Android, but it won't actually sync".

#### Summary

https://bugzilla.mozilla.org/show_bug.cgi?id=1253740 says it's milestone mozilla52, but I decided to assume the current data for desktop Firefox support was correct and match to that (version 53).

This needs the "KR: Real BCD" label

#### Test results and supporting details

Not tested, but see the below bug which seems to indicate that this was added in Firefox for Android at the same time as Firefox for desktop (with the caveats already mentioned in the note):

https://bugzilla.mozilla.org/show_bug.cgi?id=1253740#c471

#### Related issues

https://github.com/openwebdocs/project/issues/206