### PR TITLE
FF132 WebGL drawingBufferColorSpace supported

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -3376,12 +3376,17 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "127",
-              "version_removed": "130",
-              "partial_implementation": true,
-              "notes": "Accidental early exposure with no functionality."
-            },
+            "firefox": [
+              {
+                "version_added": "132"
+              },
+              {
+                "version_added": "127",
+                "version_removed": "130",
+                "partial_implementation": true,
+                "notes": "Accidental early exposure with no functionality."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -2496,12 +2496,17 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "127",
-              "version_removed": "130",
-              "partial_implementation": true,
-              "notes": "Accidental early exposure with no functionality."
-            },
+            "firefox": [
+              {
+                "version_added": "132"
+              },
+              {
+                "version_added": "127",
+                "version_removed": "130",
+                "partial_implementation": true,
+                "notes": "Accidental early exposure with no functionality."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF132 supports [`WebGLRenderingContext.drawingBufferColorSpace`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawingBufferColorSpace) in https://bugzilla.mozilla.org/show_bug.cgi?id=1885491

Related docs work can be tracked in https://github.com/mdn/content/issues/36112