### PR TITLE
Firefox doesn't support `createPattern()` values `repeat-{x,y}` with `fill()`

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -596,7 +596,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1.5"
+              "version_added": "1.5",
+              "notes": "The repetition values `repeat-x` and `repeat-y` are not supported with `fill()`, only with `fillRect()`, see [bug 468358](https://bugzil.la/468358)."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Firefox doesn't support `createPattern()` values `repeat-{x,y}` with `fill()`.

#### Test results and supporting details

See: https://bugzilla.mozilla.org/show_bug.cgi?id=468358#c10

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/16460.
