### PR TITLE
Add meta viewport support data

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -124,6 +124,468 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "height": {
+            "__compat": {
+              "description": "content=\"height=[value]\"",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#height",
+              "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": "≤10.1"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "initial-scale": {
+            "__compat": {
+              "description": "content=\"initial-scale=[value]\"",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#initial-scale",
+              "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": "≤10.1"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "interactive-widget": {
+            "__compat": {
+              "description": "content=\"interactive-widget=[value]\"",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#interactive-widget",
+              "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "131"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "133"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "overlays-content": {
+              "__compat": {
+                "description": "content=\"interactive-widget=overlays-content\"",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#overlays-content",
+                "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": "131"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": "133"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "resizes-content": {
+              "__compat": {
+                "description": "content=\"interactive-widget=resizes-content\"",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#resizes-content",
+                "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": "131"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": "133"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "resizes-visual": {
+              "__compat": {
+                "description": "content=\"interactive-widget=resizes-visual\"",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#resizes-visual",
+                "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": "131"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": "133"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
+          },
+          "maximum-scale": {
+            "__compat": {
+              "description": "content=\"maximum-scale=[value]\"",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#maximum-scale",
+              "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": "≤10.1"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "minimum-scale": {
+            "__compat": {
+              "description": "content=\"minimum-scale=[value]\"",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#minimum-scale",
+              "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": "≤10.1"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "user-scalable": {
+            "__compat": {
+              "description": "content=\"user-scalable=[value]\"",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#user-scalable",
+              "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": "≤10.1"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "viewport-fit": {
+            "__compat": {
+              "description": "content=\"viewport-fit=[value]\"",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
+          },
+          "width": {
+            "__compat": {
+              "description": "content=\"width=[value]\"",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag#width",
+              "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": "≤10.1"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "http-equiv": {
@@ -513,6 +975,49 @@
                 "webview_android": {
                   "version_added": false
                 },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "viewport": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag",
+              "spec_url": "https://drafts.csswg.org/css-viewport/#viewport-meta",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": "≤10.1"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "3"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
                 "webview_ios": "mirror"
               },
               "status": {


### PR DESCRIPTION
#### Summary

Adds missing support data for `<meta name="viewport">`.

#### Test results and supporting details

This PR assumes that Mobile Safari 3 for iOS shipped the first `<meta name="viewport">` implementation, and all later released mobile browsers followed.

- [Firefox 4 for Android](https://blog.mozilla.org/en/mozilla/mozilla-launches-firefox-4-for-android-allowing-users-to-take-the-power-and-customization-of-firefox-everywhere-2/)
- [Chrome 18 for Android](https://chromereleases.googleblog.com/2012/06/chrome-for-android-out-of-beta.html)
- [Opera Mobile 10](https://web.archive.org/web/20110920142131/http://www.opera.com/docs/specs/productspecs/)

There’s a [non-standard `viewport-fit` feature](https://webkit.org/blog/7929/designing-websites-for-iphone-x/) presumably shipped in Safari 11.2.

#### Related issues

Fixes #25311