### PR TITLE
Fix ry support for Safari

### DIFF
--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -24,8 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element. See <a href='https://webkit.org/b/266090'>bug 266090</a>."
+              "version_added": "≤17.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

This is not accurate https://developer.mozilla.org/en-US/docs/Web/CSS/ry#values

<img width="784" alt="SCR-20241107-uegq" src="https://github.com/user-attachments/assets/0c5a27c1-ac13-4da3-b7ae-4c3cf7387f7d">

It references to this issue: https://bugs.webkit.org/show_bug.cgi?id=266090, which is labeled as a duplicate of https://bugs.webkit.org/show_bug.cgi?id=259646, and that got fixed. I can see it working on Safari 17.5, it's broken on Safari 17.3, so it got fixed in between. You can use the reproduction provided (https://codepen.io/sidewayss/pen/GRPgqvG) in one of those issues.

---

Not that my PR is broken, it still needs to:

- [ ] Update it to cover `rx`
- [ ] Update it to cover iOS mobile

Now, I have no bandwidth for this, so feel free to either push extra commits and transfer this as a new issue. Happy to report this in any cases.