### PR TITLE
Firefox 102+ doesn't support console.profileEnd

### DIFF
--- a/api/_globals/console.json
+++ b/api/_globals/console.json
@@ -989,7 +989,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "16"
+              "version_added": "16",
+              "version_removed": "102"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/19347
See https://bugzilla.mozilla.org/show_bug.cgi?id=1730896
Test: type `console.profileEnd()` in Fx's console and read the message.
Oversight in https://github.com/mdn/browser-compat-data/pull/19387 which should have updated both.

Unblocks https://github.com/web-platform-dx/web-features/pull/1839