### PR TITLE
Suppress release workflow on forks

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   manage-release-pr:
+    if: github.repository == 'mdn/browser-compat-data'
     name: Manage release PR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   create-release:
-    if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v')
+    if: github.repository == 'mdn/browser-compat-data' && github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v')
     name: Create release
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Stop running the release PR workflow on forks.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

The release workflow fails on forks that don't have the `GH_TOKEN` secret set. Most forks won't ever do this or need to do this, so let's turn off the workflow by default.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
