### PR TITLE
Add publicKeyCredential method descriptions

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -96,6 +96,7 @@
       },
       "getClientCapabilities_static": {
         "__compat": {
+          "description": "`getClientCapabilities()` static method",
           "spec_url": "https://w3c.github.io/webauthn/#sctn-getClientCapabilities",
           "tags": [
             "web-features:webauthn"
@@ -133,6 +134,7 @@
       },
       "getClientExtensionResults": {
         "__compat": {
+          "description": "`getClientExtensionResults()` method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/getClientExtensionResults",
           "spec_url": "https://w3c.github.io/webauthn/#ref-for-dom-publickeycredential-getclientextensionresults",
           "tags": [
@@ -477,6 +479,7 @@
       },
       "signalAllAcceptedCredentials_static": {
         "__compat": {
+          "description": "`signalAllAcceptedCredentials()` static method",
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-signalallacceptedcredentials",
           "support": {
             "chrome": {
@@ -515,6 +518,7 @@
       },
       "signalCurrentUserDetails_static": {
         "__compat": {
+          "description": "`signalCurrentUserDetails()` static method",
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-signalcurrentuserdetails",
           "support": {
             "chrome": {
@@ -553,6 +557,7 @@
       },
       "signalUnknownCredential_static": {
         "__compat": {
+          "description": "`signalUnknownCredential()` static method",
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-signalunknowncredential",
           "support": {
             "chrome": {
@@ -591,6 +596,7 @@
       },
       "toJSON": {
         "__compat": {
+          "description": "`toJSON()` method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/toJSON",
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-tojson",
           "tags": [


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

While documenting some new methods on the [`PublicKeyCredential`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential) interface, it struck me how the BCD table doesn't look great, especially the static methods that are just showing `methodName_static` for the label.

This PR adds `description` fields to the methods to make them more consistent and improve the rendering.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

see https://github.com/mdn/content/pull/37557 for the new method documentation.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
