### PR TITLE
Add bug for implementation of manifest storage.managed_schema

### DIFF
--- a/webextensions/manifest/storage.json
+++ b/webextensions/manifest/storage.json
@@ -36,7 +36,8 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1771731"
               },
               "firefox_android": "mirror",
               "opera": {


### PR DESCRIPTION
#### Summary

Add impl_url for https://bugzilla.mozilla.org/show_bug.cgi?id=1771731, the bug for the implementation of storage.managed_schema.
