### PR TITLE
Add Safari support for contentvisibilityautostatechange event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4231,7 +4231,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari 18 seems to now support the contentvisibilityautostatechange event on Element.

#### Test results and supporting details

**WPT**
Safari 17.6- https://wpt.fyi/results/css/css-contain/content-visibility/content-visibility-auto-state-changed.html?label=master&label=stable&product=safari-17.6%20(19618.3.11.11.5)&aligned
Safari 18.0- https://wpt.fyi/results/css/css-contain/content-visibility/content-visibility-auto-state-changed.html?label=master&label=stable&product=safari-18.0%20(20619.1.26.31.6)&aligned

Reproduction (thanks to @vwallen). Tested on Safari 17 and Safari 18.1.1
https://codepen.io/jamessw/pen/QWeeaGw?editors=1111


