### PR TITLE
FF133 Request keepalive and other web-features:fetch-keepalive

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -233,7 +233,7 @@
                 "version_added": "15"
               },
               "firefox": {
-                "version_added": "preview"
+                "version_added": "133"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1172,6 +1172,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/keepalive",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-keepalive②",
+          "tags": [
+            "web-features:fetch-keepalive"
+          ],
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -195,6 +195,9 @@
       "init_keepalive_parameter": {
         "__compat": {
           "description": "<code>init.keepalive</code> parameter",
+          "tags": [
+            "web-features:fetch-keepalive"
+          ],
           "support": {
             "chrome": {
               "version_added": "66"
@@ -207,7 +210,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "preview"
+              "version_added": "133"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Discovered some FF133 updates missed by #24863 for `fetch()` `keepalive`. This updates them to 133 and adds the tag so they are grouped.

Related docs work tracked in https://github.com/mdn/content/issues/36537