### PR TITLE
Menu update and remove error message support note

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -808,7 +808,7 @@
               "firefox": [
                 {
                   "version_added": "55",
-                  "notes": "From Firefox 135, an error message is returned when the menu item doesn't exist. Previously, the error was ignored and the promise fulfilled."
+                  "notes": "From Firefox 136, an error message is returned when the menu item doesn't exist. Previously, the error was ignored and the promise fulfilled."
                 },
                 {
                   "alternative_name": "contextMenus.remove",
@@ -873,7 +873,7 @@
               "firefox": [
                 {
                   "version_added": "55",
-                  "notes": "From Firefox 135, an error message is returned when the menu item doesn't exist. Previously, the error was ignored and the promise fulfilled."
+                  "notes": "From Firefox 136, an error message is returned when the menu item doesn't exist. Previously, the error was ignored and the promise fulfilled."
                 },
                 {
                   "alternative_name": "contextMenus.update",

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -808,7 +808,7 @@
               "firefox": [
                 {
                   "version_added": "55",
-                  "notes": "From Firefox 135, an error message is returned when the menu item doesn't exist. Previously. `undefined` was returned."
+                  "notes": "From Firefox 135, an error message is returned when the menu item doesn't exist. Previously, the error was ignored and the promise fulfilled."
                 },
                 {
                   "alternative_name": "contextMenus.remove",
@@ -873,7 +873,7 @@
               "firefox": [
                 {
                   "version_added": "55",
-                  "notes": "From Firefox 135, an error message is returned when the menu item doesn't exist. Previously. `undefined` was returned."
+                  "notes": "From Firefox 135, an error message is returned when the menu item doesn't exist. Previously, the error was ignored and the promise fulfilled."
                 },
                 {
                   "alternative_name": "contextMenus.update",

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -807,7 +807,8 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": "From Firefox 135, an error message is returned when the menu item doesn't exist. Previously. `undefined` was returned."
                 },
                 {
                   "alternative_name": "contextMenus.remove",
@@ -871,7 +872,8 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": "From Firefox 135, an error message is returned when the menu item doesn't exist. Previously. `undefined` was returned."
                 },
                 {
                   "alternative_name": "contextMenus.update",


### PR DESCRIPTION
#### Summary

Addresses the dev-docs-needed requirements of [Bug 1688743](https://bugzilla.mozilla.org/show_bug.cgi?id=1688743) menus.remove doesn't return an error when removing a non-existing menu item by adding a note about the `update` and `remove` methods returning an error message.

#### Related pull requests

Related to release note added in https://github.com/mdn/content/pull/37720