### PR TITLE
Remove never-supported http.headers.Cache-Control.stale-if-error

### DIFF
--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -82,41 +82,6 @@
             }
           }
         },
-        "stale-if-error": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/40354106"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1547587"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "stale-while-revalidate": {
           "__compat": {
             "support": {

--- a/lint/linter/test-obsolete.ts
+++ b/lint/linter/test-obsolete.ts
@@ -151,6 +151,5 @@ export default {
   },
   exceptions: [
     'html.elements.track.kind.descriptions',
-    'http.headers.Cache-Control.stale-if-error',
   ],
 } as Linter;

--- a/lint/linter/test-obsolete.ts
+++ b/lint/linter/test-obsolete.ts
@@ -149,7 +149,5 @@ export default {
       processData(logger, data);
     }
   },
-  exceptions: [
-    'html.elements.track.kind.descriptions',
-  ],
+  exceptions: ['html.elements.track.kind.descriptions'],
 } as Linter;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the feature is not supported by any browsers per the bcd entry

it is in https://httpwg.org/specs/rfc5861.html, along with `stale-while-revalidate`, which has been shipped for a long time

per https://issues.chromium.org/issues/40354106 and https://bugzilla.mozilla.org/show_bug.cgi?id=1547587, chrome and firefox seems not to implement this feature

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
