### PR TITLE
Chrome Android 92+ fully supports theme-color

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -477,10 +477,17 @@
                     "notes": "Chrome reports support, but does not actually use the color anywhere."
                   }
                 ],
-                "chrome_android": {
-                  "version_added": "80",
-                  "notes": "Chrome for Android does not use the color on devices with native dark mode enabled."
-                },
+                "chrome_android": [
+                  {
+                    "version_added": "92"
+                  },
+                  {
+                    "version_added": "39",
+                    "version_removed": "91",
+                    "partial_implementation": true,
+                    "notes": "Chrome for Android does not use the color on devices with native dark mode enabled unless it's an installed progressive web app or a trusted web activity."
+                  }
+                ],
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -472,7 +472,7 @@
                   },
                   {
                     "version_added": "39",
-                    "version_removed": "72",
+                    "version_removed": "73",
                     "partial_implementation": true,
                     "notes": "Chrome reports support, but does not actually use the color anywhere."
                   }
@@ -483,7 +483,7 @@
                   },
                   {
                     "version_added": "39",
-                    "version_removed": "91",
+                    "version_removed": "92",
                     "partial_implementation": true,
                     "notes": "Chrome for Android does not use the color on devices with native dark mode enabled unless it's an installed progressive web app or a trusted web activity."
                   }


### PR DESCRIPTION
#### Summary

Updates `html.elements.meta.theme-color` to show partial support for 39-91, and full support in 92.

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/issues/25312

#### Related issues

Closes #25312 
