### PR TITLE
Chrome 133 supports string data for ClipboardItem

### DIFF
--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -50,13 +50,19 @@
           "support": {
             "chrome": [
               {
-                "version_added": "98"
+                "version_added": "133"
+              },
+              {
+                "version_added": "98",
+                "version_removed": "133",
+                "partial_implementation": true,
+                "notes": "Only accepts a `Blob` or a Promise resolving to a `Blob` as the item data."
               },
               {
                 "version_added": "76",
                 "version_removed": "98",
                 "partial_implementation": true,
-                "notes": "The `ClipboardItem` constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See [bug 40103226](https://crbug.com/40103226)."
+                "notes": "Only accepts a `Blob` as the item data. See [bug 40103226](https://crbug.com/40103226)."
               }
             ],
             "chrome_android": [
@@ -98,6 +104,7 @@
       },
       "getType": {
         "__compat": {
+          "description": "`getType()` method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/getType",
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboarditem-gettype",
           "tags": [
@@ -176,6 +183,7 @@
       },
       "supports_static": {
         "__compat": {
+          "description": "`supports()` static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/supports_static",
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboarditem-supports",
           "tags": [


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 133 now supports using item data of type string or a promise that resolves to a string when constructing a [`ClipboardItem`](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem) object. Previously, Chrome only supported item data of type `Blob`, or a promise that resolves to a `Blob`, but this change brings it up to full standards support and parity with Firefox and Safari.

I've tested it to verify it works in Chrome 133 and can confirm also that it doesn't work in Chrome 132.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See https://chromestatus.com/feature/4926138582040576 for the data source.

The example I used for testing can be found at https://clipboard-api-string-test.glitch.me/.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
