### PR TITLE
Chrome 57 / Firefox 6 / Safari 8 added support for `text-decoration-line` CSS property values

### DIFF
--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -141,7 +141,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤10"
+                "version_added": "6"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -178,7 +178,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤10"
+                "version_added": "6"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -215,7 +215,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤10"
+                "version_added": "6"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -289,7 +289,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤10"
+                "version_added": "6"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -136,12 +136,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "57"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤10"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -151,7 +151,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -173,12 +173,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "57"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤10"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -188,7 +188,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -210,12 +210,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "57"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤10"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -225,7 +225,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -284,12 +284,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "57"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤10"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -299,7 +299,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `text-decoration-line` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-decoration-line
