### PR TITLE
Chrome 5, Firefox 6, Safari 5 supporting HTTP Upgrade

### DIFF
--- a/http/headers/Upgrade.json
+++ b/http/headers/Upgrade.json
@@ -11,14 +11,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "5"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "6"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -28,7 +28,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "1"
+              "version_added": "5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Protocol upgrade was specd in early HTTP versions (https://datatracker.ietf.org/doc/html/rfc2616#section-14.42), but first implemented for WebSocket opening handshakes:

https://www.rfc-editor.org/rfc/rfc6455#section-1.3

#### Test results and supporting details

- Firefox:
  - https://hg.mozilla.org/mozilla-central/rev/9197b91fd9f4
  - relnotes: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/6#networking
  - bug: https://bugzilla.mozilla.org/show_bug.cgi?id=640213
- Safari:
  - https://github.com/WebKit/WebKit/commit/0410f28cb701a9cca89b035d74ef8ae427cfc3d5
  - tagged [Safari-533.9](https://github.com/WebKit/WebKit/releases/tag/Safari-533.9) which is v5
- Chrome:
  - https://codereview.chromium.org/155079/


#### Related issues

Fixes #25152
