### PR TITLE
Remove unnecessary prefixes/notes from `box-shadow` subfeatures

### DIFF
--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -88,35 +88,21 @@
               "web-features:box-shadow"
             ],
             "support": {
-              "chrome": [
-                {
-                  "version_added": "10"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1"
-                }
-              ],
+              "chrome": {
+                "version_added": "1"
+              },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "4"
-                },
-                {
-                  "prefix": "-moz-",
-                  "version_added": "3.5",
-                  "version_removed": "13"
-                }
-              ],
+              "firefox": {
+                "version_added": "3.5"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "9",
                 "partial_implementation": true,
                 "notes": [
-                  "To use `box-shadow` in Internet Explorer 9 or later, you must set [`border-collapse`](https://developer.mozilla.org/docs/Web/CSS/border-collapse) to `separate`.",
                   "`inset` must be the last keyword in the declaration."
                 ]
               },
@@ -125,15 +111,9 @@
                 "version_added": "10.5"
               },
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "5.1"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "5"
-                }
-              ],
+              "safari": {
+                "version_added": "5"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -153,57 +133,31 @@
               "web-features:box-shadow"
             ],
             "support": {
-              "chrome": [
-                {
-                  "version_added": "10"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1"
-                }
-              ],
+              "chrome": {
+                "version_added": "1"
+              },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "4"
-                },
-                {
-                  "prefix": "-moz-",
-                  "version_added": "3.5",
-                  "version_removed": "13"
-                }
-              ],
+              "firefox": {
+                "version_added": "3.5"
+              },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "9",
-                "notes": "To use `box-shadow` in Internet Explorer 9 or later, you must set [`border-collapse`](https://developer.mozilla.org/docs/Web/CSS/border-collapse) to `separate`."
+                "version_added": "9"
               },
               "oculus": "mirror",
               "opera": {
                 "version_added": "10.5"
               },
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "5.1"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "3"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "5"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1"
-                }
-              ],
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
@@ -222,48 +176,28 @@
               "web-features:box-shadow"
             ],
             "support": {
-              "chrome": [
-                {
-                  "version_added": "10"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1"
-                }
-              ],
+              "chrome": {
+                "version_added": "1"
+              },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "4"
-                },
-                {
-                  "prefix": "-moz-",
-                  "version_added": "3.5",
-                  "version_removed": "13"
-                }
-              ],
+              "firefox": {
+                "version_added": "3.5"
+              },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "9",
-                "notes": "To use `box-shadow` in Internet Explorer 9 or later, you must set [`border-collapse`](https://developer.mozilla.org/docs/Web/CSS/border-collapse) to `separate`."
+                "version_added": "9"
               },
               "oculus": "mirror",
               "opera": {
                 "version_added": "10.5"
               },
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "5.1"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "5"
-                }
-              ],
+              "safari": {
+                "version_added": "5"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -102,9 +102,7 @@
               "ie": {
                 "version_added": "9",
                 "partial_implementation": true,
-                "notes": [
-                  "`inset` must be the last keyword in the declaration."
-                ]
+                "notes": "`inset` must be the last keyword in the declaration."
               },
               "oculus": "mirror",
               "opera": {


### PR DESCRIPTION
#### Summary

Subfeatures of `box-shadow` have some misleading `prefix` statements (which is misleading, because the prefix applies to the parent feature) and some unnecessarily `notes` (duplicated from the parent).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
