### PR TITLE
Updates for Chrome 133 beta

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -426,6 +426,40 @@
           }
         }
       },
+      "overallProgress": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/web-animations-2/#dom-animation-overallprogress",
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pause": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/pause",

--- a/api/Document.json
+++ b/api/Document.json
@@ -5750,6 +5750,39 @@
           }
         }
       },
+      "moveBefore": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mozSetImageElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/mozSetImageElement",

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -326,6 +326,39 @@
           }
         }
       },
+      "moveBefore": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "prepend": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentFragment/prepend",

--- a/api/Element.json
+++ b/api/Element.json
@@ -7210,6 +7210,39 @@
           }
         }
       },
+      "moveBefore": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "namespaceURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/namespaceURI",

--- a/api/FileSystemObserver.json
+++ b/api/FileSystemObserver.json
@@ -1,0 +1,137 @@
+{
+  "api": {
+    "FileSystemObserver": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "133"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "FileSystemObserver": {
+        "__compat": {
+          "description": "`FileSystemObserver()` constructor",
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disconnect": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "observe": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -87,6 +87,40 @@
           }
         }
       },
+      "attributionSrc": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-htmlattributionsrcelementutils-attributionsrc",
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "coords": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/coords",

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -580,6 +580,40 @@
           }
         }
       },
+      "finalResponseHeadersStart": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-finalresponseheadersstart",
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "firstInterimResponseStart": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/firstInterimResponseStart",

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -103,7 +103,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "133"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -122,7 +122,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -293,14 +293,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "113",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -587,14 +580,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "113",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -896,14 +882,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "113",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -1076,14 +1055,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "113",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -1262,14 +1234,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "113",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "deno": {

--- a/css/properties/container-type.json
+++ b/css/properties/container-type.json
@@ -112,6 +112,40 @@
             }
           }
         },
+        "scroll-state": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-type-scroll-state",
+            "support": {
+              "chrome": {
+                "version_added": "133"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "size": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-type-size",

--- a/css/properties/scroll-initial-target.json
+++ b/css/properties/scroll-initial-target.json
@@ -1,0 +1,108 @@
+{
+  "css": {
+    "properties": {
+      "scroll-initial-target": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#propdef-scroll-initial-target",
+          "support": {
+            "chrome": {
+              "version_added": "133"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "nearest": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#valdef-scroll-initial-target-nearest",
+            "support": {
+              "chrome": {
+                "version_added": "133"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-scroll-snap-2/#valdef-scroll-initial-target-none",
+            "support": {
+              "chrome": {
+                "version_added": "133"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/open.json
+++ b/css/selectors/open.json
@@ -12,12 +12,17 @@
             "web-features:open-closed"
           ],
           "support": {
-            "chrome": {
-              "version_added": "114",
-              "version_removed": "122",
-              "partial_implementation": true,
-              "notes": "The selector is recognized, but has no effect."
-            },
+            "chrome": [
+              {
+                "version_added": "133"
+              },
+              {
+                "version_added": "114",
+                "version_removed": "122",
+                "partial_implementation": true,
+                "notes": "The selector is recognized, but has no effect."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -55,7 +55,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -79,7 +79,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -93,7 +93,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -468,6 +468,47 @@
             }
           }
         },
+        "pause": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-atomics-microwait/#Atomics.pause",
+            "support": {
+              "chrome": {
+                "version_added": "133"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1937805"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "store": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store",

--- a/webassembly/memory64.json
+++ b/webassembly/memory64.json
@@ -5,7 +5,7 @@
         "spec_url": "https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "133"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -28,7 +28,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.8 found new features shipping in Chrome 133 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 41 features as shipping in Chrome 133:

- api.Animation.overallProgress
- api.ClipboardItem.ClipboardItem
- api.Document.moveBefore
- api.DocumentFragment.moveBefore
- api.Element.moveBefore
- api.FileSystemObserver
- api.FileSystemObserver.FileSystemObserver
- api.FileSystemObserver.disconnect
- api.FileSystemObserver.observe
- api.HTMLAreaElement.attributionSrc
- api.MLGraphBuilder.dequantizeLinear
- api.MLGraphBuilder.gatherElements
- api.MLGraphBuilder.gru
- api.MLGraphBuilder.gruCell
- api.MLGraphBuilder.quantizeLinear
- api.MLGraphBuilder.scatterElements
- api.PerformanceResourceTiming.finalResponseHeadersStart
- api.PublicKeyCredential.getClientCapabilities_static
- api.SubtleCrypto.deriveBits.x25519
- api.SubtleCrypto.deriveKey.x25519
- api.SubtleCrypto.exportKey.x25519
- api.SubtleCrypto.generateKey.x25519
- api.SubtleCrypto.importKey.x25519
- css.properties.container-type.scroll-state
- css.properties.scroll-initial-target
- css.properties.scroll-initial-target.nearest
- css.properties.scroll-initial-target.none
- css.properties.text-box-edge
- css.properties.text-box-edge.auto
- css.properties.text-box-trim
- css.properties.text-box-trim.none
- css.properties.text-box-trim.trim-both
- css.properties.text-box-trim.trim-end
- css.properties.text-box-trim.trim-start
- css.properties.text-box
- css.properties.text-box.normal
- css.selectors.open
- css.types.attr.fallback
- css.types.attr.type-or-unit
- javascript.builtins.Atomics.pause
- webassembly.memory64

See also the 133 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-133-beta

Note: The FileSystemObserver API and the moveBefore method have no spec_urls because they are still in unmerged PRs against the specs.