### PR TITLE
Add Node/Deno info for some request features

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -159,12 +159,18 @@
                 "version_added": "125"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
+                "version_added": false
+              },
+              "nodejs": {
                 "version_added": false
               },
               "oculus": "mirror",
@@ -193,12 +199,18 @@
                 "version_added": "115"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
+                "version_added": false
+              },
+              "nodejs": {
                 "version_added": false
               },
               "oculus": "mirror",
@@ -1371,6 +1383,9 @@
               "ie": {
                 "version_added": false
               },
+              "nodejs": {
+                "version_added": false
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
@@ -1592,12 +1607,18 @@
               "version_added": "124"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "oculus": "mirror",

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -141,12 +141,18 @@
               "version_added": "125"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "oculus": "mirror",
@@ -175,12 +181,18 @@
               "version_added": "115"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`Request.mode` `navigate` value - not supported by nodejs, like deno

```js
new Request('https://developer.mozilla.org/en-US/docs/Web/API/Request', { mode: 'navigate' }).mode

// Uncaught TypeError: Request constructor: invalid request mode navigate.
//     at webidl.errors.exception (node:internal/deps/undici/undici:3564:14)
//     at new Request (node:internal/deps/undici/undici:9586:31)
```

`Request.targetAddressSpace` - not supported by nodejs and deno, checked in source code for [nodejs](https://github.com/nodejs/node/blob/main/deps/undici/src/lib/web/fetch/request.js) and [deno](https://github.com/denoland/deno/blob/main/ext/fetch/23_request.js)

`RequestInit.attributionReporting` and `RequestInit.browsingTopics` - surely not supported by nodejs and deno


<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
