### PR TITLE
Fix nodejs data of timer functions

### DIFF
--- a/api/_globals/clearInterval.json
+++ b/api/_globals/clearInterval.json
@@ -24,7 +24,7 @@
             "notes": "From Internet Explorer 4 through 8, <code>clearInterval</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
           },
           "nodejs": {
-            "version_added": "0.10.0",
+            "version_added": "0.0.1",
             "partial_implementation": true,
             "notes": "Takes a <code>Timeout</code> object instead of the <code>intervalID</code>."
           },

--- a/api/_globals/clearTimeout.json
+++ b/api/_globals/clearTimeout.json
@@ -24,7 +24,7 @@
             "notes": "From Internet Explorer 4 through 8, <code>clearTimeout</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
           },
           "nodejs": {
-            "version_added": "0.10.0",
+            "version_added": "0.0.1",
             "partial_implementation": true,
             "notes": "Takes a <code>Timeout</code> object instead of the <code>timeoutID</code>."
           },

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -23,7 +23,7 @@
             "version_added": "4"
           },
           "nodejs": {
-            "version_added": "0.10.0",
+            "version_added": "0.0.1",
             "partial_implementation": true,
             "notes": [
               "Returns a <code>Timeout</code> object instead of the <code>intervalID</code>.",

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -23,7 +23,7 @@
             "version_added": "4"
           },
           "nodejs": {
-            "version_added": "0.10.0",
+            "version_added": "0.0.1",
             "partial_implementation": true,
             "notes": [
               "Returns a <code>Timeout</code> object instead of the <code>timeoutID</code>.",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the added data should be 0.0.1, not 0.10.0, per documentation

https://nodejs.org/docs/latest/api/globals.html
https://nodejs.org/docs/latest/api/timers.html

(unknown how the 0.10.0 comes in https://github.com/mdn/browser-compat-data/pull/13204)

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
