### PR TITLE
Add data points for Chromium-specific limit increases

### DIFF
--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -286,10 +286,20 @@
             "web-features:webgpu"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
-            },
+            "chrome": [
+              {
+                "version_added": "120",
+                "notes": [
+                  "Maximum value increased to 64.",
+                  "Currently supported on ChromeOS, macOS, and Windows only."
+                ]
+              },
+              {
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              }
+            ],
             "chrome_android": {
               "version_added": "121"
             },
@@ -822,10 +832,20 @@
             "web-features:webgpu"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
-            },
+            "chrome": [
+              {
+                "version_added": "120",
+                "notes": [
+                  "Maximum value increased to 112.",
+                  "Currently supported on ChromeOS, macOS, and Windows only."
+                ]
+              },
+              {
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              }
+            ],
             "chrome_android": {
               "version_added": "121"
             },
@@ -878,10 +898,20 @@
             "web-features:webgpu"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
-            },
+            "chrome": [
+              {
+                "version_added": "120",
+                "notes": [
+                  "Maximum value increased to 28.",
+                  "Currently supported on ChromeOS, macOS, and Windows only."
+                ]
+              },
+              {
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              }
+            ],
             "chrome_android": {
               "version_added": "121"
             },
@@ -1090,10 +1120,20 @@
             "web-features:webgpu"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
-            },
+            "chrome": [
+              {
+                "version_added": "120",
+                "notes": [
+                  "Maximum value increased to 10.",
+                  "Currently supported on ChromeOS, macOS, and Windows only."
+                ]
+              },
+              {
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              }
+            ],
             "chrome_android": {
               "version_added": "121"
             },
@@ -1202,10 +1242,20 @@
             "web-features:webgpu"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
-            },
+            "chrome": [
+              {
+                "version_added": "126",
+                "notes": [
+                  "Maximum value increased to 2048.",
+                  "Currently supported on ChromeOS, macOS, and Windows only."
+                ]
+              },
+              {
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              }
+            ],
             "chrome_android": {
               "version_added": "121"
             },
@@ -1538,10 +1588,20 @@
             "web-features:webgpu"
           ],
           "support": {
-            "chrome": {
-              "version_added": "113",
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
-            },
+            "chrome": [
+              {
+                "version_added": "122",
+                "notes": [
+                  "Maximum value increased to 30.",
+                  "Currently supported on ChromeOS, macOS, and Windows only."
+                ]
+              },
+              {
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              }
+            ],
             "chrome_android": {
               "version_added": "121"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Generally, the maximum values of WebGPU limits (see [`GPUSupportedLimits`](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedLimits)) are the same as the default limits defined in the spec. However, some implementations have different maximum limits.

This PR adds data points to specify those limits where they differ from the specced default.

See the following links for the source of these changes:

- Increase in maxTextureArrayLayers limit (https://github.com/mdn/content/issues/36343)
  - https://developer.chrome.com/blog/new-in-webgpu-126#increase_maxtexturearraylayers_limit 
- Increase in maxVertexAttributes limit (https://github.com/mdn/content/issues/36352)
  - https://developer.chrome.com/blog/new-in-webgpu-122#increase_maxvertexattributes_limit 
- All other limit changes (https://github.com/mdn/content/issues/36361)
  - https://developer.chrome.com/blog/new-in-webgpu-120#push_the_limits 
  - This implementation issue comment contains the actual new limit numbers: https://issues.chromium.org/issues/42240429#comment17

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
