### PR TITLE
Chrome/Deno/Node/Safari started rejecting `ReadableStream*Reader.releaseLock()` with pending read requests

### DIFF
--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -307,7 +307,7 @@
             "support": {
               "chrome": {
                 "version_added": "105",
-                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 105, `releaseLock()` throws instead of rejecting."
               },
               "chrome_android": "mirror",
               "deno": {

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -303,14 +303,20 @@
         },
         "reject_pending_read_request": {
           "__compat": {
+            "description": "`releaseLock()` rejects pending read requests",
             "support": {
-              "chrome": {
-                "version_added": false,
-                "notes": "`releaseLock()` throws if there are pending read requests (rather than pending read requests being rejected)."
-              },
+              "chrome": [
+                {
+                  "version_added": "105"
+                },
+                {
+                  "version_added": false,
+                  "notes": "`releaseLock()` throws if there are pending read requests (rather than pending read requests being rejected)."
+                }
+              ],
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.18"
               },
               "edge": "mirror",
               "firefox": {
@@ -321,7 +327,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "18.9"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -335,7 +341,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -272,8 +272,9 @@
               },
               {
                 "version_added": "89",
+                "version_removed": "105",
                 "partial_implementation": true,
-                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "chrome_android": "mirror",
@@ -283,8 +284,9 @@
               },
               {
                 "version_added": "1.16",
+                "version_removed": "1.18",
                 "partial_implementation": true,
-                "notes": "Before version 1.18, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "edge": "mirror",
@@ -301,8 +303,9 @@
               },
               {
                 "version_added": "16.5.0",
+                "version_removed": "18.9.0",
                 "partial_implementation": true,
-                "notes": "Before version 18.9.0, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "oculus": "mirror",

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -266,27 +266,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/releaseLock",
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-byob-reader-release-lock②",
           "support": {
-            "chrome": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "89",
-                "partial_implementation": true,
-                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              }
-            ],
+            "chrome": {
+              "version_added": "89"
+            },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.18"
-              },
-              {
-                "version_added": "1.16",
-                "partial_implementation": true,
-                "notes": "Before version 1.18, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              }
-            ],
+            "deno": {
+              "version_added": "1.16"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "102"
@@ -295,16 +281,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "18.9.0"
-              },
-              {
-                "version_added": "16.5.0",
-                "partial_implementation": true,
-                "notes": "Before version 18.9.0, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              }
-            ],
+            "nodejs": {
+              "version_added": "16.5.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -320,6 +299,47 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "reject_pending_read_request": {
+          "__compat": {
+            "description": "`releaseLock()` rejects pending read requests",
+            "support": {
+              "chrome": {
+                "version_added": "105",
+                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.18"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "18.9.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -322,7 +322,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "18.9"
+                "version_added": "18.9.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -266,13 +266,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/releaseLock",
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-byob-reader-release-lock②",
           "support": {
-            "chrome": {
-              "version_added": "89"
-            },
+            "chrome": [
+              {
+                "version_added": "105"
+              },
+              {
+                "version_added": "89",
+                "partial_implementation": true,
+                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              }
+            ],
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.16"
-            },
+            "deno": [
+              {
+                "version_added": "1.18"
+              },
+              {
+                "version_added": "1.16",
+                "partial_implementation": true,
+                "notes": "Before version 1.18, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              }
+            ],
             "edge": "mirror",
             "firefox": {
               "version_added": "102"
@@ -281,9 +295,16 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "16.5.0"
-            },
+            "nodejs": [
+              {
+                "version_added": "18.9.0"
+              },
+              {
+                "version_added": "16.5.0",
+                "partial_implementation": true,
+                "notes": "Before version 18.9.0, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -299,47 +320,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "reject_pending_read_request": {
-          "__compat": {
-            "description": "`releaseLock()` rejects pending read requests",
-            "support": {
-              "chrome": {
-                "version_added": "105",
-                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.18"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "102"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "18.9.0"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -305,15 +305,10 @@
           "__compat": {
             "description": "`releaseLock()` rejects pending read requests",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "105"
-                },
-                {
-                  "version_added": false,
-                  "notes": "`releaseLock()` throws if there are pending read requests (rather than pending read requests being rejected)."
-                }
-              ],
+              "chrome": {
+                "version_added": "105",
+                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              },
               "chrome_android": "mirror",
               "deno": {
                 "version_added": "1.18"

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -272,9 +272,8 @@
               },
               {
                 "version_added": "89",
-                "version_removed": "105",
                 "partial_implementation": true,
-                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "chrome_android": "mirror",
@@ -284,9 +283,8 @@
               },
               {
                 "version_added": "1.16",
-                "version_removed": "1.18",
                 "partial_implementation": true,
-                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 1.18, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "edge": "mirror",
@@ -303,9 +301,8 @@
               },
               {
                 "version_added": "16.5.0",
-                "version_removed": "18.9.0",
                 "partial_implementation": true,
-                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 18.9.0, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "oculus": "mirror",

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -264,15 +264,10 @@
           "__compat": {
             "description": "`releaseLock()` rejects pending read requests",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "105"
-                },
-                {
-                  "version_added": false,
-                  "notes": "`releaseLock()` throws if there are pending read requests (rather than pending read requests being rejected)."
-                }
-              ],
+              "chrome": {
+                "version_added": "105",
+                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              },
               "chrome_android": "mirror",
               "deno": {
                 "version_added": "1.18"

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -281,7 +281,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "18.9"
+                "version_added": "18.9.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -231,9 +231,8 @@
               },
               {
                 "version_added": "43",
-                "version_removed": "105",
                 "partial_implementation": true,
-                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "chrome_android": "mirror",
@@ -243,9 +242,8 @@
               },
               {
                 "version_added": "1.0",
-                "version_removed": "1.18",
                 "partial_implementation": true,
-                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 1.18, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "edge": "mirror",
@@ -255,9 +253,8 @@
               },
               {
                 "version_added": "65",
-                "version_removed": "102",
                 "partial_implementation": true,
-                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 102, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "firefox_android": "mirror",
@@ -270,9 +267,8 @@
               },
               {
                 "version_added": "16.5.0",
-                "version_removed": "18.9.0",
                 "partial_implementation": true,
-                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 18.9.0, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "oculus": "mirror",
@@ -284,9 +280,8 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "17",
                 "partial_implementation": true,
-                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 17, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "safari_ios": "mirror",

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -225,30 +225,65 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader/releaseLock",
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-default-reader-release-lock②",
           "support": {
-            "chrome": {
-              "version_added": "43"
-            },
+            "chrome": [
+              {
+                "version_added": "105"
+              },
+              {
+                "version_added": "43",
+                "partial_implementation": true,
+                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              }
+            ],
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.0"
-            },
+            "deno": [
+              {
+                "version_added": "1.18"
+              },
+              {
+                "version_added": "1.0",
+                "partial_implementation": true,
+                "notes": "Before version 1.18, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              }
+            ],
             "edge": "mirror",
-            "firefox": {
-              "version_added": "65"
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "65",
+                "partial_implementation": true,
+                "notes": "Before version 102, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "16.5.0"
-            },
+            "nodejs": [
+              {
+                "version_added": "18.9.0"
+              },
+              {
+                "version_added": "16.5.0",
+                "partial_implementation": true,
+                "notes": "Before version 18.9.0, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10"
-            },
+            "safari": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "Before version 17, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -258,47 +293,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "reject_pending_read_request": {
-          "__compat": {
-            "description": "`releaseLock()` rejects pending read requests",
-            "support": {
-              "chrome": {
-                "version_added": "105",
-                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.18"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "102"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "18.9.0"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "17"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -262,14 +262,20 @@
         },
         "reject_pending_read_request": {
           "__compat": {
+            "description": "`releaseLock()` rejects pending read requests",
             "support": {
-              "chrome": {
-                "version_added": false,
-                "notes": "`releaseLock()` throws if there are pending read requests (rather than pending read requests being rejected)."
-              },
+              "chrome": [
+                {
+                  "version_added": "105"
+                },
+                {
+                  "version_added": false,
+                  "notes": "`releaseLock()` throws if there are pending read requests (rather than pending read requests being rejected)."
+                }
+              ],
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.18"
               },
               "edge": "mirror",
               "firefox": {
@@ -280,13 +286,13 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "18.9"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -294,7 +300,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -231,8 +231,9 @@
               },
               {
                 "version_added": "43",
+                "version_removed": "105",
                 "partial_implementation": true,
-                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "chrome_android": "mirror",
@@ -242,8 +243,9 @@
               },
               {
                 "version_added": "1.0",
+                "version_removed": "1.18",
                 "partial_implementation": true,
-                "notes": "Before version 1.18, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "edge": "mirror",
@@ -253,8 +255,9 @@
               },
               {
                 "version_added": "65",
+                "version_removed": "102",
                 "partial_implementation": true,
-                "notes": "Before version 102, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "firefox_android": "mirror",
@@ -267,8 +270,9 @@
               },
               {
                 "version_added": "16.5.0",
+                "version_removed": "18.9.0",
                 "partial_implementation": true,
-                "notes": "Before version 18.9.0, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "oculus": "mirror",
@@ -280,8 +284,9 @@
               },
               {
                 "version_added": "10",
+                "version_removed": "17",
                 "partial_implementation": true,
-                "notes": "Before version 17, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "The `releaseLock()` method would throw if there are pending read requests (rather than pending read requests being rejected)."
               }
             ],
             "safari_ios": "mirror",

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -225,65 +225,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader/releaseLock",
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-default-reader-release-lock②",
           "support": {
-            "chrome": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "43",
-                "partial_implementation": true,
-                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              }
-            ],
+            "chrome": {
+              "version_added": "43"
+            },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.18"
-              },
-              {
-                "version_added": "1.0",
-                "partial_implementation": true,
-                "notes": "Before version 1.18, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              }
-            ],
+            "deno": {
+              "version_added": "1.0"
+            },
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "102"
-              },
-              {
-                "version_added": "65",
-                "partial_implementation": true,
-                "notes": "Before version 102, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              }
-            ],
+            "firefox": {
+              "version_added": "65"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "18.9.0"
-              },
-              {
-                "version_added": "16.5.0",
-                "partial_implementation": true,
-                "notes": "Before version 18.9.0, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              }
-            ],
+            "nodejs": {
+              "version_added": "16.5.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": [
-              {
-                "version_added": "17"
-              },
-              {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Before version 17, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
-              }
-            ],
+            "safari": {
+              "version_added": "10"
+            },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -293,6 +258,47 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "reject_pending_read_request": {
+          "__compat": {
+            "description": "`releaseLock()` rejects pending read requests",
+            "support": {
+              "chrome": {
+                "version_added": "105",
+                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.18"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "18.9.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -266,7 +266,7 @@
             "support": {
               "chrome": {
                 "version_added": "105",
-                "notes": "Before version 105, `releaseLock()` would throw if there are pending read requests (rather than pending read requests being rejected)."
+                "notes": "Before version 105, `releaseLock()` throws instead of rejecting."
               },
               "chrome_android": "mirror",
               "deno": {

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -475,6 +475,13 @@
           "engine": "V8",
           "engine_version": "10.1"
         },
+        "18.9.0": {
+          "release_date": "2022-09-08",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.9.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.1"
+        },
         "18.13.0": {
           "release_date": "2023-01-06",
           "release_notes": "https://nodejs.org/en/blog/release/v18.13.0/",


### PR DESCRIPTION
#### Summary

Update the compatibility data for `reject_pending_read_request` in both `ReadableStreamDefaultReader` and `ReadableStreamBYOBReader`. See https://github.com/whatwg/streams/pull/1168 for context. All major browsers now implement the new behavior.

#### Test results and supporting details

* Chrome added support in version 105. See [the Chromium bug](https://issues.chromium.org/issues/40211172) and [the diff between Chrome 104 and 105 on wpt.fyi](https://wpt.fyi/results/streams/readable-streams/templated.any.html?label=master&product=chrome-104&product=chrome-105).
* Edge added support in version 105, mirroring Chrome. See [the diff on wpt.fyi](https://wpt.fyi/results/streams/readable-streams/templated.any.html?label=master&product=edge-104&product=edge-105).
* Safari added support in version 17.0. See [the Webkit bug](https://bugs.webkit.org/show_bug.cgi?id=254511) and [the diff between Safari 16.6 and 17.0 on wpt.fyi](https://wpt.fyi/results/streams/readable-streams/templated.any.html?label=master&label=stable&product=safari-16.6%20%2818615.3.12.11.2%29&product=safari-17.0%20%2818616.1.27.111.22%29).
  * Note that Safari does not yet support `ReadableStreamBYOBReader`, so I only updated the data for `ReadableStreamDefaultReader`.
* Node.js added support in version 18.9.0. See [the commit](https://github.com/nodejs/node/commit/65134d696b4dccebc63b527fe31dd22bf8d0e4f4) and [the 18.9.0 changelog](https://nodejs.org/en/blog/release/v18.9.0).
* Deno added support in version 1.18.0. See [the commit](https://github.com/denoland/deno/commit/659bbd731cedbabe426c76e33cefcc68ee7d1e63) and [the 1.18.0 changelog](https://github.com/denoland/deno/releases/v1.18.0).
