### PR TITLE
Update Edge data for css feature

### DIFF
--- a/css/properties/anchor-scope.json
+++ b/css/properties/anchor-scope.json
@@ -14,9 +14,7 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -54,9 +52,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -95,9 +91,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -65,9 +65,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -106,9 +104,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -147,9 +143,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -188,9 +182,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/css/properties/interpolate-size.json
+++ b/css/properties/interpolate-size.json
@@ -13,9 +13,7 @@
               "version_added": "129"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -51,9 +49,7 @@
                 "version_added": "129"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -90,9 +86,7 @@
                 "version_added": "129"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/css/properties/text-wrap-style.json
+++ b/css/properties/text-wrap-style.json
@@ -125,9 +125,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/css/selectors/details-content.json
+++ b/css/selectors/details-content.json
@@ -15,9 +15,7 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `css` feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css
