### PR TITLE
HTMLElement toggle and before toggle event subfeatures

### DIFF
--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -116,45 +116,6 @@
             "deprecated": false
           }
         }
-      },
-      "toggle_event": {
-        "__compat": {
-          "description": "<code>toggle</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement/toggle_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
-          "tags": [
-            "web-features:details"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "36"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "49"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -430,9 +430,6 @@
           "description": "<code>beforetoggle</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
-          "tags": [
-            "web-features:popover"
-          ],
           "support": {
             "chrome": {
               "version_added": "114"
@@ -468,9 +465,6 @@
             "description": "<code>beforetoggle</code> event fires at dialog elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
-            "tags": [
-              "web-features:popover"
-            ],
             "support": {
               "chrome": {
                 "version_added": false
@@ -482,7 +476,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "114"
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -512,7 +506,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "114"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2435,6 +2429,9 @@
             "description": "<code>toggle</code> event fires at details elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
+            "tags": [
+              "web-features:details"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -465,7 +465,7 @@
         },
         "dialog_elements": {
           "__compat": {
-            "description": "Fires at dialog elements",
+            "description": "<code>beforetoggle</code> event fires at dialog elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
             "tags": [
@@ -482,7 +482,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "114"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -504,7 +504,7 @@
         },
         "popover_elements": {
           "__compat": {
-            "description": "Fires at popover elements",
+            "description": "<code>beforetoggle</code> event fires at popover elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
             "tags": [
@@ -512,7 +512,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "114"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2400,17 +2400,14 @@
           "description": "<code>toggle</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
-          "tags": [
-            "web-features:popover"
-          ],
           "support": {
             "chrome": {
-              "version_added": "114"
+              "version_added": "36"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "125"
+              "version_added": "49"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2420,7 +2417,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "17"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2435,17 +2432,17 @@
         },
         "details_elements": {
           "__compat": {
-            "description": "Fires at details elements",
+            "description": "<code>toggle</code> event fires at details elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "36"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "133"
+                "version_added": "49"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2455,7 +2452,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2463,7 +2460,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2471,7 +2468,7 @@
         },
         "dialog_elements": {
           "__compat": {
-            "description": "Fires at dialog elements",
+            "description": "<code>toggle</code> event fires at dialog elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
             "support": {
@@ -2507,7 +2504,7 @@
         },
         "popover_elements": {
           "__compat": {
-            "description": "Fires at popover elements",
+            "description": "<code>toggle</code> event fires at popover elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
             "tags": [

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -467,7 +467,7 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "132"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2470,7 +2470,7 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "132"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -463,6 +463,45 @@
             "deprecated": false
           }
         },
+        "dialog_elements": {
+          "__compat": {
+            "description": "Fires at dialog elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event",
+            "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
+            "tags": [
+              "web-features:popover"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "popover_elements": {
           "__compat": {
             "description": "Fires at popover elements",
@@ -2392,6 +2431,117 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "details_elements": {
+          "__compat": {
+            "description": "Fires at details elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
+            "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "dialog_elements": {
+          "__compat": {
+            "description": "Fires at dialog elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
+            "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "popover_elements": {
+          "__compat": {
+            "description": "Fires at popover elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
+            "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
+            "tags": [
+              "web-features:popover"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -462,6 +462,45 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "popover_elements": {
+          "__compat": {
+            "description": "Fires at popover elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event",
+            "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
+            "tags": [
+              "web-features:popover"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "blur": {


### PR DESCRIPTION
FF133 adds support for the HTMLElement beforetoggle and toggle events that were formerly  assumed to be restricted to only being fired at popovers in https://bugzilla.mozilla.org/show_bug.cgi?id=1876762
Note, this data is confirmed by spec author/implementer in https://github.com/mdn/content/issues/36536#issuecomment-2454321830

I have added subfeatures to these events for the elements that they can be fired on. My theory being that for HTMLDialogElement I can add the particular subfeature of HTMLElement as another compat point to show the version at which the event became relevant.
I THINK this is better than trying to somehow show the events directly supported on (say) HTMLDialogElement 

It turns out though that `toggle` has been around forever on HTMLDetailsElement. However this has the same derivation and is in the spec as being defined on HTMLElement. So at some point that changed, and I don't think it is worth finding out when.
In any case, to make that work, I have update the toggle in HTMLElement to match the original details element version and deleted that subfeature.

related docs work can be tracked in https://github.com/mdn/content/issues/36536

