### PR TITLE
Chrome Android 130 also supports `text-wrap-style: pretty`

### DIFF
--- a/css/properties/text-wrap-style.json
+++ b/css/properties/text-wrap-style.json
@@ -122,9 +122,7 @@
               "chrome": {
                 "version_added": "130"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

there is no reason that the value only supported on chromium-desktop

it matches the behavior of the same value on the `text-wrap` property, which implemented in M117

it also matches other values of the `text-wrap-style` property in the same version. which all implemented in the same version

https://github.com/mdn/browser-compat-data/blob/7382003e9b32e24026ed6aa5afcc0f205e0f324d/css/properties/text-wrap.json#L117-L154

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

test in local mobile device and confirms its support

https://github.com/mdn/browser-compat-data/pull/24663 - the PR that add the data

https://chromestatus.com/feature/5793719555719168 - related chromium entry

https://issues.chromium.org/issues/338529223 -  related chromium bug

https://github.com/chromium/chromium/commit/ee5d3f203d98899e31221786c36baf443ea11acc - related commit

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25218

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
