### PR TITLE
Update Safari data for api.HTMLElement.contentEditable.plaintext-only

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -696,7 +696,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `contentEditable.plaintext-only` member of the `HTMLElement` API. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code:

```

document.body.contentEditable = 'plaintext-only'; console.log(document.body.contentEditable == 'plaintext-only');

```
