### PR TITLE
Chromium 129 respects inherited color-scheme on iframes

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1375,9 +1375,16 @@
                 "web-features:prefers-color-scheme"
               ],
               "support": {
-                "chrome": {
-                  "version_added": false
-                },
+                "chrome": [
+                  {
+                    "version_added": "129"
+                  },
+                  {
+                    "version_added": "111",
+                    "partial_implementation": true,
+                    "notes": "Only supports SVG images, not iframes"
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1382,7 +1382,7 @@
                   {
                     "version_added": "111",
                     "partial_implementation": true,
-                    "notes": "Only supports SVG images, not iframes"
+                    "notes": "Only supports SVG images, not iframes."
                   }
                 ],
                 "chrome_android": "mirror",


### PR DESCRIPTION
Support for inherited color-scheme on SVG images was added to Chromium in https://issues.chromium.org/issues/40232082 (Chromium 111)

Support for inherited color-scheme on iframes was added to Chromium in https://issues.chromium.org/issues/40234347 (Chromium 129)