### PR TITLE
SVGRect: links to future pages

### DIFF
--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -48,6 +48,7 @@
         }
       },
       "height": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRect/height",
         "__compat": {
           "tags": [
             "web-features:svg"
@@ -94,6 +95,7 @@
         }
       },
       "width": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRect/width",
         "__compat": {
           "tags": [
             "web-features:svg"
@@ -187,6 +189,7 @@
         }
       },
       "y": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRect/y",
         "__compat": {
           "tags": [
             "web-features:svg"


### PR DESCRIPTION

#### Summary

Add links to the new pages that are being written for the `SVGRect` properties; SVGRect is an alias for DOMRect

#### Related issues

Part of https://github.com/openwebdocs/project/issues/214. The pages are currently being written (PR isn't done yet. will update this PR with that PR when submitted tomorrow)
