### PR TITLE
Safari 18 supports typedFunctionReferences WebAssembly feature

### DIFF
--- a/webassembly/typedFunctionReferences.json
+++ b/webassembly/typedFunctionReferences.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `typedFunctionReferences` WebAssembly feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.7).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/typedFunctionReferences
