### PR TITLE
FF133 ServiceWorkerContainer supported in workers

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -44,7 +44,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "impl_url": "https://issues.chromium.org/issues/40364838"
+              "impl_url": "https://crbug.com/40364838"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -38,6 +38,42 @@
           "deprecated": false
         }
       },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "133"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11.3"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "controller": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/controller",

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -43,7 +43,8 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://issues.chromium.org/issues/40364838"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
FF133 exposes [`ServiceWorkerContainer`](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer) in workers in https://bugzilla.mozilla.org/show_bug.cgi?id=1131324

This mirrors support in  [WorkerNavigator.serviceWorker](https://developer.mozilla.org/en-US/docs/Web/API/WorkerNavigator/serviceWorker) that was added by @Elchi3 in https://github.com/mdn/browser-compat-data/pull/24863 (`WorkerNavigator.serviceWorker` is a `ServiceWorkerContainer`.

Tested that this is not supported on chrome and that it is on Safari.

Related docs work can be tracked in https://github.com/mdn/content/issues/36532