### PR TITLE
Chrome 37-40 partially implemented SubtleCrypto.digest()

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -639,9 +639,17 @@
             "web-features:web-cryptography"
           ],
           "support": {
-            "chrome": {
-              "version_added": "37"
-            },
+            "chrome": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "37",
+                "version_removed": "41",
+                "partial_implementation": true,
+                "notes": "Before version 41, Chrome expected the `algorithm` parameter to be an object."
+              }
+            ],
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.11"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 37-40 supported `SubtleCrypto.digest()` only partially, because it expected the `algorithm` parameter to be an object rather than a string.

#### Test results and supporting details

Verified with BrowserStack Live, see: https://github.com/mdn/browser-compat-data/issues/14804#issuecomment-2596082365

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/14804.
