### PR TITLE
Remove bluetooth permission descriptor

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -192,42 +192,6 @@
           }
         }
       },
-      "permission_bluetooth": {
-        "__compat": {
-          "description": "<code>bluetooth</code> permission",
-          "support": {
-            "chrome": {
-              "version_added": "104"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "permission_camera": {
         "__compat": {
           "description": "<code>camera</code> permission",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the data is added in https://github.com/mdn/browser-compat-data/pull/22525, notice the chrome status says permission policy, not permission descriptor

1. if trying in to test in console (latest stable chrome), a `TypeError` will report

    ![image](https://github.com/user-attachments/assets/13767799-be2a-4c33-a6e9-556b54191e82)

2. in [chromium source code](https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/modules/permissions/permission_descriptor.idl#L17), there is a `bluetooth` item, but it is comment, which means it is not support in real browser (and notice that when the item added in https://github.com/chromium/chromium/commit/9e5d5b7ac865085906a106d1408e101ceefedea6#diff-8ca96e3c008c457658e681b87bade1fdf5e235e551a34c8959c79ef21a8b4489, it is already comment and no change happens after that)

    also, no related info found when viewing other permission-related source code files

3. the [chromium bug](https://issues.chromium.org/issues/40481036) also confident is not supported

so I think chromium never implement this feature

the status for chrome should be set to `false`, and then no platform will support this feature, so it can be removed

see also the related content update at https://github.com/mdn/content/pull/32533

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
