### PR TITLE
Mirror Safari iOS for MessagePort worker support

### DIFF
--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -99,9 +99,7 @@
             "safari": {
               "version_added": "5"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
#### Summary

It's likely that iOS should mirror desktop here, but need to verify.

#### Test results and supporting details

 Can't find anything in release notes yet.
