### PR TITLE
Safari 1 supported api.MediaList.toString

### DIFF
--- a/api/MediaList.json
+++ b/api/MediaList.json
@@ -271,7 +271,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `toString` member of the `MediaList` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaList/toString
