### PR TITLE
fix(workflows/labeler): grant "issues: write" permission

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 permissions:
   contents: read # to determine modified files
+  issues: write # pr-size-labeler uses the issues API until https://github.com/CodelyTV/pr-size-labeler/pull/89 is merged
   pull-requests: write # to add labels to PRs
 
 jobs:


### PR DESCRIPTION
#### Summary

The `label-by-size` job is failing silently, because it doesn't have the `issues: write` permission, which it needs, because `pr-size-labeler` currently uses the issues API (`PATCH issues/{id}`) rather than the issue label API (`POST issues/{id}/labels`).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Same PR in mdn/content:

- https://github.com/mdn/content/pull/31759

Upstream PR removing the dependency on that permission:

- https://github.com/CodelyTV/pr-size-labeler/pull/89
