### PR TITLE
Update all browsers data for line-break CSS property

### DIFF
--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -133,7 +133,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "8"
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -118,16 +118,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "25"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "69"
               },
-              "firefox_android": {
-                "version_added": "79"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -135,7 +133,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -157,16 +155,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "25"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "69"
               },
-              "firefox_android": {
-                "version_added": "79"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -174,7 +170,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -201,11 +197,9 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "69"
               },
-              "firefox_android": {
-                "version_added": "79"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -235,16 +229,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "25"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "69"
               },
-              "firefox_android": {
-                "version_added": "79"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -252,7 +244,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `line-break` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/line-break
