### PR TITLE
Revert "Add Firefox 132 support for JSON.parse wth source features (#…

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -93,7 +93,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -237,7 +237,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -282,7 +282,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -72,7 +72,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "132"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -93,7 +93,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -216,7 +216,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "132"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -237,7 +237,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -261,7 +261,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "132"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -282,7 +282,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Reverts #24617 (commit 22fbfaa3afedc9af3107176362da724f5e6679d1)

The feature was undone in https://bugzilla.mozilla.org/show_bug.cgi?id=1925334

Note that I added a follow on commit to make this no longer experimental.

Related docs work can be tracked in https://github.com/mdn/content/issues/36113

