### PR TITLE
Update Edge versions for srcset and sizes in <img> and <source>

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -875,7 +875,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "38"

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -135,7 +135,7 @@
               ],
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "38"
@@ -217,7 +217,7 @@
               ],
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "38"


### PR DESCRIPTION
Unblocks https://github.com/web-platform-dx/web-features/pull/2349

Version numbers are taken from:
- api.HTMLImageElement.srcset
- api.HTMLSourceElement.sizes
- api.HTMLSourceElement.srcset