### PR TITLE
Chrome 69 + Firefox 62 added mutable-globals WebAssembly feature

### DIFF
--- a/webassembly/mutable-globals.json
+++ b/webassembly/mutable-globals.json
@@ -5,14 +5,14 @@
         "spec_url": "https://webassembly.github.io/spec/js-api/#dom-globaldescriptor-mutable",
         "support": {
           "chrome": {
-            "version_added": "≤80"
+            "version_added": "69"
           },
           "chrome_android": "mirror",
           "edge": {
             "version_added": "≤80"
           },
           "firefox": {
-            "version_added": "≤72"
+            "version_added": "62"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `mutable-globals` WebAssembly feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/mutable-globals
