### PR TITLE
Update Chrome/Firefox/Safari data for clip-rule CSS property

### DIFF
--- a/css/properties/clip-rule.json
+++ b/css/properties/clip-rule.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤4"
+              "version_added": "3.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -51,7 +51,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "3.5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -88,7 +88,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "3.5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/clip-rule.json
+++ b/css/properties/clip-rule.json
@@ -10,12 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "≤4"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,12 +46,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -83,12 +83,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -98,7 +98,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `clip-rule` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/clip-rule
