### PR TITLE
fix(script/diff-features): replace wrong merge commit ref

### DIFF
--- a/scripts/diff-features.ts
+++ b/scripts/diff-features.ts
@@ -150,6 +150,12 @@ const getEnumerationFromGithub = async (ref: string): Promise<string[]> => {
  * @returns Feature list from reference
  */
 const enumerateFeatures = (ref = 'HEAD', quiet = false): string[] => {
+  // GitHub API returns wrong merge commit for https://github.com/mdn/browser-compat-data/pull/25668.
+  ref = ref.replace(
+    '19d8ce0fd1016c3cd1cb6f7b98f72e99ae2f3f16',
+    '3af3a24bdf71f5393893f3724bc47acdd23acfe0',
+  );
+
   // Get the short hash for this ref.
   // Most of the time, you check out named references (a branch or a tag).
   // However, if `ref` is already checked out, then `git worktree add` fails. As

--- a/scripts/diff-features.ts
+++ b/scripts/diff-features.ts
@@ -155,24 +155,9 @@ const enumerateFeatures = (ref = 'HEAD', quiet = false): string[] => {
   // However, if `ref` is already checked out, then `git worktree add` fails. As
   // long as you haven't checked out a detached HEAD for `ref`, then
   // `git worktree add` for the hash succeeds.
-  const hash = (() => {
-    try {
-      return execSync(`git rev-parse --short ${ref}`, {
-        encoding: 'utf-8',
-      }).trim();
-    } catch (e) {
-      // See: https://github.com/mdn/browser-compat-data/issues/25678
-      if (process.env.GITHUB_ACTIONS === 'true') {
-        console.error(`::error::${e}`);
-      }
-
-      execSync(`git fetch origin ${ref}`);
-
-      return execSync(`git rev-parse --short ${ref}`, {
-        encoding: 'utf-8',
-      }).trim();
-    }
-  })();
+  const hash = execSync(`git rev-parse --short ${ref}`, {
+    encoding: 'utf-8',
+  }).trim();
 
   const worktree = `__enumerating__${hash}`;
 


### PR DESCRIPTION
#### Summary

Replaces the wrong merge commit hash with the correct one.

#### Test results and supporting details

The previous workaround didn't work, because fetching the wrong merge commit fails: https://github.com/mdn/browser-compat-data/actions/runs/12830337479/job/35778298222#step:6:32

Ran `npm run release` locally on this branch, and it worked.

#### Related issues

Fixes #25678.