### PR TITLE
Chrome 8 + Safari 5.1 supported {block,inline}-size via `-webkit-logical-*`

### DIFF
--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -12,9 +12,15 @@
             "web-features:logical-properties"
           ],
           "support": {
-            "chrome": {
-              "version_added": "57"
-            },
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "alternative_name": "-webkit-logical-height",
+                "version_added": "8"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -27,9 +33,15 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "12.1"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "alternative_name": "-webkit-logical-height",
+                "version_added": "5.1"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -12,9 +12,15 @@
             "web-features:logical-properties"
           ],
           "support": {
-            "chrome": {
-              "version_added": "57"
-            },
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "alternative_name": "-webkit-logical-width",
+                "version_added": "8"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -27,9 +33,15 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "12.1"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "alternative_name": "-webkit-logical-width",
+                "version_added": "5.1"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
…al-*`



<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome and Safari already supported the new `block-size` and `inline-size` properties as `-webkit-logical-width` and `-webkit-logical-height` before they were standardized.

#### Test results and supporting details

See:
- https://github.com/WebKit/WebKit/commit/d2ecf440f5acbcd9d38ca461822e29ca42769366

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/17724.
