### PR TITLE
Chromium 130 supports `text-wrap: stable`

### DIFF
--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -161,7 +161,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "130"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `stable` member of the `text-wrap` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-wrap/stable
