### PR TITLE
Mark api.PaintRenderingContext2D.filter as non-standard

### DIFF
--- a/api/PaintRenderingContext2D.json
+++ b/api/PaintRenderingContext2D.json
@@ -390,7 +390,6 @@
       "filter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/filter",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-filter-dev",
           "support": {
             "chrome": {
               "version_added": "65"
@@ -417,7 +416,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the `filter` property is defined via `CanvasFilters` mixin, but `PaintRenderingContext2D` didn't include this mixin, meaning the `PaintRenderingContext2D.filter` property is non-standard

see https://drafts.css-houdini.org/css-paint-api/#paintrenderingcontext2d and https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters

note that chromium has shipped this feature, see https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/modules/csspaint/paint_rendering_context_2d.idl#L33

the `PaintRenderingContext2D.filter` property's definition is still under discussion, see https://github.com/w3c/css-houdini-drafts/issues/1056, https://github.com/w3c/css-houdini-drafts/issues/1022, https://github.com/w3c/css-houdini-drafts/issues/398

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25098
Document update at https://github.com/mdn/content/pull/36830

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
