### PR TITLE
`svg.elements.animate*`: not supported in EdgeHTML

### DIFF
--- a/svg/elements/animate.json
+++ b/svg/elements/animate.json
@@ -10,9 +10,7 @@
               "version_added": "2"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "4"
             },
@@ -222,9 +220,7 @@
                 "version_added": "50"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "51"
               },

--- a/svg/elements/animateMotion.json
+++ b/svg/elements/animateMotion.json
@@ -10,9 +10,7 @@
               "version_added": "19"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "4"
             },
@@ -117,9 +115,7 @@
                 "version_added": "50"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "51"
               },

--- a/svg/elements/animateTransform.json
+++ b/svg/elements/animateTransform.json
@@ -10,9 +10,7 @@
               "version_added": "2"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "4"
             },
@@ -156,9 +154,7 @@
                 "version_added": "50"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "51"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

EdgeHTML never supported the SMIL SVG animation elements; this PR eliminates three version ranges.

#### Test results and supporting details

I used the collector tests for these elements in BrowserStack in Edge 18. None passed.

I also spot checked `animateMotion` with an actual working animation to make sure it wasn't some issue with the element interface. It wasn't—it really didn't animate.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered via https://github.com/web-platform-dx/web-features/pull/1771

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
