### PR TITLE
Fix Chrome support for RTCPeerConnection parameters

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -307,11 +307,9 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "23"
+                  "version_added": "45"
                 },
-                "chrome_android": {
-                  "version_added": "57"
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": "≤79"
                 },
@@ -351,9 +349,7 @@
                 "chrome": {
                   "version_added": false
                 },
-                "chrome_android": {
-                  "version_added": "57"
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": "≤79"
                 },
@@ -387,11 +383,9 @@
               "description": "`configuration.iceServers.url` parameter",
               "support": {
                 "chrome": {
-                  "version_added": "25"
+                  "version_added": "45"
                 },
-                "chrome_android": {
-                  "version_added": "57"
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": "≤79"
                 },
@@ -433,11 +427,9 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "34"
+                  "version_added": "45"
                 },
-                "chrome_android": {
-                  "version_added": "57"
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": "≤79"
                 },
@@ -477,11 +469,9 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "29"
+                  "version_added": "45"
                 },
-                "chrome_android": {
-                  "version_added": "57"
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": "≤79"
                 },

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -224,11 +224,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "23"
+                "version_added": "59"
               },
-              "chrome_android": {
-                "version_added": "57"
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"
               },
@@ -268,11 +266,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "23"
+                "version_added": "45"
               },
-              "chrome_android": {
-                "version_added": "57"
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"
               },
@@ -527,12 +523,16 @@
               "web-features:webrtc"
             ],
             "support": {
-              "chrome": {
-                "version_added": "23"
-              },
-              "chrome_android": {
-                "version_added": "57"
-              },
+              "chrome": [
+                {
+                  "version_added": "56"
+                },
+                {
+                  "alternative_name": "iceTransports",
+                  "version_added": "38"
+                }
+              ],
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"
               },


### PR DESCRIPTION
#### Summary

Fixes Chrome support data for the following `RTCPeerConnection` parameters:

- `iceCandidatePoolSize`
- `iceServers`
- `iceTransportPolicy` (aka `iceTransports`)

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/issues/16595#issuecomment-2598717595 for the evidence.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/16595.