### PR TITLE
Chromium doesn't support `FontFaceSetLoadEvent` in workers

### DIFF
--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -94,9 +94,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -6,8 +6,7 @@
         "spec_url": "https://drafts.csswg.org/css-font-loading/#fontfacesetloadevent",
         "support": {
           "chrome": {
-            "version_added": "35",
-            "notes": "The <code>FontFaceSetLoadEvent</code> interface is not exposed to workers. See <a href='https://crbug.com/40498266'>bug 40498266</a>."
+            "version_added": "35"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -76,7 +75,7 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -6,7 +6,8 @@
         "spec_url": "https://drafts.csswg.org/css-font-loading/#fontfacesetloadevent",
         "support": {
           "chrome": {
-            "version_added": "35"
+            "version_added": "35",
+            "notes": "The <code>FontFaceSetLoadEvent</code> interface is not exposed to workers. See <a href='https://crbug.com/40498266'>bug 40498266</a>."
           },
           "chrome_android": "mirror",
           "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the `FontFaceSetLoadEvent` interface is not exposed to workerscope , only available in window scope; though it is still used on font-related events

see https://issues.chromium.org/issues/40498266 and https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/font_face_set_load_event.idl

Note per my research by view  https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/core/css/font_face_set_load_event.idl history, the interface is never exposed to worker (a todo at present)

![image](https://github.com/user-attachments/assets/b04fe9ff-eb88-4fa9-9418-9bf4bdc0958f)

tested with https://worker-playground.glitch.me/:

For latest Chrome:

![image](https://github.com/user-attachments/assets/f2fbe1d0-9a32-4e1c-9272-d1f053e08d84)

For latest Firefox:

![image](https://github.com/user-attachments/assets/56f9c00c-b539-45ed-8d46-f7957e3af58e)

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
