### PR TITLE
Firefox 131 does NOT support position-area

### DIFF
--- a/css/properties/position-area.json
+++ b/css/properties/position-area.json
@@ -21,9 +21,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "131",
-              "partial_implementation": true,
-              "notes": "The property is parsed and accepted, but it has no effect yet, because both [`anchor-name`](https://developer.mozilla.org/docs/Web/CSS/anchor-name) and [`position-anchor`](https://developer.mozilla.org/docs/Web/CSS/position-anchor) are not yet supported."
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1838746"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -41,7 +40,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -59,7 +58,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -77,7 +77,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -96,7 +96,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -114,7 +115,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -133,7 +134,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -151,7 +153,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -170,7 +172,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -188,7 +191,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -207,7 +210,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -225,7 +229,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -244,7 +248,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -262,7 +267,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -281,7 +286,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -299,7 +305,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -318,7 +324,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -336,7 +343,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -355,7 +362,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -373,7 +381,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -392,7 +400,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -410,7 +419,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -429,7 +438,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -447,7 +457,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -466,7 +476,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -484,7 +495,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -503,7 +514,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -521,7 +533,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -540,7 +552,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -558,7 +571,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -577,7 +590,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -595,7 +609,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -614,7 +628,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -632,7 +647,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -651,7 +666,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -669,7 +685,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -688,7 +704,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -706,7 +723,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -725,7 +742,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -743,7 +761,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -762,7 +780,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -780,7 +799,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -799,7 +818,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -817,7 +837,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -836,7 +856,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -854,7 +875,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -873,7 +894,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -891,7 +913,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -910,7 +932,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -928,7 +951,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -947,7 +970,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -965,7 +989,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -984,7 +1008,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1002,7 +1027,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1021,7 +1046,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1039,7 +1065,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1058,7 +1084,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1076,7 +1103,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1095,7 +1122,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1113,7 +1141,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1132,7 +1160,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1150,7 +1179,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1169,7 +1198,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1187,7 +1217,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1206,7 +1236,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1224,7 +1255,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1243,7 +1274,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1261,7 +1293,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1280,7 +1312,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1298,7 +1331,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1317,7 +1350,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1838746"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1335,7 +1369,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR reverts #24454.  The collector reports no support for the `position-area` property in Firefox, and from manual testing, the browser does not recognize the property at all.  It appears that it was only exposed early in Firefox Nightly, but not available in stable at all.
