### PR TITLE
Chrome 127 fully supports `webextensions.api.action.openPopup`

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -464,10 +464,16 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup",
             "support": {
-              "chrome": {
-                "version_added": "118",
-                "notes": "Is only available to policy installed extensions and dev builds (e.g., Canary) between Chrome 118 and Chrome 126."
-              },
+              "chrome": [
+                {
+                  "version_added": "127",
+                },
+                {
+                  "version_added": "118",
+                  "partial_implementation": true,
+                  "notes": "Only available to policy installed extensions and dev builds (e.g., Canary)."
+                },
+              ],
               "edge": "mirror",
               "firefox": {
                 "version_added": "109",

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -466,7 +466,7 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "127",
+                  "version_added": "127"
                 },
                 {
                   "version_added": "118",

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -466,7 +466,7 @@
             "support": {
               "chrome": {
                 "version_added": "118",
-                "notes": "Is only available to policy installed extensions and dev builds (e.g., Canary)."
+                "notes": "Is only available to policy installed extensions and dev builds (e.g., Canary) between Chrome 118 and Chrome 126."
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -472,7 +472,7 @@
                   "version_added": "118",
                   "partial_implementation": true,
                   "notes": "Only available to policy installed extensions and dev builds (e.g., Canary)."
-                },
+                }
               ],
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
```diff
-                "notes": "Is only available to policy installed extensions and dev builds (e.g., Canary)."
+                "notes": "Is only available to policy installed extensions and dev builds (e.g., Canary) between Chrome 118 and Chrome 126."
```

---

FYI:

1. https://developer.chrome.com/docs/extensions/reference/api/action#method-openPopup, 
2. https://github.com/chromium/chromium/commit/c04d4383e76d3f190bef7b431fc29b4a85c7b8b0

![image](https://github.com/user-attachments/assets/2085b559-dfec-459e-8696-0ae4bb09dfb7)
