### PR TITLE
Add Deno 2.0/2.1 releases

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -331,9 +331,23 @@
         "1.46": {
           "release_date": "2024-08-22",
           "release_notes": "https://deno.com/blog/v1.46",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "12.9"
+        },
+        "2.0": {
+          "release_date": "2024-10-09",
+          "release_notes": "https://deno.com/blog/v2.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "12.9"
+        },
+        "2.1": {
+          "release_date": "2024-11-21",
+          "release_notes": "https://deno.com/blog/v2.1",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "13.0"
         }
       }
     }


### PR DESCRIPTION

#### Summary

Updates the releases data for Deno to include the missing releases of v2.0, and v2.1

Information validated against the Deno release notes available:

- https://github.com/denoland/deno/releases
- https://deno.com/blog/v2.0
- https://deno.com/blog/v2.1
