### PR TITLE
Chrome 120 removed webkit-prefixed mask properties

### DIFF
--- a/css/properties/-webkit-mask-composite.json
+++ b/css/properties/-webkit-mask-composite.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "120"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -15,7 +15,8 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "120"
               }
             ],
             "chrome_android": "mirror",

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -16,6 +16,7 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "1",
+                "version_removed": "120",
                 "notes": "From version 8, Chrome added support for gradient values. Initially, Chrome supported only `-webkit-` prefixed values for gradients (such as `-webkit-linear-gradient()`). Later, support for unprefixed values was added."
               }
             ],

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -15,7 +15,8 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "120"
               }
             ],
             "chrome_android": "mirror",

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -15,7 +15,8 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "120"
               }
             ],
             "chrome_android": "mirror",

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -15,7 +15,8 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "120"
               }
             ],
             "chrome_android": "mirror",

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -15,7 +15,8 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "120"
               }
             ],
             "chrome_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 120 removed webkit-prefixed mask properties.

#### Test results and supporting details

Computed properties no longer return them: https://github.com/caugner/css-properties/commit/878db3e3d89f3938ba1418f40688bb1ecdb3ffce

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
