### PR TITLE
Chromium 131 validates depth bias on line and point topologies

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -653,6 +653,46 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "deprecate_depth_bias_lines_points": {
+          "__compat": {
+            "description": "<code>depthBias</code>, <code>depthBiasSlopeScale</code>, and <code>depthBiasClamp</code> must be <code>0</code> for line and point topologies.",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "128"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createRenderPipelineAsync": {
@@ -712,6 +752,46 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "deprecate_depth_bias_lines_points": {
+          "__compat": {
+            "description": "<code>depthBias</code>, <code>depthBiasSlopeScale</code>, and <code>depthBiasClamp</code> must be <code>0</code> for line and point topologies.",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "128"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -654,9 +654,9 @@
             "deprecated": false
           }
         },
-        "deprecate_depth_bias_lines_points": {
+        "validates_depth_bias_for_line_and_point_topologies": {
           "__compat": {
-            "description": "<code>depthBias</code>, <code>depthBiasSlopeScale</code>, and <code>depthBiasClamp</code> must be <code>0</code> for line and point topologies.",
+            "description": "Validates that <code>depthBias</code>, <code>depthBiasSlopeScale</code>, and <code>depthBiasClamp</code> must be <code>0</code> for line and point topologies.",
             "tags": [
               "web-features:webgpu"
             ],

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -662,7 +662,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "128"
+                "version_added": "131"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -754,15 +754,15 @@
             "deprecated": false
           }
         },
-        "deprecate_depth_bias_lines_points": {
+        "validates_depth_bias_for_line_and_point_topologies": {
           "__compat": {
-            "description": "<code>depthBias</code>, <code>depthBiasSlopeScale</code>, and <code>depthBiasClamp</code> must be <code>0</code> for line and point topologies.",
+            "description": "Validates that <code>depthBias</code>, <code>depthBiasSlopeScale</code>, and <code>depthBiasClamp</code> must be <code>0</code> for line and point topologies.",
             "tags": [
               "web-features:webgpu"
             ],
             "support": {
               "chrome": {
-                "version_added": "128"
+                "version_added": "131"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 128 deprecates setting depth bias for lines and points ([Chrome issue](https://issues.chromium.org/issues/352567424), [spec change](https://github.com/gpuweb/gpuweb/pull/4743)).

This PR adds a datapoint for this change in behavior to `GPUDevice.createRenderPipeline()` and `GPUDevice.createRenderPipelineAsync()`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See the [description and data source](https://developer.chrome.com/blog/new-in-webgpu-128#deprecate_setting_depth_bias_for_lines_and_points)

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

See related MDN project issue: https://github.com/mdn/content/issues/36341

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
