### PR TITLE
`css.properties.overscroll-behavior{,-x,-y}`: fix EdgeHTML notes and partials

### DIFF
--- a/css/properties/overscroll-behavior-x.json
+++ b/css/properties/overscroll-behavior-x.json
@@ -117,10 +117,17 @@
                 "version_added": "63"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "18",
-                "notes": "Before Edge 79, the <code>none</code> value incorrectly behaved as <code>contain</code> (allowing for the elastic bounce effect)."
-              },
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "notes": "The <code>none</code> value incorrectly behaves as <code>contain</code> (allowing for the elastic bounce effect)."
+                }
+              ],
               "firefox": {
                 "version_added": "59"
               },

--- a/css/properties/overscroll-behavior-y.json
+++ b/css/properties/overscroll-behavior-y.json
@@ -11,9 +11,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "18",
-              "partial_implementation": true,
-              "notes": "Currently the <code>none</code> value incorrectly behaves as <code>contain</code> (allowing for the elastic bounce effect)."
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "59"
@@ -115,7 +113,17 @@
                 "version_added": "≤83"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "notes": "The <code>none</code> value incorrectly behaves as <code>contain</code> (allowing for the elastic bounce effect)."
+                }
+              ],
               "firefox": {
                 "version_added": "59"
               },

--- a/css/properties/overscroll-behavior.json
+++ b/css/properties/overscroll-behavior.json
@@ -11,9 +11,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "18",
-              "partial_implementation": true,
-              "notes": "Currently the <code>none</code> value incorrectly behaves as <code>contain</code> (allowing for the elastic bounce effect)."
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "59"
@@ -115,7 +113,17 @@
                 "version_added": "63"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "notes": "The <code>none</code> value incorrectly behaves as <code>contain</code> (allowing for the elastic bounce effect)."
+                }
+              ],
               "firefox": {
                 "version_added": "59"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `overscroll-behavior` data is inconsistent, with conflicting reports of partial implementation for the same issue and notes placed on the wrong features. I've made an attempt to clean it up.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/issues/24511

I made the assumption that EdgeHTML bugs were not reimplemented in Chromium.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24511

Discovered via https://github.com/web-platform-dx/web-features/pull/1834/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
