### PR TITLE
Updates for Firefox 135 beta

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -107,7 +107,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "135"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -125,7 +125,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -3401,7 +3401,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "135"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -6151,7 +6151,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "135"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -6169,7 +6169,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -6475,6 +6475,44 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "14.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "rid": {
+          "__compat": {
+            "description": "`rid` in 'outbound-rtp' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcoutboundrtpstreamstats-rid",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "105"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "135"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/-moz-user-input.json
+++ b/css/properties/-moz-user-input.json
@@ -11,7 +11,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "135"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -43,7 +44,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "135"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -76,7 +78,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "135"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -72,7 +72,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "135"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -216,7 +216,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "135"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -261,7 +261,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "135"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.8 found new features shipping in Firefox 135 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 10 features as shipping in Firefox 135:

- api.PublicKeyCredential.getClientCapabilities_static
- api.RTCStatsReport.type_inbound-rtp.mid (manually added)
- api.RTCStatsReport.type_outbound-rtp.mid (manually added)
- api.RTCStatsReport.type_outbound-rtp.rid (manually added)
- css.properties.-moz-user-input (removal)
- css.properties.-moz-user-input.auto (removal)
- css.properties.-moz-user-input.none (removal)
- javascript.builtins.JSON.isRawJSON
- javascript.builtins.JSON.parse.reviver_parameter_context_argument
- javascript.builtins.JSON.rawJSON

See also https://github.com/mdn/mdn/issues/620 and https://www.mozilla.org/en-US/firefox/135.0beta/releasenotes/