### PR TITLE
@view-transition now supported in Safari 18.2

### DIFF
--- a/css/at-rules/view-transition.json
+++ b/css/at-rules/view-transition.json
@@ -26,7 +26,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
+              "version_added": "18.2",
               "impl_url": "https://webkit.org/b/278247"
             },
             "safari_ios": "mirror",

--- a/css/at-rules/view-transition.json
+++ b/css/at-rules/view-transition.json
@@ -35,7 +35,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
See https://webkit.org/blog/16301/webkit-features-in-safari-18-2/
