### PR TITLE
Chrome 105 / Deno 1.7 / Node 18 support `fetch()` with `ReadableStream` body

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -375,7 +375,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1387483"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -381,6 +381,9 @@
               "ie": {
                 "version_added": false
               },
+              "nodejs": {
+                "version_added": "18.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -131,7 +131,7 @@
       },
       "body_readablestream": {
         "__compat": {
-          "description": "`ReadableStream` as body",
+          "description": "Send `ReadableStream` in body",
           "spec_url": "https://fetch.spec.whatwg.org/#concept-body-stream",
           "support": {
             "chrome": {

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -384,6 +384,42 @@
             "deprecated": false
           }
         }
+      },
+      "stream_body_support": {
+        "__compat": {
+          "description": "Support for `ReadableStream` as body",
+          "spec_url": "https://fetch.spec.whatwg.org/#concept-body-stream",
+          "support": {
+            "chrome": {
+              "version_added": "105"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1387483"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirorr",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -150,6 +150,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -129,6 +129,45 @@
           }
         }
       },
+      "body_readablestream": {
+        "__compat": {
+          "description": "`ReadableStream` as body",
+          "spec_url": "https://fetch.spec.whatwg.org/#concept-body-stream",
+          "support": {
+            "chrome": {
+              "version_added": "105"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.7"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1387483"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "init_attributionReporting_parameter": {
         "__compat": {
           "description": "`init.attributionReporting` parameter",
@@ -380,45 +419,6 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "stream_body_support": {
-        "__compat": {
-          "description": "Support for `ReadableStream` as body",
-          "spec_url": "https://fetch.spec.whatwg.org/#concept-body-stream",
-          "support": {
-            "chrome": {
-              "version_added": "105"
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.7"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1387483"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -394,6 +394,9 @@
               "version_added": "105"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.7"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false,
@@ -407,15 +410,15 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirorr",
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

Add subfeature for [the fetch spec change allowing `ReadableStream` as `fetch()` body in 2017](https://github.com/whatwg/fetch/pull/425).

#### Test results and supporting details

- Chrome ✅ - see https://issues.chromium.org/issues/40505032 / https://chromiumdash.appspot.com/commit/9bbd1d6504a1d63d1b409e696c522497b111a572
- Deno ✅ - see https://deno.com/blog/v1.7#support-for-fetch-request-body-streaming
- Firefox ❌ - see https://bugzilla.mozilla.org/show_bug.cgi?id=1387483
- Node.js ✅ - see https://github.com/nodejs/undici/commit/95c82ab48758f5ec6aa566b2d8fb0adaa6e8430f#diff-bd6db9a8bceb4e9fce3f93ba5284c81f46a44a1187909e8609006e1efeab2570R20
- Safari ❌ - see https://searchfox.org/wubkat/rev/aff26e20aa2d3bdc4f9666b090b8f912c0a3deec/Source/WebCore/Modules/fetch/FetchResponse.cpp#274

Test case:

```js
// Create a simple ReadableStream
const stream = new ReadableStream({
  start(controller) {
    // Push some data into the stream
    controller.enqueue(new TextEncoder().encode("Hello, "));
    controller.enqueue(new TextEncoder().encode("this is a streamed request!"));
    controller.close(); // Close the stream
  },
});

// Use fetch with the ReadableStream as the body
fetch('https://httpbin.org/post', {
  method: 'POST',
  headers: {
    'Content-Type': 'text/plain',
  },
  body: stream,
  duplex: 'half', // This is required for streaming requests
})
  .then((response) => {
    if (!response.ok) {
      throw new Error(`HTTP error! Status: ${response.status}`);
    }
    return response.json();
  })
  .then((data) => {
    // If supported: `Response from server: Hello, this is a streamed request!`
    // Otherwise: `Response from server: [object ReadableStream]`
    console.log('Response from server:', data.data);
  })
  .catch((error) => {
    console.error('Fetch error:', error);
  });
```

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/12188.