### PR TITLE
`css.properties.column-fill`: correct Firefox versions

### DIFF
--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -70,7 +70,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "17"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -106,7 +106,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "17"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -19,19 +19,11 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "13",
+                "version_added": "17",
                 "version_removed": "74"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "14"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This corrects the initial version for `column-fill: auto` and `column-fill: balance` in Firefox. It doesn't make sense that they'd be different from the property itself.

#### Test results and supporting details

In researching this, I found that the initial data for the property itself was incorrect. It was backed out of Firefox 13 and re-landed in Firefox 17.

- https://bugzilla.mozilla.org/show_bug.cgi?id=695222
- https://bugzilla.mozilla.org/show_bug.cgi?id=764567

I tested this manually in BrowserStack for the unprefixed property, to the values shown in the diff. I spot checked some earlier versions, but not completely to Firefox 17 for the prefixed property. Given the bug links, I don't think we need much more than that.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->



<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered via https://github.com/web-platform-dx/web-features/pull/1819

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
