### PR TITLE
Fix spec urls for DedicatedWorkerGlobalScope message events

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -137,7 +137,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/message_event",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/indices.html#event-message",
-            "https://html.spec.whatwg.org/multipage/workers.html#handler-dedicatedworkerglobalscope-onmessage"
+            "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageeventtarget-onmessage"
           ],
           "tags": [
             "web-features:postmessage"
@@ -192,7 +192,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/messageerror_event",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/indices.html#event-messageerror",
-            "https://html.spec.whatwg.org/multipage/workers.html#handler-dedicatedworkerglobalscope-onmessageerror"
+            "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageeventtarget-onmessageerror"
           ],
           "tags": [
             "web-features:messageerror"


### PR DESCRIPTION
Found by https://github.com/mdn/browser-compat-data/pull/23958