### PR TITLE
Chrome/Safari ignore Content-Disposition filename on save if disposition type is inline

### DIFF
--- a/http/headers/Content-Disposition.json
+++ b/http/headers/Content-Disposition.json
@@ -13,7 +13,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "When saving documents, the document title is used instead of the `filename` parameter if the disposition type is `inline` [bug 352093465](https://crbug.com/352093465)."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/http/headers/Content-Disposition.json
+++ b/http/headers/Content-Disposition.json
@@ -14,7 +14,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "When saving documents, the document title is used instead of the `filename` parameter if the disposition type is `inline` [bug 352093465](https://crbug.com/352093465)."
+              "notes": "When saving documents, the document title is used instead of the `filename` parameter if the disposition type is `inline`. See [bug 352093465](https://crbug.com/352093465)."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -32,7 +32,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "When saving documents, the document title is used instead of the `filename` parameter if the disposition type is `inline`. See [bug 18384](https://webkit.org/b/18384)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Adding a note about behavior that deviates in Chrome in the following condition:

```http
Content-Disposition: inline; filename="something"
```

__background:__

Usually, the `filename` parameter is used to prefill the file name for `attachment` types -> this triggers a save-as dialog immediately on navigation:

```http
Content-Disposition: attachment; filename=example.html
```

`inline` means the user agent is supposed to render the document "as usual" instead of prompting the user to download. In this case, adding a filename is allowed for cases where the user saves the document at a later stage. I've added some more details in the linked issue.

__actual behavior:__

Chrome uses the document title (PDF / HTML) instead of the `filename` parameter, which may be unexpected for some developers.

#### Test results and supporting details

It's visible in the linked BCD issue and there are multiple reproducers in the Chrome bug.

#### Related issues

Fixes #18108
