### PR TITLE
Chrome 130 supports WebAssemblyCompileOptions, which enable JS String Builtins

### DIFF
--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -373,7 +373,7 @@
             "description": "`compileOptions` parameter",
             "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
             "tags": [
-              "web-features:wasm"
+              "web-features:wasm-string-builtins"
             ],
             "support": {
               "chrome": {

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -187,7 +187,7 @@
         "compile_options": {
           "__compat": {
             "description": "`compileOptions` parameter",
-            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
               "web-features:wasm"
             ],

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -90,6 +90,50 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "compile_options": {
+          "__compat": {
+            "description": "`compileOptions` parameter",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "tags": [
+              "web-features:wasm"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "compileStreaming_static": {
@@ -139,6 +183,50 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "compile_options": {
+          "__compat": {
+            "description": "`compileOptions` parameter",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "tags": [
+              "web-features:wasm"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "instantiate_static": {
@@ -185,6 +273,50 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "compile_options": {
+          "__compat": {
+            "description": "`compileOptions` parameter",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "tags": [
+              "web-features:wasm"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -235,6 +367,50 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "compile_options": {
+          "__compat": {
+            "description": "`compileOptions` parameter",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "tags": [
+              "web-features:wasm"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "validate_static": {
@@ -281,6 +457,50 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "compile_options": {
+          "__compat": {
+            "description": "`compileOptions` parameter",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "tags": [
+              "web-features:wasm"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -371,7 +371,7 @@
         "compile_options": {
           "__compat": {
             "description": "`compileOptions` parameter",
-            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
               "web-features:wasm-string-builtins"
             ],

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -278,7 +278,7 @@
         "compile_options": {
           "__compat": {
             "description": "`compileOptions` parameter",
-            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
               "web-features:wasm"
             ],

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -464,7 +464,7 @@
             "description": "`compileOptions` parameter",
             "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
-              "web-features:wasm"
+              "web-features:wasm-string-builtins"
             ],
             "support": {
               "chrome": {

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -462,7 +462,7 @@
         "compile_options": {
           "__compat": {
             "description": "`compileOptions` parameter",
-            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
               "web-features:wasm"
             ],

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -96,7 +96,7 @@
             "description": "`compileOptions` parameter",
             "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
-              "web-features:wasm"
+              "web-features:wasm-string-builtins"
             ],
             "support": {
               "chrome": {

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -280,7 +280,7 @@
             "description": "`compileOptions` parameter",
             "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
-              "web-features:wasm"
+              "web-features:wasm-string-builtins"
             ],
             "support": {
               "chrome": {

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -189,7 +189,7 @@
             "description": "`compileOptions` parameter",
             "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
-              "web-features:wasm"
+              "web-features:wasm-string-builtins"
             ],
             "support": {
               "chrome": {

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -94,7 +94,7 @@
         "compile_options": {
           "__compat": {
             "description": "`compileOptions` parameter",
-            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+            "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
             "tags": [
               "web-features:wasm"
             ],

--- a/webassembly/api/Module.json
+++ b/webassembly/api/Module.json
@@ -91,6 +91,50 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "compile_options": {
+            "__compat": {
+              "description": "`compileOptions` parameter",
+              "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+              "tags": [
+                "web-features:wasm"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "130"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "customSections_static": {

--- a/webassembly/api/Module.json
+++ b/webassembly/api/Module.json
@@ -95,7 +95,7 @@
           "compile_options": {
             "__compat": {
               "description": "`compileOptions` parameter",
-              "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#using-builtins",
+              "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
               "tags": [
                 "web-features:wasm"
               ],

--- a/webassembly/api/Module.json
+++ b/webassembly/api/Module.json
@@ -97,7 +97,7 @@
               "description": "`compileOptions` parameter",
               "spec_url": "https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md#:~:text=dictionary-,webassemblycompileoptions",
               "tags": [
-                "web-features:wasm"
+                "web-features:wasm-string-builtins"
               ],
               "support": {
                 "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 130 supports [WebAssembly JS String builtins](https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md). Specifically, This PR adds data points for the `compileOptions` parameter used to enable these built-ins, which is added to:

- [`WebAssembly.compile()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/compile_static)
- [`WebAssembly.compileStreaming()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/compileStreaming_static)
- [`WebAssembly.instantiate()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate_static)
- [`WebAssembly.instantiateStreaming()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiateStreaming_static)
- [`WebAssembly.validate()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/validate_static)
- The [`WebAssembly.Module()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module/Module) constructor

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See https://chromestatus.com/feature/6695587390423040 for the data source. I have also tested each of the above cases and found them to work by default in Chrome 130/131.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
