### PR TITLE
Updates for Firefox 134 beta

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -346,7 +346,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "134"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -226,7 +226,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -471,7 +471,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -139,7 +139,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -163,7 +163,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -587,7 +587,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -215,7 +215,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -236,7 +236,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/lint/linter/test-spec-urls.ts
+++ b/lint/linter/test-spec-urls.ts
@@ -39,6 +39,8 @@ const specsExceptions = [
   'https://github.com/WebAssembly/threads/blob/main/proposal',
   'https://github.com/WebAssembly/relaxed-simd/blob/main/proposals',
   'https://github.com/WebAssembly/multi-memory/blob/main/proposals',
+  'https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md',
+  'https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md',
 ];
 
 const allowedSpecURLs = [

--- a/webassembly/memory64.json
+++ b/webassembly/memory64.json
@@ -1,15 +1,13 @@
 {
   "webassembly": {
-    "jsStringBuiltins": {
+    "memory64": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md",
         "support": {
           "chrome": {
-            "version_added": "130"
-          },
-          "chrome_android": {
             "version_added": false
           },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": "134"
@@ -30,7 +28,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.6 found new features shipping in Firefox 134 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 9 features as shipping in Firefox 134:

- api.PushManager.supportedContentEncodings_static
- api.ReadableStreamBYOBReader.read.options_min_parameter (manually added)
- css.properties.align-self.position_absolute_context (manually added)
- css.properties.justify-self.position_absolute_context (manually added)
- css.properties.place-self.position_absolute_context (manually added)
- javascript.builtins.Promise.try
- javascript.builtins.RegExp.escape
- webassembly.jsStringBuiltins
- webassembly.memory64

See also https://github.com/mdn/mdn/issues/603 and https://www.mozilla.org/en-US/firefox/134.0beta/releasenotes/