### PR TITLE
Chrome 115 added HTMLFencedFrameElement.sandbox

### DIFF
--- a/api/Fence.json
+++ b/api/Fence.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "117"
+            "version_added": "115"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -46,7 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -84,7 +84,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -122,7 +122,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/FencedFrameConfig.json
+++ b/api/FencedFrameConfig.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "117"
+            "version_added": "115"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -46,7 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLFencedFrameElement.json
+++ b/api/HTMLFencedFrameElement.json
@@ -151,6 +151,43 @@
           }
         }
       },
+      "sandbox": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/fenced-frame/#element-attrdef-fencedframe-sandbox",
+          "tags": [
+            "web-features:fencedframe"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "117"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFencedFrameElement/width",

--- a/api/HTMLFencedFrameElement.json
+++ b/api/HTMLFencedFrameElement.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "117"
+            "version_added": "115"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -46,7 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -84,7 +84,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -122,7 +122,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -159,7 +159,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -197,7 +197,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -888,7 +888,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1557,7 +1557,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -7063,7 +7063,7 @@
       },
       "updateCommands": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/updateCommands",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -7063,7 +7063,7 @@
       },
       "updateCommands": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/updateCommands",
           "support": {
             "chrome": {
               "version_added": false

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -923,7 +923,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "117"
+                  "version_added": "115"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/html/elements/fencedframe.json
+++ b/html/elements/fencedframe.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -46,7 +46,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "115"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -83,7 +83,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "115"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -120,7 +120,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "115"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -321,7 +321,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "115"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/http/headers/Sec-Fetch-Dest.json
+++ b/http/headers/Sec-Fetch-Dest.json
@@ -46,7 +46,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "115"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
Looks like it is mentioned with the original implementation issue: https://issues.chromium.org/issues/40053214, so setting to 117. (collector says it would be 126 but I didn't find any evidence for that.)