### PR TITLE
FF133 HTMLMediaElement add onwaitingforkey event handler

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3569,9 +3569,17 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "52"
-            },
+            "firefox": [
+              {
+                "version_added": "133"
+              },
+              {
+                "version_added": "52",
+                "version_removed": "133",
+                "partial_implementation": true,
+                "notes": "`onwaitingforkey` content attribute not implemented."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF133 adds support for the `onwaitingforkey` content attribute in https://bugzilla.mozilla.org/show_bug.cgi?id=1925952

Verified using this test on browserstack FF132 and 133 - works on the later, stalls on the former for onwaitingforkey: https://wpt.live/encrypted-media/media-element-event-handler-attributes.html

I did this by marking the old event version as partial.

Related docs can be tracked in https://github.com/mdn/content/issues/36558