### PR TITLE
Opera supports `hidden="until-found"` + rename `until-found_value` to `until-found`

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -602,7 +602,7 @@
             "deprecated": false
           }
         },
-        "until-found_value": {
+        "until-found": {
           "__compat": {
             "description": "`until-found` value",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/hidden",
@@ -625,9 +625,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,


### PR DESCRIPTION
#### Summary

This PR aligns the naming conventions for HTML attribute values, specifically removing the `_value` suffix from `hidden="until-found"` to maintain consistency with other attribute values like `contenteditable="plaintext-only"`. Additionally, compatibility details for the `hidden="until-found"` attribute in Opera have been updated.

#### Test results and supporting details

Compatibility for Opera was tested as follows:
- Opera 87 (via BrowserStack) — attribute `hidden="until-found"` does not work
- Opera 88 (via BrowserStack) — attribute `hidden="until-found"` works
- Opera 115 (tested on a physical device) — attribute `hidden="until-found"` works
