### PR TITLE
Chrome 108/109 added `webextensions.api.action.isEnabled/{get,set}BadgeTextColor`

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -187,7 +187,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getBadgeTextColor",
             "support": {
               "chrome": {
-                "version_added": "110"
+                "version_added": "109"
               },
               "edge": "mirror",
               "firefox": {
@@ -329,7 +329,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/isEnabled",
             "support": {
               "chrome": {
-                "version_added": "110"
+                "version_added": "108"
               },
               "edge": "mirror",
               "firefox": {
@@ -592,7 +592,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setBadgeTextColor",
             "support": {
               "chrome": {
-                "version_added": "110"
+                "version_added": "109"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -187,7 +187,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getBadgeTextColor",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "110"
               },
               "edge": "mirror",
               "firefox": {
@@ -329,7 +329,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/isEnabled",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "110"
               },
               "edge": "mirror",
               "firefox": {
@@ -592,7 +592,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setBadgeTextColor",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "110"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
per https://developer.chrome.com/docs/extensions/reference/api/action#method-setBadgeTextColor、https://developer.chrome.com/docs/extensions/reference/api/action#method-getBadgeTextColor、https://developer.chrome.com/docs/extensions/reference/api/action#method-isEnabled

fixes mdn/browser-compat-data#25348

also note that chrome.action have new members not included in BCD yet: `UserSettingsChanged`、`onUserSettingsChanged` added in Chrome 130; should they also be included in BCD?
