### PR TITLE
Chrome Android also supports anchor-scope CSS property

### DIFF
--- a/css/properties/anchor-scope.json
+++ b/css/properties/anchor-scope.json
@@ -11,9 +11,7 @@
             "chrome": {
               "version_added": "131"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -49,9 +47,7 @@
               "chrome": {
                 "version_added": "131"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -88,9 +84,7 @@
               "chrome": {
                 "version_added": "131"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
#### Summary

#24778 added `anchor-scope`, with `chrome_android` set to false, but it should have been set to `mirror`.

#### Test results and supporting details

https://chromestatus.com/feature/5094192052436992