### PR TITLE
Fix tags for WebSocketStream

### DIFF
--- a/api/WebSocketError.json
+++ b/api/WebSocketError.json
@@ -3,7 +3,7 @@
     "WebSocketError": {
       "__compat": {
         "tags": [
-          "web-features:web-features:web-socket-stream",
+          "web-features:web-socket-stream",
           "web-features:websockets"
         ],
         "support": {
@@ -40,7 +40,7 @@
         "__compat": {
           "description": "<code>WebSocketError()</code> constructor",
           "tags": [
-            "web-features:web-features:web-socket-stream",
+            "web-features:web-socket-stream",
             "web-features:websockets"
           ],
           "support": {
@@ -77,7 +77,7 @@
       "closeCode": {
         "__compat": {
           "tags": [
-            "web-features:web-features:web-socket-stream",
+            "web-features:web-socket-stream",
             "web-features:websockets"
           ],
           "support": {
@@ -114,7 +114,7 @@
       "reason": {
         "__compat": {
           "tags": [
-            "web-features:web-features:web-socket-stream",
+            "web-features:web-socket-stream",
             "web-features:websockets"
           ],
           "support": {

--- a/api/WebSocketStream.json
+++ b/api/WebSocketStream.json
@@ -4,7 +4,7 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream",
         "tags": [
-          "web-features:web-features:web-socket-stream"
+          "web-features:web-socket-stream"
         ],
         "support": {
           "chrome": {
@@ -41,7 +41,7 @@
           "description": "<code>WebSocketStream()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/WebSocketStream",
           "tags": [
-            "web-features:web-features:web-socket-stream"
+            "web-features:web-socket-stream"
           ],
           "support": {
             "chrome": {
@@ -78,7 +78,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/close",
           "tags": [
-            "web-features:web-features:web-socket-stream"
+            "web-features:web-socket-stream"
           ],
           "support": {
             "chrome": {
@@ -115,7 +115,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/closed",
           "tags": [
-            "web-features:web-features:web-socket-stream"
+            "web-features:web-socket-stream"
           ],
           "support": {
             "chrome": {
@@ -152,7 +152,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/opened",
           "tags": [
-            "web-features:web-features:web-socket-stream"
+            "web-features:web-socket-stream"
           ],
           "support": {
             "chrome": {
@@ -189,7 +189,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/url",
           "tags": [
-            "web-features:web-features:web-socket-stream"
+            "web-features:web-socket-stream"
           ],
           "support": {
             "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the *tags* should be _web-features:web-socket-stream_, not _web-features:web-features:web-socket-stream_

maybe a replace bug introduced in https://github.com/mdn/browser-compat-data/pull/22875

see also https://websockets.spec.whatwg.org/ and https://github.com/whatwg/websockets/pull/48

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
