### PR TITLE
Update all browsers data for non-trapping-float-to-int-conversions WebAssembly feature

### DIFF
--- a/webassembly/non-trapping-float-to-int-conversions.json
+++ b/webassembly/non-trapping-float-to-int-conversions.json
@@ -5,14 +5,14 @@
         "spec_url": "https://github.com/WebAssembly/spec/blob/main/proposals/nontrapping-float-to-int-conversion/Overview.md",
         "support": {
           "chrome": {
-            "version_added": "≤80"
+            "version_added": "75"
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "≤80"
+            "version_added": "18"
           },
           "firefox": {
-            "version_added": "≤72"
+            "version_added": "64"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `non-trapping-float-to-int-conversions` WebAssembly feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/non-trapping-float-to-int-conversions
