### PR TITLE
Mark `@font-face/font-variant` descriptor as non-standard

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -662,8 +662,6 @@
         },
         "font-variant": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face",
-            "spec_url": "https://drafts.csswg.org/css-fonts/#font-variant-prop",
             "tags": [
               "web-features:font-variant"
             ],
@@ -701,7 +699,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

unlike `font-variant` property, `@font-face/font-variant` descriptor has removed from spec for a long time, see https://github.com/w3c/csswg-drafts/issues/2531

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://drafts.csswg.org/css-fonts/#at-font-face-rule
https://drafts.csswg.org/css-fonts-5/#at-font-face-rule

https://github.com/mdn/content/pull/21481 for mdn docs update
https://developer.mozilla.org/en-US/docs/Web/API/FontFace/variant for the similar case

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
