### PR TITLE
Add note for required web app manifest members

### DIFF
--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -7,7 +7,8 @@
           "spec_url": "https://w3c.github.io/manifest/#display-member",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "39",
+              "notes": "<code>display</code> and/or <code>display_override</code> are required for a web app to be installable."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/manifest/display_override.json
+++ b/html/manifest/display_override.json
@@ -7,7 +7,8 @@
           "spec_url": "https://wicg.github.io/manifest-incubations/#display_override-member",
           "support": {
             "chrome": {
-              "version_added": "89"
+              "version_added": "89",
+              "notes": "<code>display_override</code> and/or <code>display</code> are required for a web app to be installable."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -7,7 +7,8 @@
           "spec_url": "https://w3c.github.io/manifest/#icons-member",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "39",
+              "notes": "<code>icons</code> is required for a web app to be installable."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -25,11 +26,11 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "17",
-              "notes": "Only used when no <code>apple-touch-icon</code> is present with <code>\"purpose\": \"any\"</code> or no <code>\"purpose\"</code> key."
+              "notes": "Only used when no <code>apple-touch-icon</code> is present and either <code>\"purpose\" is set to \"any\"</code> or <code>\"purpose\"</code> is not specified."
             },
             "safari_ios": {
               "version_added": "15.4",
-              "notes": "Only used when no <code>apple-touch-icon</code> is present with <code>\"purpose\": \"any\"</code> or no <code>\"purpose\"</code> key."
+              "notes": "Only used when no <code>apple-touch-icon</code> is present and either <code>\"purpose\" is set to \"any\"</code> or <code>\"purpose\"</code> is not specified."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -7,7 +7,8 @@
           "spec_url": "https://w3c.github.io/manifest/#name-member",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "39",
+              "notes": "<code>name</code> or <code>short_name</code> is required for a web app to be installable."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -7,7 +7,8 @@
           "spec_url": "https://w3c.github.io/manifest/#prefer_related_applications-member",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "<code>prefer_related_applications</code> must be <code>false</code> or not present for a web app to be installable."
             },
             "chrome_android": {
               "version_added": "44"

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -7,7 +7,8 @@
           "spec_url": "https://w3c.github.io/manifest/#short_name-member",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "39",
+              "notes": "<code>short_name</code> or <code>name</code> is required for a web app to be installable."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/manifest/start_url.json
+++ b/html/manifest/start_url.json
@@ -7,7 +7,8 @@
           "spec_url": "https://w3c.github.io/manifest/#start_url-member",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "39",
+              "notes": "<code>start_url</code> is required for a web app to be installable."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

### Summary

This PR adds a note to the manifest members that are required for a web app to be installable.

Bonus edit: In the `icons` file, I've rephrased the safari note so that we don't use "key" because we refer them as (manifest) members in content.

### Supporting details

The following browser-specific information is good to be included in the BCD table (instead of being added as a note on respective manifest member pages):

> [Required manifest members](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#required_manifest_members):
> Chromium-based browsers, including Google Chrome, Samsung Internet, and Microsoft Edge, require that the manifest includes the following members:
> - name or short_name
> - icons must contain a 192px and a 512px icon
> - start_url
> - display and/or display_override
> - prefer_related_applications must be false or not present

Context: https://github.com/mdn/content/pull/35847#discussion_r1781993285

### Assumptions and questions

- I am assuming that by virtue of "mirror" value, the added note will be replicated to all chromium-based browsers. Is that correct?
I've added the note only to Chrome, but it also applies to Chrome Android, Edge, Opera (and Android), Samsung Internet, WebView Android.

- I am unclear about some of the values showing in the table. For example:

| | chrome | edge | opera |
| --- | --- | --- | --- |
| [`display` on MDN](https://developer.mozilla.org/en-US/docs/Web/Manifest/display#browser_compatibility)|39 | 79 | 26 |
| [`display` in BCD](https://github.com/mdn/browser-compat-data/blob/main/html/manifest/display.json) | 39 | mirror | mirror |

I am not sure what's the source of the values visible on MDN.