### PR TITLE
Add `transformer.cancel` method to `TransformStream` constructor

### DIFF
--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -88,7 +88,7 @@
             "deprecated": false
           }
         },
-        "cancel": {
+        "transformer_cancel": {
           "__compat": {
             "description": "`transformer.cancel` method",
             "spec_url": "https://streams.spec.whatwg.org/#dom-transformer-cancel",

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -110,9 +110,15 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "20.14.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "21.5.0"
+                },
+                {
+                  "version_added": "20.14.0",
+                  "version_removed": "21.0.0"
+                }
+              ],
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -94,7 +94,8 @@
             "spec_url": "https://streams.spec.whatwg.org/#dom-transformer-cancel",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40283531"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -102,7 +103,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1856103"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -115,7 +117,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/262424"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -87,6 +87,47 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "cancel": {
+          "__compat": {
+            "description": "`transformer.cancel` method",
+            "spec_url": "https://streams.spec.whatwg.org/#dom-transformer-cancel",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.38"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "20.14.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "readable": {

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -657,6 +657,13 @@
           "engine": "V8",
           "engine_version": "11.8"
         },
+        "21.5.0": {
+          "release_date": "2023-12-19",
+          "release_notes": "https://nodejs.org/en/blog/release/v21.5.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.8"
+        },
         "21.7.0": {
           "release_date": "2024-03-06",
           "release_notes": "https://nodejs.org/en/blog/release/v21.7.0",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -615,6 +615,13 @@
           "engine": "V8",
           "engine_version": "11.3"
         },
+        "20.14.0": {
+          "release_date": "2024-05-28",
+          "release_notes": "https://nodejs.org/en/blog/release/v20.14.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.3"
+        },
         "20.16.0": {
           "release_date": "2024-07-24",
           "release_notes": "https://nodejs.org/en/blog/release/v20.16.0",


### PR DESCRIPTION
#### Summary

The transformer object passed to the `TransformStream` constructor can now also have a `cancel` method, which is called whenever the readable side is cancelled or when the writable side is aborted. See [the specification](https://streams.spec.whatwg.org/#dom-transformer-cancel) and [the spec change](https://github.com/whatwg/streams/pull/1283) for context.

#### Test results and supporting details

This method is not yet supported in any browser. However, server runtimes such as Node.js and Deno already support it:
* Node.js: implemented in https://github.com/nodejs/node/commit/3dd96f1fabf39661dcebd4f3677c76d9a670e04e, shipped in [version 20.14.0](https://nodejs.org/en/blog/release/v20.14.0)
* Deno: implemented in https://github.com/denoland/deno/commit/6450334f5bbb059b55005cebfef57fa7969b625e, shipped in [version 1.38.0](https://github.com/denoland/deno/releases/tag/v1.38.0)
