### PR TITLE
fix(build/mirror): do not mirror browser name in url

### DIFF
--- a/scripts/build/mirror.test.ts
+++ b/scripts/build/mirror.test.ts
@@ -288,6 +288,23 @@ describe('mirror', () => {
         const mirrored = mirrorSupport('edge', support);
         assert.deepEqual(mirrored, { version_added: false });
       });
+
+      it('link with Chrome in hash', () => {
+        const support = {
+          chrome: {
+            version_added: '35',
+            notes:
+              '[Non-standard exceptions in Chrome](https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Chrome)',
+          },
+        };
+
+        const mirrored = mirrorSupport('chrome_android', support);
+        assert.deepEqual(mirrored, {
+          version_added: '35',
+          notes:
+            '[Non-standard exceptions in Chrome Android](https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Chrome)',
+        });
+      });
     });
   });
 });

--- a/scripts/build/mirror.ts
+++ b/scripts/build/mirror.ts
@@ -234,14 +234,13 @@ export const bumpSupport = (
   }
 
   if (sourceData.notes) {
+    const sourceBrowserName =
+      sourceBrowser === 'chrome'
+        ? '(Google )?Chrome'
+        : `(${browsers[sourceBrowser].name})`;
     const newNotes = updateNotes(
       sourceData.notes,
-      new RegExp(
-        sourceBrowser === 'chrome'
-          ? '(Google )?Chrome(?!OS)'
-          : `(${browsers[sourceBrowser].name})`,
-        'g',
-      ),
+      new RegExp(`\\b${sourceBrowserName}\\b`, 'g'),
       browsers[destination].name,
       (v: string) => getMatchingBrowserVersion(destination, v),
     );


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Use word boundaries to avoid the mirror script from replacing browser names in urls. 

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
