### PR TITLE
Add note re. setting valueAsDate using Date object

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2913,7 +2913,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/input.html#dom-input-valueasdate-dev",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "5",
+              "notes": "Chrome doesn't allow setting this property using a `Date` object. See [bug 380321442](https://crbug.com/380321442)."
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
#### Summary

Chrome doesn't allow setting the `valueAsDate` property on an input of type `datetime-local` using a `Date` object.

#### Test results and supporting details

See [bug 380321442](https://crbug.com/380321442).