### PR TITLE
Add chrome support for css `text-box`

### DIFF
--- a/css/properties/text-box-edge.json
+++ b/css/properties/text-box-edge.json
@@ -9,7 +9,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "133"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -32,7 +32,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -45,7 +45,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -68,7 +68,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-box-trim.json
+++ b/css/properties/text-box-trim.json
@@ -9,7 +9,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "133"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -32,7 +32,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -45,7 +45,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -68,7 +68,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -82,7 +82,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -105,7 +105,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -119,7 +119,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -142,7 +142,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -156,7 +156,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -179,7 +179,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-box.json
+++ b/css/properties/text-box.json
@@ -9,7 +9,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "133"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -32,7 +32,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -45,7 +45,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -68,7 +68,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add support for CSS `text-box`, `text-box-trim` and `text-box-edge` in Chrome 128 (behind a flag) and in Chrome 133

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Tested in Codepan in Chrome 132 with flag enabled

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://chromestatus.com/feature/5174589850648576

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
