### PR TITLE
Set `IntlLegacyConstructedSymbol` to non-deprecated

### DIFF
--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -159,7 +159,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "deprecated": true
+                  "deprecated": false
                 }
               }
             },

--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -152,7 +152,7 @@
                 "status": {
                   "experimental": false,
                   "standard_track": true,
-                  "deprecated": true
+                  "deprecated": false
                 }
               }
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The spec doesn't appear to discourage these features.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

These features are specified as a "Normative Optional" but not "Normative Optional, Legacy" behavior. Given [the distinction that the spec makes between legacy and non-legacy](https://tc39.es/ecma262/#sec-conformance) parts of the language, "[Normative optional](https://tc39.es/ecma402/#sec-chaindatetimeformat)" should not be marked as deprecated.

Confusingly, the symbol's description contains the substring `Legacy`. This was [a later addition to the spec](https://github.com/tc39/ecma402/commit/44107b64949017960c905ebb876216a2075973e7) that doesn't have much of a paper trail (and is older than the contemporary specification's "legacy" terminology—that is, it didn't have a defined meaning at the time). I think we should weigh the spec's explicit conformance text over a partial string match.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://github.com/web-platform-dx/web-features/pull/2564
https://github.com/mdn/browser-compat-data/pull/17410

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
