### PR TITLE
Allowlist web-feature tags

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -236,9 +236,6 @@
             "description": "`init.keepalive` parameter",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/keepalive",
             "spec_url": "https://fetch.spec.whatwg.org/#dom-requestinit-keepalive",
-            "tags": [
-              "web-features:fetch-keepalive"
-            ],
             "support": {
               "chrome": {
                 "version_added": "66"

--- a/api/WebSocketError.json
+++ b/api/WebSocketError.json
@@ -3,7 +3,6 @@
     "WebSocketError": {
       "__compat": {
         "tags": [
-          "web-features:web-socket-stream",
           "web-features:websockets"
         ],
         "support": {
@@ -40,7 +39,6 @@
         "__compat": {
           "description": "`WebSocketError()` constructor",
           "tags": [
-            "web-features:web-socket-stream",
             "web-features:websockets"
           ],
           "support": {
@@ -77,7 +75,6 @@
       "closeCode": {
         "__compat": {
           "tags": [
-            "web-features:web-socket-stream",
             "web-features:websockets"
           ],
           "support": {
@@ -114,7 +111,6 @@
       "reason": {
         "__compat": {
           "tags": [
-            "web-features:web-socket-stream",
             "web-features:websockets"
           ],
           "support": {

--- a/api/WebSocketStream.json
+++ b/api/WebSocketStream.json
@@ -3,9 +3,6 @@
     "WebSocketStream": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream",
-        "tags": [
-          "web-features:web-socket-stream"
-        ],
         "support": {
           "chrome": {
             "version_added": "124"
@@ -40,9 +37,6 @@
         "__compat": {
           "description": "`WebSocketStream()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/WebSocketStream",
-          "tags": [
-            "web-features:web-socket-stream"
-          ],
           "support": {
             "chrome": {
               "version_added": "124"
@@ -77,9 +71,6 @@
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/close",
-          "tags": [
-            "web-features:web-socket-stream"
-          ],
           "support": {
             "chrome": {
               "version_added": "124"
@@ -114,9 +105,6 @@
       "closed": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/closed",
-          "tags": [
-            "web-features:web-socket-stream"
-          ],
           "support": {
             "chrome": {
               "version_added": "124"
@@ -151,9 +139,6 @@
       "opened": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/opened",
-          "tags": [
-            "web-features:web-socket-stream"
-          ],
           "support": {
             "chrome": {
               "version_added": "124"
@@ -188,9 +173,6 @@
       "url": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocketStream/url",
-          "tags": [
-            "web-features:web-socket-stream"
-          ],
           "support": {
             "chrome": {
               "version_added": "124"

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -641,9 +641,6 @@
             "integrity": {
               "__compat": {
                 "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#normalizing-a-module-integrity-map",
-                "tags": [
-                  "web-features:import-map-integrity"
-                ],
                 "support": {
                   "chrome": {
                     "version_added": "127"

--- a/lint/linter/test-tags.test.ts
+++ b/lint/linter/test-tags.test.ts
@@ -28,7 +28,7 @@ describe('test.check', () => {
 
   it('should not log error when tags are valid', () => {
     const data: CompatStatement = {
-      tags: ['web-features:tag1'],
+      tags: ['web-features:javascript'],
       support: {},
     };
 
@@ -61,15 +61,19 @@ describe('test.check', () => {
     assert.ok(logger.messages[0].message.includes('Invalid tag found:'));
   });
 
-  it('should log error when tag name uses characters other than lowercase alphanumeric and hyphen', () => {
+  it('should log an error when an invalid web-feature ID is used', () => {
     const data: CompatStatement = {
-      tags: ['namespace1:tag$'],
+      tags: ['web-features:foo'],
       support: {},
     };
 
     test.check(logger, { data });
 
     assert.equal(logger.messages.length, 1);
-    assert.ok(logger.messages[0].message.includes('Invalid tag found:'));
+    assert.ok(
+      logger.messages[0].message.includes(
+        'Non-registered web-features ID found:',
+      ),
+    );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "tempy": "^3.1.0",
         "tsx": "^4.19.2",
         "typescript": "~5.7.2",
+        "web-features": "^2.15.0",
         "web-specs": "^3.0.0",
         "yargs": "~17.7.0"
       },
@@ -7998,6 +7999,13 @@
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
+    },
+    "node_modules/web-features": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.15.0.tgz",
+      "integrity": "sha512-sTuDfFU2UgQmGT3VRNRb6h+nH1C0SxR6l4nUyQ3qGJPzqgc6SnsqkjZs0TRc2YtGN5ysJqWQRknkgibe11ffOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/web-specs": {
       "version": "3.32.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "tempy": "^3.1.0",
     "tsx": "^4.19.2",
     "typescript": "~5.7.2",
+    "web-features": "^2.15.0",
     "web-specs": "^3.0.0",
     "yargs": "~17.7.0"
   },


### PR DESCRIPTION
#### Summary

Prevent BCD authors from creating new web-features tags (i.e., BCD uses web-features IDs as an allowlist for tags)

#### Test results and supporting details

Updated test files so that `'web-features:foo'` fails and `'web-features:javascript'` passes.

#### Related issues

@ddbeck, Kadir and I talked about the entire workflow yesterday and while want BCD authors to use and apply existing web-feature IDs to BCD features (useful for when BCD features are renamed, or when existing features get additions), we want to prevent that entirely new feature IDs are created in BCD. Instead they should be created in web-features.

For more details, see https://github.com/web-platform-dx/web-features/issues/1672#issuecomment-2578098349