### PR TITLE
Fix data version of `NavigateEvent.canTransition`

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -118,7 +118,7 @@
           "support": {
             "chrome": {
               "version_added": "102",
-              "version_removed": "108"
+              "notes": "<code>canTransition</code> property become an alias of <code>canIntercept</code> property in Chrome 105."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -83,9 +83,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/canIntercept",
           "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-canintercept-dev",
           "support": {
-            "chrome": {
-              "version_added": "105"
-            },
+            "chrome": [
+              {
+                "version_added": "105"
+              },
+              {
+                "alternative_name": "canTransition",
+                "version_added": "102"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -110,40 +116,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "canTransition": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "102",
-              "notes": "<code>canTransition</code> property become an alias of <code>canIntercept</code> property in Chrome 105."
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

this property is never removed from chromium implement, though the property is non-standard and deprecated

between M102 and M104, only `canTransition` is supported; M105+, both `canTransition` and `canIntercept` are supported, and the two property are the same

this is updated in https://github.com/mdn/browser-compat-data/pull/18105

but note that the property still existed in [source code](https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/core/navigation_api/navigate_event.idl#L13), and it has changed to be an alias for `canIntercept` in https://github.com/chromium/chromium/commit/d53817e29d5e857782ff8d977dbc3b89eb53831b, which is landed in [M105](https://chromiumdash.appspot.com/commit/d53817e29d5e857782ff8d977dbc3b89eb53831b)

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

check chromium source and observe in lates stable chrome

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
