### PR TITLE
`css.at-rules.page`: remove erroneous Safari support

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -30,7 +30,8 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/15548"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -103,7 +104,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
@@ -142,7 +143,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -178,7 +179,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

There's some sort of feature-flagged code relating to `@page` in Safari, but actually using `@page` in Safari or Safari TP does nothing.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/issues/24566 and https://bugs.webkit.org/show_bug.cgi?id=15548.

Although https://webkit.org/blog/15798/release-notes-for-safari-technology-preview-202/ contradicts this, but again: test cases point the opposite direction.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Skepticism was noted originally in https://github.com/mdn/browser-compat-data/pull/20144.

Fixes https://github.com/mdn/browser-compat-data/issues/24566

Discovered via https://github.com/web-platform-dx/web-features/pull/1801

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
