### PR TITLE
Tag remaining WebGPU keys

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -169,6 +169,9 @@
         "discrete_adapter_default_ac": {
           "__compat": {
             "description": "On AC power, discrete GPU returned if no `powerPreference` set.",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "115",

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -123,6 +123,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter/info",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapter-info",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "127",
@@ -368,6 +371,9 @@
         "lost_device_on_duplicate": {
           "__compat": {
             "description": "Lost `GPUDevice` returned on duplicate calls.",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "116"

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -546,6 +546,9 @@
         "unset_bind_group": {
           "__compat": {
             "description": "Pass `null` to unset bind group",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117",

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -1439,6 +1439,9 @@
         "videoframe_source": {
           "__compat": {
             "description": "`VideoFrame` object as source",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "116"

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -90,6 +90,9 @@
         "message_optional": {
           "__compat": {
             "description": "`message` parameter is optional",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "113"

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -121,6 +121,9 @@
         "htmlimageelement_imagedata_source": {
           "__compat": {
             "description": "`HTMLImageElement` and `ImageData` objects as `source`",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "118"
@@ -160,6 +163,9 @@
         "videoframe_source": {
           "__compat": {
             "description": "`VideoFrame` object as `source`",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "116"

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -655,6 +655,9 @@
         "unset_bind_group": {
           "__compat": {
             "description": "Pass `null` to unset bind group",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117",
@@ -875,6 +878,9 @@
         "unset_vertex_buffer": {
           "__compat": {
             "description": "Pass `null` to unset vertex buffer",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117",

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -843,6 +843,9 @@
         "unset_bind_group": {
           "__compat": {
             "description": "Pass `null` to unset bind group",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117",
@@ -1243,6 +1246,9 @@
         "unset_vertex_buffer": {
           "__compat": {
             "description": "Pass `null` to unset vertex buffer",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "117",


### PR DESCRIPTION
Some webgpu features were missing the tag. (we usually do this in web-features but it is easier to do it here for webgpu)