### PR TITLE
Safari 39 added api.Response.Response.accept_readablestream support

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -114,7 +114,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "39"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `Response.accept_readablestream` member of the `Response` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Response/Response/accept_readablestream
