### PR TITLE
Firefox 3.6 supported `background-size: auto`

### DIFF
--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -134,11 +134,11 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "3.6"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "≤11"
+                "version_added": "9"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -138,7 +138,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "9"
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

As `auto` is the initial/default value, it was very likely supported as long as `background-size` was supported.

For Firefox, implementation happened before version 3, see:
- https://bugzilla.mozilla.org/show_bug.cgi?id=189519

#### Test results and supporting details

See also:

- [MDN page for background-size from 2013](https://web.archive.org/web/20130819235455/https://developer.mozilla.org/en-US/docs/Web/CSS/background-size)
- [CSS spec regarding background-size from 2013](https://web.archive.org/web/20130902111154/http://dev.w3.org/csswg/css-backgrounds/#background-size)

#### Related issues

Relates to https://github.com/mdn/browser-compat-data/issues/25355.
