### PR TITLE
Update auto-issue closer

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -11,17 +11,17 @@ jobs:
   close-issues-if-invalid:
     runs-on: ubuntu-latest
     steps:
-      - uses: queengooborg/invalid-issue-closer@v1.5.1
+      - uses: queengooborg/invalid-issue-closer@v1.5.2
         id: spam-check
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: "spam"
-          lock: "spam"
+          # lock: "spam"
           comment: |
-            This issue has been identified as spam and has been automatically closed and locked.
+            This issue has been identified as spam and has been automatically closed.
           normalize-newlines: true
           body-is-blank: true
-      - uses: queengooborg/invalid-issue-closer@v1.5.1
+      - uses: queengooborg/invalid-issue-closer@v1.5.2
         if: steps.spam-check.outputs.was-closed == 'false'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Due to some recent issues with the issue closer, auto-locking of spam issues has been temporarily disabled until it is confirmed to be fully functional.