### PR TITLE
Mark svg.elements.script.xlink_href as deprecated

### DIFF
--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -263,7 +263,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
#### Summary

Marks `svg.elements.script.xlink_href` as deprecated. This is in line with the other SVG elements.

#### Test results and supporting details

SVG 2 deprecated `xlink:href` in favor of `href` without a namespace. 

https://svgwg.org/svg2-draft/changes.html#linking
https://svgwg.org/svg2-draft/linking.html#XLinkTitleAttribute
