### PR TITLE
[css.types.url] Add `src()` function

### DIFF
--- a/css/types/url.json
+++ b/css/types/url.json
@@ -48,9 +48,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false,
                 "impl_url": "https://bugzil.la/1707923"
@@ -60,9 +58,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -39,6 +39,45 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "src": {
+          "__compat": {
+            "description": "<code>src()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1707923"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
This adds initial compatibility data for the new **CSS Values 4** `src(…)` function, which is like the `url(…)` function, except it doesn’t support the unquoted legacy syntax, so that `src(var(‑‑foo))` is valid.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
* **Spec URL:** https://drafts.csswg.org/css-values/#urls
* **Firefox bug:** [Bug 1707923 - [css‑values] Support the `src()` function in the CSS `<url>` type](https://bugzil.la/1707923)
