### PR TITLE
Chromium supports clearAppBadge as much as it is possible

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -642,8 +642,7 @@
           "support": {
             "chrome": {
               "version_added": "81",
-              "partial_implementation": true,
-              "notes": "Windows and macOS only."
+              "notes": "Windows and macOS only. Linux offers no universal badging API on the operating system level."
             },
             "chrome_android": {
               "version_added": "81"


### PR DESCRIPTION
I forgot this in https://github.com/mdn/browser-compat-data/pull/25375 🤦 

Really unblocks https://github.com/web-platform-dx/web-features/pull/2360#discussion_r1863518542