### PR TITLE
fix(workflows): prevent tests from running twice on every pull request

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,7 @@ name: Node.js CI
 
 on:
   push:
+    branches: ["main"]
   pull_request:
 
 permissions:


### PR DESCRIPTION
#### Summary

Currently, tests run twice on every PR, once for the `push` event, and once for the `pull_request` event.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
