### PR TITLE
KeyboardEvent.code is always empty on Android

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -174,12 +174,20 @@
             "chrome": {
               "version_added": "48"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "48",
+              "partial_implementation": true,
+              "notes": "The value is always the empty string."
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "38"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "38",
+              "partial_implementation": true,
+              "notes": "The value is always the empty string."
+            },
             "ie": {
               "version_added": false
             },

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -177,7 +177,7 @@
             "chrome_android": {
               "version_added": "48",
               "partial_implementation": true,
-              "notes": "The value is always the empty string."
+              "notes": "The value is always empty."
             },
             "edge": "mirror",
             "firefox": {
@@ -186,7 +186,7 @@
             "firefox_android": {
               "version_added": "38",
               "partial_implementation": true,
-              "notes": "The value is always the empty string."
+              "notes": "The value is always empty."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `KeyboardEvent.code` appears to be always empty on Android.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #13807.
