### PR TITLE
Add more members to SharedStorage

### DIFF
--- a/api/SharedStorage.json
+++ b/api/SharedStorage.json
@@ -104,6 +104,42 @@
           }
         }
       },
+      "createWorklet": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-createworklet",
+          "support": {
+            "chrome": {
+              "version_added": "126"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "delete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorage/delete",
@@ -139,6 +175,114 @@
           }
         }
       },
+      "get": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-get",
+          "support": {
+            "chrome": {
+              "version_added": "126"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "run": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-run",
+          "support": {
+            "chrome": {
+              "version_added": "126"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectURL": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-selecturl",
+          "support": {
+            "chrome": {
+              "version_added": "126"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "set": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorage/set",
@@ -165,6 +309,42 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "worklet": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-worklet",
+          "support": {
+            "chrome": {
+              "version_added": "126"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {


### PR DESCRIPTION
From collector tests I can observe more `SharedStorage` members shipping from Chrome 126 onwards.

According to Chromestatus and I2S email, this apparently shipped in Chrome 125. Not sure who is right.

https://chromestatus.com/feature/5145686840705024
https://groups.google.com/a/chromium.org/g/blink-dev/c/JJFldgplL58/m/RrkZ-IoMAwAJ

cc @chrisdavidmills 