### PR TITLE
Samsung Internet 27.0

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -291,12 +291,13 @@
         },
         "26.0": {
           "release_date": "2024-06-07",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "122"
         },
         "27.0": {
-          "status": "beta",
+          "release_date": "2024-09-08",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "125"
         }


### PR DESCRIPTION
#### Summary

Marks Samsung Internet 27.0 as `current`.

#### Test results and supporting details

Took date from first 27.0 APK here: https://www.apkmirror.com/uploads/?appcategory=samsung-internet-for-android

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
