### PR TITLE
Remove `webnn` tag from `MLContext.compute`

### DIFF
--- a/api/MLContext.json
+++ b/api/MLContext.json
@@ -51,9 +51,6 @@
       "compute": {
         "__compat": {
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlcontext-compute",
-          "tags": [
-            "web-features:webnn"
-          ],
           "support": {
             "chrome": {
               "version_added": "112",


### PR DESCRIPTION
#### Summary

This is deprecated and we don't yet have a way to handle deprecated keys in web-features.

#### Test results and supporting details

N/A

#### Related issues

Triggered by https://github.com/web-platform-dx/web-features/pull/2284#discussion_r1850289458