### PR TITLE
Firefox 122 supports `page-orientation` descriptor for the `@page` at-rule

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -400,7 +400,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
The `page-orientation` descriptor was enabled in FF122 in https://bugzilla.mozilla.org/show_bug.cgi?id=1869880 - as you can see from `layout.css.page-orientation.enabled` value in https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml#9475

This fell out of checks in https://github.com/mdn/content/issues/36742