### PR TITLE
Firefox previews fetch() keepalive support

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -213,6 +213,52 @@
             }
           }
         },
+        "init_keepalive_parameter": {
+          "__compat": {
+            "description": "<code>init.keepalive</code> parameter",
+            "spec_url": "https://fetch.spec.whatwg.org/#dom-requestinit-keepalive",
+            "tags": [
+              "web-features:fetch-keepalive"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "66"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "18.0.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "13"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "init_priority_parameter": {
           "__compat": {
             "description": "<code>init.priority</code> parameter",
@@ -1097,7 +1143,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -216,6 +216,7 @@
         "init_keepalive_parameter": {
           "__compat": {
             "description": "<code>init.keepalive</code> parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/keepalive",
             "spec_url": "https://fetch.spec.whatwg.org/#dom-requestinit-keepalive",
             "tags": [
               "web-features:fetch-keepalive"
@@ -1130,6 +1131,7 @@
       },
       "keepalive": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/keepalive",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-keepalive②",
           "support": {
             "chrome": {

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -207,7 +207,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -213,6 +213,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 132 ships the [`fetch()` `keepalive`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#keepalive) option in Nightly and early Beta builds.

This PR adds Fx `preview` support for `api.fetch` (as used for [`Window.fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) and [`WorkerGlobalScope.fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/fetch)) and `Request.keepalive` (doesn't yet have a docs page, but I'm going to change that).

It also adds a data point for the `init.keepalive` parameter of the [`Request()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request), which just copies the same data from the other places.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1906952 for the shipping bug.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Docs issue: https://github.com/mdn/content/issues/36120

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
