### PR TITLE
GPUSupportedLimits.maxInterStageShaderComponents no longer standard

### DIFF
--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -817,7 +817,6 @@
       "maxInterStageShaderComponents": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",
-          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadercomponents",
           "tags": [
             "web-features:webgpu"
           ],
@@ -865,7 +864,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
Will probably be removed in Chrome 135 https://chromestatus.com/feature/4853767735083008, https://issues.chromium.org/issues/364338810

Gone from the spec: https://github.com/gpuweb/gpuweb/pull/4783

Discovered by https://github.com/mdn/browser-compat-data/pull/23958