### PR TITLE
Add Firefox impl_url for `api.Element.scrollIntoViewIfNeeded`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -9376,7 +9376,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Request for implementation tracked in [bug 403510](https://bugzil.la/403510)."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -9377,7 +9377,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Request for implementation tracked in [bug 403510](https://bugzil.la/403510)."
+              "impl_url": "https://bugzil.la/403510"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Add link to https://bugzilla.mozilla.org/show_bug.cgi?id=403510 to the notes section for Firefox regarding the `scrollIntoViewIfNeeded` method. That bug tracks/requests implementation of that method. Firefox hasn't currently committed to implementing the method.

#### Test results and supporting details

* https://bugzilla.mozilla.org/show_bug.cgi?id=403510

#### Related issues

None
