### PR TITLE
Remove Safari impl_url for `messageerror` event

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -218,8 +218,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "16.4",
-              "impl_url": "https://webkit.org/b/171216"
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -272,8 +272,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "16.4",
-              "impl_url": "https://webkit.org/b/171216"
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -283,7 +283,7 @@
                 "version_added": "11.1",
                 "version_removed": "16.4",
                 "partial_implementation": true,
-                "notes": "Although the <code>onmessageerror</code> event handler property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+                "notes": "Although the <code>onmessageerror</code> event handler property is supported, the <code>messageerror</code> event is never fired."
               }
             ],
             "safari_ios": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -2877,8 +2877,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "16.4",
-              "impl_url": "https://webkit.org/b/171216"
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -475,8 +475,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4",
-              "impl_url": "https://webkit.org/b/171216"
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the impl url has been fixed and so can be removed

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
