### PR TITLE
Mark overflow.overlay as deprecated

### DIFF
--- a/css/types/overflow.json
+++ b/css/types/overflow.json
@@ -125,7 +125,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
#### Summary

`css.types.overflow.overlay` should be marked as deprecated.

#### Test results and supporting details

https://drafts.csswg.org/css-overflow/#valdef-overflow-overlay says:

`User agents must also support the overlay keyword as a [legacy value alias](https://drafts.csswg.org/css-cascade-5/#css-legacy-value-alias) of [auto](https://drafts.csswg.org/css-overflow/#valdef-overflow-auto).`

This meets the [criteria](https://github.com/mdn/browser-compat-data/blob/1c6a1cb16e7eeca7dc862b9ef10dd307fce8f5df/docs/data-guidelines/index.md#setting-deprecated) to mark a key as deprecated.
