### PR TITLE
Add web-features tags for beforetoggle/toggle events

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -431,6 +431,10 @@
           "description": "<code>beforetoggle</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
+          "tags": [
+            "web-features:popover",
+            "web-features:dialog"
+          ],
           "support": {
             "chrome": {
               "version_added": "114"
@@ -466,6 +470,9 @@
             "description": "<code>beforetoggle</code> event fires at dialog elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforetoggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle",
+            "tags": [
+              "web-features:dialog"
+            ],
             "support": {
               "chrome": {
                 "version_added": "132"
@@ -2429,6 +2436,11 @@
           "description": "<code>toggle</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
+          "tags": [
+            "web-features:popover",
+            "web-features:dialog",
+            "web-features:details"
+          ],
           "support": {
             "chrome": {
               "version_added": "36"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2515,6 +2515,9 @@
             "description": "<code>toggle</code> event fires at dialog elements",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/toggle_event",
             "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
+            "tags": [
+              "web-features:dialog"
+            ],
             "support": {
               "chrome": {
                 "version_added": "132"


### PR DESCRIPTION
Improves #24927

The beforetoggle fires on popovers and dialogs, while toggle first on  details elements as well. This adds the tag info

FYI @caugner 