### PR TITLE
No-Vary-Search spec

### DIFF
--- a/http/headers/No-Vary-Search.json
+++ b/http/headers/No-Vary-Search.json
@@ -4,6 +4,7 @@
       "No-Vary-Search": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/No-Vary-Search",
+          "spec_url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html",
           "support": {
             "chrome": [
               {

--- a/http/headers/No-Vary-Search.json
+++ b/http/headers/No-Vary-Search.json
@@ -4,7 +4,7 @@
       "No-Vary-Search": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/No-Vary-Search",
-          "spec_url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html",
+          "spec_url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html#section-2",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add link to No-Vary-Search spec. Currently this shows like below on [the MDN page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/No-Vary-Search#specifications):

<img width="343" alt="image" src="https://github.com/user-attachments/assets/26b6051b-ac77-4df3-86e2-18283660349d" />

It is also the old WICG link, but this has since [been accepted into the IETF HTTP Working group](https://lists.w3.org/Archives/Public/ietf-http-wg/2024JulSep/0301.html) (hence the new URL for the spec).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Note the old link (https://wicg.github.io/nav-speculation/no-vary-search.html) redirects to the link proposed in this PR (https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html).

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
