### PR TITLE
Updates for Firefox 133 beta

### DIFF
--- a/api/ImageDecoder.json
+++ b/api/ImageDecoder.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1749048"
+            "version_added": "133"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -33,7 +32,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -53,8 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -72,7 +70,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -92,8 +90,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -111,7 +108,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -131,8 +128,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -150,7 +146,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -170,8 +166,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -189,7 +184,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -209,8 +204,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -228,7 +222,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -249,8 +243,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -268,7 +261,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -288,8 +281,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -307,7 +299,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -327,8 +319,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -346,7 +337,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -366,8 +357,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1749048"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -385,7 +375,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ImageTrack.json
+++ b/api/ImageTrack.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "133"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -32,7 +32,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -69,7 +69,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -89,7 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -107,7 +107,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -127,7 +127,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -145,7 +145,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -165,7 +165,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -183,7 +183,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ImageTrackList.json
+++ b/api/ImageTrackList.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "133"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -32,7 +32,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -69,7 +69,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -89,7 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -107,7 +107,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -127,7 +127,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -145,7 +145,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -165,7 +165,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -183,7 +183,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Request.json
+++ b/api/Request.json
@@ -1183,7 +1183,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "preview"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -721,7 +721,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -886,7 +886,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -208,6 +208,252 @@
               }
             }
           }
+        },
+        "fromBase64": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.frombase64",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/42204568"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fromHex": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.fromhex",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/42204568"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setFromBase64": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.setfrombase64",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/42204568"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "setFromHex": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.setfromhex",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/42204568"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toBase64": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.tobase64",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/42204568"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toHex": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.tohex",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/42204568"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.5 found new features shipping in Firefox 133 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 29 features as shipping in Firefox 133:

- api.ImageDecoder
- api.ImageDecoder.ImageDecoder
- api.ImageDecoder.close
- api.ImageDecoder.complete
- api.ImageDecoder.completed
- api.ImageDecoder.decode
- api.ImageDecoder.isTypeSupported_static
- api.ImageDecoder.reset
- api.ImageDecoder.tracks
- api.ImageDecoder.type
- api.ImageTrack
- api.ImageTrack.animated
- api.ImageTrack.frameCount
- api.ImageTrack.repetitionCount
- api.ImageTrack.selected
- api.ImageTrackList
- api.ImageTrackList.length
- api.ImageTrackList.ready
- api.ImageTrackList.selectedIndex
- api.ImageTrackList.selectedTrack
- api.Request.keepalive
- api.WorkerNavigator.permissions
- api.WorkerNavigator.serviceWorker
- javascript.builtins.Uint8Array.fromBase64
- javascript.builtins.Uint8Array.fromHex
- javascript.builtins.Uint8Array.setFromBase64
- javascript.builtins.Uint8Array.setFromHex
- javascript.builtins.Uint8Array.toBase64
- javascript.builtins.Uint8Array.toHex

See also https://github.com/mdn/mdn/issues/596 and https://www.mozilla.org/en-US/firefox/133.0beta/releasenotes/