### PR TITLE
Undeprecate X-Frame-Options

### DIFF
--- a/http/headers/X-Frame-Options.json
+++ b/http/headers/X-Frame-Options.json
@@ -36,7 +36,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         },
         "ALLOW-FROM": {
@@ -113,7 +113,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Unmark X-Frame-Options as deprecated

#### Test results and supporting details

This was added in https://github.com/mdn/browser-compat-data/pull/24466

When people view the X-Frame-Options page they're presented with:

![image](https://github.com/user-attachments/assets/14faaf71-f3b4-4fbe-a7dd-180f8845bdc2)

A warning that says this feature may be removed from browsers isn't helpful for a security feature that we realistically cannot remove from browsers.

By all means MDN can and should (and does per https://github.com/mdn/content/pull/35942) point to CSP frame-ancestors as a (more powerful) alternative, this is deprecation warning isn't useful nor accurate.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
