### PR TITLE
Chrome Android 121 supports Navigator.gpu + Canvas webgpu_context

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -769,7 +769,7 @@
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "edge": "mirror",
               "firefox": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1869,7 +1869,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -401,7 +401,7 @@
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "121"
               },
               "edge": "mirror",
               "firefox": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -308,7 +308,7 @@
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "deno": [
               {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome Android supports `Navigator.gpu`.

#### Test results and supporting details

All GPU features that were first supported in Chrome Desktop 113, appear to be supported in Chrome Android 121, so I have set the value accordingly.

Checked with Chrome Android 128 via BrowserStack Live.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22159, complementing https://github.com/mdn/browser-compat-data/pull/23493.