### PR TITLE
Mark box-decoration-break as partial when only inline works

### DIFF
--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -13,6 +13,7 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "22",
+                "partial_implementation": true,
                 "notes": "This property was only supported for inline elements."
               }
             ],
@@ -49,6 +50,7 @@
             "safari": {
               "prefix": "-webkit-",
               "version_added": "7",
+              "partial_implementation": true,
               "notes": "This property is only supported for inline elements."
             },
             "safari_ios": "mirror",

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -14,7 +14,7 @@
                 "prefix": "-webkit-",
                 "version_added": "22",
                 "partial_implementation": true,
-                "notes": "This property was only supported for inline elements."
+                "notes": "This property is only supported for inline elements."
               }
             ],
             "chrome_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari (and older versions of Blink-based browsers) are supporting `box-decoration-break` only for inline elements. While a note was already present, this is not reported as being a partial implementation in such case.

#### Test results and supporting details

https://web.dev/blog/web-platform-10-2024?hl=en#full_box-decoration-break_support

#### Related issues


