### PR TITLE
Chrome 1 / Safari 5.1 add `alignment-baseline` CSS property

### DIFF
--- a/css/properties/alignment-baseline.json
+++ b/css/properties/alignment-baseline.json
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤4"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -98,7 +98,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -134,7 +134,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -170,7 +170,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -206,7 +206,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -242,7 +242,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/alignment-baseline.json
+++ b/css/properties/alignment-baseline.json
@@ -12,7 +12,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -83,7 +83,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -119,7 +119,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -134,7 +134,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -155,7 +155,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -170,7 +170,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -191,7 +191,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -206,7 +206,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -227,7 +227,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -242,7 +242,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/alignment-baseline.json
+++ b/css/properties/alignment-baseline.json
@@ -12,7 +12,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -83,7 +83,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -119,7 +119,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -134,7 +134,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -155,7 +155,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -170,7 +170,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -191,7 +191,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -206,7 +206,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -227,7 +227,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -242,7 +242,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `alignment-baseline` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/alignment-baseline
