### PR TITLE
Firefox 133 supports TrustedTypePolicyFactory.get{Attribute,Property}Type() behind pref

### DIFF
--- a/api/TrustedTypePolicyFactory.json
+++ b/api/TrustedTypePolicyFactory.json
@@ -14,7 +14,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "133",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.security.trusted_types.enabled",
+                "value_to_set": "true"
+              }
+            ],
             "impl_url": "https://bugzil.la/1508286"
           },
           "firefox_android": "mirror",
@@ -205,7 +212,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -243,7 +257,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "133",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF133 adds support for `TrustedTypePolicyFactory.getAttributeType` and `.getPropertyType` behind a pref in https://bugzilla.mozilla.org/show_bug.cgi?id=1917783 and https://bugzilla.mozilla.org/show_bug.cgi?id=1917784

Related docs work can be tracked in https://github.com/mdn/content/issues/36559