### PR TITLE
Rename Temporal timeZoneID -> timeZoneId, typo

### DIFF
--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -212,7 +212,7 @@
           },
           "epochMilliseconds": {
             "__compat": {
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmilliseconds",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochmilliseconds",
               "tags": [
                 "web-features:temporal"
               ],
@@ -264,7 +264,7 @@
           },
           "epochNanoseconds": {
             "__compat": {
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochnanoseconds",
               "tags": [
                 "web-features:temporal"
               ],

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -261,7 +261,7 @@
               }
             }
           },
-          "timeZoneID": {
+          "timeZoneId": {
             "__compat": {
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.timezoneid",
               "tags": [


### PR DESCRIPTION
#### Summary

I'm going through Temporal entries and fixing a few oddities.

__Changes:__
- Rename `timeZoneID` -> `timeZoneId` 
- typo in Temporal Instant; `zoneddatetime` -> `instant`


#### Related issues

- [x] https://github.com/mdn/content/pull/37344
- [x] https://github.com/mdn/browser-compat-data/pull/25714