### PR TITLE
Chrome 127 makes `webextensions.api.action.openPopup` generally available

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -464,10 +464,16 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup",
             "support": {
-              "chrome": {
-                "version_added": "118",
-                "notes": "Is only available to policy installed extensions and dev builds (e.g., Canary)."
-              },
+              "chrome": [
+                {
+                  "version_added": "127"
+                },
+                {
+                  "version_added": "118",
+                  "version_removed": "127",
+                  "notes": "Is only available to policy installed extensions and dev builds (e.g., Canary)."
+                }
+              ],
               "edge": "mirror",
               "firefox": {
                 "version_added": "109",


### PR DESCRIPTION
#### Summary

[Chrome documentation](https://developer.chrome.com/docs/extensions/reference/api/action#method-openPopup) indicates that `webextensions.api.action.openPopup` is generally available in Chrome 127.

#### Related issues

Fixes #25345
