### PR TITLE
Chrome 125 supports "Cause is displayed in console" feature

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -273,8 +273,7 @@
               "description": "Cause is displayed in console",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/40182832"
+                  "version_added": "125"
                 },
                 "chrome_android": "mirror",
                 "deno": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 125 implemented the "Cause is displayed in console" feature.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The [Chromium bug](https://issues.chromium.org/issues/40182832) has been marked as fixed and has been shipped on Chrome 125 [according to the What's new in DevTools blog](https://developer.chrome.com/blog/new-in-devtools-125#error-cause).

#### Related issues

N/A

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
