### PR TITLE
fix(css): mirror WebView support for `@custom-media`

### DIFF
--- a/css/at-rules/custom-media.json
+++ b/css/at-rules/custom-media.json
@@ -29,7 +29,8 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
Add "WebView on iOS" I missed on the initial PR https://github.com/mdn/browser-compat-data/pull/24338.

![image](https://github.com/user-attachments/assets/b0c259a6-87d6-471b-9a69-7e186cc1b284)