### PR TITLE
Chrome 28 / Safari 9 support `counter-increment` CSS property

### DIFF
--- a/css/properties/counter-increment.json
+++ b/css/properties/counter-increment.json
@@ -56,7 +56,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -75,7 +75,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `counter-increment` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/counter-increment

Additional Notes: Safari 9 was guesstimated from lack of support in Safari 8 and support in Safari 9.1.
