### PR TITLE
Chrome 17-33 / Safari 6+ support `-webkit-line-grid` CSS property

### DIFF
--- a/css/properties/-webkit-line-grid.json
+++ b/css/properties/-webkit-line-grid.json
@@ -5,7 +5,8 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "35"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +21,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-line-grid.json
+++ b/css/properties/-webkit-line-grid.json
@@ -6,7 +6,7 @@
           "support": {
             "chrome": {
               "version_added": "17",
-              "version_removed": "35"
+              "version_removed": "34"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `-webkit-line-grid` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/-webkit-line-grid
