### PR TITLE
Add positioned_boxes context for align/justify/place-self

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -441,6 +441,46 @@
               "deprecated": false
             }
           }
+        },
+        "positioned_boxes": {
+          "__compat": {
+            "description": "Supported for absolutely-positioned boxes",
+            "spec_url": [
+              "https://drafts.csswg.org/css-align/#align-self-property"
+            ],
+            "tags": [
+              "web-features:TODO"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "122"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -445,9 +445,7 @@
         "positioned_boxes": {
           "__compat": {
             "description": "Supported for absolutely-positioned boxes",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-self-property"
-            ],
+            "spec_url": "https://drafts.csswg.org/css-align/#align-self-property",
             "support": {
               "chrome": {
                 "version_added": "122"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -448,9 +448,6 @@
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-self-property"
             ],
-            "tags": [
-              "web-features:TODO"
-            ],
             "support": {
               "chrome": {
                 "version_added": "122"

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -121,6 +121,46 @@
               "deprecated": false
             }
           }
+        },
+        "positioned_boxes": {
+          "__compat": {
+            "description": "Supported for absolutely-positioned boxes",
+            "spec_url": [
+              "https://drafts.csswg.org/css-align/#justify-self-property"
+            ],
+            "tags": [
+              "web-features:TODO"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "122"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -125,9 +125,7 @@
         "positioned_boxes": {
           "__compat": {
             "description": "Supported for absolutely-positioned boxes",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#justify-self-property"
-            ],
+            "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
             "support": {
               "chrome": {
                 "version_added": "122"

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -128,9 +128,6 @@
             "spec_url": [
               "https://drafts.csswg.org/css-align/#justify-self-property"
             ],
-            "tags": [
-              "web-features:TODO"
-            ],
             "support": {
               "chrome": {
                 "version_added": "122"

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -152,9 +152,6 @@
             "spec_url": [
               "https://drafts.csswg.org/css-align/#place-self-property"
             ],
-            "tags": [
-              "web-features:TODO"
-            ],
             "support": {
               "chrome": {
                 "version_added": "122"

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -145,6 +145,46 @@
               "deprecated": false
             }
           }
+        },
+        "positioned_boxes": {
+          "__compat": {
+            "description": "Supported for absolutely-positioned boxes",
+            "spec_url": [
+              "https://drafts.csswg.org/css-align/#place-self-property"
+            ],
+            "tags": [
+              "web-features:TODO"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "122"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -149,9 +149,7 @@
         "positioned_boxes": {
           "__compat": {
             "description": "Supported for absolutely-positioned boxes",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#place-self-property"
-            ],
+            "spec_url": "https://drafts.csswg.org/css-align/#place-self-property",
             "support": {
               "chrome": {
                 "version_added": "122"


### PR DESCRIPTION
#### Summary

There’s a new “absolutely-positioned boxes” context for box self-alignment added in Chrome 122.

[See the demo](https://codepen.io/pepelsbey/pen/xxvLBYZ).

#### Test results and supporting details

[The spec says:](https://drafts.csswg.org/css-align/#align-self-property)

> `align-self`
> Applies to: flex items, grid items, and **absolutely-positioned boxes**

I couldn’t find anything in the [Chrome 122 release notes](https://developer.chrome.com/blog/new-in-chrome-122/), so I had to pinpoint the version.

#### Notes

I’m improvising here with the “positioned_boxes” key. Not sure how to properly make it work.