### PR TITLE
Show Firefox support across all of WebAssembly JS String builtins

### DIFF
--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -108,7 +108,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -129,7 +129,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -201,7 +201,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -222,7 +222,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -292,7 +292,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -313,7 +313,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -385,7 +385,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -406,7 +406,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -476,7 +476,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "134"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -497,7 +497,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/webassembly/api/Module.json
+++ b/webassembly/api/Module.json
@@ -109,7 +109,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "134"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -130,7 +130,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Firefox appears to support all of the WebAssembly JS String builtins proposal, but keys added later weren't updated to reflect this. This PR corrects the issue.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Reading across the following links, it appears that Firefox fully implemented wasm JavaScript String builtins, initially represented by `webassembly.jsStringBuiltins` only; when Chris added the `compile_options` keys, they weren't reconciled with the existing Firefox data.

- https://bugzilla.mozilla.org/show_bug.cgi?id=1863794
- https://github.com/mdn/browser-compat-data/pull/25230
- https://github.com/mdn/browser-compat-data/pull/25391

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Discovered in the course of https://github.com/web-platform-dx/web-features/pull/2549.
