### PR TITLE
Safari ignores ::highlight selector when combined with `user-select: none`

### DIFF
--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -30,7 +30,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "17.2",
-              "notes": "Cannot be used with `user-select: none`. See [bug 278455](https://webkit.org/b/278455)."
+              "notes": "The style is ignored when combined with `user-select: none`. See [bug 278455](https://webkit.org/b/278455)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -29,7 +29,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "17.2"
+              "version_added": "17.2",
+              "notes": "Cannot be used with `user-select: none`. See [bug 278455](https://webkit.org/b/278455)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds note for #25132

#### Test results and supporting details

Tested using MDN playground link in #25132

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
