### PR TITLE
Chrome 1 supported `background-position: bottom/center/left/right/top`

### DIFF
--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -50,7 +50,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -87,7 +87,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -124,7 +124,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -202,7 +202,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -280,7 +280,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -50,7 +50,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -87,7 +87,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -124,7 +124,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -202,7 +202,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -280,7 +280,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -50,7 +50,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -87,7 +87,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -124,7 +124,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -202,7 +202,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -280,7 +280,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `background-position` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/background-position
