### PR TITLE
Mark `api.Document.write` as deprecated

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8379,7 +8379,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The spec discourages calling `document.write()` in very clear terms.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See this very intense warning in the spec:

> … [For all these reasons, use of this method is strongly discouraged.](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document.write())

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered in the course of reviewing https://github.com/web-platform-dx/web-features/pull/2405.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
