### PR TITLE
Chrome 28 and Safari 9 support `list-item` in`counter-reset`

### DIFF
--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -56,7 +56,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83",
+                "version_added": "28",
                 "partial_implementation": true,
                 "notes": "Overriding the initial value of the implicit `list-item` counter has _no_ effect when the default marker string for list items (`::marker`) is generated; see [bug 338233131](https://crbug.com/338233131)."
               },
@@ -77,7 +77,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1",
+                "version_added": "9",
                 "partial_implementation": true,
                 "notes": "Overriding the initial value of the implicit `list-item` counter results in incorrect values for the `counter()` function used to generate content, as it is _not_ fully implemented; see [bug 260436](https://webkit.org/b/260436)."
               },


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `list-item` member of the `counter-reset` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/counter-reset/list-item

Additional Notes: Safari 9 was guesstimated from lack of support in Safari 8 and support in Safari 9.1.
