### PR TITLE
Safari iOS doesn't support `api.WorkerGlobalScope.languagechange_event`

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -279,9 +279,7 @@
             "safari": {
               "version_added": false
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -284,9 +284,7 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": {
-              "version_added": false
-            }
+            "webview_ios": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This was probably never supported.

#### Test results and supporting details

This is very difficult to test because it requires changing the system language settings, which I can't do in BrowserStack. And I don't have a device that I can directly test with. But I learned a few things:

- In a window, `languagechange` fires in contemporary macOS Safari.
- In a worker, `languagechange` does **not** fire in macOS Safari and `onlanguagechange` doesn't appear to be real (e.g., you can assign arbitrary types to it, unlike the window equivalent).
- Following the blames shows this data was originally migrated from the wiki. https://github.com/mdn/browser-compat-data/pull/982
- Searching webkit/webkit shows evidence of the window exposure, like tests, but I couldn't find anything even hinting at worker exposure.

Taken together, I'm rather certain that Safari doesn't actually support this and it's spurious data from the wiki days.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered reviewing https://github.com/web-platform-dx/web-features/pull/1931

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
