### PR TITLE
Combine status options in traverse

### DIFF
--- a/scripts/traverse.test.ts
+++ b/scripts/traverse.test.ts
@@ -43,9 +43,11 @@ describe('iterateFeatures', () => {
       depth: 2,
       tag: '',
       identifier: '',
-      deprecated: undefined,
-      standard_track: undefined,
-      experimental: undefined,
+      support: {
+        deprecated: undefined,
+        standard_track: undefined,
+        experimental: undefined,
+      },
     };
   });
 
@@ -57,9 +59,6 @@ describe('iterateFeatures', () => {
         options.values,
         options.depth,
         options.tag,
-        options.deprecated,
-        options.standard_track,
-        options.experimental,
         options.identifier,
       ),
     );
@@ -68,7 +67,7 @@ describe('iterateFeatures', () => {
   });
 
   it('should filter out deprecated', () => {
-    options.deprecated = false;
+    options.support.deprecated = false;
     obj.feature2.__compat.status.deprecated = true;
     const result = Array.from(
       iterateFeatures(
@@ -77,10 +76,8 @@ describe('iterateFeatures', () => {
         options.values,
         options.depth,
         options.tag,
-        options.deprecated,
-        options.standard_track,
-        options.experimental,
         options.identifier,
+        options.support,
       ),
     );
 
@@ -88,7 +85,7 @@ describe('iterateFeatures', () => {
   });
 
   it('should filter out non-deprecated', () => {
-    options.deprecated = true;
+    options.support.deprecated = true;
     obj.feature2.__compat.status.deprecated = true;
     const result = Array.from(
       iterateFeatures(
@@ -97,10 +94,8 @@ describe('iterateFeatures', () => {
         options.values,
         options.depth,
         options.tag,
-        options.deprecated,
-        options.standard_track,
-        options.experimental,
         options.identifier,
+        options.support,
       ),
     );
 
@@ -109,7 +104,7 @@ describe('iterateFeatures', () => {
 
   it('should filter out non-experimental', () => {
     obj.feature2.__compat.status.experimental = true;
-    options.experimental = true;
+    options.support.experimental = true;
     const result = Array.from(
       iterateFeatures(
         obj,
@@ -117,10 +112,8 @@ describe('iterateFeatures', () => {
         options.values,
         options.depth,
         options.tag,
-        options.deprecated,
-        options.standard_track,
-        options.experimental,
         options.identifier,
+        options.support,
       ),
     );
 
@@ -129,7 +122,7 @@ describe('iterateFeatures', () => {
 
   it('should filter out experimental', () => {
     obj.feature2.__compat.status.experimental = true;
-    options.experimental = false;
+    options.support.experimental = false;
     const result = Array.from(
       iterateFeatures(
         obj,
@@ -137,10 +130,8 @@ describe('iterateFeatures', () => {
         options.values,
         options.depth,
         options.tag,
-        options.deprecated,
-        options.standard_track,
-        options.experimental,
         options.identifier,
+        options.support,
       ),
     );
 
@@ -149,7 +140,7 @@ describe('iterateFeatures', () => {
 
   it('should filter out non-standard track', () => {
     obj.feature1.__compat.status.standard_track = false;
-    options.standard_track = true;
+    options.support.standard_track = true;
     const result = Array.from(
       iterateFeatures(
         obj,
@@ -157,10 +148,8 @@ describe('iterateFeatures', () => {
         options.values,
         options.depth,
         options.tag,
-        options.deprecated,
-        options.standard_track,
-        options.experimental,
         options.identifier,
+        options.support,
       ),
     );
 
@@ -169,7 +158,7 @@ describe('iterateFeatures', () => {
 
   it('should filter out standard track', () => {
     obj.feature1.__compat.status.standard_track = false;
-    options.standard_track = false;
+    options.support.standard_track = false;
     const result = Array.from(
       iterateFeatures(
         obj,
@@ -177,10 +166,8 @@ describe('iterateFeatures', () => {
         options.values,
         options.depth,
         options.tag,
-        options.deprecated,
-        options.standard_track,
-        options.experimental,
         options.identifier,
+        options.support,
       ),
     );
 

--- a/scripts/traverse.test.ts
+++ b/scripts/traverse.test.ts
@@ -43,7 +43,7 @@ describe('iterateFeatures', () => {
       depth: 2,
       tag: '',
       identifier: '',
-      support: {
+      status: {
         deprecated: undefined,
         standard_track: undefined,
         experimental: undefined,
@@ -67,7 +67,7 @@ describe('iterateFeatures', () => {
   });
 
   it('should filter out deprecated', () => {
-    options.support.deprecated = false;
+    options.status.deprecated = false;
     obj.feature2.__compat.status.deprecated = true;
     const result = Array.from(
       iterateFeatures(
@@ -77,7 +77,7 @@ describe('iterateFeatures', () => {
         options.depth,
         options.tag,
         options.identifier,
-        options.support,
+        options.status,
       ),
     );
 
@@ -85,7 +85,7 @@ describe('iterateFeatures', () => {
   });
 
   it('should filter out non-deprecated', () => {
-    options.support.deprecated = true;
+    options.status.deprecated = true;
     obj.feature2.__compat.status.deprecated = true;
     const result = Array.from(
       iterateFeatures(
@@ -95,7 +95,7 @@ describe('iterateFeatures', () => {
         options.depth,
         options.tag,
         options.identifier,
-        options.support,
+        options.status,
       ),
     );
 
@@ -104,7 +104,7 @@ describe('iterateFeatures', () => {
 
   it('should filter out non-experimental', () => {
     obj.feature2.__compat.status.experimental = true;
-    options.support.experimental = true;
+    options.status.experimental = true;
     const result = Array.from(
       iterateFeatures(
         obj,
@@ -113,7 +113,7 @@ describe('iterateFeatures', () => {
         options.depth,
         options.tag,
         options.identifier,
-        options.support,
+        options.status,
       ),
     );
 
@@ -122,7 +122,7 @@ describe('iterateFeatures', () => {
 
   it('should filter out experimental', () => {
     obj.feature2.__compat.status.experimental = true;
-    options.support.experimental = false;
+    options.status.experimental = false;
     const result = Array.from(
       iterateFeatures(
         obj,
@@ -131,7 +131,7 @@ describe('iterateFeatures', () => {
         options.depth,
         options.tag,
         options.identifier,
-        options.support,
+        options.status,
       ),
     );
 
@@ -140,7 +140,7 @@ describe('iterateFeatures', () => {
 
   it('should filter out non-standard track', () => {
     obj.feature1.__compat.status.standard_track = false;
-    options.support.standard_track = true;
+    options.status.standard_track = true;
     const result = Array.from(
       iterateFeatures(
         obj,
@@ -149,7 +149,7 @@ describe('iterateFeatures', () => {
         options.depth,
         options.tag,
         options.identifier,
-        options.support,
+        options.status,
       ),
     );
 
@@ -158,7 +158,7 @@ describe('iterateFeatures', () => {
 
   it('should filter out standard track', () => {
     obj.feature1.__compat.status.standard_track = false;
-    options.support.standard_track = false;
+    options.status.standard_track = false;
     const result = Array.from(
       iterateFeatures(
         obj,
@@ -167,7 +167,7 @@ describe('iterateFeatures', () => {
         options.depth,
         options.tag,
         options.identifier,
-        options.support,
+        options.status,
       ),
     );
 

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -9,7 +9,7 @@ import { BrowserName, Identifier } from '../types/types.js';
 import { InternalSupportStatement } from '../types/index.js';
 import bcd, { dataFolders } from '../index.js';
 
-interface SupportFilters {
+interface StatusFilters {
   deprecated: boolean | undefined;
   standard_track: boolean | undefined;
   experimental: boolean | undefined;
@@ -23,7 +23,7 @@ interface SupportFilters {
  * @param depth The depth to traverse
  * @param tag The tag to filter results with
  * @param identifier The identifier of the current object
- * @param [support] Whether to filter by support statuses
+ * @param status Whether to filter by status flags
  * @yields {string} The feature identifier
  */
 export function* iterateFeatures(
@@ -33,9 +33,9 @@ export function* iterateFeatures(
   depth: number,
   tag: string,
   identifier: string,
-  support: SupportFilters | null = null,
+  status: StatusFilters | null = null,
 ): IterableIterator<string> {
-  const { deprecated, standard_track, experimental } = support ?? {};
+  const { deprecated, standard_track, experimental } = status ?? {};
   depth--;
   if (depth >= 0) {
     for (const i in obj) {
@@ -134,7 +134,7 @@ export function* iterateFeatures(
           depth,
           tag,
           identifier + i + '.',
-          support,
+          status,
         );
       }
     }
@@ -149,7 +149,7 @@ export function* iterateFeatures(
  * @param depth The depth to traverse
  * @param tag The tag to filter results with
  * @param identifier The identifier of the current object
- * @param support Whether to filter by support statuses
+ * @param status Whether to filter by status flags
  * @returns An array of the features
  */
 const traverseFeatures = (
@@ -159,10 +159,10 @@ const traverseFeatures = (
   depth: number,
   tag: string,
   identifier: string,
-  support: SupportFilters,
+  status: StatusFilters,
 ): string[] => {
   const features = Array.from(
-    iterateFeatures(obj, browsers, values, depth, tag, identifier, support),
+    iterateFeatures(obj, browsers, values, depth, tag, identifier, status),
   );
 
   return features.filter((item, pos) => features.indexOf(item) == pos);
@@ -175,7 +175,7 @@ const traverseFeatures = (
  * @param values The version values to traverse for
  * @param depth The depth to traverse
  * @param tag The tag to filter results with
- * @param support Whether to filter by support statuses
+ * @param status Whether to filter by status flags
  * @returns The list of features
  */
 const main = (
@@ -186,7 +186,7 @@ const main = (
   values = ['null', 'true'],
   depth = 100,
   tag = '',
-  support = {} as SupportFilters,
+  status = {} as StatusFilters,
 ): string[] => {
   const features: string[] = [];
 
@@ -199,7 +199,7 @@ const main = (
         depth,
         tag,
         folders[folder] + '.',
-        support,
+        status,
       ),
     );
   }
@@ -266,21 +266,21 @@ if (esMain(import.meta)) {
           type: 'boolean',
           default: process.stdout.isTTY,
         })
-        .option('support.deprecated', {
+        .option('status.deprecated', {
           alias: 'x',
           describe:
             'Filter features by deprecation status. Set to `true` to only show deprecated features or `false` to only show non-deprecated features.',
           type: 'boolean',
           default: undefined,
         })
-        .option('support.standard_track', {
+        .option('status.standard_track', {
           alias: 's',
           describe:
             'Filter features by standard_track status. Set to `true` to only show standards track features or `false` to only show non-standards track features.',
           type: 'boolean',
           default: undefined,
         })
-        .option('support.experimental', {
+        .option('status.experimental', {
           alias: 'e',
           describe:
             'Filter features by experimental status. Set to `true` to only show experimental features or `false` to only show non-experimental features.',
@@ -312,19 +312,19 @@ if (esMain(import.meta)) {
           'Find all features with no tags.',
         )
         .example(
-          'npm run traverse -- --support.deprecated',
+          'npm run traverse -- --status.deprecated',
           'Find all features that are deprecated.',
         )
         .example(
-          'npm run traverse -- --no-support.deprecated',
+          'npm run traverse -- --no-status.deprecated',
           'Omit all features that are deprecated.',
         )
         .example(
-          'npm run traverse -- --support.standard_track',
+          'npm run traverse -- --status.standard_track',
           'Find all features that are on the standard track.',
         )
         .example(
-          'npm run traverse -- --support.experimental',
+          'npm run traverse -- --status.experimental',
           'Find all features that are experimental.',
         );
     },
@@ -338,7 +338,7 @@ if (esMain(import.meta)) {
     filter,
     argv.depth,
     argv.tag,
-    argv.support,
+    argv.status,
   );
   console.log(features.join('\n'));
   if (argv.showCount) {

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -9,6 +9,12 @@ import { BrowserName, Identifier } from '../types/types.js';
 import { InternalSupportStatement } from '../types/index.js';
 import bcd, { dataFolders } from '../index.js';
 
+interface SupportFilters {
+  deprecated: boolean | undefined;
+  standard_track: boolean | undefined;
+  experimental: boolean | undefined;
+}
+
 /**
  * Traverse all of the features within a specified object and find all features that have one of the specified values
  * @param obj The compat data to traverse through
@@ -16,10 +22,8 @@ import bcd, { dataFolders } from '../index.js';
  * @param values The values to test for
  * @param depth The depth to traverse
  * @param tag The tag to filter results with
- * @param deprecated Whether to filter by deprecation status
- * @param standard_track Whether to filter by standard track status
- * @param experimental Whether to filter by experimental status
  * @param identifier The identifier of the current object
+ * @param [support] Whether to filter by support statuses
  * @yields {string} The feature identifier
  */
 export function* iterateFeatures(
@@ -28,11 +32,10 @@ export function* iterateFeatures(
   values: string[],
   depth: number,
   tag: string,
-  deprecated: boolean | undefined,
-  standard_track: boolean | undefined,
-  experimental: boolean | undefined,
   identifier: string,
+  support: SupportFilters | null = null,
 ): IterableIterator<string> {
+  const { deprecated, standard_track, experimental } = support ?? {};
   depth--;
   if (depth >= 0) {
     for (const i in obj) {
@@ -130,10 +133,8 @@ export function* iterateFeatures(
           values,
           depth,
           tag,
-          deprecated,
-          standard_track,
-          experimental,
           identifier + i + '.',
+          support,
         );
       }
     }
@@ -147,10 +148,8 @@ export function* iterateFeatures(
  * @param values The version values to traverse for
  * @param depth The depth to traverse
  * @param tag The tag to filter results with
- * @param deprecated Whether to filter by deprecation status
- * @param standard_track Whether to filter by standard track status
- * @param experimental Whether to filter by experimental status
  * @param identifier The identifier of the current object
+ * @param support Whether to filter by support statuses
  * @returns An array of the features
  */
 const traverseFeatures = (
@@ -159,23 +158,11 @@ const traverseFeatures = (
   values: string[],
   depth: number,
   tag: string,
-  deprecated: boolean | undefined,
-  standard_track: boolean | undefined,
-  experimental: boolean | undefined,
   identifier: string,
+  support: SupportFilters,
 ): string[] => {
   const features = Array.from(
-    iterateFeatures(
-      obj,
-      browsers,
-      values,
-      depth,
-      tag,
-      deprecated,
-      standard_track,
-      experimental,
-      identifier,
-    ),
+    iterateFeatures(obj, browsers, values, depth, tag, identifier, support),
   );
 
   return features.filter((item, pos) => features.indexOf(item) == pos);
@@ -188,9 +175,7 @@ const traverseFeatures = (
  * @param values The version values to traverse for
  * @param depth The depth to traverse
  * @param tag The tag to filter results with
- * @param deprecated Whether to filter by deprecation status
- * @param standard_track Whether to filter by standard track status
- * @param experimental Whether to filter by experimental status
+ * @param support Whether to filter by support statuses
  * @returns The list of features
  */
 const main = (
@@ -201,9 +186,7 @@ const main = (
   values = ['null', 'true'],
   depth = 100,
   tag = '',
-  deprecated = undefined,
-  standard_track = undefined,
-  experimental = undefined,
+  support = {} as SupportFilters,
 ): string[] => {
   const features: string[] = [];
 
@@ -215,10 +198,8 @@ const main = (
         values,
         depth,
         tag,
-        deprecated,
-        standard_track,
-        experimental,
         folders[folder] + '.',
+        support,
       ),
     );
   }
@@ -285,21 +266,21 @@ if (esMain(import.meta)) {
           type: 'boolean',
           default: process.stdout.isTTY,
         })
-        .option('deprecated', {
+        .option('support.deprecated', {
           alias: 'x',
           describe:
             'Filter features by deprecation status. Set to `true` to only show deprecated features or `false` to only show non-deprecated features.',
           type: 'boolean',
           default: undefined,
         })
-        .option('standard_track', {
+        .option('support.standard_track', {
           alias: 's',
           describe:
             'Filter features by standard_track status. Set to `true` to only show standards track features or `false` to only show non-standards track features.',
           type: 'boolean',
           default: undefined,
         })
-        .option('experimental', {
+        .option('support.experimental', {
           alias: 'e',
           describe:
             'Filter features by experimental status. Set to `true` to only show experimental features or `false` to only show non-experimental features.',
@@ -331,20 +312,20 @@ if (esMain(import.meta)) {
           'Find all features with no tags.',
         )
         .example(
-          'npm run traverse -- --deprecated',
+          'npm run traverse -- --support.deprecated',
           'Find all features that are deprecated.',
         )
         .example(
-          'npm run traverse -- --no-deprecated',
+          'npm run traverse -- --no-support.deprecated',
           'Omit all features that are deprecated.',
         )
         .example(
-          'npm run traverse -- --standard_track',
+          'npm run traverse -- --support.standard_track',
           'Find all features that are on the standard track.',
         )
         .example(
-          'npm run traverse -- --experimental',
-          'Omit all features that are deprecated.',
+          'npm run traverse -- --support.experimental',
+          'Find all features that are experimental.',
         );
     },
   );
@@ -357,9 +338,7 @@ if (esMain(import.meta)) {
     filter,
     argv.depth,
     argv.tag,
-    argv.deprecated,
-    argv.standard_track,
-    argv.experimental,
+    argv.support,
   );
   console.log(features.join('\n'));
   if (argv.showCount) {


### PR DESCRIPTION
#### Summary

Combines status-related filters into a single object, and moves it to the final argument to unbreak the breaking changes.

#### Test results and supporting details

Some examples:

```
npm run traverse -- ---status.deprecated // Only depreceated
npm run traverse -- --no-status.deprecated // Only non-deprecated
npm run traverse -- --x  // Only deprecated
npm run traverse -- --no-x // Only non-deprecated
npm run traverse -- --status.standard_track false --support.experimental // Only non-standard track experimental
npm run traverse -- --no-x --s --no-e // Only non-deprecated, standard track, non-experimental
```

#### Related issues

Fixes #24609, unbreaks #24707 
