### PR TITLE
Update nodejs data for `crypto` global property

### DIFF
--- a/api/_globals/crypto.json
+++ b/api/_globals/crypto.json
@@ -26,9 +26,17 @@
             "prefix": "ms",
             "version_added": "11"
           },
-          "nodejs": {
-            "version_added": "15.0.0"
-          },
+          "nodejs": [
+            {
+              "version_added": "19.0.0"
+            },
+            {
+              "alternative_name": "webcrypto",
+              "version_added": "15.0.0",
+              "partial_implementation": true,
+              "notes": "Available as a part of the <code>crypto</code> module."
+            }
+          ],
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The support for the Web Crypto API is:

in v15.0.0, the API has been shipped, but can't access globally, access via the `crypto` module with the alternative name `webcrypto`

in v17.6.0, v16.15.0, the API can be available to global context, but need to be enabled with `--experimental-global-webcrypto` CLI flag

in v19.0.0, the API is available to global context without flags, but can be disabled with `--no-experimental-global-webcrypto` CLI flag

in v23.0.0, the API is marked as not experimental

see also https://nodejs.org/docs/latest/api/crypto.html#cryptowebcrypto

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
