### PR TITLE
Chrome 83 / Firefox 69 / Safari 13 added `line-break: anywhere` support

### DIFF
--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -79,16 +79,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "73"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "69"
               },
-              "firefox_android": {
-                "version_added": "79"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -96,7 +94,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "13"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -79,7 +79,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "73"
+                "version_added": "83"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `anywhere` member of the `line-break` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/line-break/anywhere
