### PR TITLE
Update Chrome/Safari data for -webkit-* CSS property

### DIFF
--- a/css/properties/-webkit-border-horizontal-spacing.json
+++ b/css/properties/-webkit-border-horizontal-spacing.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-border-horizontal-spacing.json
+++ b/css/properties/-webkit-border-horizontal-spacing.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-border-vertical-spacing.json
+++ b/css/properties/-webkit-border-vertical-spacing.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-border-vertical-spacing.json
+++ b/css/properties/-webkit-border-vertical-spacing.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-column-break-after.json
+++ b/css/properties/-webkit-column-break-after.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-column-break-after.json
+++ b/css/properties/-webkit-column-break-after.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-column-break-before.json
+++ b/css/properties/-webkit-column-break-before.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-column-break-before.json
+++ b/css/properties/-webkit-column-break-before.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-column-break-inside.json
+++ b/css/properties/-webkit-column-break-inside.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-column-break-inside.json
+++ b/css/properties/-webkit-column-break-inside.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-locale.json
+++ b/css/properties/-webkit-locale.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "11"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/-webkit-locale.json
+++ b/css/properties/-webkit-locale.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-logical-height.json
+++ b/css/properties/-webkit-logical-height.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "8"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-logical-height.json
+++ b/css/properties/-webkit-logical-height.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-logical-width.json
+++ b/css/properties/-webkit-logical-width.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "8"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-logical-width.json
+++ b/css/properties/-webkit-logical-width.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-margin-after.json
+++ b/css/properties/-webkit-margin-after.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "8"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-margin-after.json
+++ b/css/properties/-webkit-margin-after.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-margin-before.json
+++ b/css/properties/-webkit-margin-before.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "8"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-margin-before.json
+++ b/css/properties/-webkit-margin-before.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-max-logical-height.json
+++ b/css/properties/-webkit-max-logical-height.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "8"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-max-logical-height.json
+++ b/css/properties/-webkit-max-logical-height.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-max-logical-width.json
+++ b/css/properties/-webkit-max-logical-width.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "8"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-max-logical-width.json
+++ b/css/properties/-webkit-max-logical-width.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-min-logical-height.json
+++ b/css/properties/-webkit-min-logical-height.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "8"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-min-logical-height.json
+++ b/css/properties/-webkit-min-logical-height.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-min-logical-width.json
+++ b/css/properties/-webkit-min-logical-width.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "8"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-min-logical-width.json
+++ b/css/properties/-webkit-min-logical-width.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-perspective-origin-x.json
+++ b/css/properties/-webkit-perspective-origin-x.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-perspective-origin-x.json
+++ b/css/properties/-webkit-perspective-origin-x.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-perspective-origin-y.json
+++ b/css/properties/-webkit-perspective-origin-y.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-perspective-origin-y.json
+++ b/css/properties/-webkit-perspective-origin-y.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-rtl-ordering.json
+++ b/css/properties/-webkit-rtl-ordering.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-rtl-ordering.json
+++ b/css/properties/-webkit-rtl-ordering.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-text-combine.json
+++ b/css/properties/-webkit-text-combine.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "9"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/-webkit-text-combine.json
+++ b/css/properties/-webkit-text-combine.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-text-decorations-in-effect.json
+++ b/css/properties/-webkit-text-decorations-in-effect.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4",
+              "version_removed": "13.1",
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-text-decorations-in-effect.json
+++ b/css/properties/-webkit-text-decorations-in-effect.json
@@ -21,7 +21,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "≤4",
-              "version_removed": "13.1",
+              "version_removed": "13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-text-decorations-in-effect.json
+++ b/css/properties/-webkit-text-decorations-in-effect.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-transform-origin-x.json
+++ b/css/properties/-webkit-transform-origin-x.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-transform-origin-x.json
+++ b/css/properties/-webkit-transform-origin-x.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-transform-origin-y.json
+++ b/css/properties/-webkit-transform-origin-y.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-transform-origin-y.json
+++ b/css/properties/-webkit-transform-origin-y.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-transform-origin-z.json
+++ b/css/properties/-webkit-transform-origin-z.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-transform-origin-z.json
+++ b/css/properties/-webkit-transform-origin-z.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-user-drag.json
+++ b/css/properties/-webkit-user-drag.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-user-drag.json
+++ b/css/properties/-webkit-user-drag.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for various `-webkit-*` CSS properties. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._
