### PR TITLE
Update windows.json | Add compatibility data for top & left for windows.create

### DIFF
--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -669,8 +669,8 @@
                 "notes": [
                   "'url' and 'tabId options can't both be set together.",
                   "The returned 'Window' object contains the 'tabs' property only from version 52 onwards.",
-                  "From Firefox 86, the <code>focused: false</code> option is ignored."
-                  "From Firefox 109, the <code>top: value</code>, <code>left: value</code> is considered - FIX D73419."
+                  "From Firefox 86, the <code>focused: false</code> option is ignored.",
+                  "From Firefox 109, the <code>top: value</code>, <code>left: value</code> is considered - FIX#D73419"
                 ]
               },
               "firefox_android": {

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -670,6 +670,7 @@
                   "'url' and 'tabId options can't both be set together.",
                   "The returned 'Window' object contains the 'tabs' property only from version 52 onwards.",
                   "From Firefox 86, the <code>focused: false</code> option is ignored."
+                  "From Firefox 109, the <code>top: value</code> & <code>left: value</code> is considered (FIX D73419)."
                 ]
               },
               "firefox_android": {

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -670,7 +670,7 @@
                   "'url' and 'tabId options can't both be set together.",
                   "The returned 'Window' object contains the 'tabs' property only from version 52 onwards.",
                   "From Firefox 86, the <code>focused: false</code> option is ignored."
-                  "From Firefox 109, the <code>top: value</code> & <code>left: value</code> is considered (FIX D73419)."
+                  "From Firefox 109, the <code>top: value</code>, <code>left: value</code> is considered - FIX D73419."
                 ]
               },
               "firefox_android": {

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -670,7 +670,7 @@
                   "'url' and 'tabId options can't both be set together.",
                   "The returned 'Window' object contains the 'tabs' property only from version 52 onwards.",
                   "From Firefox 86, the <code>focused: false</code> option is ignored.",
-                  "From Firefox 109, the <code>top: value</code>, <code>left: value</code> is considered - FIX#D73419"
+                  "From Firefox 109, the <code>top</code> and <code>left</code> are used to determine window placement; previously, they were ignored."
                 ]
               },
               "firefox_android": {


### PR DESCRIPTION
api.windows.create

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Browser Compatibility Data - webextensions.api.windows.create - top and left is supported in Firefox >= 109. Updated for https://github.com/mdn/browser-compat-data/issues/24827

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

🔨 If applicable, use "Fixes #24827"

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
