### PR TITLE
Update Chromium data for privacy Web Extensions api properties

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -62,7 +62,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "≤90"
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -62,7 +62,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤90"
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -164,7 +164,7 @@
                   "version_added": "18"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "mirror"
                 },
                 "firefox": {
                   "version_added": false
@@ -223,7 +223,7 @@
                   "version_added": "18"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "mirror"
                 },
                 "firefox": {
                   "version_added": false

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -161,7 +161,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "edge": {
                   "version_added": "79"
@@ -220,7 +220,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "edge": {
                   "version_added": "79"

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -163,9 +163,7 @@
                 "chrome": {
                   "version_added": "18"
                 },
-                "edge": {
-                  "version_added": "mirror"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -222,9 +220,7 @@
                 "chrome": {
                   "version_added": "18"
                 },
-                "edge": {
-                  "version_added": "mirror"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },


### PR DESCRIPTION
#### Summary

The privacy API, at the time already containing both services.alternateErrorPagesEnabled and services.autofillEnabled, was moved out of the experimental status in https://source.chromium.org/chromium/chromium/src/+/607e6522f841933e0d3130c09d33207876850948, which according to https://source.chromium.org/chromium/chromium/src/+/607e6522f841933e0d3130c09d33207876850948:chrome/VERSION was Chrome 18.

This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `privacy` Web Extensions api property network.httpsOnlyMode. This sets the feature(s) to a version range based upon the date that the feature was added to BCD with the intent of replacing `true` values with ranged values to eliminate `true` values from BCD.

Commit/PR Adding the Feature: https://github.com/mdn/browser-compat-data/pull/8830

This needs the "KR: Real BCD" label

#### Test results and supporting details

https://source.chromium.org/chromium/chromium/src/+/607e6522f841933e0d3130c09d33207876850948
https://github.com/mdn/browser-compat-data/pull/8830

#### Related issues

https://github.com/openwebdocs/project/issues/206
