### PR TITLE
Remove linter rule for link styling

### DIFF
--- a/lint/linter/test-style.ts
+++ b/lint/linter/test-style.ts
@@ -98,16 +98,6 @@ const processData = (
       { fixable: true },
     );
   }
-
-  const hrefDoubleQuoteIndex = actual.indexOf('href=\\"');
-  if (hrefDoubleQuoteIndex >= 0) {
-    logger.error(
-      chalk`${indexToPos(
-        actual,
-        hrefDoubleQuoteIndex,
-      )} - Found {yellow \\"}, but expected {green \'} for <a href>.`,
-    );
-  }
 };
 
 export default {

--- a/lint/linter/test-style.ts
+++ b/lint/linter/test-style.ts
@@ -3,14 +3,7 @@
 
 import chalk from 'chalk-template';
 
-import {
-  Linter,
-  Logger,
-  LinterData,
-  IS_WINDOWS,
-  indexToPos,
-  jsonDiff,
-} from '../utils.js';
+import { Linter, Logger, LinterData, IS_WINDOWS, jsonDiff } from '../utils.js';
 import { orderSupportBlock } from '../fixer//browser-order.js';
 import { orderFeatures } from '../fixer//feature-order.js';
 import { orderStatements } from '../fixer//statement-order.js';


### PR DESCRIPTION
Now that we are using Markdown formatting, we do not need to enforce this particular styling rule.  This PR removes it accordingly.
