### PR TITLE
Chrome 16 / Safari 6 supported `border-image-width` CSS property

### DIFF
--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "15",
+              "version_added": "16",
               "notes": "Before Chrome 112, a border image's absolute or percentage length width may not take precedence over a narrower `border-width` ([bug 40541033](https://crbug.com/40541033))."
             },
             "chrome_android": "mirror",
@@ -50,7 +50,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "18"
+                "version_added": "16"
               },
               "chrome_android": "mirror",
               "edge": {

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -50,7 +50,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "18"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -67,7 +67,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `border-image-width` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/border-image-width
