### PR TITLE
Updates for Chrome 132 release (late additions)

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -59,6 +59,43 @@
           "deprecated": false
         }
       },
+      "adapterInfo": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-adapterinfo",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "132"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "createBindGroup": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createBindGroup",

--- a/api/IdentityProvider.json
+++ b/api/IdentityProvider.json
@@ -136,7 +136,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/IdentityProvider.json
+++ b/api/IdentityProvider.json
@@ -111,6 +111,40 @@
             "deprecated": false
           }
         }
+      },
+      "resolve_static": {
+        "__compat": {
+          "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityprovider-resolve",
+          "support": {
+            "chrome": {
+              "version_added": "132"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1655,6 +1655,40 @@
           }
         }
       },
+      "getInterestGroupAdAuctionData": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/turtledove/#getInterestGroupAdAuctionData",
+          "support": {
+            "chrome": {
+              "version_added": "132"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getUserMedia": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia",


### PR DESCRIPTION
I just ran the collector on the release version of Chrome 132 and here are three new APIs that are reported as shipping. Maybe they came late in the 132 beta cycle.

I will have a PR for the fresh Chrome 133 beta later today.