### PR TITLE
Chrome 126 validates GPUQueue.submit() command buffer uniqueness

### DIFF
--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -345,7 +345,7 @@
             "deprecated": false
           }
         },
-        "unique_command_buffers": {
+        "validates_command_buffer_uniqueness": {
           "__compat": {
             "description": "Validates that submitted command buffers are unique.",
             "tags": [

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -344,6 +344,47 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "unique_command_buffers": {
+          "__compat": {
+            "description": "Validates that submitted command buffers are unique.",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "126",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "writeBuffer": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In Chrome 126, the behavior of the [`GPUQueue.submit()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUQueue/submit) method has been updated to be correct as per spec — the referenced command buffers must be unique.

This PR adds a data point for this update.

See https://developer.chrome.com/blog/new-in-webgpu-126#submitted_command_buffers_must_be_unique for the information source.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

project issue: https://github.com/mdn/content/issues/36344

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
