### PR TITLE
No-Vary-Search and expects_no_vary_search are now supported for prerender

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -822,11 +822,16 @@
                   "web-features:speculation-rules"
                 ],
                 "support": {
-                  "chrome": {
-                    "version_added": "121",
-                    "partial_implementation": true,
-                    "notes": "Supported for `prefetch` only."
-                  },
+                  "chrome": [
+                    {
+                      "version_added": "127"
+                    },
+                    {
+                      "version_added": "121",
+                      "partial_implementation": true,
+                      "notes": "Supported for `prefetch` only."
+                    }
+                  ],
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {

--- a/http/headers/No-Vary-Search.json
+++ b/http/headers/No-Vary-Search.json
@@ -5,11 +5,16 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/No-Vary-Search",
           "support": {
-            "chrome": {
-              "version_added": "121",
-              "partial_implementation": true,
-              "notes": "Supported for navigation prefetch cache only."
-            },
+            "chrome": [
+              {
+                "version_added": "127"
+              },
+              {
+                "version_added": "121",
+                "partial_implementation": true,
+                "notes": "Supported for navigation prefetch cache only."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

`No-Vary-Search` and `expects_no_vary_search` where originally implemented for `prefetch` only  but as of Chrome 127 also support prerender.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Demo site used to test:
https://speculation-rules-no-vary-search.glitch.me/prerender.html

Details of when it was added:
https://chromestatus.com/feature/5099218903760896

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
