### PR TITLE
http.headers.X-XSS-Protection : mark deprecated

### DIFF
--- a/http/headers/X-XSS-Protection.json
+++ b/http/headers/X-XSS-Protection.json
@@ -38,7 +38,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
#### Summary

The feature [has been marked deprecated](https://github.com/mdn/content/pull/36862/files#diff-35a3c4188ae51e9b163064c8122d7916123841263089a1f06d74b0a554b731cfR11) in the `mdn/content`. The PR tries to reflect the same in BCD.

#### Related issues

- https://github.com/mdn/content/pull/36862