### PR TITLE
Update spec url for `grid-template-{columns,rows}.fit-content()`

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -131,7 +131,7 @@
           "__compat": {
             "description": "`fit-content()`",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fit-content",
-            "spec_url": "https://drafts.csswg.org/css-sizing-4/#sizing-values",
+            "spec_url": "https://drafts.csswg.org/css-grid/#funcdef-grid-template-columns-fit-content",
             "tags": [
               "web-features:grid"
             ],

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -131,7 +131,7 @@
           "__compat": {
             "description": "`fit-content()`",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fit-content",
-            "spec_url": "https://drafts.csswg.org/css-sizing-4/#sizing-values",
+            "spec_url": "https://drafts.csswg.org/css-grid/#funcdef-grid-template-columns-fit-content",
             "tags": [
               "web-features:grid"
             ],


### PR DESCRIPTION
#### Summary

It's better to point to the Grid Layout module. The entire [fit-content() MDN page](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function) is about the Grid layout and not the box-sizing.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
