### PR TITLE
Remove `lighting-color` from svg global attributes

### DIFF
--- a/svg/elements/feDiffuseLighting.json
+++ b/svg/elements/feDiffuseLighting.json
@@ -156,6 +156,46 @@
             }
           }
         },
+        "lighting-color": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/lighting-color",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#propdef-lighting-color",
+            "tags": [
+              "web-features:svg"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "5"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "≤11"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "surfaceScale": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/surfaceScale",

--- a/svg/elements/feSpecularLighting.json
+++ b/svg/elements/feSpecularLighting.json
@@ -122,6 +122,46 @@
             }
           }
         },
+        "lighting-color": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/lighting-color",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#LightingColorProperty",
+            "tags": [
+              "web-features:svg"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "5"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "≤11"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "specularConstant": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/specularConstant",

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -1772,46 +1772,6 @@
           }
         }
       },
-      "lighting-color": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/lighting-color",
-          "spec_url": "https://drafts.fxtf.org/filter-effects/#LightingColorProperty",
-          "tags": [
-            "web-features:svg"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "5"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "3"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": "≤11"
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "marker-end": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/marker-end",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the `lighting-color` property only take effect on `<feDiffuseLighting>` and `<feSpecularLighting>` elements, it is not a global attribute

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://drafts.fxtf.org/filter-effects/#propdef-lighting-color
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/lighting-color
https://developer.mozilla.org/en-US/docs/Web/CSS/lighting-color

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
