### PR TITLE
fix(update-mdn-urls): filter on package-lock.json

### DIFF
--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -3,7 +3,7 @@ name: Update MDN urls
 on:
   pull_request_target:
     paths:
-      - "package.json"
+      - "package-lock.json"
 
 jobs:
   update-mdn-urls:


### PR DESCRIPTION
#### Summary

The mdn-content-inventory PR doesn't update `package.json`, only `package-lock.json`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
