### PR TITLE
Remove irrelevant CSS gradient impl_url and flag data

### DIFF
--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -176,23 +176,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -227,23 +213,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -425,23 +397,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -476,23 +434,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -870,23 +814,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -921,23 +851,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -1085,23 +1001,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -1136,23 +1038,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -1335,23 +1223,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -1386,23 +1260,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -1783,23 +1643,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
@@ -1834,23 +1680,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "127",
-                    "impl_url": "https://hg.mozilla.org/mozilla-central/rev/c2620aeeeb85"
-                  },
-                  {
-                    "version_added": "121",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.gradient-color-interpolation-method.enabled",
-                        "value_to_set": "true"
-                      }
-                    ],
-                    "impl_url": "https://bugzil.la/1838740"
-                  }
-                ],
+                "firefox": {
+                  "version_added": "127"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removes irrelevant `impl_url` and flag data for CSS gradient subfeatures.

#### Test results and supporting details

1. We don't usually record commits as `impl_url`.
2. See Guidelines about [Removal of irrelevant flag data](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data).

#### Related issues

See https://github.com/mdn/browser-compat-data/issues/16598#issuecomment-2598805316.