### PR TITLE
fix(workflows/release-pr): use token for checkout

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -35,7 +36,6 @@ jobs:
 
       - name: "Setup git"
         run: |
-          git remote set-url origin https://mdn-bot:$GH_TOKEN@github.com/${{ github.repository }}.git
           git config user.email 108879845+mdn-bot@users.noreply.github.com
           git config user.name mdn-bot
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Uses checkout with `token` instead of manually setting the remote url.

(This seems to already work for the `update-mdn-urls` workflow, so I'm somewhat hopeful it also works here, so that the checks finally run on the release PR.)

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
