### PR TITLE
Firefox 132 supports `text-emphasis-position: auto`

### DIFF
--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -47,6 +47,39 @@
             "deprecated": false
           }
         },
+        "auto": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "132"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "left": {
           "__compat": {
             "support": {


### PR DESCRIPTION
#### Summary

Added firefox support for `text-emphasis-position: auto` value.
Working on [#36125](https://github.com/mdn/content/issues/36125)

#### Test results and supporting details

Tested in:
- Firefox Nightly 133.0a1 - ✅ supported
- Firefox Beta 132.0b5 - ✅ supported
- Chrome Canary 131.0.6766.0 - ❌ unsupported
- Edge Canary 131.0.2883.0 - ❌ unsupported
- Safari 17.6 - ❌ unsupported

#### Related issues

- [RESOLVED: add `auto` value for `text-emphasis-position`](https://github.com/w3c/csswg-drafts/issues/1198#issuecomment-2358986319)
- Content PR - working on this
- Firefox Release note PR - working on this
