### PR TITLE
Add note about lack of proper support for webkitdirectory on mobile

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3005,7 +3005,10 @@
             "chrome": {
               "version_added": "7"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "18",
+              "notes": "While this property is recognized, the File API does not actually allow directory selection. See <a href='https://crbug.com/40248532'>bug 40248532</a>."
+            },
             "edge": {
               "version_added": "13"
             },
@@ -3024,7 +3027,10 @@
             "safari": {
               "version_added": "11.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "11.3",
+              "notes": "While this property is recognized, the File API does not actually allow directory selection. See <a href='https://webkit.org/b/271705'>bug 271705</a>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3006,8 +3006,9 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": "18",
-              "notes": "While this property is recognized, the File API does not actually allow directory selection. See <a href='https://crbug.com/40248532'>bug 40248532</a>."
+              "version_added": false,
+              "impl_url": "https://crbug.com/40248532",
+              "notes": "The property can be set, but has no effect."
             },
             "edge": {
               "version_added": "13"
@@ -3028,8 +3029,9 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.3",
-              "notes": "While this property is recognized, the File API does not actually allow directory selection. See <a href='https://webkit.org/b/271705'>bug 271705</a>."
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/271705",
+              "notes": "The property can be set, but has no effect."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
#### Summary

It's "supported" in that it is recognized by the browser but there is no code in the file chooser interface on mobile phones to allow selection of a directory when using it.

#### Test results and supporting details

I tried using this option on a phone and there was no way to choose a folder to upload.
https://bugs.webkit.org/show_bug.cgi?id=271705
https://issues.chromium.org/issues/40248532
https://bugzilla.mozilla.org/show_bug.cgi?id=1887878

#### Related issues

Fixes #24357
