### PR TITLE
`api.WakeLock`: remove partial from Safari on iOS

### DIFF
--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -28,7 +28,6 @@
           },
           "safari_ios": {
             "version_added": "16.4",
-            "partial_implementation": true,
             "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
           },
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`WakeLock` is marked as partially implemented; this removes the partial implementation flag, but lets the note stand (it's accurate).

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I think this is weird and noteworthy. But it's otherwise inside the behaviors permitted by the spec and broadly compatible with other browsers on other platforms, so I ultimately came to the conclusion that it should _not_ be marked as partially implemented.

First, the spec. It seems to give wide latitude to implementers to arbitrarily ignore wake lock requests. These two points specifically:

- [Auto-releasing wake locks](https://w3c.github.io/screen-wake-lock/#auto-releasing-wake-locks)

  > A user agent may release a wake lock at any time.

- [A note](https://w3c.github.io/screen-wake-lock/#ref-for-dfn-acquire-a-wake-lock-2) in the [The <code>request()</code> method](https://w3c.github.io/screen-wake-lock/#the-request-method) section:

  > The acquire a wake lock algorithm may ultimately be unable to acquire a lock from the operating system, but this is indistinguishable from a successful lock acquisition to avoid user fingerprinting (failure to acquire a lock can indicate low battery levels, for example).

I can't say why Apple has made wake lock non-functioning in home screen apps, but it seems to me that it's strictly permitted by the spec and would necessarily be beyond inspection by developers.

And since wake lock _does_ work in a regular web page used in the regular Safari browser context, I think we can say that wake lock is broadly compatible with other implementations in other browsers, even if it doesn't work in an iOS-specific context.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Original PR: https://github.com/mdn/browser-compat-data/pull/21830
- Prompted by a ~~regression on~~ screen wake lock's Baseline status: https://github.com/GoogleChrome/webstatus.dev/issues/740 (it looks like this didn't regress after all—I got confused)

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
