### PR TITLE
Fix Safari support for link rel=manifest

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -923,9 +923,11 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
+                  "version_added": "17"
+                },
+                "safari_ios": {
                   "version_added": "11.1"
                 },
-                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
                 "webview_ios": "mirror"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -926,7 +926,7 @@
                   "version_added": "17"
                 },
                 "safari_ios": {
-                  "version_added": "11.1"
+                  "version_added": "11.3"
                 },
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This is a follow-up to #24971, which I'm opening to address @jensimmons' feedback:

> `<link rel=manifest>` is supported in:
> * Safari 11.1 on iOS 11.3 or later
> * Safari 17 on macOS Sonoma or later

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/pull/24971#issuecomment-2460519228

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
