### PR TITLE
Add Chromium note about `AbortSignal.timeout()` 

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -396,9 +396,17 @@
             "web-features:aborting"
           ],
           "support": {
-            "chrome": {
-              "version_added": "103"
-            },
+            "chrome": [
+              {
+                "version_added": "124"
+              },
+              {
+                "version_added": "103",
+                "version_removed": "124",
+                "partial_implementation": true,
+                "notes": "Always aborts with an <code>AbortError</code> on timeout, not a <code>TimeoutError</code>."
+              }
+            ],
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.20"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 103-123 never aborted `AbortSignal.timeout()` with a `TimeoutError`.

#### Test results and supporting details

Tested with https://developer.mozilla.org/en-US/play?id=Ully%2FbncqOhlj%2FACZTtIJLg1HtNlADkcgP4iWysbI6ercjFSzCJWkHPuAi5NNQRqGhL5ZlO5oTWm7TEr in BrowserStack Live, see [this comment](https://github.com/mdn/browser-compat-data/issues/20381#issuecomment-2405413530).

#### Related issues

Fixes #20381.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
