### PR TITLE
fix(generate-types): run tsc with --skipLibCheck

### DIFF
--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -167,7 +167,10 @@ const compile = async (
     generateCompatDataTypes(),
   ].join('\n\n');
   await fs.writeFile(destination, ts);
-  execSync('tsc ../types/types.d.ts', { cwd: dirname, stdio: 'inherit' });
+  execSync('tsc --skipLibCheck ../types/types.d.ts', {
+    cwd: dirname,
+    stdio: 'inherit',
+  });
 };
 
 if (esMain(import.meta)) {


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Runs `tsc` with the `--skipLibCheck` to avoid the following error:

```
error TS2451: Cannot redeclare block-scoped variable 'TrustedHTML'.
```

Note: This option is [already set in `tsconfig.json`](https://github.com/mdn/browser-compat-data/blob/2f4e7db88bb9051db98c46df0cdc87e9f05b6b42/tsconfig.json#L16), but this isn't taken into consideration for the `tsc` call.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
