### PR TITLE
Remove Chromium impl_url and add Firefox impl_url for `NavigationActivation`

### DIFF
--- a/api/NavigationActivation.json
+++ b/api/NavigationActivation.json
@@ -9,13 +9,13 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "123",
-            "impl_url": "https://crbug.com/40285670/"
+            "version_added": "123"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -48,8 +48,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "123",
-              "impl_url": "https://crbug.com/40285670/"
+              "version_added": "123"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -87,8 +86,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "123",
-              "impl_url": "https://crbug.com/40285670/"
+              "version_added": "123"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -126,8 +124,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "123",
-              "impl_url": "https://crbug.com/40285670/"
+              "version_added": "123"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

same as title (the chromium's issue has been marked as fixed)

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

see the proposal issue https://github.com/whatwg/html/issues/9760 and PR https://github.com/whatwg/html/pull/9856

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
