### PR TITLE
Fix problematic notes

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -479,7 +479,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "59",
-              "notes": "Before version 59, the pending status was reported by a <code><strong>\"pending\"</strong></code> value returned from <a href='https://developer.mozilla.org/docs/Web/API/Animation/playState'><code>Animation.playState</code></a>."
+              "notes": "Before version 59, the pending status was reported by a <code>\"pending\"</code> value returned from <a href='https://developer.mozilla.org/docs/Web/API/Animation/playState'><code>Animation.playState</code></a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -1385,10 +1385,7 @@
               "version_added": "33",
               "notes": "Starting in Firefox 69, the first parameter (<code>scale</code>) is now optional with a default value of 1, per the specification. Previously it was required."
             },
-            "firefox_android": {
-              "version_added": "33",
-              "notes": "Firefox for Android requires the first parameter (<code>scale</code>)."
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -1422,13 +1419,9 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "33",
-              "notes": "Firefox 69 introduced support for the modern six-parameter syntax for <code>scaleSelf()</code>. Previously, it only supported the older three-parameter syntax: <code>scale(<em>scaleX</em>[, <em>originX</em>][, <em>originY</em>]]])</code>."
+              "notes": "Firefox 69 introduced support for the modern six-parameter syntax for <code>scaleSelf()</code>. Previously, it only supported the older three-parameter syntax: <code>scale(scaleX[, originX][, originY]]])</code>."
             },
-            "firefox_android": {
-              "version_added": "33",
-              "partial_implementation": true,
-              "notes": "Firefox for Android only supports the older three-parameter syntax for <code>scaleSelf()</code>: <code>scale(<em>scaleX</em>[, <em>originX</em>][, <em>originY</em>]]])</code>, and not the six-parameter syntax."
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1306,12 +1306,9 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "33",
-              "notes": "Firefox 69 introduced support for the modern six-parameter syntax for <code>scale()</code>. Previously, it only supported the older three-parameter syntax: <code>scale(<em>scaleX</em>[, <em>originX</em>][, <em>originY</em>]]])</code>."
+              "notes": "Version 69 introduced support for the modern six-parameter syntax for <code>scale()</code>. Previously, it only supported the older three-parameter syntax: <code>scale(scaleX[, originX][, originY]]])</code>."
             },
-            "firefox_android": {
-              "version_added": "33",
-              "notes": "Firefox for Android 79 introduced support for the modern six-parameter syntax for <code>scale()</code>. Previously, it only supported the older three-parameter syntax: <code>scale(<em>scaleX</em>[, <em>originX</em>][, <em>originY</em>]]])</code>."
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -1347,10 +1344,7 @@
               "version_added": "33",
               "notes": "Starting in Firefox 69, the first parameter (<code>scale</code>) is now optional with a default value of 1, per the specification. Previously it was required."
             },
-            "firefox_android": {
-              "version_added": "33",
-              "notes": "Starting in Firefox for Android 79, the first parameter (<code>scale</code>) is now optional with a default value of 1, per the specification. Previously it was required."
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/Element.json
+++ b/api/Element.json
@@ -8274,16 +8274,7 @@
                 "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or <code>&lt;object&gt;</code> element to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code>&lt;iframe&gt;</code> element with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "64"
-              },
-              {
-                "alternative_name": "mozRequestFullScreen",
-                "version_added": "9",
-                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or an <code>&lt;object&gt;</code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><code>&lt;iframe&gt;</code></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "prefix": "ms",
               "version_added": "11"

--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": {
             "version_added": "≤18",
-            "notes": "Edge only supports this API in drag-and-drop scenarios using the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'>&lt;input&gt;</a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
+            "notes": "Before Edge 79, this API was only supported in drag-and-drop scenarios using the <a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'><code>DataTransferItem.webkitGetAsEntry()</code></a> method. It was not available for use in file or folder picker panels (such as when you use an <a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'><code>&lt;input&gt;</code></a> element with the <a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'><code>HTMLInputElement.webkitdirectory</code></a> attribute."
           },
           "firefox": {
             "version_added": "50"

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -87,7 +87,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "50",
-              "notes": "In Firefox, the <code>errorCallback</code>'s input parameter is a <code><a href='https://developer.mozilla.org/docs/Web/API/DOMException'>DOMException</a></code> rather than a <code><a href='https://developer.mozilla.org/docs/Web/API/FileError'>FileError</a></code> object."
+              "notes": "In Firefox, the <code>errorCallback</code>'s input parameter is a <a href='https://developer.mozilla.org/docs/Web/API/DOMException'><code>DOMException</code></a> rather than a <a href='https://developer.mozilla.org/docs/Web/API/FileError'><code>FileError</code></a> object."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -127,7 +127,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "50",
-              "notes": "In Firefox, the <code>errorCallback</code>'s input parameter is a <code><a href='https://developer.mozilla.org/docs/Web/API/DOMException'>DOMException</a></code> rather than a <code><a href='https://developer.mozilla.org/docs/Web/API/FileError'>FileError</a></code> object."
+              "notes": "In Firefox, the <code>errorCallback</code>'s input parameter is a <a href='https://developer.mozilla.org/docs/Web/API/DOMException'><code>DOMException</code></a> rather than a <a href='https://developer.mozilla.org/docs/Web/API/FileError'><code>FileError</code></a> object."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Location.json
+++ b/api/Location.json
@@ -423,7 +423,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of https://z.com/x?a=true&amp;b=false, <code>pathname</code> would return \"/x?a=true&amp;b=false\" rather than \"/x\"."
+              "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of <code>https://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return \"/x?a=true&amp;b=false\" rather than \"/x\"."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -681,7 +681,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of https://z.com/x?a=true&amp;b=false, <code>search</code> would return \"\", rather than \"?a=true&amp;b=false\"."
+              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of <code>https://z.com/x?a=true&amp;b=false</code>, <code>search</code> would return \"\", rather than \"?a=true&amp;b=false\"."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -169,7 +169,7 @@
               {
                 "version_added": "33",
                 "version_removed": "66",
-                "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>. Before 52 it relied on a client-configurable list of allowed sites."
+                "notes": "Since Firefox 33 you can capture screen data using <a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'><code>getUserMedia()</code></a>, with a <code>video</code> constraint called <code>mediaSource</code>. Before 52 it relied on a client-configurable list of allowed sites."
               }
             ],
             "firefox_android": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4150,7 +4150,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "108",
-              "notes": "API access is gated by installation of a <a href='https://support.mozilla.org/en-US/kb/site-permission-add-ons'>site permission add-on</a> (user prompt), secure context, and <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/midi'>Permission Policy: <code>midi</code></a>."
+              "notes": "API access is gated by installation of a <a href='https://support.mozilla.org/en-US/kb/site-permission-add-ons'>site permission add-on</a> (user prompt), secure context, and <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/midi'><code>Permission Policy: midi</code></a>."
             },
             "firefox_android": {
               "version_added": false

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -132,7 +132,7 @@
               "firefox": {
                 "version_added": "113",
                 "partial_implementation": true,
-                "notes": "<code>content: &lt;gradient&gt;</code>` doesn't paint on ::before/::after pseudo elements. See <a href='https://bugzil.la/1832901'>bug 1832901</a>."
+                "notes": "<code>content: &lt;gradient&gt;</code> doesn't paint on ::before/::after pseudo elements. See <a href='https://bugzil.la/1832901'>bug 1832901</a>."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -476,7 +476,7 @@
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": "10",
-                  "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <code><a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</a></code>."
+                  "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'><code>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</code></a>."
                 },
                 "oculus": "mirror",
                 "opera": [
@@ -519,7 +519,7 @@
                     "prefix": "-webkit-",
                     "version_added": "5.1",
                     "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
+                      "Safari 4 was supporting an experimental <a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'><code>-webkit-gradient(linear,…)</code></a> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
                       "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
                     ]
                   }
@@ -867,7 +867,7 @@
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": "10",
-                  "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <code><a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</a></code>."
+                  "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'><code>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</code></a>."
                 },
                 "oculus": "mirror",
                 "opera": [
@@ -905,7 +905,7 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "5.1",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
+                    "notes": "Safari 4 was supporting an experimental <a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'><code>-webkit-gradient(radial,…)</code></a> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
                 "safari_ios": "mirror",
@@ -1353,7 +1353,7 @@
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": "10",
-                  "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <code><a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</a></code>."
+                  "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'><code>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</code></a>."
                 },
                 "oculus": "mirror",
                 "opera": [
@@ -1396,7 +1396,7 @@
                     "prefix": "-webkit-",
                     "version_added": "5.1",
                     "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
+                      "Safari 4 was supporting an experimental <a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'><code>-webkit-gradient(linear,…)</code></a> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
                       "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
                     ]
                   }
@@ -1762,7 +1762,7 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "5.1",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
+                    "notes": "Safari 4 was supporting an experimental <a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'><code>-webkit-gradient(radial,…)</code></a> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
                 "safari_ios": "mirror",

--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -17,7 +17,7 @@
               },
               "firefox": {
                 "version_added": "1",
-                "notes": "Unlike other browsers, Firefox by default <a href='https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&lt;button&gt;</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
+                "notes": "Unlike other browsers, Firefox by default <a href='https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&lt;button&gt;</code> across page loads. Use the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'><code>autocomplete</code></a> attribute to control this feature."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -17,7 +17,7 @@
               },
               "firefox": {
                 "version_added": "1",
-                "notes": "Unlike other browsers, Firefox by default <a href='https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&lt;button&gt;</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
+                "notes": "Unlike other browsers, Firefox by default <a href='https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&lt;button&gt;</code> across page loads. Use the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'><code>autocomplete</code></a> attribute to control this feature."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -13,7 +13,7 @@
             "firefox": {
               "version_added": "48",
               "notes": [
-                "Firefox does not support 'http://127.0.0.1' or 'http://localhost' as script sources: they must be served over HTTPS.",
+                "Firefox does not support <code>http://127.0.0.1'</code> or <code>http://localhost</code> as script sources; they must be served over HTTPS.",
                 "Until Firefox 105, the <code>object-src</code> directive was required with a secure source. From Firefox 106, the <code>object-src</code> directive is optional."
               ]
             },


### PR DESCRIPTION
This PR fixes a number of notes that have markup, formatting or other issues.  These issues were found during updates for #21495.

Fixes Performed:
- Ensure code tags are inside of anchors (`<code>(<a href='[\w:;#&/=_().-]+'>)([\w\s.,…()&:;-]+)</a></code>` -> `$1<code>$2</code></a>`)
- Removed tags (`<strong>`, `<em>`) inside of inline code blocks
- Drive-by fix: tweak Edge note for FileSystem API to state the behavior applies to previous versions of Edge
- Add `<code>` blocks to example URLs that needed them
- Set a note to mirror from upstream as needed (for accuracy)
