### PR TITLE
Chrome 1 / Firefox 3 / Safari 3 added CSS `color-interpolation-filters` support

### DIFF
--- a/css/properties/color-interpolation-filters.json
+++ b/css/properties/color-interpolation-filters.json
@@ -10,12 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤5"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,12 +46,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤5"
+                "version_added": "3"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5"
+                "version_added": "3"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/color-interpolation-filters.json
+++ b/css/properties/color-interpolation-filters.json
@@ -10,12 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "≤5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,12 +46,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -83,12 +83,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "22"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -98,7 +98,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -120,12 +120,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "22"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -135,7 +135,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `color-interpolation-filters` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/color-interpolation-filters

Additional Notes: Safari 9 was guesstimated from lack of support in Safari 8 and support in Safari 9.1.
