### PR TITLE
Add Firefox impl_url for CSS View Transition (level 1 & level 2)

### DIFF
--- a/api/CSSViewTransitionRule.json
+++ b/api/CSSViewTransitionRule.json
@@ -10,7 +10,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1860854"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -7526,7 +7526,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1823896"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PageRevealEvent.json
+++ b/api/PageRevealEvent.json
@@ -12,7 +12,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1860854"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/PageSwapEvent.json
+++ b/api/PageSwapEvent.json
@@ -12,7 +12,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1881438"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/ViewTransition.json
+++ b/api/ViewTransition.json
@@ -14,7 +14,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1823896"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -161,7 +162,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1860854"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ViewTransitionTypeSet.json
+++ b/api/ViewTransitionTypeSet.json
@@ -10,7 +10,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1860854"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -3845,7 +3845,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1860854"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3922,7 +3923,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1881438"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/view-transition-class.json
+++ b/css/properties/view-transition-class.json
@@ -11,7 +11,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1860854"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/view-transition-name.json
+++ b/css/properties/view-transition-name.json
@@ -15,7 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1823896"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-group.json
+++ b/css/selectors/view-transition-group.json
@@ -16,7 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1823896"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-image-pair.json
+++ b/css/selectors/view-transition-image-pair.json
@@ -16,7 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1823896"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-new.json
+++ b/css/selectors/view-transition-new.json
@@ -16,7 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1823896"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-old.json
+++ b/css/selectors/view-transition-old.json
@@ -16,7 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1823896"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition.json
+++ b/css/selectors/view-transition.json
@@ -16,7 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1823896"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

https://bugzilla.mozilla.org/show_bug.cgi?id=1823896 for implement CSS View Transitions 1
https://bugzilla.mozilla.org/show_bug.cgi?id=1860854 for implement CSS View Transitions 2
https://bugzilla.mozilla.org/show_bug.cgi?id=1881438 for implement `pageswap` event & `PageSwapEvent` interface

https://drafts.csswg.org/css-view-transitions-1/
https://drafts.csswg.org/css-view-transitions-2/

https://github.com/whatwg/html/pull/9818 for `pagereveal` event & `PageRevealEvent` interface
https://github.com/whatwg/html/pull/10002 for `pageswap` event & `PageSwapEvent` interface

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
