### PR TITLE
Samsung Internet 23.0 supports most Client Hints

### DIFF
--- a/http/headers/Sec-CH-Prefers-Color-Scheme.json
+++ b/http/headers/Sec-CH-Prefers-Color-Scheme.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-Prefers-Reduced-Motion.json
+++ b/http/headers/Sec-CH-Prefers-Reduced-Motion.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-Prefers-Reduced-Transparency.json
+++ b/http/headers/Sec-CH-Prefers-Reduced-Transparency.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA-Arch.json
+++ b/http/headers/Sec-CH-UA-Arch.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA-Bitness.json
+++ b/http/headers/Sec-CH-UA-Bitness.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA-Full-Version-List.json
+++ b/http/headers/Sec-CH-UA-Full-Version-List.json
@@ -31,7 +31,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA-Full-Version.json
+++ b/http/headers/Sec-CH-UA-Full-Version.json
@@ -26,7 +26,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA-Mobile.json
+++ b/http/headers/Sec-CH-UA-Mobile.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA-Model.json
+++ b/http/headers/Sec-CH-UA-Model.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA-Platform-Version.json
+++ b/http/headers/Sec-CH-UA-Platform-Version.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA-Platform.json
+++ b/http/headers/Sec-CH-UA-Platform.json
@@ -29,7 +29,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },

--- a/http/headers/Sec-CH-UA.json
+++ b/http/headers/Sec-CH-UA.json
@@ -30,7 +30,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },


### PR DESCRIPTION
`Sec-CH-Prefers-Reduced-Transparency` is not sent.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Samsung Internet added support for Client Hints only in 23.0, not in 15.0.

#### Test results and supporting details

Tested locally using https://browserleaks.com/client-hints with an Android phone:

- :x: 21.0.3.6
- :x: 22.0.6.9
- ✅ 23.0.8.2
- ✅ 24.0.7.1

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/15821.