### PR TITLE
Add Date.toTemporalInstant

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -3024,6 +3024,58 @@
             }
           }
         },
+        "toTemporalInstant": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-temporal/#sec-date.prototype.totemporalinstant",
+            "tags": [
+              "web-features:temporal"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/42201538"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.40",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--unstable-temporal"
+                  }
+                ]
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1519167"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview",
+                "impl_url": "https://webkit.org/b/223166"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "toTimeString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString",


### PR DESCRIPTION
#### Summary

Everything for Temporal has been added under ./javascript/builtins/Temporal

This seems to be missed because it's exposed under Date instead:

>Use this method to convert legacy Date values to the Temporal API, then further convert it to other Temporal classes as necessary.

Spec: https://tc39.es/proposal-temporal/#sec-date.prototype.totemporalinstant

Incoming docs: https://github.com/mdn/content/blob/1a21ed666271ebd4ed404ab009f4410d2e047e9f/files/en-us/web/javascript/reference/global_objects/date/totemporalinstant/index.md?plain=1

#### Test results and supporting details

Example:

```js
const legacyDate = new Date("2021-07-01T12:34:56.789Z");
const instant = legacyDate.toTemporalInstant();
console.log(instant);

// Further convert to other objects
const zdt = instant.toZonedDateTimeISO("UTC");
const date = zdt.toPlainDate();
console.log(date.toString()); // 2021-07-01
```

#### Related issues

- [x] https://github.com/mdn/browser-compat-data/pull/25714
- [ ] https://github.com/mdn/browser-compat-data/pull/25715
- [x] https://github.com/mdn/content/pull/37344
