### PR TITLE
Firefox 133 unshipped `Document.caretPositionFromPoint` shadow root behaviour

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -927,9 +927,15 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "131"
-              },
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "131"
+                  "version_removed": "133"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -932,7 +932,7 @@
                   "version_added": "preview"
                 },
                 {
-                  "version_added": "131"
+                  "version_added": "131",
                   "version_removed": "133"
                 }
               ],


### PR DESCRIPTION
FF133 rolls back the shadow mode behaviour on Document.caretPositionFromPoint that was added as a parameter option in FF133 in #24405 (and originally documented in https://github.com/mdn/content/issues/35702).

The option is now behind a pref that is set to be enabled in nightly/preview, as per https://bugzilla.mozilla.org/show_bug.cgi?id=1914596#c8