### PR TITLE
Firefox Android doesn't support ScreenOrientation.unlock() yet

### DIFF
--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -244,9 +244,18 @@
               "partial_implementation": true,
               "notes": "Always throws `NotSupportedError`."
             },
-            "firefox_android": {
-              "version_added": "43"
-            },
+            "firefox_android": [
+              {
+                "version_added": "79",
+                "version_removed": "97",
+                "partial_implementation": true,
+                "notes": "The API exists but returns `NS_ERROR_UNEXPECTED`."
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79"
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
#### Summary

Replicates the support statements from `ScreenOrientation.lock()`.

_Note_: It is somewhat surprising that the feature was supposedly already added in Firefox Android 43 and removed in Firefox Android 79, but this is harder to research and definitely less severe than saying Firefox Android supports `unlock()`.

#### Test results and supporting details

Firefox doesn't support `ScreenOrientation.{lock,unlock}()` yet, so Firefox Android cannot support it either, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1744125

#### Related issues

Fixes #15919.
