### PR TITLE
Remove MLContext.compute

### DIFF
--- a/api/MLContext.json
+++ b/api/MLContext.json
@@ -48,52 +48,6 @@
           "deprecated": false
         }
       },
-      "compute": {
-        "__compat": {
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlcontext-compute",
-          "support": {
-            "chrome": {
-              "version_added": "112",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "dispatch": {
         "__compat": {
           "spec_url": "https://www.w3.org/TR/webnn/#api-mlcontext-dispatch",


### PR DESCRIPTION
Not in the spec anymore https://github.com/webmachinelearning/webnn/pull/795
(Discovered by https://github.com/mdn/browser-compat-data/pull/23958)

Also tested in Canary with flag enabled and `compute` is not there anymore.