### PR TITLE
Don't run `send_repo_dispatch_event` job from forks

### DIFF
--- a/.github/workflows/update_bcd-utils_api.yml
+++ b/.github/workflows/update_bcd-utils_api.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   send_repo_dispatch_event:
     runs-on: ubuntu-latest
+    if: github.repository == 'mdn/browser-compat-data'
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
This PR turns off running the `send_repo_dispatch_event` job from forks, which are very unlikely to have the required token.

#### Test results and supporting details

Because the release package workflow completes cleanly, synchronizing `main` on a fork triggers the `update_bcd-utils_api` workflow. This produces annoying workflow failure notifications on the fork.

Ideally, I'd condition on this on the presence of the token (for whomever needs to test this in the future), but the job-level `if` condition can't read from `secrets` or `env`.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->