### PR TITLE
Add feature for focusable `display: contents` elements

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -83,6 +83,7 @@
         },
         "contents": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display/#valdef-display-contents",
             "support": {
               "chrome": {
                 "version_added": "65"
@@ -142,6 +143,46 @@
               },
               "status": {
                 "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "focusable_elements": {
+            "__compat": {
+              "description": "Elements with <code>display: contents</code> are focusable",
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/40866683"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": [
+                    "https://bugzil.la/1791648",
+                    "https://bugzil.la/1553549"
+                  ]
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/255149"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add a feature representing a specification change, where descendants of `display: contents` must be accessible.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

`display: contents` has severe accessibility issues ([for example](https://ericwbailey.design/published/display-contents-considered-harmful/)). It's difficult for web-features to generate a status for `display: contents` without data reflecting this fact. This PR attempts to add the data needed to accurately report support for `display: contents` in a non-surprising way.

Admittedly, this is a weird feature. No browser has actually shipped this "feature" yet, though there's work in progress in Chrome ([Chrome Platform Status](https://chromestatus.com/feature/6237396851228672); [intent to ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/9hvYiSZy868/m/8fJc_92wAAAJ)) and it's [an Interop 2024 selection](https://github.com/web-platform-tests/interop/issues/568).

Alternatives considered:

- Representing this as a `partial_implementation` on `css.properties.display.contents` itself. Advantages include more aggressively warning developers about the seriousness of `display: contents` as it is currently implemented. The disadvantages include trying to communicate a rather large thing as an unstructured note and that it would (wrongly) imply that browsers have implemented `display: contents` incorrectly or non-interoperably, when it was the spec that changed.

- Representing this _inversely_ as a deprecated feature (e.g., `css.properties.display.contents.unfocusable_elements`). This has a maintenance advantage: you get to remove this feature as irrelevant in a few years, after everyone has "removed" the old behavior. This has the disadvantage of implying that browsers have shipped some _extra_ behavior, not that the behavior is, strictly speaking, wrong.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Links

- https://github.com/whatwg/html/pull/9425
- [`css/css-display/focus/display-contents-focus.html` on wpt.fyi](https://wpt.fyi/results/css/css-display/focus/display-contents-focus.html?label=experimental&label=master&aligned)
- https://github.com/web-platform-tests/interop/issues/568
- Standards positions:
  - https://github.com/mozilla/standards-positions/issues/772
  - https://github.com/WebKit/standards-positions/issues/164

#### Related issues

- https://github.com/mdn/browser-compat-data/issues/19994
- https://github.com/web-platform-dx/web-features/pull/1966#discussion_r1803434536

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
