### PR TITLE
Chromium supports setAppBadge as much as it is possible

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4750,8 +4750,7 @@
           "support": {
             "chrome": {
               "version_added": "81",
-              "partial_implementation": true,
-              "notes": "Windows and macOS only."
+              "notes": "Windows and macOS only. Linux offers no universal badging API on the operating system level."
             },
             "chrome_android": {
               "version_added": false


### PR DESCRIPTION
Unblocks https://github.com/web-platform-dx/web-features/pull/2360#discussion_r1863518542

It seems unfair to mark Chromium as partial implementation when WebKit isn't marked as partial either and when support is implemented as much as operating systems allow it.

cc @captainbrosset 