### PR TITLE
Firefox 127 supports `dns-prefetch` on HTTPS pages

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -792,10 +792,17 @@
                 "edge": {
                   "version_added": "≤79"
                 },
-                "firefox": {
-                  "version_added": "3",
-                  "notes": "Before Firefox 127, only HTTP pages were supported."
-                },
+                "firefox": [
+                  {
+                    "version_added": "127"
+                  },
+                  {
+                    "version_added": "3",
+                    "version_removed": "127",
+                    "partial_implementation": true,
+                    "notes": "Only HTTP pages were supported."
+                  }
+                ],
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -793,7 +793,8 @@
                   "version_added": "≤79"
                 },
                 "firefox": {
-                  "version_added": "3"
+                  "version_added": "3",
+                  "notes": "Before Firefox 127, only HTTP pages were supported."
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
#### Summary

Firefox 127 supports `dns-prefetch` on HTTPS pages. Before that, only HTTP pages were supported.

#### Test results and supporting details

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1596935

#### Related issues

See #16299.
