### PR TITLE
`css.properties.grid-auto-flow.*`: remove Safari version ranges

### DIFF
--- a/css/properties/grid-auto-flow.json
+++ b/css/properties/grid-auto-flow.json
@@ -62,7 +62,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -130,7 +130,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Unroll the ranged values for `css.properties.grid-auto-flow` to be the same as `grid-auto-flow`.

#### Test results and supporting details

It's not plausible that Safari would've had support for the values after shipping the property itself—what else what would the property have done? Testing in BrowserStack confirms that they were all supported.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Completes work started in https://github.com/mdn/browser-compat-data/pull/22459.

Discovered in https://github.com/web-platform-dx/web-features/pull/1854/

Fixes https://github.com/mdn/browser-compat-data/issues/24535

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
