### PR TITLE
InkPresenter -> DelegatedInkTrailPresenter

### DIFF
--- a/api/DelegatedInkTrailPresenter.json
+++ b/api/DelegatedInkTrailPresenter.json
@@ -1,9 +1,8 @@
 {
   "api": {
-    "InkPresenter": {
+    "DelegatedInkTrailPresenter": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/InkPresenter",
-        "spec_url": "https://wicg.github.io/ink-enhancement/#ink-presenter",
+        "spec_url": "https://wicg.github.io/ink-enhancement/#delegatedinktrailpresenter",
         "support": {
           "chrome": {
             "version_added": "94"
@@ -38,15 +37,15 @@
       },
       "expectedImprovement": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InkPresenter/expectedImprovement",
-          "spec_url": "https://wicg.github.io/ink-enhancement/#dom-inkpresenter-expectedimprovement",
           "support": {
             "chrome": {
-              "version_added": "94"
+              "version_added": "94",
+              "version_removed": "130"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "93"
+              "version_added": "93",
+              "version_removed": "130"
             },
             "firefox": {
               "version_added": false
@@ -67,16 +66,15 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
       "presentationArea": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InkPresenter/presentationArea",
-          "spec_url": "https://wicg.github.io/ink-enhancement/#dom-inkpresenter-presentationarea",
+          "spec_url": "https://wicg.github.io/ink-enhancement/#dom-delegatedinktrailpresenter-presentationarea",
           "support": {
             "chrome": {
               "version_added": "94"
@@ -112,8 +110,7 @@
       },
       "updateInkTrailStartPoint": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InkPresenter/updateInkTrailStartPoint",
-          "spec_url": "https://wicg.github.io/ink-enhancement/#dom-inkpresenter-updateinktrailstartpoint",
+          "spec_url": "https://wicg.github.io/ink-enhancement/#dom-delegatedinktrailpresenter-updateinktrailstartpoint",
           "support": {
             "chrome": {
               "version_added": "94"


### PR DESCRIPTION
The `InkPresenter` interface never saw the light. Instead it has always been `DelegatedInkTrailPresenter` in implementations. The spec got corrected about this last month, see https://github.com/WICG/ink-enhancement/issues/35.

Also, `expectedImprovement` has been removed from the spec (https://github.com/WICG/ink-enhancement/pull/34) and dropped in Chrome 130 (https://chromestatus.com/feature/5194773674328064)