### PR TITLE
Firefox 1 supported `stroke-*` properties

### DIFF
--- a/css/properties/stroke-dasharray.json
+++ b/css/properties/stroke-dasharray.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-dashoffset.json
+++ b/css/properties/stroke-dashoffset.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-linecap.json
+++ b/css/properties/stroke-linecap.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-linejoin.json
+++ b/css/properties/stroke-linejoin.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-miterlimit.json
+++ b/css/properties/stroke-miterlimit.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-opacity.json
+++ b/css/properties/stroke-opacity.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-width.json
+++ b/css/properties/stroke-width.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -2395,7 +2395,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2433,7 +2433,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2471,7 +2471,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2509,7 +2509,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2547,7 +2547,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2585,7 +2585,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2623,7 +2623,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 1 appears to have already supported these `stroke-*` properties:

- `stroke-dasharray`
- `stroke-dashoffset`
- `stroke-linecap`
- `stroke-linejoin`
- `stroke-miterlimit`
- `stroke-opacity`
- `stroke-width`

#### Test results and supporting details

See:
https://searchfox.org/mozilla-central/rev/b3baf9e836ff2300c3b967a44d03b1a871c77a67/content/svg/content/src/nsSVGElement.cpp#415

#### Related issues

Relates to https://github.com/mdn/browser-compat-data/issues/25355.
