### PR TITLE
Safari TP 204 supports Render blocking

### DIFF
--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -110,7 +110,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://webkit.org/b/267232"
             },
             "safari_ios": "mirror",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -149,7 +149,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://webkit.org/b/267232"
             },
             "safari_ios": "mirror",

--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -68,7 +68,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://webkit.org/b/267232"
             },
             "safari_ios": "mirror",

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -107,7 +107,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/267232"
               },
               "safari_ios": "mirror",

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -144,7 +144,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/267232"
               },
               "safari_ios": "mirror",

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -68,7 +68,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/267232"
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
As part of cross-document view transitions: https://webkit.org/blog/15978/release-notes-for-safari-technology-preview-204/
