### PR TITLE
Node.js 20.16/22.3 supports `{Request,Response}.bytes()`

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -644,6 +644,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "22.3.0"
+              },
+              {
+                "version_added": "20.16.0",
+                "version_removed": "21.0.0"
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/Response.json
+++ b/api/Response.json
@@ -440,6 +440,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "22.3.0"
+              },
+              {
+                "version_added": "20.16.0",
+                "version_removed": "21.0.0"
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the feature is added in https://github.com/nodejs/node/commit/4d7706676bd98ceaede12f68e0386645049a03b6 (https://github.com/nodejs/node/pull/53034) 

spec proposal link at https://github.com/whatwg/fetch/issues/1732, feature issue at https://github.com/nodejs/undici/issues/3256

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
