### PR TITLE
HTMLElement.autocorrect full implementation

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -308,9 +308,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1",
-              "partial_implementation": true,
-              "notes": "Values are <code>true</code>/<code>false</code> (instead of <code>on</code>/<code>off</code>)."
+              "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This fixes an error I injected in #24249 stating that the `HTMLElement.autocorrect` is a partial implementation. That was because I thought it was an error to return `true`/`false`. Actually that is what the spec states (the value should be set as `on`/`off` in HTML but returns true/false through the API).

Note that the corresponding global attribute is still partial.

This is part of https://github.com/mdn/content/pull/35692