### PR TITLE
Add Promise.try() support for Firefox 132

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -584,14 +584,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "132",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.promise_try",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -584,7 +584,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "132"
+                "version_added": "132",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.promise_try",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -612,7 +612,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -584,7 +584,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "132"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -605,7 +605,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

[`Promise.try()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try) is supported in Firefox as of version 132. See https://bugzilla.mozilla.org/show_bug.cgi?id=1905364 for implementation details.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Main project issue: https://github.com/mdn/content/issues/36118

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
