### PR TITLE
Mark `api.Document.createEvent` as deprecated

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1892,7 +1892,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mark `api.Document.createEvent` as deprecated.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

The spec has [a note](https://dom.spec.whatwg.org/#ref-for-concept-event%E2%91%A4%E2%91%A3) that cautions developers against using the API:

> Event constructors ought to be used instead.

[MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent) also has a warning advising against using the API.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://github.com/web-platform-dx/web-features/pull/2277

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
