### PR TITLE
Chrome 121 supports display-p3 color space for GPUDevice.importExternalTexture()

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -1436,6 +1436,49 @@
             "deprecated": false
           }
         },
+        "color_space_display-p3": {
+          "__compat": {
+            "description": "<code>display-p3</code> color space",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "121",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "videoframe_source": {
           "__compat": {
             "description": "`VideoFrame` object as source",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 121 supports the `display-p3` color space for [`GPUDevice.importExternalTexture()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/importExternalTexture) - see https://developer.chrome.com/blog/new-in-webgpu-121#support_display-p3_as_gpuexternaltexture_color_space

This PR adds a data point for it.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Project issue: https://github.com/mdn/content/issues/36353.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
