### PR TITLE
fix(release-pr): grant permissions

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -12,6 +12,10 @@ env:
 concurrency:
   group: ${{ github.workflow }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   manage-release-pr:
     name: Manage release PR


### PR DESCRIPTION
#### Summary

Grants the `release-pr` permissions, so that the workflow has access to secrets on Dependabot merges.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
