### PR TITLE
Rename css.types.calc-constant to css.types.calc-keyword

### DIFF
--- a/css/types/calc-keyword.json
+++ b/css/types/calc-keyword.json
@@ -5,9 +5,9 @@
         "__compat": {
           "description": "`&lt;calc-keyword&gt;`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc-keyword",
-          "spec_url": "https://drafts.csswg.org/css-values/#calc-syntax",
+          "spec_url": "https://drafts.csswg.org/css-values/#typedef-calc-keyword",
           "tags": [
-            "web-features:calc-keywords"
+            "web-features:calc-constants"
           ],
           "support": {
             "chrome": {
@@ -43,7 +43,7 @@
           "__compat": {
             "description": "`NaN` constant",
             "tags": [
-              "web-features:calc-keywords"
+              "web-features:calc-constants"
             ],
             "support": {
               "chrome": {
@@ -80,7 +80,7 @@
           "__compat": {
             "description": "`e` constant",
             "tags": [
-              "web-features:calc-keywords"
+              "web-features:calc-constants"
             ],
             "support": {
               "chrome": {
@@ -117,7 +117,7 @@
           "__compat": {
             "description": "`infinity` and `-infinity` constants",
             "tags": [
-              "web-features:calc-keywords"
+              "web-features:calc-constants"
             ],
             "support": {
               "chrome": {
@@ -154,7 +154,7 @@
           "__compat": {
             "description": "`pi` constant",
             "tags": [
-              "web-features:calc-keywords"
+              "web-features:calc-constants"
             ],
             "support": {
               "chrome": {

--- a/css/types/calc-keyword.json
+++ b/css/types/calc-keyword.json
@@ -1,12 +1,13 @@
 {
   "css": {
     "types": {
-      "calc-constant": {
+      "calc-keyword": {
         "__compat": {
-          "description": "`&lt;calc-constant&gt;`",
-          "spec_url": "https://drafts.csswg.org/css-values/#calc-constants",
+          "description": "`&lt;calc-keyword&gt;`",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc-keyword",
+          "spec_url": "https://drafts.csswg.org/css-values/#calc-syntax",
           "tags": [
-            "web-features:calc-constants"
+            "web-features:calc-keywords"
           ],
           "support": {
             "chrome": {
@@ -42,7 +43,7 @@
           "__compat": {
             "description": "`NaN` constant",
             "tags": [
-              "web-features:calc-constants"
+              "web-features:calc-keywords"
             ],
             "support": {
               "chrome": {
@@ -79,7 +80,7 @@
           "__compat": {
             "description": "`e` constant",
             "tags": [
-              "web-features:calc-constants"
+              "web-features:calc-keywords"
             ],
             "support": {
               "chrome": {
@@ -116,7 +117,7 @@
           "__compat": {
             "description": "`infinity` and `-infinity` constants",
             "tags": [
-              "web-features:calc-constants"
+              "web-features:calc-keywords"
             ],
             "support": {
               "chrome": {
@@ -153,7 +154,7 @@
           "__compat": {
             "description": "`pi` constant",
             "tags": [
-              "web-features:calc-constants"
+              "web-features:calc-keywords"
             ],
             "support": {
               "chrome": {


### PR DESCRIPTION
#### Summary

This has been renamed in the spec and on MDN. 

- https://developer.mozilla.org/en-US/docs/Web/CSS/calc-keyword


#### Open questions

- [x] Does `web-features:calc-constants` need to be renamed? See https://github.com/web-platform-dx/web-features/blob/main/features/calc-constants.yml

#### Related issues

- [x] https://github.com/mdn/content/issues/34348


Fixes #24036
