### PR TITLE
fix(typos): 'retured' -> 'returned' and CSS 'propery'

### DIFF
--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -117,7 +117,7 @@
             "firefox": {
               "version_added": "1.5",
               "notes": [
-                "Before Firefox 128, the `getBBox()` method retured an empty `DOMRect` when there is no fill ([bug 1019326](https://bugzil.la/1019326)).",
+                "Before Firefox 128, the `getBBox()` method returned an empty `DOMRect` when there is no fill ([bug 1019326](https://bugzil.la/1019326)).",
                 "Before Firefox 68, this method didn't work for `&lt;textPath&gt;` and `&lt;tspan&gt;` elements ([bug 937268](https://bugzil.la/937268))."
               ]
             },

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -11,7 +11,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "The propery is recognized, but has no effect."
+              "notes": "The property is recognized, but has no effect."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -48,7 +48,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "The propery is recognized, but has no effect."
+                "notes": "The property is recognized, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -86,7 +86,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "The propery is recognized, but has no effect."
+                "notes": "The property is recognized, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -124,7 +124,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "The propery is recognized, but has no effect."
+                "notes": "The property is recognized, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
#### Summary

Some small typos I found while working on related docs.
