### PR TITLE
Chrome not detecting sourcemap set by HTTP header only for ESM JS

### DIFF
--- a/http/headers/SourceMap.json
+++ b/http/headers/SourceMap.json
@@ -11,7 +11,8 @@
           "support": {
             "chrome": [
               {
-                "version_added": "18"
+                "version_added": "18",
+                "notes": "Not supported for ECMAScript Modules (`<script type=\"module\">`). See [bug 40854862](https://crbug.com/40854862)."
               },
               {
                 "prefix": "X-",


### PR DESCRIPTION
#### Summary

You can set a source map for code via annotation (`sourceMappingURL=path/to/thing.map`) or via the HTTP header for that resource:

```
HTTP/1.1 200 OK
Content-Type: application/javascript
SourceMap: /path/to/file.js.map

<my js>
```

This appears to be broken in Chrome for the following case:

```html
<script type="module">
    import { thing } from '/file.esm.js';
    …
</script>
```

#### Test results and supporting details

* Bug: https://issues.chromium.org/issues/40854862
* Reproducer: https://test-esm-sourcemap.vercel.app/hidden-sourcemap/esm.html  

Firefox and Safari both show source files in the debugger ("original file" below):

![image](https://github.com/user-attachments/assets/d7e85ffc-472b-4b0c-a2d7-2538e88322b7)

#### Related issues

Fixes #18183
