### PR TITLE
Extract CSS.supports() sub-feature `optional_parens`

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -2199,40 +2199,16 @@
             "web-features:css-supports"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "61"
-              },
-              {
-                "version_added": "28",
-                "version_removed": "61",
-                "partial_implementation": true,
-                "notes": "The parentheses-less one-argument version is not supported."
-              }
-            ],
+            "chrome": {
+              "version_added": "28"
+            },
             "chrome_android": "mirror",
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "12",
-                "version_removed": "79",
-                "partial_implementation": true,
-                "notes": "The parentheses-less one-argument version is not supported."
-              }
-            ],
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "55",
-                "partial_implementation": true,
-                "notes": "The parentheses-less one-argument version is not supported."
-              }
-            ],
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "22"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -2240,17 +2216,9 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": [
-              {
-                "version_added": "11"
-              },
-              {
-                "version_added": "9",
-                "version_removed": "11",
-                "partial_implementation": true,
-                "notes": "The parentheses-less one-argument version is not supported."
-              }
-            ],
+            "safari": {
+              "version_added": "9"
+            },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -2260,6 +2228,40 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "optional_parens": {
+          "__compat": {
+            "description": "Parentheses for single-argument version are optional.",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Extracts `optional_parens` sub-feature of `CSS.supports()`.

#### Test results and supporting details

Spec change from July 2016: https://github.com/w3c/csswg-drafts/commit/042f955362de14e1601af8d072c9c211a9024fb6

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
