### PR TITLE
FF132 permissions API - camera, microphone

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -203,7 +203,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "132"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -509,7 +509,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "132"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF132 enabled the pref for camera and microphone permissions API in https://bugzilla.mozilla.org/show_bug.cgi?id=1916993. This just updates the feature.

Fell out of work done in https://github.com/mdn/content/issues/36742