### PR TITLE
added :has-slotted pseudo-class

### DIFF
--- a/css/selectors/has-slotted.json
+++ b/css/selectors/has-slotted.json
@@ -1,0 +1,51 @@
+{
+  "css": {
+    "selectors": {
+      "has-slotted": {
+        "__compat": {
+          "description": "`:has-slotted`",
+          "spec_url": "https://drafts.csswg.org/css-scoping/#the-has-slotted-pseudo",
+          "tags": [
+            "web-features:slot"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.has-slotted-selector.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

- Added the :has-slotted CSS pseudo-class

#### Test results and supporting details

- Tested in Firefox beta/developer/nightly v133 with the flag `layout.css.has-slotted-selector.enabled`
- Not yet supported in other browsers

#### Related issues

- [Content PR]()
- [Firefox release notes PR]()