### PR TITLE
Add missing spec_url for svg `<linearGradient>` & `<radialGradient>` elements

### DIFF
--- a/svg/elements/linearGradient.json
+++ b/svg/elements/linearGradient.json
@@ -46,7 +46,7 @@
         "gradientTransform": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/gradientTransform",
-            "spec_url":  "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientTransformAttribute",
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientTransformAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/svg/elements/linearGradient.json
+++ b/svg/elements/linearGradient.json
@@ -46,11 +46,7 @@
         "gradientTransform": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/gradientTransform",
-            "spec_url": [
-              "https://drafts.csswg.org/css-transforms/#typedef-transform-list",
-              "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientTransformAttribute",
-              "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementGradientTransformAttribute"
-            ],
+            "spec_url":  "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientTransformAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -84,6 +80,7 @@
         },
         "gradientUnits": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientUnitsAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -154,10 +151,7 @@
         "spreadMethod": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/spreadMethod",
-            "spec_url": [
-              "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementSpreadMethodAttribute",
-              "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementSpreadMethodAttribute"
-            ],
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementSpreadMethodAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -191,6 +185,7 @@
         },
         "x1": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementX1Attribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -224,6 +219,7 @@
         },
         "x2": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementX2Attribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -258,6 +254,7 @@
         "xlink_href": {
           "__compat": {
             "description": "`xlink:href`",
+            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkHrefAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -291,6 +288,7 @@
         },
         "y1": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementY1Attribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -324,6 +322,7 @@
         },
         "y2": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementY2Attribute",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/svg/elements/radialGradient.json
+++ b/svg/elements/radialGradient.json
@@ -45,6 +45,7 @@
         },
         "cx": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCXAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -78,6 +79,7 @@
         },
         "cy": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCYAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -216,6 +218,7 @@
         },
         "gradientTransform": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementGradientTransformAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -249,6 +252,7 @@
         },
         "gradientUnits": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementGradientUnitsAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -318,6 +322,7 @@
         },
         "r": {
           "__compat": {
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementRAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -352,10 +357,7 @@
         "spreadMethod": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/spreadMethod",
-            "spec_url": [
-              "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementSpreadMethodAttribute",
-              "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementSpreadMethodAttribute"
-            ],
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementSpreadMethodAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -390,6 +392,7 @@
         "xlink_href": {
           "__compat": {
             "description": "`xlink:href`",
+            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkHrefAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

part of the https://github.com/mdn/browser-compat-data/issues/24162

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
