### PR TITLE
`overflow: overlay`: add pre-standardization compat details

### DIFF
--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -99,7 +99,7 @@
                 },
                 {
                   "alternative_name": "overlay",
-                  "version_added": "≤13.1"
+                  "version_added": "12"
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -65,15 +65,7 @@
                   "version_added": "114"
                 }
               ],
-              "chrome_android": [
-                {
-                  "version_added": "18"
-                },
-                {
-                  "alternative_name": "overlay",
-                  "version_added": "114"
-                }
-              ],
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -62,7 +62,7 @@
                 },
                 {
                   "alternative_name": "overlay",
-                  "version_added": "15"
+                  "version_added": "114"
                 }
               ],
               "chrome_android": [
@@ -71,7 +71,7 @@
                 },
                 {
                   "alternative_name": "overlay",
-                  "version_added": "100"
+                  "version_added": "114"
                 }
               ],
               "edge": {

--- a/css/types/overflow.json
+++ b/css/types/overflow.json
@@ -112,7 +112,7 @@
                   "version_added": "100",
                   "version_removed": "114",
                   "partial_implementation": true,
-                  "notes": "Before version 114, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 114, the keyword aliases to the standard `auto` keyword.  See [bug 40444262](https://crbug.com/40444262)."
+                  "notes": "Before version 114, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 114, the keyword aliases to the standard `auto` keyword. See [bug 40444262](https://crbug.com/40444262)."
                 }
               ],
               "edge": "mirror",

--- a/css/types/overflow.json
+++ b/css/types/overflow.json
@@ -93,12 +93,25 @@
         "overlay": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "15"
+              "chrome": [{
+                "version_added": "114"
+              }, {
+                "version_removed": "114",
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "Before version 114, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 114, the keyword aliases to the standard `auto` keyword. See [bug 40444262](https://issues.chromium.org/issues/40444262)."
+              }
+            ],
+              "chrome_android": [{
+                "version_added": "114"
               },
-              "chrome_android": {
-                "version_added": "100"
-              },
+              {
+                "version_removed": "114",
+                "version_added": "100",
+                "partial_implementation": true,
+                "notes": "Before version 114, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 114, the keyword aliases to the standard `auto` keyword.  See [bug 40444262](https://issues.chromium.org/issues/40444262)."
+              }
+            ],
               "edge": "mirror",
               "firefox": {
                 "version_added": "112"

--- a/css/types/overflow.json
+++ b/css/types/overflow.json
@@ -93,25 +93,28 @@
         "overlay": {
           "__compat": {
             "support": {
-              "chrome": [{
-                "version_added": "114"
-              }, {
-                "version_removed": "114",
-                "version_added": "15",
-                "partial_implementation": true,
-                "notes": "Before version 114, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 114, the keyword aliases to the standard `auto` keyword. See [bug 40444262](https://issues.chromium.org/issues/40444262)."
-              }
-            ],
-              "chrome_android": [{
-                "version_added": "114"
-              },
-              {
-                "version_removed": "114",
-                "version_added": "100",
-                "partial_implementation": true,
-                "notes": "Before version 114, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 114, the keyword aliases to the standard `auto` keyword.  See [bug 40444262](https://issues.chromium.org/issues/40444262)."
-              }
-            ],
+              "chrome": [
+                {
+                  "version_added": "114"
+                },
+                {
+                  "version_added": "15",
+                  "version_removed": "114",
+                  "partial_implementation": true,
+                  "notes": "Before version 114, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 114, the keyword aliases to the standard `auto` keyword. See [bug 40444262](https://crbug.com/40444262)."
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "114"
+                },
+                {
+                  "version_added": "100",
+                  "version_removed": "114",
+                  "partial_implementation": true,
+                  "notes": "Before version 114, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 114, the keyword aliases to the standard `auto` keyword.  See [bug 40444262](https://crbug.com/40444262)."
+                }
+              ],
               "edge": "mirror",
               "firefox": {
                 "version_added": "112"
@@ -130,11 +133,12 @@
                   "version_added": "12"
                 },
                 {
+                  "version_added": "4",
                   "version_removed": "12",
-                "version_added": "4",
-                "partial_implementation": true,
-                "notes": "Before version 12, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 12, the keyword aliases to the standard `auto` keyword. See [bug 189811](https://bugs.webkit.org/show_bug.cgi?id=189811)."
-              }],
+                  "partial_implementation": true,
+                  "notes": "Before version 12, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 12, the keyword aliases to the standard `auto` keyword. See [bug 189811](https://webkit.org/b/189811)."
+                }
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "4.0"

--- a/css/types/overflow.json
+++ b/css/types/overflow.json
@@ -125,9 +125,16 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "≤13.1"
-              },
+              "safari": [
+                {
+                  "version_added": "12"
+                },
+                {
+                  "version_removed": "12",
+                "version_added": "4",
+                "partial_implementation": true,
+                "notes": "Before version 12, the `overlay` keyword caused non-standard behavior, allowing scrollbars to overlay content without taking up layout space. From version 12, the keyword aliases to the standard `auto` keyword. See [bug 189811](https://bugs.webkit.org/show_bug.cgi?id=189811)."
+              }],
               "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "4.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Before `overflow: overlay` became a standardized legacy alias, it had non-standard behavior in Chrome and Safari.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

The data already existed for the standard behavior. For the non-standard behavior, I relied mostly on:

- https://chromestatus.com/feature/5194091479957504
- https://bugs.webkit.org/show_bug.cgi?id=189811
- https://caniuse.com/css-overflow-overlay

I didn't actually test the introduction of the non-standard behavior, figuring that it's the boundary between standard and non-standard that was most interesting. That said, the version numbers involved look plausible based on commit dates.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Needed for https://github.com/web-platform-dx/web-features/pull/2486/
- Previously:
  - https://github.com/mdn/browser-compat-data/pull/15834
  - https://github.com/mdn/browser-compat-data/issues/22531

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
