### PR TITLE
Chrome 60 and Firefox 59 set `relatedTarget` on `DragEvent`

### DIFF
--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -142,6 +142,9 @@
             "version_added": "59"
           },
           "firefox_android": "mirror",
+          "ie": {
+            "version_added": "9"
+          },
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -127,6 +127,39 @@
           }
         }
       }
+    },
+    "relatedTarget": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/relatedTarget",
+        "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-relatedtarget",
+        "support": {
+          "chrome": {
+            "version_added": "60"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "59"
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false,
+            "impl_url": "https://webkit.org/b/66547"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
     }
   }
 }

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -127,42 +127,6 @@
           }
         }
       }
-    },
-    "relatedTarget": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/relatedTarget",
-        "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-relatedtarget",
-        "support": {
-          "chrome": {
-            "version_added": "60"
-          },
-          "chrome_android": "mirror",
-          "edge": "mirror",
-          "firefox": {
-            "version_added": "59"
-          },
-          "firefox_android": "mirror",
-          "ie": {
-            "version_added": "9"
-          },
-          "oculus": "mirror",
-          "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": false,
-            "impl_url": "https://webkit.org/b/66547"
-          },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror",
-          "webview_ios": "mirror"
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      }
     }
   }
 }

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -988,6 +988,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "drag_events": {
+          "__compat": {
+            "description": "Available on `DragEvent`",
+            "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#:~:text=relatedtarget",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/66547"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "screenX": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 60 and Firefox 59 set `relatedTarget` on `DragEvent`, but Safari doesn't.

#### Test results and supporting details

Bugs:

- https://bugs.chromium.org/p/chromium/issues/detail?id=159534
- https://bugzilla.mozilla.org/show_bug.cgi?id=1420590
- https://bugs.webkit.org/show_bug.cgi?id=66547

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/16871.