### PR TITLE
chore(issue-templates): add "needs-triage" label

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -1,6 +1,7 @@
 name: "Data problem"
 title: "<NAME THE FEATURE> - <SUMMARIZE THE PROBLEM>"
 description: Report incorrect, incomplete, or missing data
+labels: ["needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,6 +1,6 @@
 name: "Enhancement"
 description: An enhancement to BCD's infrastructure
-labels: ["enhancement"]
+labels: ["needs-triage", "enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/infra-problem.yml
+++ b/.github/ISSUE_TEMPLATE/infra-problem.yml
@@ -1,5 +1,6 @@
 name: "Infrastructure/Linter Problem"
 description: Report issues with infrastructure, including scripts and linters
+labels: ["needs-triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
#### Summary

Add needs-triage label to new issues.

#### Test results and supporting details

Discussed in BCD meeting on 2024-11-26.

#### Related issues

Reverts https://github.com/mdn/browser-compat-data/pull/21503.
