### PR TITLE
Safari 18 supports mixed type parameters in CSS color types

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -405,7 +405,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -570,7 +570,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1425,7 +1425,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Safari now fully supports mixed types in color functions.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://codepen.io/romainmenke/pen/wvNYKmR

<img width="1178" alt="Screenshot 2024-12-02 at 07 44 00" src="https://github.com/user-attachments/assets/734136de-ea69-410a-a5c7-a668083597e1">

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://webkit.org/blog/15865/webkit-features-in-safari-18-0/#css

> - Fixed hsl() and hsla() implementation to match the latest spec changes.
> - Fixed the implementation of rgb() and rgba() to match the latest spec.
> - Fixed the hwb() implementation to match the latest spec.
> - Fixed the remaining color types to be synced with the latest spec changes.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

N/A