### PR TITLE
FF132 CloseWatcher behind pref

### DIFF
--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -11,7 +11,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "132",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.closewatcher.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "ie": {
@@ -46,7 +53,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "132",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.closewatcher.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -82,7 +96,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "132",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.closewatcher.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -117,7 +138,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "132",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.closewatcher.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -153,7 +181,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "132",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.closewatcher.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -188,7 +223,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "132",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.closewatcher.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -223,7 +265,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "132",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.closewatcher.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF321 supports [`CloseWatcher`](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) in https://bugzilla.mozilla.org/show_bug.cgi?id=1888729 behind the pref `dom.closewatcher.enabled`.

This updates the feature.

Related docs work can be tracked in https://github.com/mdn/content/issues/36126