### PR TITLE
Chromium 125 supports depthSlice option for GPUCommandEncoder.beginComputePass()

### DIFF
--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -177,6 +177,50 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "depthSlice_option": {
+          "__compat": {
+            "description": "color attachment <code>depthSlice</code> option",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpasscolorattachment-depthslice",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "125"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "clearBuffer": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 125 adds support for the [`beginRenderPass()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/beginRenderPass) [`depthSlice`](https://gpuweb.github.io/gpuweb/#dom-gpurenderpasscolorattachment-depthslice) option. This PR adds a data point for this option.

See https://developer.chrome.com/blog/new-in-webgpu-125#render_to_slice_of_3d_texture for evidence of addition.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

See https://github.com/mdn/content/issues/36345 for project tracking issue.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
