### PR TITLE
Chromium 24 added `-webkit-app-region` CSS property

### DIFF
--- a/css/properties/-webkit-app-region.json
+++ b/css/properties/-webkit-app-region.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "24"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `-webkit-app-region` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/-webkit-app-region
