### PR TITLE
FF132 HTMLVideoElement.requestVideoFrameCallback()

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -61,7 +61,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "132",
               "impl_url": "https://bugzil.la/1800882"
             },
             "firefox_android": "mirror",
@@ -660,10 +660,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1800882",
-              "partial_implementation": true,
-              "notes": "The <code>metadata</code> argument of the callback function does not support the following properties: <code>processingDuration</code> (<a href='https://bugzil.la/1908246'>bug 1908246</a>), <code>captureTime</code>, <code>receiveTime</code>, and <code>rtpTimestamp</code> (<a href='https://bugzil.la/1908245'>bug 1908245</a>)."
+              "version_added": "132",
+              "impl_url": [
+                "https://bugzil.la/1800882",
+                "https://bugzil.la/1908245"
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF132 ships [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback) and [`HTMLVideoElement.cancelVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/cancelVideoFrameCallback) in https://bugzilla.mozilla.org/show_bug.cgi?id=1919367 (remaining implementation in https://bugzil.la/1908245)

This updates the two features.

Related docs work can be tracked in https://github.com/mdn/content/issues/36123