### PR TITLE
Remove Safari's support for `tag` and `icon` properties in the Notifications API

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -650,12 +650,10 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11"
+              "version_added": false,
+              "notes": "While Safari supports setting the icon property, the browser does not display the icon in the notification."
             },
-            "safari_ios": {
-              "version_added": "16.4",
-              "notes": "Notifications are supported in web apps saved to the home screen."
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -1158,12 +1156,11 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
-            },
-            "safari_ios": {
               "version_added": false,
-              "notes": "This property is exposed but is not implemented. See <a href='https://webkit.org/b/258922'>bug 258922</a>."
+              "impl_url": "https://webkit.org/b/258922",
+              "notes": "While Safari supports setting the tag property, the browser doesn't use tags to avoid displaying many notifications."
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Although Safari supports the `tag` and `icon` properties in the Notifications API, setting them doesn't do anything.

The `icon` property is supposed to allow developers to set an icon to be displayed in the system notification, replacing the default browser icon. But Safari doesn't actually display the icon.

The `tag` property is supposed to allow developers to avoid displaying too many notifications in a short amount of time. When developers use the same `tag` value, then new notifications replace old ones that haven't yet been displayed.
Safari doesn't seem to use tags, and sending bursts of same-tag notifications does still lead to multiple notifications being displayed to the user (although not all of them, but the logic seems UA-controlled, as opposed to based on the tag).

This PR therefore marks those 2 properties as not supported by Safari, with a note.

#### Test results and supporting details

Test page: https://patrickbrosset.com/lab/2024-09-26-notifications-with-icon-and-tag/