### PR TITLE
Opera supports CSS `box-decoration-break`, `speak`, HTML `fieldset.disabled` and HTTP header `Cross-Origin-Opener-Policy`

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -851,19 +851,33 @@
         "113": {
           "release_date": "2024-08-22",
           "release_notes": "https://blogs.opera.com/desktop/2024/08/opera-113/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "127"
         },
         "114": {
-          "status": "beta",
+          "release_date": "2024-09-25",
+          "release_notes": "https://blogs.opera.com/desktop/2024/09/opera-114/",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "128"
         },
         "115": {
+          "release_date": "2024-11-27",
+          "release_notes": "https://blogs.opera.com/desktop/2024/11/opera-115/",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "130"
+        },
+        "116": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "131"
+        },
+        "117": {
           "status": "nightly",
           "engine": "Blink",
-          "engine_version": "129"
+          "engine_version": "132"
         }
       }
     }

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -486,9 +486,22 @@
         },
         "84": {
           "release_date": "2024-08-26",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "127"
+        },
+        "85": {
+          "release_date": "2024-10-29",
+          "release_notes": "https://blogs.opera.com/mobile/2024/10/opera-for-android-adds-image-understanding/",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "128"
+        },
+        "86": {
+          "release_date": "2024-12-02",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "130"
         }
       }
     }

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -32,6 +32,9 @@
             "oculus": "mirror",
             "opera": [
               {
+                "version_added": "115"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "15"
               },
@@ -41,6 +44,9 @@
               }
             ],
             "opera_android": [
+              {
+                "version_added": "86"
+              },
               {
                 "prefix": "-webkit-",
                 "version_added": "14"

--- a/css/properties/speak.json
+++ b/css/properties/speak.json
@@ -14,11 +14,7 @@
               "notes": "The implementation is not compliant with the specification, see [bug 40813740](https://crbug.com/40813740)."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤80",
-              "partial_implementation": true,
-              "notes": "The implementation is not compliant with the specification, see [bug 40813740](https://crbug.com/40813740)."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "impl_url": "https://bugzil.la/1748064"

--- a/css/properties/speak.json
+++ b/css/properties/speak.json
@@ -15,7 +15,9 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤80"
+              "version_added": "≤80",
+              "partial_implementation": true,
+              "notes": "The implementation is not compliant with the specification, see [bug 40813740](https://crbug.com/40813740)."
             },
             "firefox": {
               "version_added": false,

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -58,11 +58,16 @@
                 "version_added": "20"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "partial_implementation": true,
-                "notes": "Does not work with nested fieldsets. For example: `&lt;fieldset disabled&gt;&lt;fieldset&gt;&lt;!--Still enabled--&gt;&lt;/fieldset&gt;&lt;/fieldset&gt;`"
-              },
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "12",
+                  "partial_implementation": true,
+                  "notes": "Does not work with nested fieldsets. For example: `&lt;fieldset disabled&gt;&lt;fieldset&gt;&lt;!--Still enabled--&gt;&lt;/fieldset&gt;&lt;/fieldset&gt;`"
+                }
+              ],
               "firefox": {
                 "version_added": "4"
               },

--- a/http/headers/Cross-Origin-Opener-Policy.json
+++ b/http/headers/Cross-Origin-Opener-Policy.json
@@ -19,12 +19,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },


### PR DESCRIPTION
#### Summary

- Fixed compatibility details for the CSS property `box-decoration-break`
- Improved data for the CSS property `speak` with updated browser support.
- Updated the HTML `disabled` attribute compatibility for `fieldset` element.
- Refreshed version data for Opera and Opera Android.

#### Test results and supporting details

The proposed changes do not require testing because they involve aligning compatibility data for specific browsers based on the Chromium engine version they use. These updates are sourced from vendor release notes and publicly available documentation, ensuring accuracy without requiring direct feature testing.

- https://blogs.opera.com/desktop/2024/09/opera-114/
- https://blogs.opera.com/desktop/2024/11/opera-115/
- https://blogs.opera.com/mobile/2024/10/opera-for-android-adds-image-understanding/
- https://get.opera.com/ftp/pub/opera/android/8600/

#### Related issues

Fixes #25290
