### PR TITLE
Chrome 1-27 / Safari support `-webkit-nbsp-mode` CSS property

### DIFF
--- a/css/properties/-webkit-nbsp-mode.json
+++ b/css/properties/-webkit-nbsp-mode.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤15",
+              "version_added": "1",
               "version_removed": "28"
             },
             "chrome_android": "mirror",

--- a/css/properties/-webkit-nbsp-mode.json
+++ b/css/properties/-webkit-nbsp-mode.json
@@ -5,7 +5,8 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤15",
+              "version_removed": "28"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -20,7 +21,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/-webkit-nbsp-mode.json
+++ b/css/properties/-webkit-nbsp-mode.json
@@ -21,7 +21,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `-webkit-nbsp-mode` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/-webkit-nbsp-mode
