### PR TITLE
Update Color relative syntax support

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -148,11 +148,16 @@
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
-                "safari": {
-                  "version_added": "16.4",
-                  "partial_implementation": true,
-                  "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified as percentages with units (`%`)."
-                },
+                "safari": [
+                  {
+                    "version_added": "18"
+                  },
+                  {
+                    "version_added": "16.4",
+                    "partial_implementation": true,
+                    "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified as percentages with units (`%`)."
+                  }
+                ],
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
@@ -439,11 +444,16 @@
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
-                "safari": {
-                  "version_added": "16.4",
-                  "partial_implementation": true,
-                  "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified with units (`deg` for `h`, `%` for `s` and `l`)."
-                },
+                "safari": [
+                  {
+                    "version_added": "18"
+                  },
+                  {
+                    "version_added": "16.4",
+                    "partial_implementation": true,
+                    "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified with units (`deg` for `h`, `%` for `s` and `l`)."
+                  }
+                ],
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
@@ -594,11 +604,16 @@
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
-                "safari": {
-                  "version_added": "16.4",
-                  "partial_implementation": true,
-                  "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified with units (`deg` for `h`, `%` for `w` and `b`)."
-                },
+                "safari": [
+                  {
+                    "version_added": "18"
+                  },
+                  {
+                    "version_added": "16.4",
+                    "partial_implementation": true,
+                    "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified with units (`deg` for `h`, `%` for `w` and `b`)."
+                  }
+                ],
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
@@ -824,11 +839,16 @@
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
-                "safari": {
-                  "version_added": "16.4",
-                  "partial_implementation": true,
-                  "notes": "Implementation based on older spec version. As a result, calculations with `h` channel values do not work correctly, requiring values to be specified with units (`deg`)."
-                },
+                "safari": [
+                  {
+                    "version_added": "18"
+                  },
+                  {
+                    "version_added": "16.4",
+                    "partial_implementation": true,
+                    "notes": "Implementation based on older spec version. As a result, calculations with `h` channel values do not work correctly, requiring values to be specified with units (`deg`)."
+                  }
+                ],
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
@@ -1229,11 +1249,16 @@
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
-                "safari": {
-                  "version_added": "16.4",
-                  "partial_implementation": true,
-                  "notes": "Implementation based on older spec version. As a result, calculations with `h` channel values do not work correctly, requiring values to be specified with units (`deg`)."
-                },
+                "safari": [
+                  {
+                    "version_added": "18"
+                  },
+                  {
+                    "version_added": "16.4",
+                    "partial_implementation": true,
+                    "notes": "Implementation based on older spec version. As a result, calculations with `h` channel values do not work correctly, requiring values to be specified with units (`deg`)."
+                  }
+                ],
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
@@ -1434,11 +1459,16 @@
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
-                "safari": {
-                  "version_added": "16.4",
-                  "partial_implementation": true,
-                  "notes": "Implementation based on older spec version. As a result, channel value calculations do not work correctly, requiring values to be specified as percentages with units (e.g. 30%, which would be equivalent to a 76.5 `&lt;number&gt;` value). See [bug 267647](https://webkit.org/b/267647)."
-                },
+                "safari": [
+                  {
+                    "version_added": "18"
+                  },
+                  {
+                    "version_added": "16.4",
+                    "partial_implementation": true,
+                    "notes": "Implementation based on older spec version. As a result, channel value calculations do not work correctly, requiring values to be specified as percentages with units (e.g. 30%, which would be equivalent to a 76.5 `&lt;number&gt;` value). See [bug 267647](https://webkit.org/b/267647)."
+                  }
+                ],
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -427,11 +427,16 @@
                 "web-features:relative-color"
               ],
               "support": {
-                "chrome": {
-                  "version_added": "119",
-                  "partial_implementation": true,
-                  "notes": "`s` and `l` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `s` and `l` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%)."
-                },
+                "chrome": [
+                  {
+                    "version_added": "125"
+                  },
+                  {
+                    "version_added": "119",
+                    "partial_implementation": true,
+                    "notes": "`s` and `l` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `s` and `l` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%)."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
@@ -587,11 +592,16 @@
                 "web-features:relative-color"
               ],
               "support": {
-                "chrome": {
-                  "version_added": "119",
-                  "partial_implementation": true,
-                  "notes": "`w` and `b` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `w` and `b` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%)."
-                },
+                "chrome": [
+                  {
+                    "version_added": "125"
+                  },
+                  {
+                    "version_added": "119",
+                    "partial_implementation": true,
+                    "notes": "`w` and `b` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `w` and `b` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%)."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

Adds full support for relative_syntax in:

- HSL & HWB- Chrome 125
- HSL, HWB, LCH, OKLch, RGB, color()- Safari 18.

#### Test results and supporting details

Codepen- https://codepen.io/jamessw/pen/WNVXMLR

#### Related issues

Fixes #24528, Fixes #22961


