### PR TITLE
Bug-1496075 Missed search_provider object properties

### DIFF
--- a/webextensions/manifest/chrome_settings_overrides.json
+++ b/webextensions/manifest/chrome_settings_overrides.json
@@ -334,6 +334,27 @@
               }
             }
           },
+          "search_url_get_params": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "search_url_post_params": {
             "__compat": {
               "support": {
@@ -373,6 +394,27 @@
                 "opera": {
                   "version_added": false
                 },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "suggest_url_get_params": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },


### PR DESCRIPTION
#### Summary

The manifest key [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) `search_provider` object properties `search_url_get_params` and `suggest_url_get_params` were added in [Bug 1496075](https://bugzilla.mozilla.org/show_bug.cgi?id=1496075) Support loading search extensions on startup but omitted from the BCD

#### Test results and supporting details

See https://hg.mozilla.org/mozilla-central/rev/7efb082cc25d#l3.30

#### Related issues

MDN content changes in TBC
