### PR TITLE
fix(workflows/release-pr): manage release PR as mdn-bot + ignore Dependabot commits

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   manage-release-pr:
-    if: github.repository == 'mdn/browser-compat-data'
+    if: github.repository == 'mdn/browser-compat-data' && github.actor != 'dependabot[bot]'
     name: Manage release PR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -12,10 +12,6 @@ env:
 concurrency:
   group: ${{ github.workflow }}
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   manage-release-pr:
     if: github.repository == 'mdn/browser-compat-data'


### PR DESCRIPTION
#### Summary

Manages release PRs as @mdn-bot, and ignores Dependabot commits.

This should resolve the issue that the checks are not running on release PRs.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Reverts https://github.com/mdn/browser-compat-data/pull/24935.
