### PR TITLE
Run ordering fixes after all other fixes

### DIFF
--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -26,16 +26,16 @@ import { LintOptions } from './utils.js';
 const dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const FIXES = Object.freeze({
-  browser_order: fixBrowserOrder,
-  feature_order: fixFeatureOrder,
-  property_order: fixPropertyOrder,
-  statement_order: fixStatementOrder,
   descriptions: fixDescriptions,
   flags: fixFlags,
   links: fixLinks,
   mdn_urls: fixMDNURLs,
   status: fixStatus,
   mirror: fixMirror,
+  browser_order: fixBrowserOrder,
+  feature_order: fixFeatureOrder,
+  property_order: fixPropertyOrder,
+  statement_order: fixStatementOrder,
 });
 
 /**


### PR DESCRIPTION
This PR updates the order that the fix scripts are run in, so that the ordering fixes are run after all other fixes are performed.
