### PR TITLE
Chromium 79 improved api.RTCStatsReport.type_inbound-rtp support

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -2550,7 +2550,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-framesdecoded",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "79"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2971,7 +2971,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-keyframesdecoded",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "79"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -3291,7 +3291,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-qpsum",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "79"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -3535,7 +3535,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-totaldecodetime",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "79"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -3570,7 +3570,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-totalinterframedelay",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "79"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -3710,7 +3710,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-totalsquaredinterframedelay",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "79"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `type_inbound-rtp` member of the `RTCStatsReport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport/type_inbound-rtp
