### PR TITLE
Fix exact version for cloneInto and exportFunction

### DIFF
--- a/webextensions/api/contentScriptGlobalScope.json
+++ b/webextensions/api/contentScriptGlobalScope.json
@@ -10,7 +10,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "30"
+              "version_added": "49"
             },
             "firefox_android": "mirror",
             "opera": "mirror",
@@ -29,7 +29,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "30"
+                "version_added": "49"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -49,7 +49,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "30"
+                "version_added": "49"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1280482, this was added in Firefox 49

#### Summary

Fix for https://github.com/mdn/browser-compat-data/pull/24521 according to https://github.com/mdn/browser-compat-data/pull/24521#issuecomment-2374921466

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1280482

#### Related issues

https://github.com/openwebdocs/project/issues/206
