### PR TITLE
Firefox 1 supported `dominant-baseline`

### DIFF
--- a/css/properties/dominant-baseline.json
+++ b/css/properties/dominant-baseline.json
@@ -18,7 +18,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -54,7 +54,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -91,7 +91,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -128,7 +128,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -165,7 +165,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -202,7 +202,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -239,7 +239,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -276,7 +276,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Firefox 1 appears to have already supported `dominant-baseline`.

#### Test results and supporting details

See:
- https://searchfox.org/mozilla-central/diff/5c676d4a472c56281b102fdef1336d42f04fd466/layout/base/nsStyleConsts.h#644
- https://bugzilla.mozilla.org/show_bug.cgi?id=182533#c46

#### Related issues

Relates to https://github.com/mdn/browser-compat-data/issues/25355.
