### PR TITLE
Remove unimplement css.types.image.image

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -2024,43 +2024,6 @@
             }
           }
         },
-        "image": {
-          "__compat": {
-            "description": "`image()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image",
-            "spec_url": "https://drafts.csswg.org/css-images-4/#image-notation",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "notes": "See [bug 703217](https://bugzil.la/703217)."
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "image-set": {
           "__compat": {
             "description": "`image-set()`",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

no implement by any browser, the only bug seems to be not active for a very long time

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
