### PR TITLE
Firefox 1 supported `fill-opacity`

### DIFF
--- a/css/properties/fill-opacity.json
+++ b/css/properties/fill-opacity.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -1064,7 +1064,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Firefox 1 appears to have already supported `fill-opacity`.

#### Test results and supporting details

See [bug 273672](https://bugzilla.mozilla.org/show_bug.cgi?id=273672) for the evidence.

#### Related issues

Relates to https://github.com/mdn/browser-compat-data/issues/25355.