### PR TITLE
Remove svg.global_attributes.stop-color

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -2105,41 +2105,6 @@
           }
         }
       },
-      "stop-color": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-color",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty",
-          "support": {
-            "chrome": {
-              "version_added": "≤80"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "≤72"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "≤13.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "stroke": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`stop-color` is not a global attribute, it can only use on SVG `<stop>` elements

current data in https://github.com/mdn/browser-compat-data/blob/main/svg/elements/stop.json#L91-L133 has already covered this feature and is more detailed

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://svgwg.org/svg2-draft/pservers.html#StopColorProperty
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stop-color

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Relates to https://github.com/mdn/browser-compat-data/pull/25131
Relates to https://github.com/mdn/data/pull/782

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
