### PR TITLE
Bug-1736575 scripting.RegisteredContentScript supports world property

### DIFF
--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -172,7 +172,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "128"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
#### Summary

Add details of support for the `world` property in `scripting.RegisteredContentScript`. This was added in. [Bug 1736575](https://bugzilla.mozilla.org/show_bug.cgi?id=1736575) Support execution world MAIN in `scripting.executeScript()` and content_scripts (see https://hg.mozilla.org/integration/autoland/rev/d9dcbf38d3f8)

#### Related issues

Fixes #24055
