### PR TITLE
Chrome for Android 132 fully supports webkitdirectory

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3233,6 +3233,9 @@
             },
             "chrome_android": [
               {
+                "version_added": "132"
+              },
+              {
                 "version_added": "131",
                 "partial_implementation": true,
                 "notes": "In Chrome for Android 131, if a user selects a directory, the browser crashes (see [bug 376834374](https://crbug.com/376834374))."


### PR DESCRIPTION
#### Summary

Chrome for Android 132 fully supports webkitdirectory. Thinking about it, I don't remember why this wasn't added as part of #25036

#### Test results and supporting details

Used webkitdirectory on the latest Chrome for Android.
