### PR TITLE
Revert "Firefox 36+ applies object-position to iframes (#23631)"

### DIFF
--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -65,39 +65,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "applies_to_iframe_elements": {
-          "__compat": {
-            "description": "Applies to `&lt;iframe&gt;` elements",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "36"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This reverts commit 11f4a775b2bc6dc72504699b4636bb534aedf210.

#### Summary

#23631 was merged to address https://github.com/mdn/browser-compat-data/issues/23586, but it has been identified as needing a different approach- see [this comment](https://github.com/mdn/browser-compat-data/issues/23586#issuecomment-2425049201).

This reverts the PR, to remove the `css.properties.object-position.applies_to_iframe_elements` key, in preparation for a more thorough documenting of which replaced elements `object-position` (and `object-fit`) apply to. 