### PR TITLE
Node.js 22.1.0 supports URL.parse()

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -474,6 +474,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "22.1.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",


### PR DESCRIPTION
#### Summary

Add Node.js version added for URL.parse.

#### Test results and supporting details

`npm test` passes.

This version is from https://nodejs.org/api/url.html#urlparseinput-base

#### Related issues

None