### PR TITLE
Add toneMapping and getConfiguration()

### DIFF
--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -144,6 +144,89 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "toneMapping": {
+          "__compat": {
+            "description": "<code>toneMapping</code> config property",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucanvasconfiguration-tonemapping",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "129",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "getConfiguration": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getconfiguration",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "131",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "getCurrentTexture": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds two new [WebGPU](https://gpuweb.github.io/gpuweb) features added recently in Chrome:

- The [`GPUCanvasContext.getConfiguration()`](https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getconfiguration) method, added in Chrome 131 (see relevant [ChromeStatus](https://chromestatus.com/feature/6195110870777856) entry).
- The `GPUCanvasContext` configuration [`toneMapping`](https://gpuweb.github.io/gpuweb/#dom-gpucanvasconfiguration-tonemapping) option, added in Chrome 129 (see relevant [ChromeStatus](https://chromestatus.com/feature/6196313866895360) entry).



<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Features testing in Chrome 131 with the following snippet:

```js
const canvas = document.querySelector("canvas");
const context = canvas.getContext("webgpu");

async function init() {
  if (!navigator.gpu) {
    throw Error("WebGPU not supported.");
  }

  const adapter = await navigator.gpu.requestAdapter();
  if (!adapter) {
    throw Error("Couldn't request WebGPU adapter.");
  }

  const device = await adapter.requestDevice();

  context.configure({
    device: device,
    format: navigator.gpu.getPreferredCanvasFormat(),
    alphaMode: "premultiplied",
    toneMapping: {
      mode: "extended"
    }
  });

  console.log(context.getConfiguration());
}

init();
```

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
