### PR TITLE
Firefox 126 removed / Nightly unremoved some moz-prefixed CSS properties

### DIFF
--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -38,14 +38,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "10",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.transforms",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -39,7 +39,13 @@
               {
                 "prefix": "-moz-",
                 "version_added": "10",
-                "version_removed": "preview"
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.transforms",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -38,14 +38,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "10",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.transforms",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -39,7 +39,13 @@
               {
                 "prefix": "-moz-",
                 "version_added": "10",
-                "version_removed": "preview"
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.transforms",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -38,14 +38,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "10",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.transforms",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -39,7 +39,13 @@
               {
                 "prefix": "-moz-",
                 "version_added": "10",
-                "version_removed": "preview"
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.transforms",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -38,14 +38,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "3.5",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.transforms",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "3.5"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -39,7 +39,13 @@
               {
                 "prefix": "-moz-",
                 "version_added": "3.5",
-                "version_removed": "preview"
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.transforms",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -38,14 +38,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "10",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.transforms",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -39,7 +39,13 @@
               {
                 "prefix": "-moz-",
                 "version_added": "10",
-                "version_removed": "preview"
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.transforms",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -41,7 +41,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "≤40"
+                "version_added": "3.5"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -41,14 +41,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "≤40",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.transforms",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "≤40"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -42,7 +42,13 @@
               {
                 "prefix": "-moz-",
                 "version_added": "≤40",
-                "version_removed": "preview"
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.transforms",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -39,7 +39,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4",
-                "version_removed": "preview"
+                "version_removed": "126"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -39,7 +39,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4",
-                "version_removed": "preview"
+                "version_removed": "126"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -39,7 +39,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4",
-                "version_removed": "preview"
+                "version_removed": "126"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -39,7 +39,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4",
-                "version_removed": "preview"
+                "version_removed": "126"
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
This reverts the `layout.css.prefixes.transforms` prefixed changes made in #21195 to reenable the `-moz` prefixed transforms:

- `-moz-backface-visibility`
- `-moz-perspective-origin`
- `-moz-perspective`
- `-moz-transform-origin`
- `-moz-transform-style`
- `-moz-transform`

This was done in https://bugzilla.mozilla.org/show_bug.cgi?id=1886134 - I've removed the original nightly changes invisible and replaced it with the preference, since that is what makes most sense.

FF126 also sets the following as false by default (removes the following) as part of adding CSS zoom in https://bugzilla.mozilla.org/show_bug.cgi?id=390936

- `-moz-transition-delay`
- `-moz-transition-duration`
- `-moz-transition-property`
- `-moz-transition-timing-function`
- `-moz-transition`

For those it changes preview to 126.

This fell out of checks in https://github.com/mdn/content/issues/36742






