### PR TITLE
Update spec urls of CSS pseudo classes

### DIFF
--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:active",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-active",
-            "https://drafts.csswg.org/selectors/#the-active-pseudo"
+            "https://drafts.csswg.org/selectors/#active-pseudo"
           ],
           "tags": [
             "web-features:user-action-pseudos"

--- a/css/selectors/autofill.json
+++ b/css/selectors/autofill.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "`:autofill`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:autofill",
-          "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill",
+            "https://drafts.csswg.org/selectors/#selectordef-autofill"
+          ],
           "tags": [
             "web-features:autofill"
           ],

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:checked",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-checked",
-            "https://drafts.csswg.org/selectors/#checked"
+            "https://drafts.csswg.org/selectors/#checked-pseudo"
           ],
           "tags": [
             "web-features:input-selectors"

--- a/css/selectors/defined.json
+++ b/css/selectors/defined.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "`:defined`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:defined",
-          "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-defined",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-defined",
+            "https://drafts.csswg.org/selectors/#defined-pseudo"
+          ],
           "tags": [
             "web-features:autonomous-custom-elements"
           ],

--- a/css/selectors/dir.json
+++ b/css/selectors/dir.json
@@ -7,7 +7,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:dir",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-ltr",
-            "https://drafts.csswg.org/selectors/#the-dir-pseudo"
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-rtl",
+            "https://drafts.csswg.org/selectors/#dir-pseudo"
           ],
           "tags": [
             "web-features:dir-pseudo"

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:disabled",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-disabled",
-            "https://drafts.csswg.org/selectors/#enableddisabled"
+            "https://drafts.csswg.org/selectors/#disabled-pseudo"
           ],
           "tags": [
             "web-features:input-selectors"

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:enabled",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-enabled",
-            "https://drafts.csswg.org/selectors/#enableddisabled"
+            "https://drafts.csswg.org/selectors/#enabled-pseudo"
           ],
           "tags": [
             "web-features:input-selectors"

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:hover",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-hover",
-            "https://drafts.csswg.org/selectors/#the-hover-pseudo"
+            "https://drafts.csswg.org/selectors/#hover-pseudo"
           ],
           "tags": [
             "web-features:user-action-pseudos"

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:indeterminate",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-indeterminate",
-            "https://drafts.csswg.org/selectors/#indeterminate"
+            "https://drafts.csswg.org/selectors/#indeterminate-pseudo"
           ],
           "tags": [
             "web-features:indeterminate"

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:invalid",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-invalid",
-            "https://drafts.csswg.org/selectors/#validity-pseudos"
+            "https://drafts.csswg.org/selectors/#invalid-pseudo"
           ],
           "tags": [
             "web-features:form-validity-pseudos"

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:link",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-link",
-            "https://drafts.csswg.org/selectors/#link"
+            "https://drafts.csswg.org/selectors/#link-pseudo"
           ],
           "tags": [
             "web-features:link-selectors"

--- a/css/selectors/modal.json
+++ b/css/selectors/modal.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "`:modal`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:modal",
-          "spec_url": "https://drafts.csswg.org/selectors/#modal-state",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-modal",
+            "https://drafts.csswg.org/selectors/#selectordef-modal"
+          ],
           "tags": [
             "web-features:modal"
           ],

--- a/css/selectors/open.json
+++ b/css/selectors/open.json
@@ -4,7 +4,10 @@
       "open": {
         "__compat": {
           "description": "`:open`",
-          "spec_url": "https://drafts.csswg.org/selectors-4/#open-state",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-open",
+            "https://drafts.csswg.org/selectors/#selectordef-open"
+          ],
           "tags": [
             "web-features:open-closed"
           ],

--- a/css/selectors/optional.json
+++ b/css/selectors/optional.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:optional",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-optional",
-            "https://drafts.csswg.org/selectors/#opt-pseudos"
+            "https://drafts.csswg.org/selectors/#optional-pseudo"
           ],
           "tags": [
             "web-features:form-validity-pseudos"

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "`:placeholder-shown`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown",
-          "spec_url": "https://drafts.csswg.org/selectors/#placeholder",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-placeholder-shown",
+            "https://drafts.csswg.org/selectors/#placeholder-shown-pseudo"
+          ],
           "tags": [
             "web-features:placeholder-shown"
           ],

--- a/css/selectors/popover-open.json
+++ b/css/selectors/popover-open.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "`:popover-open`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:popover-open",
-          "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open",
+            "https://drafts.csswg.org/selectors/#selectordef-popover-open"
+          ],
           "tags": [
             "web-features:popover"
           ],

--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:read-only",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only",
-            "https://drafts.csswg.org/selectors/#rw-pseudos"
+            "https://drafts.csswg.org/selectors/#read-only-pseudo"
           ],
           "tags": [
             "web-features:read-write-pseudos"

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:read-write",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-write",
-            "https://drafts.csswg.org/selectors/#rw-pseudos"
+            "https://drafts.csswg.org/selectors/#read-write-pseudo"
           ],
           "tags": [
             "web-features:read-write-pseudos"

--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:required",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-required",
-            "https://drafts.csswg.org/selectors/#opt-pseudos"
+            "https://drafts.csswg.org/selectors/#required-pseudo"
           ],
           "tags": [
             "web-features:form-validity-pseudos"

--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:target",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-target",
-            "https://drafts.csswg.org/selectors/#the-target-pseudo"
+            "https://drafts.csswg.org/selectors/#target-pseudo"
           ],
           "tags": [
             "web-features:target"

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "`:user-invalid`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-invalid",
-          "spec_url": "https://drafts.csswg.org/selectors/#user-invalid-pseudo",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-user-invalid",
+            "https://drafts.csswg.org/selectors/#user-invalid-pseudo"
+          ],
           "tags": [
             "web-features:user-pseudos"
           ],

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -5,7 +5,10 @@
         "__compat": {
           "description": "`:user-valid`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-valid",
-          "spec_url": "https://drafts.csswg.org/selectors/#user-valid-pseudo",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-user-valid",
+            "https://drafts.csswg.org/selectors/#user-valid-pseudo"
+          ],
           "tags": [
             "web-features:user-pseudos"
           ],

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:valid",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-valid",
-            "https://drafts.csswg.org/selectors/#validity-pseudos"
+            "https://drafts.csswg.org/selectors/#valid-pseudo"
           ],
           "tags": [
             "web-features:form-validity-pseudos"

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:visited",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-visited",
-            "https://drafts.csswg.org/selectors/#link"
+            "https://drafts.csswg.org/selectors/#visited-pseudo"
           ],
           "tags": [
             "web-features:link-selectors"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

for some pseudo classes, only one spec is added (either the whatwg one, or the csswg one)
for others, the csswg one link to the paragraph title, rather than the link directly to that feature

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
