### PR TITLE
Safari supports CSS column-gap with percentages and `calc()` values

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -300,7 +300,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "12.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -339,7 +339,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "12"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari supports `column-gap` with percentages (since 12) and `calc()` values (since 12.1).

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/issues/16972#issuecomment-2602948836

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/16972.
