### PR TITLE
Add missing spec_url for svg `<stop>` element

### DIFF
--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -47,6 +47,7 @@
         },
         "offset": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopElementOffsetAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -90,6 +91,8 @@
         },
         "stop-color": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-color",
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Part of the https://github.com/mdn/browser-compat-data/issues/24162
Relates to https://github.com/mdn/browser-compat-data/pull/25130
Relates to https://github.com/mdn/data/pull/782

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
