### PR TITLE
Chrome 124/130 support new DocumentPictureInPicture.requestWindow() options

### DIFF
--- a/api/DocumentPictureInPicture.json
+++ b/api/DocumentPictureInPicture.json
@@ -118,6 +118,86 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "option_disallowReturnToOpener": {
+          "__compat": {
+            "description": "`disallowReturnToOpener` option",
+            "spec_url": "https://wicg.github.io/document-picture-in-picture/#dom-documentpictureinpictureoptions-disallowreturntoopener",
+            "tags": [
+              "web-features:document-picture-in-picture"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "124"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "option_preferInitialWindowPlacement": {
+          "__compat": {
+            "description": "`preferInitialWindowPlacement` option",
+            "spec_url": "https://wicg.github.io/document-picture-in-picture/#dom-documentpictureinpictureoptions-preferinitialwindowplacement",
+            "tags": [
+              "web-features:document-picture-in-picture"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "window": {


### PR DESCRIPTION
…indow()

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds data points for two new options available to the [`DocumentPictureInPicture.requestWindow()`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentPictureInPicture/requestWindow) method:

- Chrome 124 adds the `disallowReturnToOpener` option. When set to `true`, it hides the "back to tab" button that by default appears in the top bar of the PIP window. See https://chromestatus.com/feature/6223347936657408.
- Chrome 130 adds the `preferInitialWindowPlacement` option. When set to `true`, it causes the PIP window to always appear back at its default initial position and size when closed and then reopened. By default, it will reopen at its previous position and size. See https://chromestatus.com/feature/5183881532932096.

I've tested that both features work in the latest Chrome, but I've not tested exact versions in detail.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
