### PR TITLE
Add & fix Safari notes for Permissions-Policy

### DIFF
--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -34,7 +34,7 @@
               "alternative_name": "Feature-Policy",
               "version_added": "11.1",
               "partial_implementation": true,
-              "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
+              "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/101034'>bug 101034</a>)"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -329,7 +329,9 @@
               },
               "safari": {
                 "alternative_name": "Feature-Policy: camera",
-                "version_added": "11.1"
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/101034'>bug 101034</a>)"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -446,7 +448,7 @@
                 "alternative_name": "Feature-Policy: display-capture",
                 "version_added": "13",
                 "partial_implementation": true,
-                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/101034'>bug 101034</a>)"
               },
               "safari_ios": {
                 "version_added": false
@@ -981,7 +983,9 @@
               },
               "safari": {
                 "alternative_name": "Feature-Policy: microphone",
-                "version_added": "11.1"
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/101034'>bug 101034</a>)"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -34,7 +34,7 @@
               "alternative_name": "Feature-Policy",
               "version_added": "11.1",
               "partial_implementation": true,
-              "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/101034'>bug 101034</a>)"
+              "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/253126'>bug 253126</a>)"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -331,7 +331,7 @@
                 "alternative_name": "Feature-Policy: camera",
                 "version_added": "11.1",
                 "partial_implementation": true,
-                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/101034'>bug 101034</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/253126'>bug 253126</a>)"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -448,7 +448,7 @@
                 "alternative_name": "Feature-Policy: display-capture",
                 "version_added": "13",
                 "partial_implementation": true,
-                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/101034'>bug 101034</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/253126'>bug 253126</a>)"
               },
               "safari_ios": {
                 "version_added": false
@@ -985,7 +985,7 @@
                 "alternative_name": "Feature-Policy: microphone",
                 "version_added": "11.1",
                 "partial_implementation": true,
-                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/101034'>bug 101034</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://webkit.org/b/253126'>bug 253126</a>)"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

these notes in safari should link to webkit issue, not firefox issue, this might be a bug caused when working on https://github.com/mdn/browser-compat-data/pull/20729

also note that safari only support `allow` syntax at present

I think https://github.com/mdn/browser-compat-data/pull/23470 does not affect this, if not, simply close it is fine

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
