### PR TITLE
enhance(lint/fix): add --only option

### DIFF
--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -21,14 +21,36 @@ import fixLinks from './fixer/links.js';
 import fixMDNURLs from './fixer/mdn-urls.js';
 import fixStatus from './fixer/status.js';
 import fixMirror from './fixer/mirror.js';
+import { LintOptions } from './utils.js';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
 
+const FIXES = Object.freeze({
+  browser_order: fixBrowserOrder,
+  feature_order: fixFeatureOrder,
+  property_order: fixPropertyOrder,
+  statement_order: fixStatementOrder,
+  descriptions: fixDescriptions,
+  flags: fixFlags,
+  links: fixLinks,
+  mdn_urls: fixMDNURLs,
+  status: fixStatus,
+  mirror: fixMirror,
+});
+
 /**
  * Recursively load one or more files and/or directories passed as arguments and perform automatic fixes.
+ * @param options The lint options
  * @param files The files to load and perform fix upon
  */
-const load = async (...files: string[]): Promise<void> => {
+const load = async (
+  options: LintOptions,
+  ...files: string[]
+): Promise<void> => {
+  const fixes = Object.entries(FIXES)
+    .filter(([key]) => !options.only || options.only.includes(key))
+    .map(([, fix]) => fix);
+
   for (let file of files) {
     if (file.indexOf(dirname) !== 0) {
       file = path.resolve(dirname, '..', file);
@@ -45,25 +67,14 @@ const load = async (...files: string[]): Promise<void> => {
 
     if (fsStats.isFile()) {
       if (path.extname(file) === '.json' && !file.endsWith('.schema.json')) {
-        if (!file.includes('/browsers/')) {
-          fixBrowserOrder(file);
-          fixFeatureOrder(file);
-          fixStatementOrder(file);
-          fixDescriptions(file);
-          fixFlags(file);
-          fixLinks(file);
-          fixMDNURLs(file);
-          fixStatus(file);
-          fixMirror(file);
-        }
-        fixPropertyOrder(file);
+        fixes.forEach((fix) => fix(file));
       }
     } else {
       const subFiles = (await fs.readdir(file)).map((subfile) =>
         path.join(file, subfile),
       );
 
-      await load(...subFiles);
+      await load(options, ...subFiles);
     }
   }
 };
@@ -71,21 +82,26 @@ const load = async (...files: string[]): Promise<void> => {
 /**
  * Fix any errors in specified file(s) and/or folder(s), or all of BCD
  * @param files The file(s) and/or folder(s) to fix. Leave undefined for everything.
+ * @param options Lint options
+ * @returns Promise<void>
  */
-const main = async (files: string[]) => {
-  load(...files);
+const main = async (files: string[], options: LintOptions) => {
+  load(options, ...files);
 };
 
 if (esMain(import.meta)) {
-  const { argv } = yargs(hideBin(process.argv)).command(
-    '$0 [files..]',
-    false,
-    (yargs) =>
+  const { argv } = yargs(hideBin(process.argv))
+    .command('$0 [files..]', false, (yargs) =>
       yargs.positional('files...', {
         description: 'The files to fix (leave blank to test everything)',
         type: 'string',
       }),
-  );
+    )
+    .option('only', {
+      array: true,
+      description: 'The checks to run',
+    })
+    .choices('only', Object.keys(FIXES));
 
   const {
     files = [
@@ -101,9 +117,10 @@ if (esMain(import.meta)) {
       'webdriver',
       'webextensions',
     ],
-  } = argv as any;
+    only,
+  } = argv as { files?: string[] } & LintOptions;
 
-  await main(files);
+  await main(files, { only });
 }
 
 export default load;

--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -7,6 +7,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import esMain from 'es-main';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import chalk from 'chalk-template';
 
 import fixBrowserOrder from './fixer/browser-order.js';
@@ -66,11 +68,27 @@ const load = async (...files: string[]): Promise<void> => {
   }
 };
 
+/**
+ * Fix any errors in specified file(s) and/or folder(s), or all of BCD
+ * @param files The file(s) and/or folder(s) to fix. Leave undefined for everything.
+ */
+const main = async (files: string[]) => {
+  load(...files);
+};
+
 if (esMain(import.meta)) {
-  if (process.argv[2]) {
-    await load(process.argv[2]);
-  } else {
-    await load(
+  const { argv } = yargs(hideBin(process.argv)).command(
+    '$0 [files..]',
+    false,
+    (yargs) =>
+      yargs.positional('files...', {
+        description: 'The files to fix (leave blank to test everything)',
+        type: 'string',
+      }),
+  );
+
+  const {
+    files = [
       'api',
       'browsers',
       'css',
@@ -82,8 +100,10 @@ if (esMain(import.meta)) {
       'webassembly',
       'webdriver',
       'webextensions',
-    );
-  }
+    ],
+  } = argv as any;
+
+  await main(files);
 }
 
 export default load;

--- a/lint/fixer/browser-order.ts
+++ b/lint/fixer/browser-order.ts
@@ -44,6 +44,10 @@ export const orderSupportBlock = (
  * @param filename The path to the file to fix in-place
  */
 const fixBrowserOrder = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = JSON.stringify(JSON.parse(actual, orderSupportBlock), null, 2);
 

--- a/lint/fixer/descriptions.ts
+++ b/lint/fixer/descriptions.ts
@@ -12,6 +12,10 @@ import walk from '../../utils/walk.js';
  * @param filename The filename containing compatibility info
  */
 const fixDescriptions = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   let actual = fs.readFileSync(filename, 'utf-8').trim();
 
   const data = JSON.parse(actual);

--- a/lint/fixer/feature-order.ts
+++ b/lint/fixer/feature-order.ts
@@ -35,6 +35,10 @@ export const orderFeatures = (_: string, value: Identifier): Identifier => {
  * @param filename The filename to perform fix upon
  */
 const fixFeatureOrder = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = JSON.stringify(JSON.parse(actual, orderFeatures), null, 2);
 

--- a/lint/fixer/flags.ts
+++ b/lint/fixer/flags.ts
@@ -58,6 +58,10 @@ export const removeIrrelevantFlags = (
  * @param filename The filename containing compatibility info
  */
 const fixFlags = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   let actual = fs.readFileSync(filename, 'utf-8').trim();
 
   const data = JSON.parse(actual);

--- a/lint/fixer/links.ts
+++ b/lint/fixer/links.ts
@@ -11,6 +11,10 @@ import { processData } from '../linter/test-links.js';
  * @param filename The name of the file to fix
  */
 const fixLinks = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   const original = fs.readFileSync(filename, 'utf-8').trim();
   const errors = processData(original);
   let data = original;

--- a/lint/fixer/mdn-urls.ts
+++ b/lint/fixer/mdn-urls.ts
@@ -12,6 +12,10 @@ import walk from '../../utils/walk.js';
  * @param filename The filename containing compatibility info
  */
 const fixMDNURLs = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   let actual = fs.readFileSync(filename, 'utf-8').trim();
 
   const data = JSON.parse(actual);

--- a/lint/fixer/mirror.ts
+++ b/lint/fixer/mirror.ts
@@ -64,6 +64,10 @@ export const mirrorIfEquivalent = (bcd: CompatData): void => {
  * @param filename The name of the file to fix
  */
 const fixMirror = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   const actual = fs.readFileSync(filename, 'utf-8').trim();
   const bcd = JSON.parse(actual);
   mirrorIfEquivalent(bcd);

--- a/lint/fixer/property-order.ts
+++ b/lint/fixer/property-order.ts
@@ -11,6 +11,10 @@ import stringifyAndOrderProperties from '../../scripts/lib/stringify-and-order-p
  * @param filename The name of the file to fix
  */
 const fixPropertyOrder = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = stringifyAndOrderProperties(actual);
 

--- a/lint/fixer/statement-order.ts
+++ b/lint/fixer/statement-order.ts
@@ -35,6 +35,10 @@ export const orderStatements = (
  * @param filename The name of the file to fix
  */
 const fixStatementOrder = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = JSON.stringify(JSON.parse(actual, orderStatements), null, 2);
 

--- a/lint/fixer/status.ts
+++ b/lint/fixer/status.ts
@@ -37,6 +37,10 @@ const fixStatus = (key: string, value: Identifier): Identifier => {
  * @param filename The name of the file to fix
  */
 const fixStatusFromFile = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = JSON.stringify(JSON.parse(actual, fixStatus), null, 2);
 

--- a/lint/utils.ts
+++ b/lint/utils.ts
@@ -8,6 +8,10 @@ import chalk from 'chalk-template';
 import { DataType } from '../types/index.js';
 import { BrowserName } from '../types/types.js';
 
+export interface LintOptions {
+  only?: string[];
+}
+
 const now = new Date();
 
 /* The date, exactly two years ago */


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Allows running `npm run lint:fix -- --only=mdn_urls` to selectively only fix MDN urls.

Note: This adds the `--only` option only to the `lint:fix` script, not the `lint` script.

#### Test results and supporting details

```
% npm run lint:fix -- --help

> @mdn/browser-compat-data@5.6.5 lint:fix
> node --loader=ts-node/esm --no-warnings=ExperimentalWarning lint/fix.ts --help

fix.ts [files..]

Positionals:
  files...  The files to fix (leave blank to test everything)           [string]

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
  --only     The checks to run
  [array] [choices: "browser_order", "feature_order", "property_order", "stateme
    nt_order", "descriptions", "flags", "links", "mdn_urls", "status", "mirror"]
```

#### Related issues

Unblocks https://github.com/mdn/browser-compat-data/pull/23810, if we add a workflow that automatically fixes the MDN urls in a PR.
