### PR TITLE
Update Edge data for CSSMarginRule API

### DIFF
--- a/api/CSSMarginRule.json
+++ b/api/CSSMarginRule.json
@@ -13,9 +13,7 @@
           "chrome_android": {
             "version_added": false
           },
-          "edge": {
-            "version_added": false
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },
@@ -53,9 +51,7 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -94,9 +90,7 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `CSSMarginRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSMarginRule
