### PR TITLE
Updates for Chrome 130 beta

### DIFF
--- a/api/CSSNestedDeclarations.json
+++ b/api/CSSNestedDeclarations.json
@@ -5,7 +5,7 @@
         "spec_url": "https://drafts.csswg.org/css-nesting-1/#cssnesteddeclarations",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "130"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -30,7 +30,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -40,7 +40,7 @@
           "spec_url": "https://drafts.csswg.org/css-nesting-1/#dom-cssnesteddeclarations-style",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "130"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -65,7 +65,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -114,6 +114,44 @@
           }
         }
       },
+      "connected": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/serial/#dom-serialport-connected",
+          "support": {
+            "chrome": {
+              "version_added": "130"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "disconnect_event": {
         "__compat": {
           "description": "<code>disconnect</code> event",

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -6,11 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-decoration-break",
           "spec_url": "https://drafts.csswg.org/css-break/#break-decoration",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "22",
-              "notes": "This property is only supported for inline elements."
-            },
+            "chrome": [
+              {
+                "version_added": "130"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "22",
+                "notes": "This property was only supported for inline elements."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -61,9 +66,16 @@
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-break/#valdef-box-decoration-break-clone",
             "support": {
-              "chrome": {
-                "version_added": "22"
-              },
+              "chrome": [
+                {
+                  "version_added": "130"
+                },
+                {
+                  "version_added": "22",
+                  "partial_implementation": true,
+                  "notes": "This value was only supported with the -webkit- prefix."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -97,9 +109,16 @@
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-break/#valdef-box-decoration-break-slice",
             "support": {
-              "chrome": {
-                "version_added": "22"
-              },
+              "chrome": [
+                {
+                  "version_added": "130"
+                },
+                {
+                  "version_added": "22",
+                  "partial_implementation": true,
+                  "notes": "This value was only supported with the -webkit- prefix."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/text-wrap-style.json
+++ b/css/properties/text-wrap-style.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-text-4/#text-wrap-style",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "130"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -40,7 +40,7 @@
             "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-auto",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "130"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -74,7 +74,7 @@
             "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-balance",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "130"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -103,12 +103,50 @@
             }
           }
         },
+        "pretty": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-pretty",
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "stable": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-stable",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "130"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -274,11 +274,16 @@
                 "web-features:intl-locale-info"
               ],
               "support": {
-                "chrome": {
-                  "alternative_name": "calendars",
-                  "version_added": "99",
-                  "notes": "Implemented as an accessor property."
-                },
+                "chrome": [
+                  {
+                    "version_added": "130"
+                  },
+                  {
+                    "alternative_name": "calendars",
+                    "version_added": "99",
+                    "notes": "Implemented as an accessor property."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.19"
@@ -330,11 +335,16 @@
                 "web-features:intl-locale-info"
               ],
               "support": {
-                "chrome": {
-                  "alternative_name": "collations",
-                  "version_added": "99",
-                  "notes": "Implemented as an accessor property."
-                },
+                "chrome": [
+                  {
+                    "version_added": "130"
+                  },
+                  {
+                    "alternative_name": "collations",
+                    "version_added": "99",
+                    "notes": "Implemented as an accessor property."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.19"
@@ -386,11 +396,16 @@
                 "web-features:intl-locale-info"
               ],
               "support": {
-                "chrome": {
-                  "alternative_name": "hourCycles",
-                  "version_added": "99",
-                  "notes": "Implemented as an accessor property."
-                },
+                "chrome": [
+                  {
+                    "version_added": "130"
+                  },
+                  {
+                    "alternative_name": "hourCycles",
+                    "version_added": "99",
+                    "notes": "Implemented as an accessor property."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.19"
@@ -442,11 +457,16 @@
                 "web-features:intl-locale-info"
               ],
               "support": {
-                "chrome": {
-                  "alternative_name": "numberingSystems",
-                  "version_added": "99",
-                  "notes": "Implemented as an accessor property."
-                },
+                "chrome": [
+                  {
+                    "version_added": "130"
+                  },
+                  {
+                    "alternative_name": "numberingSystems",
+                    "version_added": "99",
+                    "notes": "Implemented as an accessor property."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.19"
@@ -498,11 +518,16 @@
                 "web-features:intl-locale-info"
               ],
               "support": {
-                "chrome": {
-                  "alternative_name": "textInfo",
-                  "version_added": "99",
-                  "notes": "Implemented as an accessor property."
-                },
+                "chrome": [
+                  {
+                    "version_added": "130"
+                  },
+                  {
+                    "alternative_name": "textInfo",
+                    "version_added": "99",
+                    "notes": "Implemented as an accessor property."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "deno": {
                   "alternative_name": "textInfo",
@@ -556,11 +581,16 @@
                 "web-features:intl-locale-info"
               ],
               "support": {
-                "chrome": {
-                  "alternative_name": "timeZones",
-                  "version_added": "99",
-                  "notes": "Implemented as an accessor property."
-                },
+                "chrome": [
+                  {
+                    "version_added": "130"
+                  },
+                  {
+                    "alternative_name": "timeZones",
+                    "version_added": "99",
+                    "notes": "Implemented as an accessor property."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.19"
@@ -609,11 +639,16 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo",
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo",
               "support": {
-                "chrome": {
-                  "alternative_name": "weekInfo",
-                  "version_added": "99",
-                  "notes": "Implemented as an accessor property."
-                },
+                "chrome": [
+                  {
+                    "version_added": "130"
+                  },
+                  {
+                    "alternative_name": "weekInfo",
+                    "version_added": "99",
+                    "notes": "Implemented as an accessor property."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.19"

--- a/webassembly/jsStringBuiltins.json
+++ b/webassembly/jsStringBuiltins.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "jsStringBuiltins": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "130"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.02 found new features shipping in Chrome 130 beta which was released on September 18. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 19 features as shipping in Chrome 130:

- api.CSSNestedDeclarations
- api.CSSNestedDeclarations.style
- api.SerialPort.connected
- css.properties.box-decoration-break
- css.properties.box-decoration-break.clone
- css.properties.box-decoration-break.slice
- css.properties.text-wrap-style
- css.properties.text-wrap-style.auto
- css.properties.text-wrap-style.balance
- css.properties.text-wrap-style.pretty
- css.properties.text-wrap-style.stable
- javascript.builtins.Intl.Locale.getCalendars
- javascript.builtins.Intl.Locale.getCollations
- javascript.builtins.Intl.Locale.getHourCycles
- javascript.builtins.Intl.Locale.getNumberingSystems
- javascript.builtins.Intl.Locale.getTextInfo
- javascript.builtins.Intl.Locale.getTimeZones
- javascript.builtins.Intl.Locale.getWeekInfo
- webassembly.jsStringBuiltins

See also the 129 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-130-beta