### PR TITLE
Safari 6 added and Safari 8 removed `FileSystemSync` and `webkitRequestFileSystem`

### DIFF
--- a/api/FileSystemSync.json
+++ b/api/FileSystemSync.json
@@ -20,7 +20,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "6"
+            "version_added": "6",
+            "version_removed": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/FileSystemSync.json
+++ b/api/FileSystemSync.json
@@ -55,7 +55,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -90,7 +91,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -4693,7 +4693,9 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "prefix": "webkit",
+              "version_added": "6",
+              "version_removed": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari 6 added and Safari 8 removed FileSystemSync and webkitRequestFileSystem

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/issues/20811#issuecomment-2605926666

> The [commit](https://github.com/WebKit/WebKit/commit/f28579c215697ad52dd3d8182322c0174d0925f7) landed in [WebKit 538.2.0](https://github.com/WebKit/WebKit/blob/f28579c215697ad52dd3d8182322c0174d0925f7/Source/WebCore/Configurations/Version.xcconfig#L24-L26) before Safari 8/538.35.
> 
> It looks like webkitRequestFileSystem() was originally implemented in https://github.com/WebKit/WebKit/commit/b90d4ad935235d029997db77bb3b314579a00f4b in [WebKit 534.7.0](https://github.com/WebKit/WebKit/blob/b90d4ad935235d029997db77bb3b314579a00f4b/WebCore/Configurations/Version.xcconfig#L24-L26) before Safari 5.1/534.48.
> 
> FileSystemSync was implemented in https://github.com/WebKit/WebKit/commit/0ba55ff5f6c708438bfc2008449b31de6ce38453, also in [WebKit 534.7.0](https://github.com/WebKit/WebKit/blob/0ba55ff5f6c708438bfc2008449b31de6ce38453/WebCore/Configurations/Version.xcconfig#L24-L26).

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20811.