### PR TITLE
Remove redundant workaround in Markdown conversion

### DIFF
--- a/scripts/build/index.ts
+++ b/scripts/build/index.ts
@@ -54,13 +54,7 @@ export const generateMeta = (): any => ({
  */
 const mdToHtml = (markdown: string): string => {
   // "as string" cast because TS thinks response could be a promise
-  return (
-    marked.parseInline(
-      markdown
-        .replace(/(?<!<\w+ (href='[\w:;#&/=_().-]+')?>)<code>/g, '`')
-        .replace(/<\/code>(?!<\/\w+>)/g, '`'),
-    ) as string
-  )
+  return (marked.parseInline(markdown) as string)
     .replace(/&#39;/g, "'")
     .replace(/&quot;/g, '"')
     .replace(/&amp;([\w#]+);/g, '&$1;');


### PR DESCRIPTION
This PR removes a now-redundant workaround in the Markdown formatting.  There was a small bug in the Markdown converter where code blocks inside of anchor tags were misformatted, so some regex was used to mitigate the issue.  Now that we are using Markdown everywhere, this workaround is no longer needed.

Depends on #25110.
