### PR TITLE
Updates for Chrome 132 beta

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -97,8 +97,7 @@
               "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40101963"
+              "version_added": "132"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/DevicePosture.json
+++ b/api/DevicePosture.json
@@ -8,7 +8,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "132"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -47,7 +47,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "132"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -86,7 +86,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "132"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -939,7 +939,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "132"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -460,6 +460,120 @@
           }
         }
       },
+      "signalAllAcceptedCredentials_static": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-signalallacceptedcredentials",
+          "support": {
+            "chrome": {
+              "version_added": "132"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "signalCurrentUserDetails_static": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-signalcurrentuserdetails",
+          "support": {
+            "chrome": {
+              "version_added": "132"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "signalUnknownCredential_static": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-signalunknowncredential",
+          "support": {
+            "chrome": {
+              "version_added": "132"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/toJSON",

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -158,7 +158,7 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-pushmessagedata-bytes",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "132"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -177,7 +177,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": {
               "version_added": false
             }

--- a/api/Request.json
+++ b/api/Request.json
@@ -609,7 +609,7 @@
           "spec_url": "https://fetch.spec.whatwg.org/#dom-body-bytes",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "132"
             },
             "chrome_android": "mirror",
             "deno": {

--- a/api/Response.json
+++ b/api/Response.json
@@ -411,7 +411,7 @@
           "spec_url": "https://fetch.spec.whatwg.org/#dom-body-bytes",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "132"
             },
             "chrome_android": "mirror",
             "deno": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -6219,8 +6219,7 @@
               "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40101963"
+              "version_added": "132"
             },
             "edge": "mirror",
             "firefox": {
@@ -6305,8 +6304,7 @@
               "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40101963"
+              "version_added": "132"
             },
             "edge": "mirror",
             "firefox": {
@@ -6346,8 +6344,7 @@
               "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40101963"
+              "version_added": "132"
             },
             "edge": "mirror",
             "firefox": {

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -251,7 +251,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "132"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -284,7 +284,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "132"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.6 found new features shipping in Chrome 132 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 12 features as shipping in Chrome 132:

- api.DevicePosture
- api.DevicePosture.change_event
- api.DevicePosture.type
- api.Navigator.devicePosture
- api.PublicKeyCredential.signalAllAcceptedCredentials_static
- api.PublicKeyCredential.signalCurrentUserDetails_static
- api.PublicKeyCredential.signalUnknownCredential_static
- api.PushMessageData.bytes
- api.Request.bytes
- api.Response.bytes
- css.properties.writing-mode.sideways-lr
- css.properties.writing-mode.sideways-rl

See also the 132 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-132-beta