### PR TITLE
Deprecate zoom.reset

### DIFF
--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -75,8 +75,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
#### Summary

`css.properties.zoom.reset` is deprecated- it has been removed from Chrome. As far as I can tell, it has never been part of the spec.

#### Test results and supporting details

https://groups.google.com/a/chromium.org/g/blink-dev/c/Udxmfvq4Wf8/m/SQuUvI5lBAAJ

[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom#values) says: `Do not use this value, use the standard unset value instead.`