### PR TITLE
Firefox recognizes Server-Timing header, but only partially supports Trailer headers (DevTools only)

### DIFF
--- a/http/headers/Server-Timing.json
+++ b/http/headers/Server-Timing.json
@@ -39,6 +39,43 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "trailer": {
+          "__compat": {
+            "description": "`Server-Timing` as HTTP trailer",
+            "support": {
+              "chrome": {
+                "version_added": "false"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "false"
+              },
+              "firefox": {
+                "version_added": "71",
+                "notes": "Only the `Server-Timing` header is a recognized trailer, and it is only exposed to DevTools in the network Timing tab ([bug 1403051](https://bugzil.la/1403051)). Developers cannot access trailers via the Fetch API or XHR."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "false"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "false"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/http/headers/Server-Timing.json
+++ b/http/headers/Server-Timing.json
@@ -45,7 +45,8 @@
             "description": "`Server-Timing` as HTTP trailer",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40811358"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/http/headers/Server-Timing.json
+++ b/http/headers/Server-Timing.json
@@ -45,25 +45,23 @@
             "description": "`Server-Timing` as HTTP trailer",
             "support": {
               "chrome": {
-                "version_added": "false"
+                "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "false"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "71",
                 "notes": "Only the `Server-Timing` header is a recognized trailer, and it is only exposed to DevTools in the network Timing tab ([bug 1403051](https://bugzil.la/1403051)). Developers cannot access trailers via the Fetch API or XHR."
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "false"
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "false"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/http/headers/Trailer.json
+++ b/http/headers/Trailer.json
@@ -10,12 +10,10 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "false"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "false"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "71",
               "partial_implementation": true,
@@ -23,13 +21,13 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "false"
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "false"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Trailer.json
+++ b/http/headers/Trailer.json
@@ -10,24 +10,26 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "false"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "false"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "71",
+              "partial_implementation": true,
+              "notes": "Only the `Server-Timing` header is a recognized trailer, and it is only exposed to DevTools in the network Timing tab ([bug 1403051](https://bugzil.la/1403051)). Developers cannot access trailers via the Fetch API or XHR."
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "≤11"
+              "version_added": "false"
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "1"
+              "version_added": "false"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

The support for HTTP Trailer header is misleading, as it's removed from the Fetch spec & not accessible there anyway / XHR. As far as I can see, the only support that exists in browsers is exclusively for `Server-Timing`, and at that, it's only used for DevTools in Network -> Timing, all other headers (as trailers) are a no-op / discarded. For this reason, I've set it to partial support for `Trailer`, and full support for Server-Timing header as trailer, which no other browser appears to do.

#### Test results and supporting details

- **Firefox** `Server-Timing` implementation bug -> https://bugzilla.mozilla.org/show_bug.cgi?id=1403051:
  - Networking aspect landed in Fx59 -> https://bugzilla.mozilla.org/show_bug.cgi?id=1413999
  - Exposed in DevTools in Fx71 -> https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/71#developer_tools
  - MDN docs issue -> https://github.com/mdn/sprints/issues/2277
  - Necko source for [handling of trailers](https://github.com/mozilla/gecko-dev/blob/2deb9bcf801f9de83d4f30c890d442072b9b6595/netwerk/protocol/http/nsHttpTransaction.cpp#L3095-L3143)

- **ChrBugs** -> https://issues.chromium.org/issues/40811358


Node repro:

```js
const http = require("http");
http
  .createServer((req, res) => {
    res.writeHead(200, {
      "Content-Type": "text/plain",
      "Transfer-Encoding": "chunked",
      // Server-Timing as header
      // "Server-Timing": "custom-metric;dur=567.123",
      Trailer: "Server-Timing",
    });
    res.write("Hello.\n");
    // Server-Timing as trailer
    // See https://nodejs.org/api/http.html#responseaddtrailersheaders
    res.addTrailers({
      "Server-Timing": "custom-metric;dur=666.123",
    });
    res.end();
  })
  .listen(3000, () => {
    console.log("Server running at http://localhost:3000");
  });
```

#### Related issues

- [ ] https://github.com/mdn/browser-compat-data/issues/24684
- [ ] https://github.com/mdn/browser-compat-data/issues/18441
- [ ] https://github.com/mdn/browser-compat-data/issues/14703
- [ ] https://github.com/mdn/content/issues/7137
