### PR TITLE
Update context name for align/justify/place-self

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -442,7 +442,7 @@
             }
           }
         },
-        "positioned_boxes": {
+        "position_absolute_context": {
           "__compat": {
             "description": "Supported for absolutely-positioned boxes",
             "spec_url": "https://drafts.csswg.org/css-align/#align-self-property",

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -122,7 +122,7 @@
             }
           }
         },
-        "positioned_boxes": {
+        "position_absolute_context": {
           "__compat": {
             "description": "Supported for absolutely-positioned boxes",
             "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -146,7 +146,7 @@
             }
           }
         },
-        "positioned_boxes": {
+        "position_absolute_context": {
           "__compat": {
             "description": "Supported for absolutely-positioned boxes",
             "spec_url": "https://drafts.csswg.org/css-align/#place-self-property",


### PR DESCRIPTION
#### Summary

Better naming for the new context where `align/justify/place-self` now work.

```diff
- "positioned_boxes": {
+ "position_absolute_context": {
```

#### Related issues

A follow-up for the https://github.com/mdn/browser-compat-data/pull/24789