### PR TITLE
Edge 12 supported BaseAudioContext API

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -747,7 +747,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "49"
@@ -988,7 +988,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "16"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "36"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `BaseAudioContext` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/BaseAudioContext
