### PR TITLE
fix(update-mdn-urls): merge paths + paths-ignore

### DIFF
--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -5,9 +5,8 @@ on:
     types:
       - opened
     paths:
+      - "!**"
       - "package.json"
-    paths-ignore:
-      - "**/*.json"
 
 jobs:
   update-mdn-urls:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes a syntax error in the `update-mdn-urls` workflow, because `paths` and `paths-ignore` apparently cannot be used together, even if [the GitHub docs suggest otherwise](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Follow-up of these:
- https://github.com/mdn/browser-compat-data/pull/24825
- https://github.com/mdn/browser-compat-data/pull/24860
- https://github.com/mdn/browser-compat-data/pull/24862