### PR TITLE
Safari 15.5 shipped `html.global_attributes.a.nonce_hiding`

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -888,6 +888,7 @@
         "nonce_hiding": {
           "__compat": {
             "description": "`nonce` hiding behavior",
+            "spec_url": "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#nonce-does-not-update-dom",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -905,8 +906,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/179728"
+                "version_added": "15.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Safari shipped this feature in 15.5. I've also added a specification URL.

#### Test results and supporting details

- [Safari 15.5 release notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_5-release-notes#:~:text=Fixed%20nonce%20hiding%20from%20the%20DOM)
- Resolved [Webkit bug 179728](https://bugs.webkit.org/show_bug.cgi?id=179728)
- Confirmed [`content-security-policy/nonce-hiding/nonces.html`](https://wpt.live/content-security-policy/nonce-hiding/nonces.html) passed in contemporary browser

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered reviewing https://github.com/web-platform-dx/web-features/pull/2423

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
