### PR TITLE
Add Document member support notes for Chrome

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1320,11 +1320,11 @@
           "support": {
             "chrome": [
               {
-                "version_added": "64"
+                "version_added": "45"
               },
               {
                 "version_added": "1",
-                "version_removed": "64",
+                "version_removed": "45",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
@@ -1394,9 +1394,17 @@
             "web-features:dom"
           ],
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "8"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "8",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
@@ -2514,9 +2522,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/designMode",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-document-designmode-dev",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "36",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
@@ -2560,11 +2576,11 @@
           "support": {
             "chrome": [
               {
-                "version_added": "64"
+                "version_added": "36"
               },
               {
                 "version_added": "1",
-                "version_removed": "64",
+                "version_removed": "36",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
@@ -2919,11 +2935,11 @@
           "support": {
             "chrome": [
               {
-                "version_added": "64"
+                "version_added": "36"
               },
               {
                 "version_added": "1",
-                "version_removed": "64",
+                "version_removed": "36",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
@@ -4717,7 +4733,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "2"
+              "version_added": "34"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -5469,11 +5485,11 @@
           "support": {
             "chrome": [
               {
-                "version_added": "64"
+                "version_added": "45"
               },
               {
                 "version_added": "1",
-                "version_removed": "64",
+                "version_removed": "45",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
@@ -5678,11 +5694,11 @@
           "support": {
             "chrome": [
               {
-                "version_added": "64"
+                "version_added": "36"
               },
               {
                 "version_added": "1",
-                "version_removed": "64",
+                "version_removed": "36",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
@@ -7439,9 +7455,17 @@
             "web-features:dom"
           ],
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "36",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
@@ -8347,9 +8371,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/write",
           "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-write-dev",
           "support": {
-            "chrome": {
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "45"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "45",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
@@ -8390,11 +8422,11 @@
           "support": {
             "chrome": [
               {
-                "version_added": "64"
+                "version_added": "45"
               },
               {
                 "version_added": "1",
-                "version_removed": "64",
+                "version_removed": "45",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }


### PR DESCRIPTION
#### Summary

For every `Document` member that, in some Chrome versions, is only exposed to `HTMLDocument` (and not also to `SVGDocument` and `XMLDocument`), ensures that there is a corresponding note.

#### Test results and supporting details

Source: https://github.com/caugner/document-members/blob/main/SUMMARY.md#chrome

#### Related issues

Part of https://github.com/mdn/browser-compat-data/issues/10682.
