### PR TITLE
Safari 18.3 unshipped Clear-Site-Data: executionContext

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -230,7 +230,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "17"
+                "version_added": "17",
+                "version_removed": "18.3"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
See 
- https://developer.apple.com/documentation/safari-release-notes/safari-18_3-release-notes
- https://github.com/WebKit/WebKit/pull/35724
- https://bugs.webkit.org/show_bug.cgi?id=271700