### PR TITLE
Firefox Android only supports `a[download]` for `blob:`/`data:` URI schemes

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -210,7 +210,7 @@
               "firefox_android": {
                 "version_added": "20",
                 "partial_implementation": true,
-                "notes": "Only supported for `blob:` and `data:` URLs. For other URLs, the value is ignored."
+                "notes": "Only supports `blob:` and `data:` URI schemes. Other schemes are ignored."
               },
               "ie": {
                 "version_added": false

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -207,7 +207,11 @@
               "firefox": {
                 "version_added": "20"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "20",
+                "partial_implementation": true,
+                "notes": "Only supported for `blob:` and `data:` URLs. For other URLs, the value is ignored."
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox Android only partially supports the `download` attribute on an `<a>` element.

#### Test results and supporting details

Tested myself with BrowserStack Live and BrowserStack Local, see: https://github.com/mdn/browser-compat-data/issues/16069#issuecomment-2598340070

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/16069.