### PR TITLE
Chrome 68 / Firefox 27 / Safari 11 supported `cursor: grabbing`

### DIFF
--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -657,9 +657,16 @@
               "web-features:cursor"
             ],
             "support": {
-              "chrome": {
-                "version_added": "68"
-              },
+              "chrome": [
+                {
+                  "version_added": "68"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1",
+                  "notes": "Chrome 22 added Windows support."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -658,12 +658,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "68"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "27"
               },
               "firefox_android": {
                 "version_added": "95"
@@ -675,7 +675,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "11"
               },
               "safari_ios": {
                 "version_added": false,


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `grabbing` member of the `cursor` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/cursor/grabbing
