### PR TITLE
fix(update-browser-releases): rename Chrome nightly branch to dev

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -190,7 +190,9 @@ export const updateChromiumReleases = async (options) => {
   // Add a planned version entry
   //
   if (data[options.nightlyBranch]) {
-    const plannedVersion = (data[options.nightlyBranch].version + 1).toString();
+    const plannedVersion = (
+      Number(data[options.nightlyBranch].version) + 1
+    ).toString();
     if (chromeBCD.browsers[options.bcdBrowserName].releases[plannedVersion]) {
       result += updateBrowserEntry(
         chromeBCD,

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -85,7 +85,7 @@ const options = {
     browserEngine: 'Blink',
     releaseBranch: 'stable',
     betaBranch: 'beta',
-    nightlyBranch: 'canary',
+    nightlyBranch: 'dev',
     releaseNoteCore: 'stable-channel-update-for-desktop',
     firstRelease: 1,
     skippedReleases: [82], // 82 was skipped during COVID
@@ -98,7 +98,7 @@ const options = {
     browserEngine: 'Blink',
     releaseBranch: 'stable',
     betaBranch: 'beta',
-    nightlyBranch: 'canary',
+    nightlyBranch: 'dev',
     releaseNoteCore: 'chrome-for-android-update',
     firstRelease: 25,
     skippedReleases: [82], // 82 was skipped during COVID
@@ -111,7 +111,7 @@ const options = {
     browserEngine: 'Blink',
     releaseBranch: 'stable',
     betaBranch: 'beta',
-    nightlyBranch: 'canary',
+    nightlyBranch: 'dev',
     releaseNoteCore: 'chrome-for-android-update',
     firstRelease: 37,
     skippedReleases: [82], // 82 was skipped during COVID


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Ensures that Chrome nightly and planned versions are properly updated again.

#### Test results and supporting details

Looking at https://chromestatus.com/api/v0/channels revealed that the "canary" branch was renamed to "dev", and this explains why nightly versions were no longer updated (and planned versions, which are based on the nightly version).

#### Related issues

Noticed here: https://github.com/mdn/browser-compat-data/pull/24538#discussion_r1784755230
