### PR TITLE
Add datapoints for optional depthCompare and depthWriteEnabled properties

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -822,6 +822,48 @@
             }
           }
         },
+        "optional_depthcompare_depthwriteenabled": {
+          "__compat": {
+            "description": "`depthCompare` and `depthWriteEnabled` properties are optional when not needed (for example, formats without depth).",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": {
+                "version_added": "121"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "optional_entryPoint": {
           "__compat": {
             "description": "`entryPoint` properties are optional for determined default fragment and vertex shader entry points.",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In Chrome 120, the `depthCompare` and `depthWriteEnabled` properties of the [`createRenderPipeline`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createRenderPipeline)/[`createRenderPipelineAsync`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createRenderPipelineAsync) descriptors have been made optional when not needed. See https://developer.chrome.com/blog/new-in-webgpu-120#changes_to_depth-stencil_state.

This PR adds a datapoint for this, for each method.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Project issue: https://github.com/mdn/content/issues/36370

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
