### PR TITLE
Chrome 83 added `:xr-overlay` CSS selector

### DIFF
--- a/css/selectors/xr-overlay.json
+++ b/css/selectors/xr-overlay.json
@@ -1,0 +1,46 @@
+{
+  "css": {
+    "selectors": {
+      "xr-overlay": {
+        "__compat": {
+          "description": "`:xr-overlay`",
+          "spec_url": "https://immersive-web.github.io/dom-overlays/#selectordef-xr-overlay",
+          "tags": [
+            "web-features:webxr-dom-overlays"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Data comes from the OWD collector v10.12.6.
Spec: https://immersive-web.github.io/dom-overlays/#selectordef-xr-overlay
Part of WebXR DOM overlays https://chromestatus.com/feature/6048666307526656
https://web-platform-dx.github.io/web-features-explorer/features/webxr-dom-overlays/