### PR TITLE
Firefox 78 allows number values in CSS aspect ratio

### DIFF
--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -58,14 +58,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "70",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.aspect-ratio-number.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "78"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF78 enabled and removed the pref  `layout.css.aspect-ratio-number.enabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=1635939 (and noted in https://bugzilla.mozilla.org/show_bug.cgi?id=1621090#c2). 

This updates the associated feature accordingly.

Fell out of work done in https://github.com/mdn/content/issues/36742
