### PR TITLE
Firefox 72 allows for MIME sniffing on top-level documents when no Content Type is set

### DIFF
--- a/http/headers/X-Content-Type-Options.json
+++ b/http/headers/X-Content-Type-Options.json
@@ -20,9 +20,16 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "50"
-            },
+            "firefox": [
+              {
+                "version_added": "72",
+                "impl_url": "https://bugzil.la/1591932",
+                "notes": "Content Type sniffing is enabled on top-level documents that have no `Content-Type`, even when `X-Content-Type-Options: nosniff` is set."
+              },
+              {
+                "version_added": "50"
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "8"

--- a/http/headers/X-Content-Type-Options.json
+++ b/http/headers/X-Content-Type-Options.json
@@ -20,16 +20,11 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "72",
-                "impl_url": "https://bugzil.la/1591932",
-                "notes": "Content Type sniffing is enabled on top-level documents that have no `Content-Type`, even when `X-Content-Type-Options: nosniff` is set."
-              },
-              {
-                "version_added": "50"
-              }
-            ],
+            "firefox": {
+              "version_added": "50",
+              "impl_url": "https://bugzil.la/1591932",
+              "notes": "Since version 72, Content Type sniffing is enabled on top-level documents that have no `Content-Type`, even when `X-Content-Type-Options: nosniff` is set."
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": "8"


### PR DESCRIPTION
#### Summary

Adding impl_ulrs for some HTTP features. These were documented in MDN content prose, and removed in recent PRs.

- https://github.com/mdn/content/pull/36862/files#diff-6d93852f46300729c5d2d2fd850f48e170246f9d26495d4b8afbc02cf6496777

#### Related issues

Follow-up from:

- [x] https://github.com/mdn/content/pull/36862