### PR TITLE
FF134 HTML autocorrect attribute in Nightly

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -299,7 +299,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -127,7 +127,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF134 adds support for the HTML [`autocorrect`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocorrect) attribute and [`HTMLElement.autocorrect)`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/autocorrect) property in https://bugzilla.mozilla.org/show_bug.cgi?id=1725806#c19 

This is behind the preference `dom.forms.autocorrect` that is enabled in nightly.

This updates the relevant subfeatures with "preview"

Related docs work can be tracked in https://github.com/mdn/content/issues/36919