### PR TITLE
Safari 13.1 supports `font-family` values for ui-families

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -52,6 +52,7 @@
         },
         "math": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#math",
             "tags": [
               "web-features:font-family-math"
             ],
@@ -88,6 +89,7 @@
         },
         "system-ui": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#system-ui",
             "tags": [
               "web-features:font-family-system"
             ],
@@ -125,6 +127,142 @@
                   "version_added": "9"
                 }
               ],
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ui-monospace": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#ui-monospace",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ui-rounded": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#ui-rounded",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ui-sans-serif": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#ui-sans-serif",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ui-serif": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#ui-serif",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "13.1"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -144,12 +144,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#ui-monospace",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40194142"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1461302"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -178,12 +180,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#ui-rounded",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40194142"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1461302"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -212,12 +216,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#ui-sans-serif",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40194142"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1461302"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -246,12 +252,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family#ui-serif",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40194142"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1461302"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

- Adds support info for the generic font families: `ui-serif`, `ui-sans-serif`, `ui-monospace`, and `ui-rounded`.
- Links to MDN docs per value

#### Test results and supporting details

These are supported [since Safari 13.1](https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/#:~:text=new%20font%20keywords%20are%20available%20for%20using%20platform-specific%20fonts)

<img width="574" alt="image" src="https://github.com/user-attachments/assets/b06cb610-abd9-4d8d-9fed-a0b2a6ba1bad" />

Tests show that Chrome and Firefox don’t support those.