### PR TITLE
fix(scripts/diff-features): fetch missing ref

### DIFF
--- a/scripts/diff-features.ts
+++ b/scripts/diff-features.ts
@@ -155,9 +155,24 @@ const enumerateFeatures = (ref = 'HEAD', quiet = false): string[] => {
   // However, if `ref` is already checked out, then `git worktree add` fails. As
   // long as you haven't checked out a detached HEAD for `ref`, then
   // `git worktree add` for the hash succeeds.
-  const hash = execSync(`git rev-parse --short ${ref}`, {
-    encoding: 'utf-8',
-  }).trim();
+  const hash = (() => {
+    try {
+      return execSync(`git rev-parse --short ${ref}`, {
+        encoding: 'utf-8',
+      }).trim();
+    } catch (e) {
+      // See: https://github.com/mdn/browser-compat-data/issues/25678
+      if (process.env.GITHUB_ACTIONS === 'true') {
+        console.error(`::error::${e}`);
+      }
+
+      execSync(`git fetch origin ${ref}`);
+
+      return execSync(`git rev-parse --short ${ref}`, {
+        encoding: 'utf-8',
+      }).trim();
+    }
+  })();
 
   const worktree = `__enumerating__${hash}`;
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Makes the `diff-features` script more resilient to missing refs.

#### Test results and supporting details

In our case, the GitHub API returns the wrong merge commit, which is not in the `main` branch.

As a workaround, let's fall back to fetching the missing commit.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25678.