### PR TITLE
Add Firefox 132 support for JSON.parse with source features

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -72,7 +72,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "132"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -93,7 +93,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -216,7 +216,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "132"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -237,7 +237,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -261,7 +261,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "132"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -282,7 +282,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Firefox 132 enables the [`JSON.parse()` with source](https://github.com/tc39/proposal-json-parse-with-source) proposal by default, which specifically includes the following features:

- [The `JSON.parse()` `reviver` parameter `context` argument](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter)
- [`JSON.isRawJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/isRawJSON)
- [`JSON.rawJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/rawJSON)

This PR adds Firefox 132 support for the above features, and sets their `experimental` properties to `false`.

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1913085 for the release bug.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I've tested these features in Firefox 132 using the test cases available in https://github.com/mdn/browser-compat-data/pull/22766 and https://github.com/mdn/browser-compat-data/pull/22800.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Main project issue: https://github.com/orgs/mdn/projects/12/views/6?pane=issue&itemId=81563770

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
