### PR TITLE
Update `transition.transition-behavior` to mirror `transition-behavior`

### DIFF
--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -158,8 +158,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1805727"
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -169,7 +168,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -177,7 +176,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary

`css.properties.transition.transition-behavior` support should be the same as `css.properties.transition-behavior`, as it is just the shorthand version.

#### Test results and supporting details

`CSS.supports('transition', 'allow-discrete')` passes in Safari and Firefox.

The implementing issue for Firefox- https://bugzil.la/1805727 is closed.

