### PR TITLE
Move SVG attributes `stop-color` and `stop-opacity` to global attributes

### DIFF
--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -4,7 +4,7 @@
       "stop": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/stop",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#GradientStops",
+          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopElement",
           "tags": [
             "web-features:svg"
           ],
@@ -82,108 +82,6 @@
               "safari_ios": {
                 "version_added": "3"
               },
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "3"
-              },
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "stop-color": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-color",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty",
-            "tags": [
-              "web-features:svg"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1.5"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "9"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "9"
-              },
-              "opera_android": {
-                "version_added": "10.1"
-              },
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": {
-                "version_added": "3"
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "3"
-              },
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "stop-opacity": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-opacity",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty",
-            "tags": [
-              "web-features:svg"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1.5"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "9"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "9"
-              },
-              "opera_android": {
-                "version_added": "10.1"
-              },
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": [
-                {
-                  "version_added": "14"
-                },
-                {
-                  "version_added": "3",
-                  "version_removed": "11"
-                }
-              ],
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "3"

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -280,52 +280,6 @@
           }
         }
       },
-      "paint-order": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/paint-order",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrder",
-          "tags": [
-            "web-features:paint-order"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "≤73"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": "≤66"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": "≤12"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/class",
@@ -2141,6 +2095,52 @@
           }
         }
       },
+      "paint-order": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/paint-order",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrder",
+          "tags": [
+            "web-features:paint-order"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "≤73"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": "≤66"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤12"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pointer-events": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/pointer-events",
@@ -2216,6 +2216,108 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stop-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-color",
+          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty",
+          "tags": [
+            "web-features:svg"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "9"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "3"
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": "3"
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stop-opacity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-opacity",
+          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty",
+          "tags": [
+            "web-features:svg"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "9"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "3",
+                "version_removed": "11"
+              }
+            ],
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": "3"
+            },
             "webview_ios": "mirror"
           },
           "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`stop-color,stop-opacity` are also presentation attributes and so they'd better present in global attributes (as they apply to all elements)

also including a move of `paint-order` global attribute

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
