### PR TITLE
FF133 EventSource in ServiceWorkers

### DIFF
--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -149,9 +149,17 @@
               "version_added": "1.38"
             },
             "edge": "mirror",
-            "firefox": {
-              "version_added": "53"
-            },
+            "firefox": [
+              {
+                "version_added": "133"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "133",
+                "partial_implementation": true,
+                "notes": "Not supported in service workers."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF133 exposes `EventSource` in ServiceWorkers in https://bugzilla.mozilla.org/show_bug.cgi?id=1681218.

The spec says that it should be in all types of workers, so added a separate version and made the old one "partial implementation".

Related work can be tracked in https://github.com/mdn/content/issues/36531