### PR TITLE
Chromium only partially supports WebUSB API in web workers

### DIFF
--- a/api/USB.json
+++ b/api/USB.json
@@ -43,9 +43,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -55,6 +52,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -78,7 +76,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USB.json
+++ b/api/USB.json
@@ -41,43 +41,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "connect_event": {

--- a/api/USB.json
+++ b/api/USB.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USB.json
+++ b/api/USB.json
@@ -76,8 +76,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USB.json
+++ b/api/USB.json
@@ -51,12 +51,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USB.json
+++ b/api/USB.json
@@ -47,11 +47,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USB.json
+++ b/api/USB.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBAlternateInterface": {
+        "__compat": {
+          "description": "<code>USBAlternateInterface()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBAlternateInterface": {
-        "__compat": {
-          "description": "<code>USBAlternateInterface()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "alternateSetting": {

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "alternateSetting": {

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -117,8 +117,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -84,9 +84,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -96,6 +93,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -119,7 +117,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -92,12 +92,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -82,43 +82,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "configurationName": {

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -40,46 +40,6 @@
           "deprecated": false
         }
       },
-      "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
-          },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
-        }
-      },
       "USBConfiguration": {
         "__compat": {
           "description": "<code>USBConfiguration()</code> constructor",
@@ -119,6 +79,46 @@
             "standard_track": true,
             "deprecated": false
           }
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": "61",
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "configurationName": {

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -88,11 +88,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -117,8 +117,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -84,9 +84,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -96,6 +93,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -119,7 +117,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -92,12 +92,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -82,43 +82,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "device": {

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -40,46 +40,6 @@
           "deprecated": false
         }
       },
-      "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
-          },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
-        }
-      },
       "USBConnectionEvent": {
         "__compat": {
           "description": "<code>USBConnectionEvent()</code> constructor",
@@ -119,6 +79,46 @@
             "standard_track": true,
             "deprecated": false
           }
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": "61",
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "device": {

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -88,11 +88,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -43,9 +43,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -55,6 +52,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -78,7 +76,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -76,8 +76,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -41,43 +41,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "claimInterface": {

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -51,12 +51,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -47,11 +47,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBEndpoint": {
+        "__compat": {
+          "description": "<code>USBEndpoint()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBEndpoint": {
-        "__compat": {
-          "description": "<code>USBEndpoint()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "direction": {

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "direction": {

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "data": {

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBInTransferResult": {
+        "__compat": {
+          "description": "<code>USBInTransferResult()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBInTransferResult": {
-        "__compat": {
-          "description": "<code>USBInTransferResult()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "data": {

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBInterface": {
+        "__compat": {
+          "description": "<code>USBInterface()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBInterface": {
-        "__compat": {
-          "description": "<code>USBInterface()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "alternate": {

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "alternate": {

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "data": {

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBIsochronousInTransferPacket": {
+        "__compat": {
+          "description": "<code>USBIsochronousInTransferPacket()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBIsochronousInTransferPacket": {
-        "__compat": {
-          "description": "<code>USBIsochronousInTransferPacket()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "data": {

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "data": {

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBIsochronousInTransferResult": {
+        "__compat": {
+          "description": "<code>USBIsochronousInTransferResult()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBIsochronousInTransferResult": {
-        "__compat": {
-          "description": "<code>USBIsochronousInTransferResult()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "data": {

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "bytesWritten": {

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBIsochronousOutTransferPacket": {
+        "__compat": {
+          "description": "<code>USBIsochronousOutTransferPacket()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBIsochronousOutTransferPacket": {
-        "__compat": {
-          "description": "<code>USBIsochronousOutTransferPacket()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "bytesWritten": {

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBIsochronousOutTransferResult": {
+        "__compat": {
+          "description": "<code>USBIsochronousOutTransferResult()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBIsochronousOutTransferResult": {
-        "__compat": {
-          "description": "<code>USBIsochronousOutTransferResult()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "packets": {

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "packets": {

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -82,9 +82,6 @@
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
-          "tags": [
-            "web-features:webusb"
-          ],
           "support": {
             "chrome": [
               {
@@ -94,6 +91,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -117,7 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes this interface, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -90,12 +90,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -40,6 +40,45 @@
           "deprecated": false
         }
       },
+      "USBOutTransferResult": {
+        "__compat": {
+          "description": "<code>USBOutTransferResult()</code> constructor",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "description": "Available in workers",
         "tags": [
@@ -78,45 +117,6 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "USBOutTransferResult": {
-        "__compat": {
-          "description": "<code>USBOutTransferResult()</code> constructor",
-          "tags": [
-            "web-features:webusb"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "bytesWritten": {

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -80,43 +80,45 @@
         }
       },
       "worker_support": {
-        "description": "Available in workers",
-        "tags": [
-          "web-features:webusb"
-        ],
-        "support": {
-          "chrome": {
-            "version_added": "61",
-            "partial_implementation": true,
-            "notes": "Dedicated workers and WebExtension service workers only."
+        "__compat": {
+          "description": "Available in workers",
+          "tags": [
+            "web-features:webusb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "Dedicated workers and WebExtension service workers only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+            },
+            "webview_ios": "mirror"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": false
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
-          },
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "bytesWritten": {

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -9,7 +9,8 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "61",
+            "notes": "Not available in Shared Workers and Service Workers."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -86,11 +86,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "partial_implementation": true,
-              "notes": "Dedicated workers and WebExtension service workers only."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -9,8 +9,47 @@
         ],
         "support": {
           "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+          },
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "description": "Available in workers",
+        "tags": [
+          "web-features:webusb"
+        ],
+        "support": {
+          "chrome": {
             "version_added": "61",
-            "notes": "Not available in Shared Workers and Service Workers."
+            "partial_implementation": true,
+            "notes": "Dedicated workers and WebExtension service workers only."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -115,8 +115,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes this interface, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -941,7 +941,7 @@
           "support": {
             "chrome": {
               "version_added": "70",
-              "notes": "Not available in Shared Workers and Service Workers."
+              "notes": "Not available in Shared Workers and Service Workers (Except for WebExtension Service Workers)."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -939,10 +939,18 @@
             "web-features:webusb"
           ],
           "support": {
-            "chrome": {
-              "version_added": "70",
-              "notes": "Not available in Shared Workers and Service Workers (Except for WebExtension Service Workers)."
-            },
+            "chrome": [
+              {
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Dedicated workers and WebExtension service workers only."
+              },
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Dedicated workers only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -947,6 +947,7 @@
               },
               {
                 "version_added": "70",
+                "version_removed": "118",
                 "partial_implementation": true,
                 "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
@@ -970,7 +971,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
+              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB.",
+              "impl_url": "https://crbug.com/933055"
             },
             "webview_ios": "mirror"
           },

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -971,8 +971,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB.",
-              "impl_url": "https://crbug.com/933055"
+              "impl_url": "https://crbug.com/933055",
+              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB."
             },
             "webview_ios": "mirror"
           },

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -940,7 +940,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": "70",
+              "notes": "Not available in Shared Workers and Service Workers."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -943,12 +943,12 @@
               {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Dedicated workers and WebExtension service workers only."
+                "notes": "Available in dedicated workers and WebExtension service workers, not available in shared workers and normal service workers."
               },
               {
                 "version_added": "70",
                 "partial_implementation": true,
-                "notes": "Dedicated workers only."
+                "notes": "Available in dedicated workers, not available in shared workers and service workers."
               }
             ],
             "chrome_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the WebUSB API is not exposed to shared worker and service worker (except for webextension service workers) in chromium, which should be according to the [spec](https://wicg.github.io/webusb/)

no related browser issue is found

see [chromium source code](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/webusb/)

this can be test using https://worker-playground.glitch.me/

~Note: I'm not sure if partial_implementation or impl_url key should be added or not~

---

so full chain is:

1. expose to dedicated worker (M70)

    https://github.com/chromium/chromium/commit/841d469fc77210d9044fcaaa9acbdc1b0066de27
    https://github.com/chromium/chromium/commit/3267532a0e80b0aeb73ec4e72434df630bc9ce63
    https://github.com/chromium/chromium/commit/6ed4277143bc91de86dfd3df0ae8d753d8805510
    https://chromium-review.googlesource.com/c/chromium/src/+/1014196
    https://chromium-review.googlesource.com/c/chromium/src/+/1053063
    https://chromium-review.googlesource.com/c/chromium/src/+/1153222
    https://issues.chromium.org/issues/40573868
    https://issues.chromium.org/issues/40575664
    https://chromestatus.com/feature/5928209916887040

2. expose to webextension service worker (M118)

    https://github.com/chromium/chromium/commit/cf53ee2a4519b970e838fcf4135264f992f4d5b2
    https://chromium-review.googlesource.com/c/chromium/src/+/3894652
    https://issues.chromium.org/issues/40217296
    https://chromestatus.com/feature/5200265459269632

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
