### PR TITLE
Safari iOS 16 added `SpeechSynthesisEvent.utterance`

### DIFF
--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -375,7 +375,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari iOS 16 added `SpeechSynthesisEvent.utterance`, not Safari iOS 7.

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/issues/16864#issuecomment-2599248183

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/16864.