### PR TITLE
`css.properties.{min,max}-height`: clean up values for Edge and Firefox

### DIFF
--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -295,7 +295,9 @@
                 "version_added": "18"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "1"
               },

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -94,11 +94,16 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": {
-                "version_added": "16",
-                "version_removed": "22",
-                "notes": "Firefox 18 and later used <code>auto</code> as the initial value for <code>min-height</code>."
-              },
+              "firefox": [
+                {
+                  "version_added": "34"
+                },
+                {
+                  "version_added": "16",
+                  "version_removed": "22",
+                  "notes": "Firefox 18 and later used <code>auto</code> as the initial value for <code>min-height</code>."
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -91,7 +91,9 @@
                 "version_added": "21"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "16",
                 "version_removed": "22",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Correcting some strange discrepancies found in the course of https://github.com/web-platform-dx/web-features/pull/1872.

#### Test results and supporting details

For the Edge values, I tested with `CSS.supports()` in Edge 13. These are both pretty old and I think it makes more sense that they'd have been there from inception.

For Firefox, I tested with `CSS.supports()` in Firefox 34 and 33 to confirm the result. I assumed the existing data was true.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes https://github.com/mdn/browser-compat-data/issues/24582

https://github.com/web-platform-dx/web-features/pull/1872

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
