### PR TITLE
link to WebGL2RenderingContext `linewidth()`

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -5657,6 +5657,7 @@
       },
       "lineWidth": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/lineWidth",
           "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {


### PR DESCRIPTION
part of https://github.com/openwebdocs/project/issues/214

the other properties and methods that are identical in `WebGLRenderingContext` and `WebGL2RenderingContext `  link to the `WebGLRenderingContext`  pages