### PR TITLE
`css.properties.column-width.auto`: show support in EdgeHTML

### DIFF
--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -106,7 +106,9 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "1.5"
               },


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

I tested this back to Edge 15. It's a pretty ancient feature and has probably been supported since the beginning.

#### Test results and supporting details

Tested manually in BrowserStack.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered via https://github.com/web-platform-dx/web-features/pull/1972.

Previously: https://github.com/mdn/browser-compat-data/pull/24587

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
