### PR TITLE
Replace Chromium Find Releases tool with ChromiumDash

### DIFF
--- a/docs/matching-browser-releases/index.md
+++ b/docs/matching-browser-releases/index.md
@@ -20,14 +20,14 @@ The following sites and tools are helpful when trying to track down history info
 - [Chromium source code by release version number](https://chromium.googlesource.com/chromium/src.git/+refs)
 - [Google Chrome Platform Status](https://chromestatus.com/features)
 - [Chromium Code Search](https://source.chromium.org/chromium)
-- [Find Releases Tool](https://chromiumdash.appspot.com/commits)
+- [ChromiumDash tool](https://chromiumdash.appspot.com/commits)
 - [List of everything exposed to the Web in Chrome](https://source.chromium.org/chromiumchromium/src/android_webview/tools/system_webview_shell/test/data/webexposed/global-interface-listing-expected.txt?g=0)
 - [Interfaces not exposed to WebView](https://source.chromium.org/chromiumchromium/src/android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt)
 - [WebKit bugs](https://bugs.webkit.org/)
 
 #### Getting the Chrome version for a changeset or revision
 
-Given a particular Chrome changeset or revision number, you can look up the version number of Chrome that first shipped with those changes included using Google's [Find Releases tool](https://chromiumdash.appspot.com/commits). As long as the change happened after the Chrome code moved to `git`, this will return the corresponding version number.
+Given a particular Chrome changeset or revision number, you can look up the version number of Chrome that first shipped with those changes included using Google's [ChromiumDash tool](https://chromiumdash.appspot.com/commits). As long as the change happened after the Chrome code moved to `git`, this will return the corresponding version number.
 
 For example, given the string `05b49ea1`, the tool first looks for a match among the full commit changeset numbers, finds none, then looks at the prefixed short commits:
 

--- a/docs/matching-browser-releases/index.md
+++ b/docs/matching-browser-releases/index.md
@@ -20,14 +20,14 @@ The following sites and tools are helpful when trying to track down history info
 - [Chromium source code by release version number](https://chromium.googlesource.com/chromium/src.git/+refs)
 - [Google Chrome Platform Status](https://chromestatus.com/features)
 - [Chromium Code Search](https://source.chromium.org/chromium)
-- [Find Releases Tool](https://storage.googleapis.com/chromium-find-releases-static/index.html)
+- [Find Releases Tool](https://chromiumdash.appspot.com/commits)
 - [List of everything exposed to the Web in Chrome](https://source.chromium.org/chromiumchromium/src/android_webview/tools/system_webview_shell/test/data/webexposed/global-interface-listing-expected.txt?g=0)
 - [Interfaces not exposed to WebView](https://source.chromium.org/chromiumchromium/src/android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt)
 - [WebKit bugs](https://bugs.webkit.org/)
 
 #### Getting the Chrome version for a changeset or revision
 
-Given a particular Chrome changeset or revision number, you can look up the version number of Chrome that first shipped with those changes included using Google's [Find Releases tool](https://storage.googleapis.com/chromium-find-releases-static/index.html). As long as the change happened after the Chrome code moved to `git`, this will return the corresponding version number.
+Given a particular Chrome changeset or revision number, you can look up the version number of Chrome that first shipped with those changes included using Google's [Find Releases tool](https://chromiumdash.appspot.com/commits). As long as the change happened after the Chrome code moved to `git`, this will return the corresponding version number.
 
 For example, given the string `05b49ea1`, the tool first looks for a match among the full commit changeset numbers, finds none, then looks at the prefixed short commits:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

![image](https://github.com/user-attachments/assets/1de8494d-eccd-4183-aaac-63a332713d5a)

the https://storage.googleapis.com/chromium-find-releases-static/index.html is deprected by google and suggest using https://chromiumdash.appspot.com/commits instead

> [!Note]
> the wiki page for [Resources for finding browser versions for features](https://github.com/mdn/browser-compat-data/wiki/Resources-for-finding-browser-versions-for-features) also need update

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
