### PR TITLE
Safari 15.4 reinstates`api.{Worker,}Navigator.hardwareConcurrency`

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1641,10 +1641,16 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1",
-              "version_removed": "11"
-            },
+            "safari": [
+              {
+                "version_added": "15.4",
+                "notes": "The value of this property is clamped to 4 or 8 cores, to prevent device fingerprinting. See <a href='https://webkit.org/b/233381'>bug 233381</a>."
+              },
+              {
+                "version_added": "10.1",
+                "version_removed": "11"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -372,10 +372,16 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1",
-              "version_removed": "11"
-            },
+            "safari": [
+              {
+                "version_added": "15.4",
+                "notes": "The value of this property is clamped to 4 or 8 cores, to prevent device fingerprinting. See <a href='https://webkit.org/b/233381'>bug 233381</a>."
+              },
+              {
+                "version_added": "10.1",
+                "version_removed": "11"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`hardwareConcurrency` was shipped, then unshipped, then reinstated.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See https://bugs.webkit.org/show_bug.cgi?id=233381.

I also tested this manually in BrowserStack to confirm the 4 or 8 cores limitation.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://github.com/web-platform-dx/web-features/pull/1931#discussion_r1812881017

Fixes https://github.com/mdn/browser-compat-data/issues/20429.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
