### PR TITLE
Add Deno and Node support info for `javascript.regular_expressions.modifier`

### DIFF
--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -573,7 +573,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.44"
             },
             "edge": "mirror",
             "firefox": {
@@ -584,7 +584,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "23.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
#### Summary

Add Deno and Node support info for `javascript.regular_expressions.modifier`

#### Test results and supporting details

```js
const assert = (x) => { if (!x) throw 1 }
const re = /^foo (?i:bar)$/
assert(re.test('foo BAR'))
assert(!re.test('FOO BAR'))
```

#### Related issues

N/A
