### PR TITLE
FF97 removes SVGPathElement.getPathSegAtLength()

### DIFF
--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -990,22 +990,10 @@
               "version_added": "12",
               "version_removed": "79"
             },
-            "firefox": [
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.svg.pathSeg.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "1.5",
-                "version_removed": "97"
-              }
-            ],
+            "firefox": {
+              "version_added": "1.5",
+              "version_removed": "97"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
FF97 unshipped [`SVGPathElement.getPathSegAtLength()`](https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement#svgpathelement.getpathsegatlength) behind a preference. The preference was actually removed in FF129 in https://bugzilla.mozilla.org/show_bug.cgi?id=1745149 but since the feature was off since FF97, that was effectively when it was unshipped.

This removes the preference information in the feature.

This fell out of experimental features work in https://github.com/mdn/content/issues/36742