### PR TITLE
FF134 AudioParam.value note plus chrome note

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -517,7 +517,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Before version 64, the gain value of a `GainNode` would perform a smooth interpolation to prevent dezippering (instead of changing instantly)."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -525,7 +526,10 @@
             },
             "firefox": {
               "version_added": "25",
-              "notes": "Before Firefox 69, `value` did not take into account scheduled or gradiated changes to the parameter's value; instead, only explicitly set values were returned."
+              "notes": [
+                "Before Firefox 134, setting `value` was ignored when done at the same time as scheduled automation events.",
+                "Before Firefox 69, `value` did not take into account scheduled or gradiated changes to the parameter's value; instead, only explicitly set values were returned."
+              ]
             },
             "firefox_android": {
               "version_added": "25",


### PR DESCRIPTION
FF134 brings [`AudioParam.value`](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/value) to spec compliance by always setting it to the defaultValue, rather than ignoring the setter if there happens to be a scheduled event when the setter is called, in https://bugzilla.mozilla.org/show_bug.cgi?id=1308435

The spec change  is here https://github.com/webaudio/web-audio-api/commit/73c2b88d1496953137185debb28c0ae6ef80edc7#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R2889

According to the issue it breaks a lot of tests but is unlikely to break much real code.

Anyway, this adds a note to the FF release, It also adds a compat note to the Chrome release that was pulled out of the docs. 

Related docs work can be tracked in https://github.com/mdn/content/issues/36916