### PR TITLE
Safari 3 added HTMLFormControlsCollection API support

### DIFF
--- a/api/HTMLFormControlsCollection.json
+++ b/api/HTMLFormControlsCollection.json
@@ -27,7 +27,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -77,7 +77,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `HTMLFormControlsCollection` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLFormControlsCollection
