### PR TITLE
Deprecate `page-break-{after,before,inside}`

### DIFF
--- a/css/properties/page-break-after.json
+++ b/css/properties/page-break-after.json
@@ -43,7 +43,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "always": {
@@ -81,7 +81,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -120,7 +120,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -161,7 +161,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -200,7 +200,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -239,7 +239,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/css/properties/page-break-before.json
+++ b/css/properties/page-break-before.json
@@ -43,7 +43,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "always": {
@@ -81,7 +81,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -120,7 +120,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -161,7 +161,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -200,7 +200,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -239,7 +239,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/css/properties/page-break-inside.json
+++ b/css/properties/page-break-inside.json
@@ -42,7 +42,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "auto": {
@@ -80,7 +80,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -120,7 +120,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

CSS Fragmentation Module Level 3 calls these "legacy shorthands", which implies their deprecation.

See:
- https://drafts.csswg.org/css-break/#page-break-properties
- https://drafts.csswg.org/css-cascade-5/#legacy-shorthand

#### Test results and supporting details

See also: https://github.com/mdn/browser-compat-data/issues/21233#issuecomment-2607918760

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21233.