### PR TITLE
Safari iOS 18.2 supports `input type="week"`

### DIFF
--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -37,7 +37,9 @@
                 "version_added": false,
                 "impl_url": "https://webkit.org/b/200416"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "18.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"


### PR DESCRIPTION
Add support for week type for calendar inputs in iOS. Ref: https://webkit.org/blog/16301/webkit-features-in-safari-18-2/#:~:text=Safari%2018.2%20adds%20support%20for%20input%20type=week%20on%20iOS%2C%20iPadOS%2C%20and%20visionOS.