### PR TITLE
Re-add web share target specification

### DIFF
--- a/html/manifest/share_target.json
+++ b/html/manifest/share_target.json
@@ -4,6 +4,7 @@
       "share_target": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/share_target",
+          "spec_url": "https://w3c.github.io/web-share-target/#share_target-member",
           "tags": [
             "web-features:app-share-targets"
           ],
@@ -46,7 +47,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
See https://github.com/w3c/browser-specs/pull/1646 where the standing was put back to "good".