### PR TITLE
WebView Android doesn't support Background Sync

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1105,7 +1105,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40449796"
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -845,7 +845,10 @@
             "samsunginternet_android": {
               "version_added": "4.0"
             },
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40449796"
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/SyncEvent.json
+++ b/api/SyncEvent.json
@@ -29,7 +29,10 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "impl_url": "https://crbug.com/40449796"
+          },
           "webview_ios": "mirror"
         },
         "status": {
@@ -67,7 +70,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40449796"
+            },
             "webview_ios": "mirror"
           },
           "status": {
@@ -105,7 +111,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40449796"
+            },
             "webview_ios": "mirror"
           },
           "status": {
@@ -143,7 +152,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40449796"
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/SyncManager.json
+++ b/api/SyncManager.json
@@ -29,7 +29,10 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror",
+          "webview_android": {
+            "version_added": false,
+            "impl_url": "https://crbug.com/40449796"
+          },
           "webview_ios": "mirror"
         },
         "status": {
@@ -78,7 +81,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40449796"
+            },
             "webview_ios": "mirror"
           },
           "status": {
@@ -116,7 +122,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40449796"
+            },
             "webview_ios": "mirror"
           },
           "status": {
@@ -154,7 +163,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40449796"
+            },
             "webview_ios": "mirror"
           },
           "status": {


### PR DESCRIPTION
#### Summary

WebView Android doesn't support Background Sync

#### Test results and supporting details

The evidence is in https://github.com/mdn/browser-compat-data/issues/18211.

In particular, [this bug](https://issues.chromium.org/issues/40449796) disabled Background Sync in WebView in 2016, and a comment from 2019 confirmed "no plans to support Background Sync in WebView right now".

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/18211.