### PR TITLE
Split the `display` manifest member into sub-features

### DIFF
--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -25,14 +25,10 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "17",
-              "partial_implementation": true,
-              "notes": "Does not support <code>fullscreen</code> or <code>minimal-ui</code>."
+              "version_added": "17"
             },
             "safari_ios": {
-              "version_added": "11.3",
-              "partial_implementation": true,
-              "notes": "Does not support <code>fullscreen</code> or <code>minimal-ui</code>."
+              "version_added": "11.3"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -42,6 +38,158 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "browser": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/display#browser",
+            "spec_url": "https://w3c.github.io/manifest/#dfn-browser",
+            "support": {
+              "chrome": {
+                "version_added": "39"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": "47"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": {
+                "version_added": "11.3"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fullscreen": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/display#fullscreen",
+            "spec_url": "https://w3c.github.io/manifest/#dfn-fullscreen",
+            "support": {
+              "chrome": {
+                "version_added": "39"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": "47"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "minimal-ui": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/display#minimal-ui",
+            "spec_url": "https://w3c.github.io/manifest/#dfn-minimal-ui",
+            "support": {
+              "chrome": {
+                "version_added": "39"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": "47"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "standalone": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/display#standalone",
+            "spec_url": "https://w3c.github.io/manifest/#dfn-standalone",
+            "support": {
+              "chrome": {
+                "version_added": "39"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": "47"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": {
+                "version_added": "11.3"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `display` manifest member is marked as partially implemented on Safari, which is unfortunate because it makes it impossible for it to be Baseline in the [web-features](https://github.com/web-platform-dx/web-features/) project.
This manifest member _is_ supported by Safari, but just not all display types.

So, in this PR, I'm splitting it into multiple subfeatures. The top-level feature is marked as supported on Safari, and the various display types are either supported or not supported.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
