### PR TITLE
Mark link rel=manifest as supported on Safari

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -923,7 +923,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "≤15.4"
                 },
                 "safari_ios": {
                   "version_added": "11.3"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -923,11 +923,9 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "≤15.4"
+                  "version_added": "11.1"
                 },
-                "safari_ios": {
-                  "version_added": "11.3"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
                 "webview_ios": "mirror"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `<link rel=manifest>` tag is marked is unsupported in Safari desktop but that can't be right. I know that some of the members found in web app manifests _are_ used by Safari when adding an app to the Dock, namely the name and icon.

Searching through the release notes, here's the earliest mention I could find of a web app manifest member being parsed in Safari on macOS: https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes#New-Features

So, ever since 15.4, or earlier, manifests have been parsed, which means that they've been downloaded from `<link rel=manifest>` 
elements.

This PR therefore sets the support data for Safari to `≤15.4`.

If someone can find the exact version, that'd be great.

#### Test results and supporting details

* Earliest release note I could find: https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes#New-Features
* Asked on Mastodon: https://mas.to/@patrickbrosset/113436404851258333

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
