### PR TITLE
Chrome 22-34 / Safari 7+ support `-webkit-column-progression` CSS property

### DIFF
--- a/css/properties/-webkit-column-progression.json
+++ b/css/properties/-webkit-column-progression.json
@@ -5,7 +5,8 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "22",
+              "version_removed": "35"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +21,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `-webkit-column-progression` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/-webkit-column-progression
