### PR TITLE
Correct spelling of runtine.getcontexts

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -580,6 +580,7 @@
         },
         "getContexts": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getContexts",
             "support": {
               "chrome": {
                 "version_added": "116"
@@ -594,8 +595,7 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getContexts"
+            }
           }
         },
         "getFrameId": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -578,7 +578,7 @@
             }
           }
         },
-        "getContext": {
+        "getContexts": {
           "__compat": {
             "support": {
               "chrome": {
@@ -594,7 +594,8 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            }
+            },
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getContexts"
           }
         },
         "getFrameId": {


### PR DESCRIPTION
#### Summary

Follow up to [query](https://github.com/mdn/browser-compat-data/pull/23305#issuecomment-2475898048) why BCD not showing on MDN and noted that the method was spelt incorrectly.
