### PR TITLE
Add Document member support notes for Safari

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -223,8 +223,8 @@
                 "version_added": "7"
               },
               {
-                "version_added": "7",
-                "version_removed": "4",
+                "version_added": "4",
+                "version_removed": "7",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }

--- a/api/Document.json
+++ b/api/Document.json
@@ -166,9 +166,17 @@
             "opera_android": {
               "version_added": "10.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "3"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "3",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -210,9 +218,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "4"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "7",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -403,7 +419,7 @@
                 "version_added": "11"
               },
               {
-                "version_added": "1.2",
+                "version_added": "1",
                 "version_removed": "11",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
@@ -480,6 +496,12 @@
                 "version_removed": "11",
                 "partial_implementation": true,
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "2",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
             ],
             "safari_ios": [
@@ -540,9 +562,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -621,9 +651,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -1295,9 +1333,17 @@
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -1415,9 +1461,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "3.1"
-            },
+            "safari": [
+              {
+                "version_added": "5.1"
+              },
+              {
+                "version_added": "3.1",
+                "version_removed": "5.1",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -1516,9 +1570,17 @@
             "opera_android": {
               "version_added": "10.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -2535,9 +2597,17 @@
             "opera_android": {
               "version_added": "10.1"
             },
-            "safari": {
-              "version_added": "1.2"
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "10.1",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -3730,9 +3800,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -4559,9 +4637,17 @@
             "opera_android": {
               "version_added": "10.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -4733,9 +4819,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "4"
-            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "version_added": "4",
+                "version_removed": "7",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -5043,9 +5137,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -5215,9 +5317,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -5366,9 +5476,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -5410,9 +5528,17 @@
             "opera_android": {
               "version_added": "10.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -7460,12 +7586,18 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "3"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "10.1",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -7985,9 +8117,23 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "3",
+                "version_removed": "4",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument) and `XMLDocument`, but not `SVGDocument` objects."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "3",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -8365,9 +8511,17 @@
             "opera": {
               "version_added": "3"
             },
-            "opera_android": {
-              "version_added": "10.1"
-            },
+            "opera_android": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
+              }
+            ],
             "safari": {
               "version_added": "1"
             },

--- a/api/Document.json
+++ b/api/Document.json
@@ -220,7 +220,7 @@
             },
             "safari": [
               {
-                "version_added": "4"
+                "version_added": "7"
               },
               {
                 "version_added": "7",
@@ -8511,7 +8511,10 @@
             "opera": {
               "version_added": "3"
             },
-            "opera_android": [
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": [
               {
                 "version_added": "11"
               },
@@ -8522,9 +8525,6 @@
                 "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
#### Summary

For every `Document` member that, in some Safari versions, is only exposed to `HTMLDocument` (and not also to `SVGDocument` and `XMLDocument`), ensures that there is a corresponding note.

#### Test results and supporting details

Source: https://github.com/caugner/document-members/blob/main/SUMMARY.md#safari

This includes some fixes where current data was wrong:
- `alinkColor`, `designMode`, `scripts` were already added in Safari 1.
- `write` was only fixed in Safari 11.

#### Related issues

Part of https://github.com/mdn/browser-compat-data/issues/10682.
