### PR TITLE
Chrome 131 removed inset-area

### DIFF
--- a/css/properties/position-area.json
+++ b/css/properties/position-area.json
@@ -15,7 +15,8 @@
               },
               {
                 "alternative_name": "inset-area",
-                "version_added": "125"
+                "version_added": "125",
+                "version_removed": "131"
               }
             ],
             "chrome_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 131 removed `inset-area`, the old name of `position-area`.

#### Test results and supporting details

This commit mentions it: https://github.com/chromium/chromium/commit/36e8cecee4e2b221a8117f330567f91cd65532c5

Computed properties no longer returns it: https://github.com/caugner/css-properties/commit/7f36097f36c02253b09fd04592fdb1dfff752176

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
