### PR TITLE
Chrome 132 supports Element Capture API

### DIFF
--- a/api/BrowserCaptureMediaStreamTrack.json
+++ b/api/BrowserCaptureMediaStreamTrack.json
@@ -106,6 +106,42 @@
             "deprecated": false
           }
         }
+      },
+      "restrictTo": {
+        "__compat": {
+          "spec_url": "https://screen-share.github.io/element-capture/#dom-browsercapturemediastreamtrack-restrictto",
+          "support": {
+            "chrome": {
+              "version_added": "132"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/RestrictionTarget.json
+++ b/api/RestrictionTarget.json
@@ -1,0 +1,77 @@
+{
+  "api": {
+    "RestrictionTarget": {
+      "__compat": {
+        "spec_url": "https://screen-share.github.io/element-capture/#dom-restrictiontarget",
+        "support": {
+          "chrome": {
+            "version_added": "132"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "fromElement_static": {
+        "__compat": {
+          "description": "`fromElement()` static method",
+          "spec_url": "https://screen-share.github.io/element-capture/#dom-restrictiontarget-fromelement",
+          "support": {
+            "chrome": {
+              "version_added": "132"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 132 supports the [Element Capture API](https://screen-share.github.io/element-capture/); see https://chromestatus.com/feature/5198989277790208, and also see https://developer.chrome.com/blog/chrome-132-beta#element_capture.

Element Capture is an extension to the [Screen Capture API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API) that allows developers to restrict the captured stream to a particular DOM element.

Specifically, this PR adds:

- `api.BrowserCaptureMediaStreamTrack.restrictTo`
- `api.RestrictionTarget`
- `api.RestrictionTarget.fromElement_static`

I decided to add these manually because the Chrome 132 beta collector run didn't pick them up. I hope that's OK.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

See also https://github.com/mdn/content/pull/36939 for the associated content addition.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
