### PR TITLE
Firefox Nightly supports Intl.DurationFormat

### DIFF
--- a/javascript/builtins/Intl/DurationFormat.json
+++ b/javascript/builtins/Intl/DurationFormat.json
@@ -19,7 +19,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -63,7 +63,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -107,7 +107,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -151,7 +151,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -195,7 +195,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
FF134 adds support for [`Intl.DurationFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat) in Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1648139#c19. (note, it is not obvious it is nightly, but that link confirms it with developer.

This updates the FF versions to "preview"

Related docs work can be tracked in https://github.com/mdn/content/issues/36917

