### PR TITLE
Add Fx132 support for MediaStreamTrack.getCapabilities()

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -1009,7 +1009,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "132"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Firefox 132 has added support for [`MediaStreamTrack.getCapabilities()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getCapabilities) (and by extension, the capabilities object returned by the method).

This PR updates the Firefox support data point for this method to 132.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1179084 for the implementation bug.

#### Test results and supporting details

I tested it using the following test case found in the implementation bug:

```
(await navigator.mediaDevices.getUserMedia({video:true, audio:true})).getTracks().map(t => t.getCapabilities())
```

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Main project issue: https://github.com/orgs/mdn/projects/12/views/6?pane=issue&itemId=81563838

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
