### PR TITLE
Merge renamed NavigateEvent features `{transitionWhile => intercept}` + `{restoreScroll => scroll}`

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -357,9 +357,16 @@
             "web-features:navigation"
           ],
           "support": {
-            "chrome": {
-              "version_added": "105"
-            },
+            "chrome": [
+              {
+                "version_added": "105"
+              },
+              {
+                "alternative_name": "transitionWhile",
+                "version_added": "102",
+                "version_removed": "108"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -425,42 +432,6 @@
           }
         }
       },
-      "restoreScroll": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "102",
-              "version_removed": "108"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "scroll": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/scroll",
@@ -469,9 +440,16 @@
             "web-features:navigation"
           ],
           "support": {
-            "chrome": {
-              "version_added": "105"
-            },
+            "chrome": [
+              {
+                "version_added": "105"
+              },
+              {
+                "alternative_name": "restoreScroll",
+                "version_added": "102",
+                "version_removed": "108"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -534,42 +512,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "transitionWhile": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "102",
-              "version_removed": "108"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
See https://github.com/WICG/navigation-api/pull/235
canTransition is now canIntercept (done in https://github.com/mdn/browser-compat-data/pull/24792)
transitionWhile is now intercept

See https://github.com/WICG/navigation-api/pull/239
restoreScroll is now scroll