### PR TITLE
HTMLImageData and ImageData valid sources for copyExternalImageToText…

### DIFF
--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -118,9 +118,48 @@
             "deprecated": false
           }
         },
+        "htmlimageelement_imagedata_source": {
+          "__compat": {
+            "description": "<code>HTMLImageElement</code> and <code>ImageData</code> objects as <code>source</code>",
+            "support": {
+              "chrome": {
+                "version_added": "118"
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "videoframe_source": {
           "__compat": {
-            "description": "<code>VideoFrame</code> object as source",
+            "description": "<code>VideoFrame</code> object as <code>source</code>",
             "support": {
               "chrome": {
                 "version_added": "116"


### PR DESCRIPTION
…ure()

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As of Chrome 118, you can use an `HTMLImageElement` or `ImageData` object as the source for a [`copyExternalImageToTexture`](https://developer.mozilla.org/docs/Web/API/GPUQueue/copyExternalImageToTexture) call. This PR adds a data point for this information.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See https://developer.chrome.com/blog/new-in-webgpu-118#htmlimageelement_and_imagedata_support_in_copyexternalimagetotexture for evidence of this change.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Project issue: https://github.com/mdn/content/issues/36374

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
