### PR TITLE
enhance(update-browser-releases): ignore Safari patch versions

### DIFF
--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -86,6 +86,9 @@ export const updateSafariReleases = async (options) => {
         chalk`{yellow Release string from Apple not understandable (${releases[id].abstract[0].text})}`,
       );
       continue;
+    } else if (/^\d+\.\d+\.\d+$/.test(releaseDataEntry.version)) {
+      // Ignore patch version (e.g. "18.0.1").
+      continue;
     }
 
     // Compute release note


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Ensures that Safari patch versions (e.g. "18.0.1") are ignored when updating the browser releases.

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/pull/24627#discussion_r1787180387

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
