### PR TITLE
Chrome 117 supports Bluetooth service class IDs in Web Serial API

### DIFF
--- a/api/Serial.json
+++ b/api/Serial.json
@@ -120,6 +120,86 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "allowedBluetoothServiceClassIds_option": {
+          "__compat": {
+            "description": "`allowedBluetoothServiceClassIds` option",
+            "spec_url": "https://wicg.github.io/serial/#dom-serialportrequestoptions-allowedbluetoothserviceclassids",
+            "tags": [
+              "web-features:serial"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "117"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "filters_bluetoothServiceClassId": {
+          "__compat": {
+            "description": "`filters` `bluetoothServiceClassId` property",
+            "spec_url": "https://wicg.github.io/serial/#dom-serialportfilter-bluetoothserviceclassid",
+            "tags": [
+              "web-features:serial"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "117"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -367,6 +367,46 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "bluetoothServiceClassId": {
+          "__compat": {
+            "description": "`bluetoothServiceClassId` return value property",
+            "spec_url": "https://wicg.github.io/serial/#dom-serialportinfo-bluetoothserviceclassid",
+            "tags": [
+              "web-features:serial"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "117"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getSignals": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome has supported the [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API) for several versions now (since Chrome 89), but the MDN docs and BCD have not been updated to include support for Bluetooth RFCOMM services (originally only wired ports such as actual serial ports and USB devices were supported). 

This was added in Chrome 117 — see https://chromestatus.com/feature/5686596809523200.

This PR adds data points for Bluetooth RFCOMM support. Specially:

- `bluetoothServiceClassId` properties inside the `Serial.requestPort()` `filters` option.
- The `Serial.requestPort()` `allowedBluetoothServiceClassIds` option.
- The `bluetoothServiceClassId` property inside the object returned by the `SerialPort.getInfo()` method.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
