### PR TITLE
Add Document member support notes for Firefox

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -152,9 +152,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "19",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -368,9 +376,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -441,9 +457,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "24"
-            },
+            "firefox": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "70",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -526,9 +550,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -607,9 +639,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -691,9 +731,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -849,9 +897,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "70",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "11"
@@ -1265,9 +1321,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "70",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -1333,9 +1397,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -1401,9 +1473,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "19",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "6"
@@ -1501,10 +1581,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1",
-              "notes": "Before Firefox 68, `cookie` was available only on HTML documents; it is now available on all documents, such as XML and SVG."
-            },
+            "firefox": [
+              {
+                "version_added": "68"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "68",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -2521,9 +2608,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -2774,10 +2869,18 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1",
-              "notes": "From Firefox 62, if the domain cannot be identified, `domain` returns an empty string instead of `null`. See [bug 819475](https://bugzil.la/819475)."
-            },
+            "firefox": [
+              {
+                "version_added": "69",
+                "notes": "From Firefox 62, if the domain cannot be identified, `domain` returns an empty string instead of `null`. See [bug 819475](https://bugzil.la/819475)."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -2932,9 +3035,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -3078,13 +3189,21 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1",
-              "notes": [
-                "From Firefox 82, nested calls are not supported (return `false`). See [bug 1634262](https://bugzil.la/1634262).",
-                "Before Firefox 89, manipulating the content of `&lt;input&gt;` and `&lt;textarea&gt;` elements using `Document.execCommand()` commands requires workarounds (see [bug 1220696](https://bugzil.la/1220696))."
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "69",
+                "notes": [
+                  "From Firefox 82, nested calls are not supported (return `false`). See [bug 1634262](https://bugzil.la/1634262).",
+                  "Before Firefox 89, manipulating the content of `&lt;input&gt;` and `&lt;textarea&gt;` elements using `Document.execCommand()` commands requires workarounds (see [bug 1220696](https://bugzil.la/1220696))."
+                ]
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -3570,9 +3689,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -3716,9 +3843,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -4677,9 +4812,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "57",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "9"
@@ -4915,9 +5058,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "4",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "9"
@@ -5029,9 +5180,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -5284,9 +5443,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -5352,9 +5519,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -5482,9 +5657,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -5691,9 +5874,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -6090,12 +6281,22 @@
             },
             "firefox": [
               {
-                "version_added": "41"
+                "version_added": "69"
+              },
+              {
+                "version_added": "41",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               },
               {
                 "version_added": "1",
                 "version_removed": "41",
-                "notes": "`queryCommandEnabled` with arguments `cut`, `copy` or `paste` would throw errors unless the script had special privileges."
+                "partial_implementation": true,
+                "notes": [
+                  "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects.",
+                  "`queryCommandEnabled` with arguments `cut`, `copy` or `paste` would throw errors unless the script had special privileges."
+                ]
               }
             ],
             "firefox_android": "mirror",
@@ -6134,9 +6335,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -6170,9 +6379,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -6212,13 +6429,22 @@
             },
             "firefox": [
               {
-                "version_added": "41"
+                "version_added": "69"
+              },
+              {
+                "version_added": "41",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               },
               {
                 "version_added": "1",
                 "version_removed": "41",
                 "partial_implementation": true,
-                "notes": "The `\"paste\"` command is reported as supported when the paste feature is available even if the calling script has insufficient privileges to actually perform the action."
+                "notes": [
+                  "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects.",
+                  "The `\"paste\"` command is reported as supported when the paste feature is available even if the calling script has insufficient privileges to actually perform the action."
+                ]
               }
             ],
             "firefox_android": "mirror",
@@ -6257,9 +6483,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -6591,9 +6825,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "70",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "11"
@@ -7446,9 +7688,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "9"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "9",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -8252,9 +8502,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "61",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -8354,9 +8612,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"
@@ -8403,9 +8669,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "4"

--- a/api/Document.json
+++ b/api/Document.json
@@ -4679,9 +4679,17 @@
               "version_added": "12",
               "notes": "Before Edge 79, this method returns an `HTMLCollection`, not a `NodeList`."
             },
-            "firefox": {
-              "version_added": "1"
-            },
+            "firefox": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "58",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "5",
@@ -5659,11 +5667,11 @@
             },
             "firefox": [
               {
-                "version_added": "61"
+                "version_added": "69"
               },
               {
                 "version_added": "1",
-                "version_removed": "61",
+                "version_removed": "69",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
@@ -6381,11 +6389,11 @@
             },
             "firefox": [
               {
-                "version_added": "61"
+                "version_added": "69"
               },
               {
                 "version_added": "1",
-                "version_removed": "61",
+                "version_removed": "69",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
@@ -8504,11 +8512,11 @@
             },
             "firefox": [
               {
-                "version_added": "61"
+                "version_added": "69"
               },
               {
                 "version_added": "1",
-                "version_removed": "61",
+                "version_removed": "69",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

For every `Document` member that, in some Firefox versions, is only exposed to `HTMLDocument` (and not also to `SVGDocument` and `XMLDocument`), ensures that there is a corresponding note.

#### Test results and supporting details

Source: https://github.com/caugner/document-members/blob/main/SUMMARY.md#firefox

#### Related issues

Part of https://github.com/mdn/browser-compat-data/issues/10682.
