### PR TITLE
Mark remaining WebVR features as removed

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -7171,7 +7171,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -7230,7 +7231,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -7293,7 +7295,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -7326,6 +7329,7 @@
             },
             "chrome_android": {
               "version_added": "56",
+              "version_removed": "80",
               "notes": [
                 "Chrome for Android 56 supports only Google Daydream View.",
                 "Chrome for Android 57 adds support for Google Cardboard."
@@ -7358,7 +7362,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -7432,7 +7437,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
WebVR has been removed. Fix this for some events on window.

Discovered when grouping the feature keys in https://github.com/web-platform-dx/web-features/pull/2512