### PR TITLE
[css.selectors.attribute] Add WebKit bug for case‑sensitive modifier

### DIFF
--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -108,7 +108,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/272573"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
**WebKit** now also has an open bug to implement this (and a W.I.P patch at <https://github.com/WebKit/WebKit/pull/27188>).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- <https://webkit.org/b/272573>
- <https://github.com/WebKit/WebKit/pull/27188>

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
- <https://github.com/mdn/browser-compat-data/pull/5472>

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
