### PR TITLE
Chrome 123 supports packed_4x8_integer_dot_product extension in WGSL

### DIFF
--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "edge": "mirror",
           "firefox": {
@@ -51,7 +51,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -79,6 +79,44 @@
           }
         }
       },
+      "extension_packed_4x8_integer_dot_product": {
+        "__compat": {
+          "description": "<code>packed_4x8_integer_dot_product</code> extension",
+          "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-packed_4x8_integer_dot_product",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "forEach": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
@@ -90,7 +128,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -129,7 +167,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -168,7 +206,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -207,7 +245,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -246,7 +284,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -286,7 +324,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 123 supports the `readonly_and_readwrite_storage_textures` language extension (see [`WGSLLanguageFeatures`](https://developer.mozilla.org/en-US/docs/Web/API/WGSLLanguageFeatures)), which allows:

- 32-bit integer scalars packing 4-component vectors of 8-bit integers to be used as inputs to dot product instructions
- and packing and unpacking instructions with packed 4-component vectors of 8-bit integers to be used

In your WGSL shader code.

This PR adds a data point for the language extension.

See https://developer.chrome.com/blog/new-in-webgpu-123#dp4a_built-in_functions_support_in_wgsl for the data source.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Project issue: https://github.com/mdn/content/issues/36349

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
