### PR TITLE
Change `<url>` to `url()` and link to Web/CSS/url_function

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -385,7 +385,7 @@
         "url": {
           "__compat": {
             "description": "`url()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url_value",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url_function",
             "spec_url": "https://drafts.csswg.org/css-values/#urls",
             "tags": [
               "web-features:content"

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -3282,6 +3282,7 @@
         },
         "symbols": {
           "__compat": {
+            "description": "`symbols()`",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/symbols",
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#symbols-function",
             "tags": [

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -3,8 +3,8 @@
     "types": {
       "url": {
         "__compat": {
-          "description": "`&lt;url&gt;`",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url_value",
+          "description": "`url()`",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url_function",
           "spec_url": "https://drafts.csswg.org/css-values/#urls",
           "tags": [
             "web-features:font-face"

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "types": {
-      "url":
+      "url": {
         "__compat": {
           "description": "`url()`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url_function",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Changes the description of `css.types.url` from `<url>` (type) to `url()` (function), and links `css.types.url` and `css.properties.content.url` to [Web/CSS/url_function](https://developer.mozilla.org/en-US/docs/Web/CSS/url_function).

Also adds a missing description to `css.properties.list-style-type.symbols`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25413.
