### PR TITLE
Add descriptions to MathML attribute values

### DIFF
--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -72,6 +72,7 @@
           },
           "toggle": {
             "__compat": {
+              "description": "`actiontype=\"toggle\"`",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -68,6 +68,7 @@
           },
           "actuarial": {
             "__compat": {
+              "description": "`notation=\"actuarial\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -101,6 +102,7 @@
           },
           "bottom": {
             "__compat": {
+              "description": "`notation=\"bottom\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -134,6 +136,7 @@
           },
           "box": {
             "__compat": {
+              "description": "`notation=\"box\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -167,6 +170,7 @@
           },
           "circle": {
             "__compat": {
+              "description": "`notation=\"circle\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -200,6 +204,7 @@
           },
           "downdiagonalstrike": {
             "__compat": {
+              "description": "`notation=\"downdiagonalstrike\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -233,6 +238,7 @@
           },
           "horizontalstrike": {
             "__compat": {
+              "description": "`notation=\"horizontalstrike\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -266,6 +272,7 @@
           },
           "left": {
             "__compat": {
+              "description": "`notation=\"left\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -299,6 +306,7 @@
           },
           "longdiv": {
             "__compat": {
+              "description": "`notation=\"longdiv\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -332,6 +340,7 @@
           },
           "madruwb": {
             "__compat": {
+              "description": "`notation=\"madruwb\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -365,6 +374,7 @@
           },
           "phasorangle": {
             "__compat": {
+              "description": "`notation=\"phasorangle\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -398,6 +408,7 @@
           },
           "right": {
             "__compat": {
+              "description": "`notation=\"right\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -431,6 +442,7 @@
           },
           "roundedbox": {
             "__compat": {
+              "description": "`notation=\"roundedbox\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -464,6 +476,7 @@
           },
           "top": {
             "__compat": {
+              "description": "`notation=\"top\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -497,6 +510,7 @@
           },
           "updiagonalarrow": {
             "__compat": {
+              "description": "`notation=\"updiagonalarrow\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -530,6 +544,7 @@
           },
           "updiagonalstrike": {
             "__compat": {
+              "description": "`notation=\"updiagonalstrike\"`",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -563,6 +578,7 @@
           },
           "verticalstrike": {
             "__compat": {
+              "description": "`notation=\"verticalstrike\"`",
               "support": {
                 "chrome": {
                   "version_added": false


### PR DESCRIPTION
#### Summary

Without description, BCD tables on MDN render attribute values as `attribute.value`, which is unexpected in the markup language context.

<img width="668" alt="image" src="https://github.com/user-attachments/assets/a221df89-8064-40d4-ad2c-926df7a8197d">

Once merged and released, this should change to what, for example, does `<iframe>`:

<img width="677" alt="image" src="https://github.com/user-attachments/assets/51a849dc-f040-4036-9bec-0c3cb8451d5f">

I expect it might be as well fixed on the MDN side, so here’s a decision to make.