### PR TITLE
Chrome 130 supports connection events with Bluetooth RFCOMM serial ports

### DIFF
--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -124,6 +124,45 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "bluetooth_rfcomm": {
+          "__compat": {
+            "description": "Bluetooth RFCOMM serial ports fire `connect` events",
+            "tags": [
+              "web-features:serial"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "connected": {
@@ -208,6 +247,45 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "bluetooth_rfcomm": {
+          "__compat": {
+            "description": "Bluetooth RFCOMM serial ports fire `disconnect` events",
+            "tags": [
+              "web-features:serial"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -127,7 +127,7 @@
         },
         "bluetooth_rfcomm": {
           "__compat": {
-            "description": "Bluetooth RFCOMM serial ports fire `connect` events",
+            "description": "Bluetooth RFCOMM serial ports dispatch `connect` events",
             "tags": [
               "web-features:serial"
             ],

--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -251,7 +251,7 @@
         },
         "bluetooth_rfcomm": {
           "__compat": {
-            "description": "Bluetooth RFCOMM serial ports fire `disconnect` events",
+            "description": "Bluetooth RFCOMM serial ports dispatch `disconnect` events",
             "tags": [
               "web-features:serial"
             ],


### PR DESCRIPTION
…onected events

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 130 supports the [`SerialPort.connected`](https://wicg.github.io/serial/#dom-serialport-connected) attribute, a boolean that reports whether a serial port is logically connected. This property is already represented in BCD.

However, another part of this work item is that the `SerialPort` `connect` and `disconnect` events were previously only fired by physical/wired serial ports. With this change, wireless Bluetooth RFCOMM serial ports also fire these events when they connect and disconnect.

This PR adds a data point to cover this new wireless support for the events. Note that it looks like this change is a result of a spec change (I'm not sure which exact spec change, but https://github.com/WICG/serial/pull/189 mentions adding Bluetooth support) rather than Chrome previously having partial support. As a result, I've added a sub-data point rather than another support item in the same support array.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See https://chromestatus.com/feature/5118102654418944

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
