### PR TITLE
Add Fx132 support for Notification.silent

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -1102,7 +1102,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "132"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 132 supports the [`Notification.silent`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/silent) property.

This PR adds Fx support to that data point.

See the shipping bug at https://bugzilla.mozilla.org/show_bug.cgi?id=1809028 

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I wrote a quick test case to test the property: see https://silent-notifications-test.glitch.me/.

I found the results somewhat inconclusive:

- In Firefox Nightly 133, the system notification fires _and_ `n.silent` returns `true`.
- In Firefox beta 132, the system notification doesn't fire, but `n.silent` returns `true` (it supports the property).
- In Firefox release 131, the system notification doesn't fire, and `n.silent` returns `undefined` (it doesn't support the property).
- In the last couple of versions of Chrome and Safari, it all works just fine (same as Fx133).

This suggests that Fx 132 does support it, but there is something going on with the actual notification firing. Is it buggy, or did I do something wrong with the permissions code? I will ask the Fx devs to look at it.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Docs issue: https://github.com/mdn/content/issues/36119

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
