### PR TITLE
feat(workflows): update MDN urls in mdn-content-inventory Dependabot PR

### DIFF
--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -1,0 +1,55 @@
+name: Update MDN urls
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: "30 4 * * 1-5"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    if: github.repository == 'mdn/browser-compat-data'
+    name: Update MDN urls
+    runs-on: ubuntu-latest
+    env:
+      RESULT: ""
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Fix
+        run: |
+          echo "RESULT<<EOF" >> $GITHUB_ENV
+          npm run lint:fix -- --only=mdn_urls >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GH_TOKEN }} # need the rights to create and edit PRs
+          commit-message: Update MDN urls
+          author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          signoff: false
+          branch: mdn-urls
+          delete-branch: true
+          add-paths: "*.json"
+          title: "Update MDN urls"
+          body: |
+            ```
+            $ npm run lint:fix -- --only=mdn_urls
+            ${{ env.RESULT }}
+            ```
+          draft: false

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  update:
+  update-mdn-urls:
     if: github.repository == 'mdn/browser-compat-data'
     name: Update MDN urls
     runs-on: ubuntu-latest

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Fix
         run: |
           npm run lint:fix -- --only=mdn_urls
-          git commit -m 'chore: run `npm run lint:fix --only=mdn_urls`' .
+          git commit -m 'chore: fix mdn urls' .
           git push

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -34,8 +34,12 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Fix
+      - name: Update
         run: |
           npm run lint:fix -- --only=mdn_urls
-          git commit -m 'chore: fix mdn urls' .
-          git push
+          if git diff --exit-code; then
+            echo "No changes."
+          else
+            git commit -m 'chore: fix mdn urls' .
+            git push
+          fi

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -1,22 +1,20 @@
 name: Update MDN urls
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - "dependabot/npm_and_yarn/ddbeck/mdn-content-inventory-*"
+      - "update-mdn-*"
 
-  schedule:
-    - cron: "30 4 * * 1-5"
-
-permissions:
-  contents: write
-  pull-requests: write
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   update-mdn-urls:
     if: github.repository == 'mdn/browser-compat-data'
     name: Update MDN urls
     runs-on: ubuntu-latest
-    env:
-      RESULT: ""
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,29 +25,17 @@ jobs:
           node-version-file: ".nvmrc"
           cache: npm
 
+      - name: "Setup git"
+        run: |
+          git remote set-url origin https://mdn-bot:$GH_TOKEN@github.com/${{ github.repository }}.git
+          git config user.email 108879845+mdn-bot@users.noreply.github.com
+          git config user.name mdn-bot
+
       - name: Install
         run: npm ci
 
       - name: Fix
         run: |
-          echo "RESULT<<EOF" >> $GITHUB_ENV
-          npm run lint:fix -- --only=mdn_urls >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Create PR
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GH_TOKEN }} # need the rights to create and edit PRs
-          commit-message: Update MDN urls
-          author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
-          signoff: false
-          branch: mdn-urls
-          delete-branch: true
-          add-paths: "*.json"
-          title: "Update MDN urls"
-          body: |
-            ```
-            $ npm run lint:fix -- --only=mdn_urls
-            ${{ env.RESULT }}
-            ```
-          draft: false
+          npm run lint:fix -- --only=mdn_urls
+          git commit -m 'chore: run `npm run lint:fix --only=mdn_urls`' .
+          git push

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "dependabot/npm_and_yarn/ddbeck/mdn-content-inventory-*"
-      - "update-mdn-*"
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -135,6 +135,7 @@
       },
       "autocomplete": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/autocomplete",
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-autocomplete",
           "tags": [
             "web-features:select"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -135,7 +135,6 @@
       },
       "autocomplete": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/autocomplete",
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-autocomplete",
           "tags": [
             "web-features:select"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a workflow that runs on the Dependabot PRs for `ddbeck/mdn-content-inventory`, updates the MDN urls, and pushes the updates to the PR.

#### Test results and supporting details

Used the [update-browser-releases](https://github.com/mdn/browser-compat-data/blob/main/.github/workflows/update-browser-releases.yml) workflow as a template.

#### Related issues

Follow-up of https://github.com/mdn/browser-compat-data/pull/24669.
Unblocks https://github.com/mdn/browser-compat-data/pull/23810.
