### PR TITLE
Firefox 15 added `border-image-width: auto` support

### DIFF
--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -57,7 +57,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "22"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -57,7 +57,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "22"
+                "version_added": "15"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `auto` member of the `border-image-width` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/border-image-width/auto
