### PR TITLE
Firefox Nightly supports `contenteditable="plaintext-only"`

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -349,7 +349,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "133"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -349,7 +349,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "133"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

- Added firefox version for `plaintext-only` value of `contenteditable` global attribute

#### Test results and supporting details

- tested in Firefox Nightly 134.0a1

#### Related issues

- [MDN Issue #36535](https://github.com/mdn/content/issues/36535)
- Content PR
- Firefox Release Notes PR