### PR TITLE
Firefox 132 ships regexp modifiers

### DIFF
--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -577,15 +577,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "javascript.options.experimental.regexp_modifiers",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1899813"
+              "version_added": "132"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -606,7 +598,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

- added version_added for regexp modifiers for ff

#### Test results and supporting details

- tested with [https://codepen.io/CodeRedDigital/pen/GRbEOLE](https://codepen.io/CodeRedDigital/pen/GRbEOLE)
  - Firefox Nightly 133.0a1
  - Firefox Beta 132.0b7

#### Related issues

- [Firefox Release Note PR](https://github.com/mdn/content/pull/36381)
