### PR TITLE
Firefox Android doesn't support textures from video elements in texImage2D/texSubImage2D

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -7206,7 +7206,7 @@
               "version_added": "51"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "51",
               "partial_implementation": true,
               "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
             },
@@ -7493,7 +7493,7 @@
               "version_added": "51"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "51",
               "partial_implementation": true,
               "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
             },

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -7208,7 +7208,7 @@
             "firefox_android": {
               "version_added": "51",
               "partial_implementation": true,
-              "notes": "Textures from video elements are not supported. See (see <a href='https://bugzil.la/1884282'>bug 1884282</a>."
+              "notes": "Textures from video elements are not supported. See <a href='https://bugzil.la/1884282'>bug 1884282</a>."
             },
             "ie": {
               "version_added": false
@@ -7495,7 +7495,7 @@
             "firefox_android": {
               "version_added": "51",
               "partial_implementation": true,
-              "notes": "Textures from video elements are not supported. See (see <a href='https://bugzil.la/1884282'>bug 1884282</a>."
+              "notes": "Textures from video elements are not supported. See <a href='https://bugzil.la/1884282'>bug 1884282</a>."
             },
             "ie": {
               "version_added": false

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -7205,7 +7205,11 @@
             "firefox": {
               "version_added": "51"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
+            },
             "ie": {
               "version_added": false
             },
@@ -7488,7 +7492,11 @@
             "firefox": {
               "version_added": "51"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -7495,7 +7495,7 @@
             "firefox_android": {
               "version_added": "51",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
+              "notes": "Textures from video elements are not supported. See (see <a href='https://bugzil.la/1884282'>bug 1884282</a>."
             },
             "ie": {
               "version_added": false

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -7208,7 +7208,7 @@
             "firefox_android": {
               "version_added": "51",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
+              "notes": "Textures from video elements are not supported. See (see <a href='https://bugzil.la/1884282'>bug 1884282</a>."
             },
             "ie": {
               "version_added": false

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5720,7 +5720,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
+              "notes": "Textures from video elements are not supported. See (see <a href='https://bugzil.la/1884282'>bug 1884282</a>."
             },
             "ie": {
               "version_added": "11"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5557,7 +5557,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1884282'>https://bugzilla.mozilla.org/show_bug.cgi?id=1884282</a>"
+              "notes": "Textures from video elements not yet supported: <a href='https://bugzil.la/1884282'>https://bugzil.la/1884282</a>"
             },
             "ie": {
               "version_added": "11"
@@ -5720,7 +5720,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1884282'>https://bugzilla.mozilla.org/show_bug.cgi?id=1884282</a>"
+              "notes": "Textures from video elements not yet supported: <a href='https://bugzil.la/1884282'>https://bugzil.la/1884282</a>"
             },
             "ie": {
               "version_added": "11"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5557,7 +5557,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=1884282\">https://bugzilla.mozilla.org/show_bug.cgi?id=1884282</a>"
+              "notes": "Textures from video elements not yet supported: <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1884282'>https://bugzilla.mozilla.org/show_bug.cgi?id=1884282</a>"
             },
             "ie": {
               "version_added": "11"
@@ -5720,7 +5720,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=1884282\">https://bugzilla.mozilla.org/show_bug.cgi?id=1884282</a>"
+              "notes": "Textures from video elements not yet supported: <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1884282'>https://bugzilla.mozilla.org/show_bug.cgi?id=1884282</a>"
             },
             "ie": {
               "version_added": "11"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5554,7 +5554,11 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "Textures from video elements not yet supported: <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=1884282\">https://bugzilla.mozilla.org/show_bug.cgi?id=1884282</a>"
+            },
             "ie": {
               "version_added": "11"
             },
@@ -5713,7 +5717,11 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "Textures from video elements not yet supported: <a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=1884282\">https://bugzilla.mozilla.org/show_bug.cgi?id=1884282</a>"
+            },
             "ie": {
               "version_added": "11"
             },

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5557,7 +5557,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements are not supported. See (see <a href='https://bugzil.la/1884282'>bug 1884282</a>."
+              "notes": "Textures from video elements are not supported. See <a href='https://bugzil.la/1884282'>bug 1884282</a>."
             },
             "ie": {
               "version_added": "11"
@@ -5720,7 +5720,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements are not supported. See (see <a href='https://bugzil.la/1884282'>bug 1884282</a>."
+              "notes": "Textures from video elements are not supported. See <a href='https://bugzil.la/1884282'>bug 1884282</a>."
             },
             "ie": {
               "version_added": "11"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5557,7 +5557,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: <a href='https://bugzil.la/1884282'>https://bugzil.la/1884282</a>"
+              "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
             },
             "ie": {
               "version_added": "11"
@@ -5720,7 +5720,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: <a href='https://bugzil.la/1884282'>https://bugzil.la/1884282</a>"
+              "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
             },
             "ie": {
               "version_added": "11"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5557,7 +5557,7 @@
             "firefox_android": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "Textures from video elements not yet supported: https://bugzil.la/1884282"
+              "notes": "Textures from video elements are not supported. See (see <a href='https://bugzil.la/1884282'>bug 1884282</a>."
             },
             "ie": {
               "version_added": "11"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Reading the doc, I was under the impression, that Firefox on Android and Fennec support video textures, but that turned to be not the case. This was reported in https://bugzilla.mozilla.org/show_bug.cgi?id=1884282 and is unresolved for quite some time. This PR adds a compatibility note with `texImage2D` and `texSubImage2D` to indicate textures from video elements not being supported.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
