### PR TITLE
Remove impl_url for Push-API & Fix impl_url for Notification API

### DIFF
--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -41,8 +41,7 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false,
-            "impl_url": "https://crbug.com/421921"
+            "version_added": false
           },
           "webview_ios": {
             "version_added": false,

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -37,8 +37,7 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false,
-            "impl_url": "https://crbug.com/421921"
+            "version_added": false
           },
           "webview_ios": {
             "version_added": false,

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -37,8 +37,7 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false,
-            "impl_url": "https://crbug.com/421921"
+            "version_added": false
           },
           "webview_ios": {
             "version_added": false,

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -37,8 +37,7 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false,
-            "impl_url": "https://crbug.com/421921"
+            "version_added": false
           },
           "webview_ios": {
             "version_added": false,

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -34,8 +34,7 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false,
-            "impl_url": "https://crbug.com/421921"
+            "version_added": false
           },
           "webview_ios": {
             "version_added": false,

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -428,8 +428,7 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/421921"
+              "version_added": false
             },
             "webview_ios": {
               "version_added": false,
@@ -515,7 +514,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "impl_url": "https://crbug.com/421921"
+              "impl_url": "https://crbug.com/551446"
             },
             "webview_ios": {
               "version_added": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the [browser issue](https://crbug.com/421921) has been used to track the implementation of Push API in webview, but this has been marked as *won't fix*, per https://github.com/mdn/browser-compat-data/blob/main/schemas/compat-data-schema.md#impl_url, keeping the link is useless anymore

also the Notification API could be updated to [browser issue](https://crbug.com/551446), which is still open at present

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
