### PR TITLE
Firefox 1 supported `display: table-caption`

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1172,7 +1172,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Firefox 1 most likely already supported `display: table-caption` (like `display: table-cell`).

#### Test results and supporting details

Based on these searches, it is fair to assume `table-caption` has been supported as long as `table-cell` has been supported:
- https://searchfox.org/mozilla-esr17/search?q=NS_STYLE_DISPLAY_TABLE_CAPTION
- https://searchfox.org/mozilla-esr17/search?q=NS_STYLE_DISPLAY_TABLE_CELL

#### Related issues

Relates to https://github.com/mdn/browser-compat-data/issues/25355.
