### PR TITLE
`css.properties.column-span`: set plausible Edge versions for values

### DIFF
--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -63,7 +63,9 @@
                 "version_added": "6"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "71"
               },
@@ -97,7 +99,9 @@
                 "version_added": "6"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "71"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

It's not plausible that Edge implemented the `column-span` values after the property itself.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I tested this manually in the oldest Edge version in BrowserStack and I'm assuming it's been supported since Edge 12.

<img width="694" alt="Screenshot 2024-09-30 at 21 23 22" src="https://github.com/user-attachments/assets/d2d09c6e-8c79-4381-990c-c0f8a9584924">


<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered in the course of https://github.com/web-platform-dx/web-features/pull/1819/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
