### PR TITLE
Update `use_dynamic_url` added version

### DIFF
--- a/webextensions/manifest/web_accessible_resources.json
+++ b/webextensions/manifest/web_accessible_resources.json
@@ -93,7 +93,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#use_dynamic_url",
             "support": {
               "chrome": {
-                "version_added": "88"
+                "version_added": "130"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

This was unintentionally documented on https://developer.chrome.com, which I suspect led to the incorrect version being added on MDN. However, the property was ignored until Chrome 130.

#### Test results and supporting details

PSA on chromium-extensions mailing list: https://groups.google.com/a/chromium.org/g/chromium-extensions/c/Nr3QNKFv74c/m/PYLvA7dOAAAJ

Stable launch: https://chromiumdash.appspot.com/commit/7468d54c1a7b26c9dc0e65d4aeaba9894b1d339e

#### Related issues

Fixes #23454
