### PR TITLE
chore(labels): remove emojis

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,6 +1,6 @@
 name: "Enhancement"
 description: An enhancement to BCD's infrastructure
-labels: ["enhancement :1st_place_medal:"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/issue-regex-labeler.yml
+++ b/.github/issue-regex-labeler.yml
@@ -1,30 +1,30 @@
-data:api :rabbit2::
+data:api:
   - 'api\.'
   - '\/docs\/Web\/API'
-data:css :art::
+data:css:
   - 'css\.'
   - '\/docs\/Web\/CSS'
-data:html :page_facing_up::
+data:html:
   - 'html\.'
   - '\/docs\/Web\/HTML'
-data:http :mountain_cableway::
+data:http:
   - 'http\.'
   - '\/docs\/Web\/HTTP'
-data:js :pager::
+data:js:
   - 'js\.'
   - '\/docs\/Web\/JavaScript'
-data:mathml :heavy_division_sign::
+data:mathml:
   - 'mathml\.'
   - '\/docs\/Web\/MathML'
-data:svg :paintbrush::
+data:svg:
   - 'svg\.'
   - '\/docs\/Web\/SVG'
-data:wasm :mechanical_arm::
+data:wasm:
   - 'webassembly\.'
   - '\/docs\/WebAssembly'
-data:webdriver :racing_car::
+data:webdriver:
   - 'webdriver\.'
   - '\/docs\/Web\/WebDriver'
-data:webext :game_die::
+data:webext:
   - 'webextensions\.'
   - '\/docs\/Mozilla\/Add-ons'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,62 +1,62 @@
 # This file is used by .github/workflows/labeler.yml to label pull requests based on the files changed in the PR.
 # Object matching syntax: https://github.com/actions/labeler/blob/main/README.md#match-object
-bulk_update :package::
+bulk_update:
   - changed-files:
       - any-glob-to-any-file:
           - "scripts/migrations/**"
-data:api :rabbit2::
+data:api:
   - changed-files:
       - any-glob-to-any-file:
           - "api/**"
-data:browsers :earth_africa::
+data:browsers:
   - changed-files:
       - any-glob-to-any-file:
           - "browsers/**"
-data:css :art::
+data:css:
   - changed-files:
       - any-glob-to-any-file:
           - "css/**"
-data:html :page_facing_up::
+data:html:
   - changed-files:
       - any-glob-to-any-file:
           - "html/**"
-data:http :mountain_cableway::
+data:http:
   - changed-files:
       - any-glob-to-any-file:
           - "http/**"
-data:js :pager::
+data:js:
   - changed-files:
       - any-glob-to-any-file:
           - "javascript/**"
-data:mathml :heavy_division_sign::
+data:mathml:
   - changed-files:
       - any-glob-to-any-file:
           - "mathml/**"
-data:svg :paintbrush::
+data:svg:
   - changed-files:
       - any-glob-to-any-file:
           - "svg/**"
-data:wasm :mechanical_arm::
+data:wasm:
   - changed-files:
       - any-glob-to-any-file:
           - "webassembly/**"
-data:webdriver :racing_car::
+data:webdriver:
   - changed-files:
       - any-glob-to-any-file:
           - "webdriver/**"
-data:webext :game_die::
+data:webext:
   - changed-files:
       - any-glob-to-any-file:
           - "webextensions/**"
-dependencies :chains::
+dependencies:
   - changed-files:
       - any-glob-to-any-file:
           - "package-lock.json"
-docs :writing_hand::
+docs:
   - changed-files:
       - any-glob-to-any-file:
           - "**/*.md"
-infra :building_construction::
+infra:
   - changed-files:
       - any-glob-to-any-file:
           - ".*"
@@ -69,15 +69,15 @@ infra :building_construction::
           - ".github/**"
           - ".husky/**"
           - ".vscode/**"
-linter :house_with_garden::
+linter:
   - changed-files:
       - any-glob-to-any-file:
           - "lint/**"
-scripts :scroll::
+scripts:
   - changed-files:
       - any-glob-to-any-file:
           - "scripts/**"
-schema :gear::
+schema:
   - changed-files:
       - any-glob-to-any-file:
           - "schemas/**"

--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: queengooborg/invalid-issue-closer@v1.4.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "invalid :no_entry_sign:"
+          labels: "invalid"
           comment: |
             This issue was automatically closed because the title was left as the default, and a summary was not added.
 

--- a/docs/issue-triage-checklist.md
+++ b/docs/issue-triage-checklist.md
@@ -69,6 +69,6 @@ After we've collected all of the required information, make a plan for what to d
 
   Or, if you're not sure what the next step is, ask for ideas, input, or help.
 
-- If applicable, **set labels seeking help**. Use the [_good first issue:100:_](https://github.com/mdn/browser-compat-data/labels/good%20first%20issue) or [_help wanted_](https://github.com/mdn/browser-compat-data/labels/help%20wanted) labels.
+- If applicable, **set labels seeking help**. Use the [_good first issue_](https://github.com/mdn/browser-compat-data/labels/good%20first%20issue) or [_help wanted_](https://github.com/mdn/browser-compat-data/labels/help%20wanted) labels.
 
 - **Thank the reporter.**

--- a/docs/issue-triage-checklist.md
+++ b/docs/issue-triage-checklist.md
@@ -6,11 +6,11 @@ Helping process and understand new issues is a great way to help the project. To
 
 Avoid wasting time on issues which are not relevant to the repository by closing them quickly.
 
-- **Is it obvious spam?** Close it without comment and label it [_spam :wastebasket:_](https://github.com/mdn/browser-compat-data/labels/spam%20%3Awastebasket%3A).
-- **Is the issue template wholly incomplete?** Close it and label it [_invalid :no_entry_sign:_](https://github.com/mdn/browser-compat-data/labels/invalid%20%3Ano_entry_sign%3A).
-- **Is the issue template largely incomplete?** Close it with a suggestion to reopen with more details and label it [_invalid :no_entry_sign:_](https://github.com/mdn/browser-compat-data/labels/invalid%20%3Ano_entry_sign%3A).
-- **Is the issue a duplicate of another issue?** Close it with a comment stating it is a duplicate, mentioning the original issue number, and label it [_duplicate :dancing_women:_](https://github.com/mdn/browser-compat-data/labels/duplicate%20%3Adancing_women%3A).
-- **Is the issue a request for web development or other unrelated help?** Close it with a brief explanation of what the repository is for and label it [_invalid :no_entry_sign:_](https://github.com/mdn/browser-compat-data/labels/invalid%20%3Ano_entry_sign%3A).
+- **Is it obvious spam?** Close it without comment and label it [_spam_](https://github.com/mdn/browser-compat-data/labels/spam).
+- **Is the issue template wholly incomplete?** Close it and label it [_invalid_](https://github.com/mdn/browser-compat-data/labels/invalid).
+- **Is the issue template largely incomplete?** Close it with a suggestion to reopen with more details and label it [_invalid_](https://github.com/mdn/browser-compat-data/labels/invalid).
+- **Is the issue a duplicate of another issue?** Close it with a comment stating it is a duplicate, mentioning the original issue number, and label it [_duplicate_](https://github.com/mdn/browser-compat-data/labels/duplicate).
+- **Is the issue a request for web development or other unrelated help?** Close it with a brief explanation of what the repository is for and label it [_invalid_](https://github.com/mdn/browser-compat-data/labels/invalid).
 
 ## Confirm the title, description, and metadata
 
@@ -39,7 +39,7 @@ Make sure the issue is connected to other relevant information.
 
   1. Copy any new information into the original issue.
   2. Comment to thank the reporter and link to the original issue.
-  3. Label the issue [_duplicate :dancing_women:_](https://github.com/mdn/browser-compat-data/labels/duplicate%20%3Adancing_women%3A).
+  3. Label the issue [_duplicate_](https://github.com/mdn/browser-compat-data/labels/duplicate).
   4. Close the issue.
 
 - **If there are related issues, link to them.** Comment or edit the issue description.
@@ -69,6 +69,6 @@ After we've collected all of the required information, make a plan for what to d
 
   Or, if you're not sure what the next step is, ask for ideas, input, or help.
 
-- If applicable, **set labels seeking help**. Use the [_good first issue:100:_](https://github.com/mdn/browser-compat-data/labels/good%20first%20issue%20%3A100%3A) or [_help wanted :sos:_](https://github.com/mdn/browser-compat-data/labels/help%20wanted%20%3Asos%3A) labels.
+- If applicable, **set labels seeking help**. Use the [_good first issue:100:_](https://github.com/mdn/browser-compat-data/labels/good%20first%20issue) or [_help wanted_](https://github.com/mdn/browser-compat-data/labels/help%20wanted) labels.
 
 - **Thank the reporter.**

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -2,7 +2,7 @@
 
 Some labels act as special-use flags. Use the following labels according to these guidelines.
 
-## not ready ⛔
+## not ready
 
 | Pulls | Issues | Blocker |
 | ----- | ------ | ------- |
@@ -14,7 +14,7 @@ Set this label on any issue or PR that cannot proceed without some additional ac
 
 For example, if a pull request cannot be merged without another issue being resolved first, then set the label and leave a comment linking to the blocking issue.
 
-## needs content update 📝
+## needs content update
 
 | Pulls | Issues | Blocker |
 | ----- | ------ | ------- |
@@ -32,7 +32,7 @@ When in doubt, set the label. Better to find that content changes are unnecessar
 
 Remove this label after a pull request, which makes the required content changes, has been opened. A content change in progress is sufficient to merge compat data changes.
 
-## semver-minor-bump ➕
+## semver-minor-bump
 
 | Pulls | Issues | Blocker |
 | ----- | ------ | ------- |
@@ -55,7 +55,7 @@ Do not set this label on a pull request when it:
 
 Remove this label upon committing a release note to a release note pull request (see [_Publishing a new version of `@mdn/browser-compat-data`_](./publishing.md#publishing-a-new-version-of-mdnbrowser-compat-data)).
 
-## semver-major-bump 🚨
+## semver-major-bump
 
 | Pulls | Issues | Blocker |
 | ----- | ------ | ------- |

--- a/scripts/release/semver-pulls.ts
+++ b/scripts/release/semver-pulls.ts
@@ -4,8 +4,8 @@
 import { queryPRs } from './utils.js';
 
 const releaseNotesLabels = {
-  major: 'semver-major-bump 🚨',
-  minor: 'semver-minor-bump ➕',
+  major: 'semver-major-bump',
+  minor: 'semver-minor-bump',
 };
 
 /**


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removes emojis from labels, as discussed in the BCD call on 2024-11-19.

#### Test results and supporting details

Removed:
- ` :[a-z0-9_]+:`
- `%20%3A[a-z0-9_]+%3A`
- ` [\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{1FB00}-\u{1FBFF}]` (selectively)

#### Related issues

⚠️ The merge of this PR needs to be coordinated with updating the labels.