### PR TITLE
Safari 17 Clear-Site-Data supports "cache", "cookies", "storage" directives

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -98,7 +98,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -106,7 +106,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -172,7 +172,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -248,7 +248,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Evidence:

- The WPTs pass https://wpt.fyi/results/clear-site-data?label=master&label=experimental&aligned
- It looks like support was added when the header was first implemented https://github.com/WebKit/WebKit/commit/c65efd2b205ccaef913dff861a6e354dbdb9a212#diff-64f7d88a9c62e60e7e2fca2cdba58ccb1058ead7c9d205ff06625b1e0dd4552bR749 (which makes sense, these directives are quite essential for the header to work).