### PR TITLE
Remove an obsolete MathML feature

### DIFF
--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -34,41 +34,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "lquote_rquote_attributes": {
-          "__compat": {
-            "description": "Surround the content of the `&lt;ms&gt;` element with quotes, specifiable via the `lquote` and `rquote` attributes.",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "107"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
Silences this warning on `main`:

`✖ mathml.elements.ms.lquote_rquote_attributes - Warning → feature was implemented and has since been removed from all browsers dating back two or more years ago.`