### PR TITLE
Remove `css.types.color.color-contrast`

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -175,7 +175,6 @@
           "__compat": {
             "description": "`color-contrast()`",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value",
-            "spec_url": "https://drafts.csswg.org/css-color-6/#colorcontrast",
             "support": {
               "chrome": {
                 "version_added": false
@@ -208,7 +207,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -171,47 +171,6 @@
             }
           }
         },
-        "color-contrast": {
-          "__compat": {
-            "description": "`color-contrast()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "15",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "CSS color-contrast()"
-                  }
-                ]
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "color-mix": {
           "__compat": {
             "description": "`color-mix()`",


### PR DESCRIPTION
#### Summary

The `color-contrast()` CSS function is no longer part of [CSS Color Module Level 6](https://drafts.csswg.org/css-color-6/#colorcontrast). It was [renamed](https://github.com/w3c/csswg-drafts/issues/7557) to `contrast-color()`, and the spec has changed since Safari and Chrome did their experimental implementations. 

There's a few layers to this decision (renaming an experimental feature and changing the functionality), but my thought is that the cleanest would be to view `color-contrast()` and `contrast-color()` as separate types, meaning:

- Set `color-contrast` to `standard_track: false`
- Remove the `color-contrast` spec link (it links to the spec for `constrast-color`)
- Create `contrast-color` once there is implementation.

I'm open to other ideas as well. 