### PR TITLE
Updates for Chrome 131 beta

### DIFF
--- a/api/CSSMarginRule.json
+++ b/api/CSSMarginRule.json
@@ -1,0 +1,118 @@
+{
+  "api": {
+    "CSSMarginRule": {
+      "__compat": {
+        "spec_url": "https://drafts.csswg.org/cssom/#the-cssmarginrule-interface",
+        "support": {
+          "chrome": {
+            "version_added": "131"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "name": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssmarginrule-name",
+          "support": {
+            "chrome": {
+              "version_added": "131"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "style": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssmarginrule-style",
+          "support": {
+            "chrome": {
+              "version_added": "131"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -270,7 +270,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "version_removed": "131"
             },
             "chrome_android": {
               "version_added": "121"

--- a/api/Request.json
+++ b/api/Request.json
@@ -859,6 +859,44 @@
           }
         }
       },
+      "duplex": {
+        "__compat": {
+          "spec_url": "https://fetch.spec.whatwg.org/#dom-request-duplex",
+          "support": {
+            "chrome": {
+              "version_added": "131"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "formData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/formData",

--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -81,7 +81,7 @@
           "spec_url": "https://immersive-web.github.io/webxr-hand-input/#dom-xrframe-filljointradii",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -106,7 +106,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {
@@ -122,7 +124,7 @@
           "spec_url": "https://immersive-web.github.io/webxr-hand-input/#dom-xrframe-fillposes",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -147,7 +149,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {
@@ -274,7 +278,7 @@
           "spec_url": "https://immersive-web.github.io/webxr-hand-input/#dom-xrframe-getjointpose",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -299,7 +303,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/XRHand.json
+++ b/api/XRHand.json
@@ -6,7 +6,7 @@
         "spec_url": "https://immersive-web.github.io/webxr-hand-input/#xrhand-interface",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "131"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -44,7 +44,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -81,7 +81,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -118,7 +118,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -155,7 +155,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -192,7 +192,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -229,7 +229,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -267,7 +267,7 @@
           "description": "[Symbol.iterator]",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/XRInputSource.json
+++ b/api/XRInputSource.json
@@ -122,7 +122,7 @@
           "spec_url": "https://immersive-web.github.io/webxr-hand-input/#dom-xrinputsource-hand",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -147,7 +147,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/XRJointPose.json
+++ b/api/XRJointPose.json
@@ -6,7 +6,7 @@
         "spec_url": "https://immersive-web.github.io/webxr-hand-input/#xrjointpose-interface",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "131"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -46,7 +46,7 @@
           "spec_url": "https://immersive-web.github.io/webxr-hand-input/#dom-xrjointpose-radius",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/XRJointSpace.json
+++ b/api/XRJointSpace.json
@@ -6,7 +6,7 @@
         "spec_url": "https://immersive-web.github.io/webxr-hand-input/#xrhand-interface",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "131"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -46,7 +46,7 @@
           "spec_url": "https://immersive-web.github.io/webxr-hand-input/#dom-xrjointspace-jointname",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -46,6 +46,318 @@
             "deprecated": false
           }
         },
+        "bottom-center": {
+          "__compat": {
+            "description": "<code>@bottom-center</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-bottom-center",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "bottom-left": {
+          "__compat": {
+            "description": "<code>@bottom-left</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-bottom-left",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "bottom-left-corner": {
+          "__compat": {
+            "description": "<code>@bottom-left-corner</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-bottom-left-corner",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "bottom-right": {
+          "__compat": {
+            "description": "<code>@bottom-right</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-bottom-right",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "bottom-right-corner": {
+          "__compat": {
+            "description": "<code>@bottom-right-corner</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-bottom-right-corner",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "left-bottom": {
+          "__compat": {
+            "description": "<code>@left-bottom</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-left-bottom",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "left-middle": {
+          "__compat": {
+            "description": "<code>@left-middle</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-left-middle",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "left-top": {
+          "__compat": {
+            "description": "<code>@left-top</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-left-top",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "page-orientation": {
           "__compat": {
             "description": "<code>page-orientation</code> descriptor",
@@ -77,6 +389,123 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "right-bottom": {
+          "__compat": {
+            "description": "<code>@right-bottom</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-right-bottom",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "right-middle": {
+          "__compat": {
+            "description": "<code>@right-middle</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-right-middle",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "right-top": {
+          "__compat": {
+            "description": "<code>@right-top</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-right-top",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -191,6 +620,201 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            }
+          }
+        },
+        "top-center": {
+          "__compat": {
+            "description": "<code>@top-center</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-top-center",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "top-left": {
+          "__compat": {
+            "description": "<code>@top-left</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-top-left",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "top-left-corner": {
+          "__compat": {
+            "description": "<code>@top-left-corner</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-top-left-corner",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "top-right": {
+          "__compat": {
+            "description": "<code>@top-right</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-top-right",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "top-right-corner": {
+          "__compat": {
+            "description": "<code>@top-right-corner</code> page-margin box",
+            "spec_url": "https://drafts.csswg.org/css-page-3/#at-ruledef-top-right-corner",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/anchor-scope.json
+++ b/css/properties/anchor-scope.json
@@ -1,0 +1,120 @@
+{
+  "css": {
+    "properties": {
+      "anchor-scope": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#propdef-anchor-scope",
+          "support": {
+            "chrome": {
+              "version_added": "131"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "all": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-anchor-scope-all",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-anchor-scope-none",
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "131"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -50,6 +50,170 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "emoji": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-variant-emoji-emoji",
+            "tags": [
+              "web-features:font-variant-emoji"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "normal": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-variant-emoji-normal",
+            "tags": [
+              "web-features:font-variant-emoji"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "text": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-variant-emoji-text",
+            "tags": [
+              "web-features:font-variant-emoji"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "unicode": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-variant-emoji-unicode",
+            "tags": [
+              "web-features:font-variant-emoji"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/selectors/details-content.json
+++ b/css/selectors/details-content.json
@@ -1,0 +1,45 @@
+{
+  "css": {
+    "selectors": {
+      "details-content": {
+        "__compat": {
+          "description": "<code>::details-content</code>",
+          "spec_url": "https://drafts.csswg.org/css-pseudo-4/#details-content-pseudo",
+          "support": {
+            "chrome": {
+              "version_added": "131"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.5 found new features shipping in Chrome 131 beta which was released last week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 53 features as shipping in Chrome 131:

- api.CSSMarginRule
- api.CSSMarginRule.name
- api.CSSMarginRule.style
- api.GPUAdapter.requestAdapterInfo (removal)
- api.GPUCanvasContext.getConfiguration
- api.HID.worker_support
- api.HIDConnectionEvent.worker_support
- api.HIDDevice.worker_support
- api.HIDInputReportEvent.worker_support
- api.Request.duplex
- api.WorkerNavigator.hid
- api.XRFrame.fillJointRadii
- api.XRFrame.fillPoses
- api.XRFrame.getJointPose
- api.XRHand
- api.XRHand.entries
- api.XRHand.forEach
- api.XRHand.get
- api.XRHand.keys
- api.XRHand.size
- api.XRHand.values
- api.XRHand.@@iterator
- api.XRInputSource.hand
- api.XRJointPose
- api.XRJointPose.radius
- api.XRJointSpace
- api.XRJointSpace.jointName
- css.at-rules.page.bottom-center
- css.at-rules.page.bottom-left
- css.at-rules.page.bottom-left-corner
- css.at-rules.page.bottom-right
- css.at-rules.page.bottom-right-corner
- css.at-rules.page.left-bottom
- css.at-rules.page.left-middle
- css.at-rules.page.left-top
- css.at-rules.page.right-bottom
- css.at-rules.page.right-middle
- css.at-rules.page.right-top
- css.at-rules.page.top-center
- css.at-rules.page.top-left
- css.at-rules.page.top-left-corner
- css.at-rules.page.top-right
- css.at-rules.page.top-right-corner
- css.properties.anchor-scope
- css.properties.anchor-scope.all
- css.properties.anchor-scope.none
- css.properties.font-variant-emoji
- css.properties.font-variant-emoji.emoji
- css.properties.font-variant-emoji.normal
- css.properties.font-variant-emoji.text
- css.properties.font-variant-emoji.unicode
- css.selectors.details-content
- http.headers.Cross-Origin-Opener-Policy.noopener-allow-popups

See also the 131 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-131-beta