### PR TITLE
Add data points for rgb10a2uint format support

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -178,7 +178,7 @@
             "deprecated": false
           }
         },
-        "format_rgb10a2uint": {
+        "texture_rgb10a2uint": {
           "__compat": {
             "description": "<code>rgb10a2uint</code> texture format",
             "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
@@ -866,21 +866,17 @@
             }
           }
         },
-        "format_rgb10a2uint": {
+        "optional_entryPoint": {
           "__compat": {
-            "description": "<code>rgb10a2uint</code> texture format",
-            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
+            "description": "`entryPoint` properties are optional for determined default fragment and vertex shader entry points.",
             "tags": [
               "web-features:webgpu"
             ],
             "support": {
               "chrome": {
-                "version_added": "119",
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
-              },
-              "chrome_android": {
                 "version_added": "121"
               },
+              "chrome_android": "mirror",
               "deno": {
                 "version_added": false
               },
@@ -910,17 +906,21 @@
             }
           }
         },
-        "optional_entryPoint": {
+        "texture_rgb10a2uint": {
           "__compat": {
-            "description": "`entryPoint` properties are optional for determined default fragment and vertex shader entry points.",
+            "description": "<code>rgb10a2uint</code> texture format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
             "tags": [
               "web-features:webgpu"
             ],
             "support": {
               "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
                 "version_added": "121"
               },
-              "chrome_android": "mirror",
               "deno": {
                 "version_added": false
               },
@@ -1095,21 +1095,17 @@
             }
           }
         },
-        "format_rgb10a2uint": {
+        "optional_entryPoint": {
           "__compat": {
-            "description": "<code>rgb10a2uint</code> texture format",
-            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
+            "description": "`entryPoint` properties are optional for determined default fragment and vertex shader entry points.",
             "tags": [
               "web-features:webgpu"
             ],
             "support": {
               "chrome": {
-                "version_added": "119",
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
-              },
-              "chrome_android": {
                 "version_added": "121"
               },
+              "chrome_android": "mirror",
               "deno": {
                 "version_added": false
               },
@@ -1139,17 +1135,21 @@
             }
           }
         },
-        "optional_entryPoint": {
+        "texture_rgb10a2uint": {
           "__compat": {
-            "description": "`entryPoint` properties are optional for determined default fragment and vertex shader entry points.",
+            "description": "<code>rgb10a2uint</code> texture format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
             "tags": [
               "web-features:webgpu"
             ],
             "support": {
               "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
                 "version_added": "121"
               },
-              "chrome_android": "mirror",
               "deno": {
                 "version_added": false
               },
@@ -1400,7 +1400,7 @@
             "deprecated": false
           }
         },
-        "format_rgb10a2uint": {
+        "texture_rgb10a2uint": {
           "__compat": {
             "description": "<code>rgb10a2uint</code> texture format",
             "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -1095,6 +1095,50 @@
             }
           }
         },
+        "format_rgb10a2uint": {
+          "__compat": {
+            "description": "<code>rgb10a2uint</code> texture format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "optional_entryPoint": {
           "__compat": {
             "description": "`entryPoint` properties are optional for determined default fragment and vertex shader entry points.",

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -177,6 +177,50 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "format_rgb10a2uint": {
+          "__compat": {
+            "description": "<code>rgb10a2uint</code> texture format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createBuffer": {
@@ -822,6 +866,50 @@
             }
           }
         },
+        "format_rgb10a2uint": {
+          "__compat": {
+            "description": "<code>rgb10a2uint</code> texture format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "optional_entryPoint": {
           "__compat": {
             "description": "`entryPoint` properties are optional for determined default fragment and vertex shader entry points.",
@@ -1266,6 +1354,50 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "format_rgb10a2uint": {
+          "__compat": {
+            "description": "<code>rgb10a2uint</code> texture format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -118,7 +118,7 @@
             "deprecated": false
           }
         },
-        "format_rgb10a2uint": {
+        "texture_rgb10a2uint": {
           "__compat": {
             "description": "<code>rgb10a2uint</code> texture format",
             "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
@@ -402,7 +402,7 @@
             "deprecated": false
           }
         },
-        "format_rgb10a2uint": {
+        "texture_rgb10a2uint": {
           "__compat": {
             "description": "<code>rgb10a2uint</code> texture format",
             "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -117,6 +117,50 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "format_rgb10a2uint": {
+          "__compat": {
+            "description": "<code>rgb10a2uint</code> texture format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "depthOrArrayLayers": {
@@ -356,6 +400,50 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "format_rgb10a2uint": {
+          "__compat": {
+            "description": "<code>rgb10a2uint</code> texture format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureformat-rgb10a2uint",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 119 (Android 121) supports the `rgb10a2uint` texture format: see https://developer.chrome.com/blog/new-in-webgpu-119#rgb10a2uint_texture_format.

I have added a sub-data point in all places where `GPUTextureFormat` is used.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Spec PR: https://github.com/gpuweb/gpuweb/pull/4245

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Project issue: https://github.com/mdn/content/issues/36372

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
