### PR TITLE
Chrome 119 (Android 121) supports the unorm10-10-10-2 vertex format

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -902,6 +902,50 @@
               "deprecated": false
             }
           }
+        },
+        "vertex_unorm10-10-10-2": {
+          "__compat": {
+            "description": "<code>unorm10-10-10-2</code> vertex format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuvertexformat-unorm10-10-10-2",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createRenderPipelineAsync": {
@@ -1059,6 +1103,50 @@
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "vertex_unorm10-10-10-2": {
+          "__compat": {
+            "description": "<code>unorm10-10-10-2</code> vertex format",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuvertexformat-unorm10-10-10-2",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
               "deno": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 119 (Android 121) supports the `unorm10-10-10-2` vertex format: see https://developer.chrome.com/blog/new-in-webgpu-119#unorm10-10-10-2_vertex_format.

I have added a sub-data point in all places where `GPUVertexFormat` is used.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Spec PR: https://github.com/gpuweb/gpuweb/pull/4288

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Project issue: https://github.com/mdn/content/issues/36373

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
