### PR TITLE
`css.properties.column-count.auto`: set plausible Edge value

### DIFF
--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -71,7 +71,9 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "1.5"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

It's not plausible that Edge shipped support for `column-count: auto` after `column-count`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I tested this manually as far back as Edge 15, in Browser Stack.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered via https://github.com/web-platform-dx/web-features/pull/1819

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
