### PR TITLE
Sync html.elements.meter with api.HTMLMeterElement

### DIFF
--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -11,7 +11,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "16"
@@ -54,7 +54,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "16"
@@ -98,7 +98,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "16"
@@ -143,7 +143,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "16"
@@ -188,7 +188,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "16"
@@ -232,7 +232,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "16"
@@ -276,7 +276,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "16"


### PR DESCRIPTION
`api.HTMLMeterElement` and `css.properties.appearance.meter` say "12" for Edge which is more precise than "≤18" and so `html.elements.meter` should say the same, so this PR updates that.

Unblocks https://github.com/web-platform-dx/web-features/pull/1419
