### PR TITLE
Deno 1.46 / Node 23 support `Promise.try()`

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -324,7 +324,7 @@
         "1.45": {
           "release_date": "2024-07-11",
           "release_notes": "https://deno.com/blog/v1.45",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "12.7"
         },

--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -327,6 +327,13 @@
           "status": "current",
           "engine": "V8",
           "engine_version": "12.7"
+        },
+        "1.46": {
+          "release_date": "2024-08-22",
+          "release_notes": "https://deno.com/blog/v1.46",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "12.9"
         }
       }
     }

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -583,7 +583,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.46"
               },
               "edge": "mirror",
               "firefox": {
@@ -594,7 +594,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "23.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

- Adds browser information for Deno 1.46
- Adds Promise.try compatibility information for node and deno, the versions correspond to v8 version 12.8 (Chrome 128) which is the first version that has Promise.try

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

node - https://github.com/nodejs/node/releases/tag/v23.0.0 - "deps: update V8 to 12.8.374.13"
deno - https://github.com/denoland/deno/releases/tag/v1.46.0 - "feat: upgrade V8 to 12.8"

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
