### PR TITLE
Chrome prevents + Firefox/Safari allow non-numeric user input to number fields

### DIFF
--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -12,14 +12,16 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": "7",
+                "notes": "Prevents users from typing non-numeric content."
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "29"
+                "version_added": "29",
+                "notes": "Allows users to type non-numeric content, with the `value` reflecting an empty string."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -29,7 +31,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "5.1"
+                "version_added": "5.1",
+                "notes": "Allows users to type non-numeric content, with the `value` reflecting an empty string."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Add notes for the way Chrome and Firefox/Safari behave differently to non-numeric user input.

#### Test results and supporting details

Using BrowserStack Live and local installs, I verified the behavior
- in the current browser versions, and
- in the earliest versions that support `<input type="number">`.

#### Related issues

Fixes #13403.