### PR TITLE
Convert <em> in notes to Markdown

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2983,7 +2983,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "53",
-              "notes": "Starting in Firefox 68, the `auxclick` event is used to trigger the <em>new tab on middle-click</em> action; previously, this had been done with the `click` event. Apps can prevent middle-click from opening new tabs (or middle-click to paste, if that feature is enabled) by intercepting `auxclick` on links, and `auxclick` event handlers can now open popups without triggering the popup blocker."
+              "notes": "Starting in Firefox 68, the `auxclick` event is used to trigger the _new tab on middle-click_ action; previously, this had been done with the `click` event. Apps can prevent middle-click from opening new tabs (or middle-click to paste, if that feature is enabled) by intercepting `auxclick` on links, and `auxclick` event handlers can now open popups without triggering the popup blocker."
             },
             "firefox_android": {
               "version_added": "53"

--- a/api/Location.json
+++ b/api/Location.json
@@ -574,7 +574,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Before Edge 79, if a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling `reload()` from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
+              "notes": "Before Edge 79, if a page added to _Trusted Sites_ contains a cross-origin iframe, then calling `reload()` from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
             },
             "firefox": {
               "version_added": "1"
@@ -582,7 +582,7 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "5.5",
-              "notes": "If a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling `reload()` from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
+              "notes": "If a page added to _Trusted Sites_ contains a cross-origin iframe, then calling `reload()` from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
             },
             "oculus": "mirror",
             "opera": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -534,7 +534,7 @@
               "notes": [
                 "If you need this capability before version 36, refer to `navigator.mozGetUserMedia`, a prefixed form of the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'>`navigator.getUserMedia`</a> API.",
                 "Before Firefox 55, `getUserMedia()` incorrectly returns `NotSupportedError` when the list of constraints specified is empty, or has all constraints set to `false`. Starting in Firefox 55, this situation now correctly calls the failure handler with a `TypeError`.",
-                "When using the Firefox-specific `video` constraint called `mediaSource` to request display capture, Firefox 66 and later consider values of `screen` and `window` to both cause a list of screens <em>and</em> windows to be shown.",
+                "When using the Firefox-specific `video` constraint called `mediaSource` to request display capture, Firefox 66 and later consider values of `screen` and `window` to both cause a list of screens _and_ windows to be shown.",
                 "Starting in Firefox 66, `getUserMedia()` can no longer be used in sandboxed `&lt;iframe&gt;`s or `data` URLs entered in the address bar by the user."
               ]
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -789,7 +789,7 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4",
-              "notes": "`navigator.cookieEnabled` returns `true` even if the browser is set to block cookies (for example, if the page is in the <em>Restricted sites</em> security zone)."
+              "notes": "`navigator.cookieEnabled` returns `true` even if the browser is set to block cookies (for example, if the page is in the _Restricted sites_ security zone)."
             },
             "oculus": "mirror",
             "opera": {

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -130,7 +130,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "Firefox does not currently support the `auto` value and only accepts values in seconds or milliseconds. It's recommended that <em>1ms</em> is used until `auto` is supported."
+                "notes": "Firefox does not currently support the `auto` value and only accepts values in seconds or milliseconds. It's recommended that _1ms_ is used until `auto` is supported."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -52,7 +52,7 @@
               "chrome": {
                 "version_added": "≤83",
                 "partial_implementation": true,
-                "notes": "Overriding the initial value of the implicit `list-item` counter has <em>no</em> effect when the default marker string for list items (`::marker`) is generated; see <a href='https://crbug.com/338233131'>bug 338233131</a>."
+                "notes": "Overriding the initial value of the implicit `list-item` counter has _no_ effect when the default marker string for list items (`::marker`) is generated; see <a href='https://crbug.com/338233131'>bug 338233131</a>."
               },
               "chrome_android": "mirror",
               "edge": {
@@ -73,7 +73,7 @@
               "safari": {
                 "version_added": "≤13.1",
                 "partial_implementation": true,
-                "notes": "Overriding the initial value of the implicit `list-item` counter results in incorrect values for the `counter()` function used to generate content, as it is <em>not</em> fully implemented; see <a href='https://webkit.org/b/260436'>bug 260436</a>."
+                "notes": "Overriding the initial value of the implicit `list-item` counter results in incorrect values for the `counter()` function used to generate content, as it is _not_ fully implemented; see <a href='https://webkit.org/b/260436'>bug 260436</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -905,7 +905,7 @@
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "3",
-                "notes": "Internet Explorer 8 and later support gray color keywords spelled with an <em>e</em> (`grey`, `darkgrey`, `darkslategrey`, `dimgrey`, `lightgrey`, and `lightslategrey`). Internet Explorer 3 to Internet Explorer 7 only support the keywords spelled with <em>a</em> (`gray`, `darkgray`, `darkslategray`, `dimgray`, `lightgray`, and `lightslategray`)."
+                "notes": "Internet Explorer 8 and later support gray color keywords spelled with an _e_ (`grey`, `darkgrey`, `darkslategrey`, `dimgrey`, `lightgrey`, and `lightslategrey`). Internet Explorer 3 to Internet Explorer 7 only support the keywords spelled with _a_ (`gray`, `darkgray`, `darkslategray`, `dimgray`, `lightgray`, and `lightslategray`)."
               },
               "oculus": "mirror",
               "opera": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -129,7 +129,7 @@
               "firefox": {
                 "version_added": "1",
                 "notes": [
-                  "From Firefox 1 to Firefox 3, `ch` was the width of the <em>M</em> character.",
+                  "From Firefox 1 to Firefox 3, `ch` was the width of the _M_ character.",
                   "From Firefox 1 to Firefox 3, `ch` did not work with <a href='https://developer.mozilla.org/docs/Web/CSS/border-width'>`border-width`</a> and <a href='https://developer.mozilla.org/docs/Web/CSS/outline-width'>`outline-width`</a> CSS properties."
                 ]
               },

--- a/webextensions/manifest/chrome_url_overrides.json
+++ b/webextensions/manifest/chrome_url_overrides.json
@@ -95,11 +95,11 @@
               },
               "safari": {
                 "version_added": "14.1",
-                "notes": "An extension can define a custom new tab or window page, but it does not take effect until the user chooses the extension to override the page in Safari's <em>General</em> settings."
+                "notes": "An extension can define a custom new tab or window page, but it does not take effect until the user chooses the extension to override the page in Safari's _General_ settings."
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "An extension can define a custom new tab or window page, but it does not take effect until the user chooses the extension to override the page in Safari's <em>Extensions</em> settings."
+                "notes": "An extension can define a custom new tab or window page, but it does not take effect until the user chooses the extension to override the page in Safari's _Extensions_ settings."
               }
             }
           }


### PR DESCRIPTION
This PR converts the `<em>` blocks to underscores to use Markdown formatting.
