### PR TITLE
Chrome 52 / Firefox 34 / Safari 9 support `font-variant: none`

### DIFF
--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -169,12 +169,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "52"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "34"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -184,7 +184,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `none` member of the `font-variant` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-variant/none
