### PR TITLE
Chrome 123 supports unrestricted_pointer_parameters extension in WGSL

### DIFF
--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -48,7 +48,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "115",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -88,7 +89,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "123",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -125,7 +127,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "115",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -164,7 +167,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "115",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -203,7 +207,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "115",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -242,7 +247,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "115",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -281,7 +287,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "115",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -321,7 +328,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "115",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -13,7 +13,7 @@
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "edge": "mirror",
           "firefox": {
@@ -51,7 +51,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -79,6 +79,44 @@
           }
         }
       },
+      "extension_unrestricted_pointer_parameters": {
+        "__compat": {
+          "description": "<code>unrestricted_pointer_parameters</code> extension",
+          "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-unrestricted_pointer_parameters",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "forEach": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
@@ -90,7 +128,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -129,7 +167,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -168,7 +206,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -207,7 +245,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -246,7 +284,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {
@@ -286,7 +324,7 @@
               "version_added": "115"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 123 supports the `unrestricted_pointer_parameters` language extension (see [`WGSLLanguageFeatures`](https://developer.mozilla.org/en-US/docs/Web/API/WGSLLanguageFeatures)), which loosens restrictions on pointers being passed to WGSL functions as follows:

- Parameter pointers to storage, uniform, and workgroup address spaces being passed to user-declared functions.
- Pointers to structure members and array elements being passed to user-declared functions.

This PR adds a data point for the language extension.

See https://developer.chrome.com/blog/new-in-webgpu-123#unrestricted_pointer_parameters_in_wgsl for the data source.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Spec PR: https://github.com/gpuweb/gpuweb/pull/4312

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Project issue: https://github.com/mdn/content/issues/36350

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
