### PR TITLE
Update documentation to indicate Markdown is now allowed

### DIFF
--- a/docs/data-guidelines/api.md
+++ b/docs/data-guidelines/api.md
@@ -73,9 +73,9 @@ This guideline is based on a discussion in [#11518](https://github.com/mdn/brows
 
 ## Constructors
 
-Name a constructor for an API feature the same as the parent feature (unless the constructor doesn't share the name of its parent feature) and have a description with text in the form of `<code>Name()</code> constructor`.
+Name a constructor for an API feature the same as the parent feature (unless the constructor doesn't share the name of its parent feature) and have a description with text in the form of ``\`Name()\` constructor``.
 
-For example, the `ImageData` constructor, `ImageData()`, is represented as `api.ImageData.ImageData`. It has the description `<code>ImageData()</code> constructor`, like this:
+For example, the `ImageData` constructor, `ImageData()`, is represented as `api.ImageData.ImageData`. It has the description ``\`ImageData()\` constructor``, like this:
 
 ```json
 {
@@ -84,7 +84,7 @@ For example, the `ImageData` constructor, `ImageData()`, is represented as `api.
       "__compat": {},
       "ImageData": {
         "__compat": {
-          "description": "<code>ImageData()</code> constructor",
+          "description": "`ImageData()` constructor",
           "support": {}
         }
       }
@@ -95,9 +95,9 @@ For example, the `ImageData` constructor, `ImageData()`, is represented as `api.
 
 ## DOM events (`eventname_event`)
 
-Add DOM events as features of their target interfaces, using the name _eventname_\_event with the description text set to `<code>eventname</code> event`. If an event can be sent to multiple interfaces, add the event as a feature of each interface that can receive it.
+Add DOM events as features of their target interfaces, using the name _eventname_\_event with the description text set to ``eventname` event`. If an event can be sent to multiple interfaces, add the event as a feature of each interface that can receive it.
 
-For example, the feature for a `focus` event targeting the `Element` interface would be named `focus_event` with the description text `<code>focus</code> event`, like this:
+For example, the feature for a `focus` event targeting the `Element` interface would be named `focus_event` with the description text ``focus` event`, like this:
 
 ```json
 {
@@ -106,7 +106,7 @@ For example, the feature for a `focus` event targeting the `Element` interface w
       "__compat": {},
       "focus_event": {
         "__compat": {
-          "description": "<code>focus</code> event",
+          "description": "`focus` event",
           "support": {}
         }
       }
@@ -115,7 +115,7 @@ For example, the feature for a `focus` event targeting the `Element` interface w
 }
 ```
 
-The event handler `onfocus` is represented by the `focus_event` entry. Don't create features for `on` event handler properties. If an implementation doesn't support the event handler property, use `partial_implementation` with the note `"The <code>onfocus</code> event handler property is not supported."`. If only the `on` event handler property is supported and not the event itself, use `"version_added": false`.
+The event handler `onfocus` is represented by the `focus_event` entry. Don't create features for `on` event handler properties. If an implementation doesn't support the event handler property, use `partial_implementation` with the note `"The `onfocus` event handler property is not supported."`. If only the `on` event handler property is supported and not the event itself, use `"version_added": false`.
 
 If a specification has two sections (the event handler property and the event name), add both specification links.
 
@@ -129,9 +129,9 @@ This practice emerged through several discussions:
 
 ## Permissions API permissions (`permissionname_permission`)
 
-Add [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API) permissions as subfeatures of [`api.Permissions`](https://developer.mozilla.org/en-US/docs/Web/API/Permissions) using the name _permissionname_\_permission with the description text set to `<code>permissionname</code> permission`.
+Add [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API) permissions as subfeatures of [`api.Permissions`](https://developer.mozilla.org/en-US/docs/Web/API/Permissions) using the name _permissionname_\_permission with the description text set to ``\`permissionname\` permission``.
 
-For example, the Geolocation permission is named `geolocation_permission` with the description text `<code>geolocation</code> permission`, like this:
+For example, the Geolocation permission is named `geolocation_permission` with the description text ``\`geolocation\` permission``, like this:
 
 ```json
 {
@@ -140,7 +140,7 @@ For example, the Geolocation permission is named `geolocation_permission` with t
       "__compat": { ... },
       "geolocation_permission": {
         "__compat": {
-          "description": "<code>geolocation</code> permission",
+          "description": "`geolocation` permission",
           "support": { ... }
         }
       }
@@ -153,7 +153,7 @@ This guideline was proposed in [#6156](https://github.com/mdn/browser-compat-dat
 
 ## Methods returning promises (`returns_promise`)
 
-When a method returns a promise in some (but not all) browser releases, use a subfeature named `returns_promise` with description text `Returns a <code>Promise</code>` to record when the method returns a promise.
+When a method returns a promise in some (but not all) browser releases, use a subfeature named `returns_promise` with description text ``Returns a \`Promise\` `` to record when the method returns a promise.
 
 For example, `HTMLMediaElement`'s `play()` method returns a promise, recorded like this:
 
@@ -166,7 +166,7 @@ For example, `HTMLMediaElement`'s `play()` method returns a promise, recorded li
         "__compat": {},
         "returns_promise": {
           "__compat": {
-            "description": "Returns a <code>Promise</code>",
+            "description": "Returns a `Promise`",
             "support": {}
           }
         }
@@ -283,9 +283,9 @@ This guideline is based on a discussion in [#3463](https://github.com/mdn/browse
 
 ### Static API members
 
-Always append the suffix `_static` to static members of an interface and have a description with text in the form of `<code>json()</code> static method`.
+Always append the suffix `_static` to static members of an interface and have a description with text in the form of ``\`json()\` static method``.
 
-For example, the `Response` interface has both, a prototype and static method called `json()`. The static method is represented as `api.Response.json_static`. It has the description `<code>json()</code> static method`. The prototype method is represented as `api.Response.json` without suffix and without description.
+For example, the `Response` interface has both, a prototype and static method called `json()`. The static method is represented as `api.Response.json_static`. It has the description ``\`json()\` static method``. The prototype method is represented as `api.Response.json` without suffix and without description.
 
 ```json
 {
@@ -297,7 +297,7 @@ For example, the `Response` interface has both, a prototype and static method ca
       },
       "json_static": {
         "__compat": {
-          "description": "<code>json()</code> static method",
+          "description": "`json()` static method",
           "support": {}
         }
       }

--- a/docs/data-guidelines/index.md
+++ b/docs/data-guidelines/index.md
@@ -164,17 +164,17 @@ This guideline was proposed in [#15703](https://github.com/mdn/browser-compat-da
 
 Sometimes it's useful to represent support for specific parameters (also known as arguments) of a function or method, as a subfeature of the function itself. To record data about whether a specific parameter is supported by a function or method, use the following naming conventions:
 
-- For named parameters, use a subfeature named `paramname_parameter` with description text `<code>paramname</code> parameter`. Where _paramname_ is the name of the parameter as it appears on the corresponding function's MDN page (or specification, if no MDN page is available).
+- For named parameters, use a subfeature named `paramname_parameter` with description text ``\`paramname\` parameter``. Where _paramname_ is the name of the parameter as it appears on the corresponding function's MDN page (or specification, if no MDN page is available).
 
-  For example, to represent support for the `firstName` parameter of a method `hello(firstName, familyName)`, use a subfeature of `hello` named `firstName_parameter` with the description text `<code>firstName</code> parameter`.
+  For example, to represent support for the `firstName` parameter of a method `hello(firstName, familyName)`, use a subfeature of `hello` named `firstName_parameter` with the description text ``\`firstName\` parameter``.
 
 - For unnamed parameters, use a subfeature named `ordinal_parameter` with description text `ordinal parameter` where _ordinal_ is the ordinal number position of the parameter.
 
   For example, to represent support for the second parameter of a method `count()`, use a subfeature of `count` named `second_parameter` and description text `Second parameter`.
 
-- For properties of parameter objects, use a subfeature named `paramname_prop_parameter` with description text `<code>paramname.prop</code> parameter`, where _paramname_ is the name of the parameter object and _prop_ is the name of the property.
+- For properties of parameter objects, use a subfeature named `paramname_prop_parameter` with description text ``\`paramname.prop\` parameter``, where _paramname_ is the name of the parameter object and _prop_ is the name of the property.
 
-  For example, to represent support for the `year` property of the `date` parameter to a method `schedule(date)` (as in `schedule({"year": 1970 })`), use a subfeature of `schedule` named `date_year_parameter` with description text `<code>date.year</code> parameter`.
+  For example, to represent support for the `year` property of the `date` parameter to a method `schedule(date)` (as in `schedule({"year": 1970 })`), use a subfeature of `schedule` named `date_year_parameter` with description text ``\`date.year\` parameter``.
 
 For existing data which does not follow this guideline, you may modify it to conform with this data, if you are you otherwise updating the data (or data related to it).
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -87,7 +87,7 @@ Here is an example of a `__compat` statement, with all of the properties and the
       "fake_event": {
         // ↓↓↓↓↓↓
         "__compat": {
-          "description": "<code>fake</code> event", // A friendly description of the feature
+          "description": "`fake` event", // A friendly description of the feature
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fake_event", // The associated MDN article
           "spec_url": [
             // The spec URL(s) for the feature if applicable, may be one or many
@@ -119,7 +119,7 @@ Here is an example of a `__compat` statement, with all of the properties and the
               // Supported since IE 10, but has a caveat that impacts compatibility
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "The <code>onfake</code> event handler property is not supported.",
+              "notes": "The `onfake` event handler property is not supported.",
             },
             "oculus": "mirror",
             "opera": {
@@ -174,7 +174,7 @@ The `__compat` object consists of the following:
 - An optional `description` property to **describe the feature**.
   A string containing a human-readable description of the feature.
   It is intended to be used as a caption or title and should be kept short.
-  The `<code>`, `<kbd>`, `<em>`, and `<strong>` HTML elements may be used.
+  This property may be formatted using Markdown, see the rules for `notes`.
 
 - An automated `source_file` property containing the path to the source file containing the feature. This is used to create links to the repository source (in the form of `https://github.com/mdn/browser-compat-data/blob/main/<source_file>`). For example, `api.History.forward` will contain a `source_file` property of `api/History.json` since the feature is defined in that file.
 
@@ -430,7 +430,7 @@ An optional array of objects describing flags that must be configured for this b
   - `preference` a flag the user can set (like in `about:config` in Firefox).
   - `runtime_flag` a flag to be set before starting the browser.
 - `name` (mandatory): a string giving the value which the specified flag must be set to for this feature to work.
-- `value_to_set` (optional): representing the actual value to set the flag to. It is a string, that may be converted to the right type (that is `true` or `false` for Boolean value, or `4` for an integer value). It doesn't need to be enclosed in `<code>` tags.
+- `value_to_set` (optional): representing the actual value to set the flag to. It is a string, that may be converted to the right type (that is `true` or `false` for Boolean value, or `4` for an integer value). It doesn't need to be enclosed in backticks.
 
 Example for one flag required:
 
@@ -491,7 +491,7 @@ Example:
 }
 ```
 
-The `<code>`, `<kbd>`, `<em>`, and `<strong>` HTML elements may be used. In addition, `<a>` tags may be used, such as to link to a browser's bug report, or MDN documentation. Do not format `notes` as Markdown.
+Notes may be formatted in Markdown. Only links, bold, italics, codeblocks, and `<kbd>` may be used. Headers, tables and other Markdown features or HTML elements may not be used.
 
 #### `partial_implementation`
 

--- a/scripts/build/mirror.test.ts
+++ b/scripts/build/mirror.test.ts
@@ -143,7 +143,7 @@ describe('mirror', () => {
           chrome: {
             version_added: '65',
             notes: [
-              'Before Chrome 70, this method always returned <code>true</code> even if the webcam was not connected. Since version 70, this method correctly returns the webcam state.',
+              'Before Chrome 70, this method always returned `true` even if the webcam was not connected. Since version 70, this method correctly returns the webcam state.',
               'Google Chrome will always use the default webcam.',
             ],
           },
@@ -153,7 +153,7 @@ describe('mirror', () => {
         assert.deepEqual(mirrored, {
           version_added: '52',
           notes: [
-            'Before Opera 57, this method always returned <code>true</code> even if the webcam was not connected. Since version 57, this method correctly returns the webcam state.',
+            'Before Opera 57, this method always returned `true` even if the webcam was not connected. Since version 57, this method correctly returns the webcam state.',
             'Opera will always use the default webcam.',
           ],
         });


### PR DESCRIPTION
This PR updates the documentation to state that Markdown is now allowed within notes and descriptions.
