### PR TITLE
Revert "fix(scripts/release): avoid force-push"

### DIFF
--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -56,7 +56,7 @@ const commitAndPR = async (
     console.log('');
   }
 
-  console.log(chalk`{blue Preparing ${branch} branch...}`);
+  console.log(chalk`{blue Preparing release branch...}`);
   exec(`
     git stash
     git switch -C ${branch} origin/main
@@ -69,18 +69,8 @@ const commitAndPR = async (
     exec(`git commit --file ${commitFile}`),
   );
 
-  const commit = exec('git rev-parse HEAD');
-
-  console.log(chalk`{blue Cherry-picking onto remote ${branch} branch...}`);
-  exec(`
-    git fetch origin ${branch} || true
-    git reset --hard origin/${branch} || true
-    git merge origin/main --strategy-option theirs
-    git cherry-pick ${commit} --strategy-option theirs || git cherry-pick --abort
-  `);
-
-  console.log(chalk`{blue Pushing ${branch} branch...}`);
-  exec(`git push --set-upstream origin ${branch}`);
+  console.log(chalk`{blue Pushing release branch...}`);
+  exec(`git push --force --set-upstream origin ${branch}`);
 
   console.log(chalk`{blue Creating/editing pull request...}`);
   await temporaryWriteTask(pr.body, (bodyFile) => {

--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -56,7 +56,7 @@ const commitAndPR = async (
     console.log('');
   }
 
-  console.log(chalk`{blue Preparing release branch...}`);
+  console.log(chalk`{blue Preparing ${branch} branch...}`);
   exec(`
     git stash
     git switch -C ${branch} origin/main
@@ -69,7 +69,7 @@ const commitAndPR = async (
     exec(`git commit --file ${commitFile}`),
   );
 
-  console.log(chalk`{blue Pushing release branch...}`);
+  console.log(chalk`{blue Pushing ${branch} branch...}`);
   exec(`git push --force --set-upstream origin ${branch}`);
 
   console.log(chalk`{blue Creating/editing pull request...}`);


### PR DESCRIPTION
Avoiding force-push did _not_ resolve the "checks on release PR not running" issue ([this](https://github.com/mdn/browser-compat-data/pull/25176) resolved it).

So let's revert that change to keep the commit history clean on the release PR.

Reverts mdn/browser-compat-data#25140