### PR TITLE
css.at-rules.media.prefers-color-scheme - safari removed "no-preference" value

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1339,10 +1339,12 @@
                   "version_added": "54"
                 },
                 "safari": {
-                  "version_added": "12.1"
+                  "version_added": "12.1",
+                  "version_removed": "15"
                 },
                 "safari_ios": {
-                  "version_added": "13"
+                  "version_added": "13",
+                  "version_removed": "15"
                 },
                 "samsunginternet_android": {
                   "version_added": "14.2"


### PR DESCRIPTION
Closes https://github.com/mdn/browser-compat-data/issues/24580

