### PR TITLE
Update Edge data for api.SerialPort.connected

### DIFF
--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -178,9 +178,7 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `connected` member of the `SerialPort` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SerialPort/connected
