### PR TITLE
`html.elements.a.download`: clarify Firefox for Android note

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -209,7 +209,7 @@
               },
               "firefox_android": {
                 "version_added": "20",
-                "notes": "The attribute's filename value only affects the suggested file name for the `blob:` and `data:` URI schemes. Other schemes ignore the suggested filename."
+                "notes": "The attribute's filename value only affects the suggested file name for the `blob:` and `data:` URI schemes. Other schemes ignore the suggested filename. See [bug 1845642](https://bugzil.la/1845642)."
               },
               "ie": {
                 "version_added": false

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -209,8 +209,7 @@
               },
               "firefox_android": {
                 "version_added": "20",
-                "partial_implementation": true,
-                "notes": "Only supports `blob:` and `data:` URI schemes. Other schemes are ignored."
+                "notes": "The attribute's filename value only affects the suggested file name for the `blob:` and `data:` URI schemes. Other schemes ignore the suggested filename."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Revise the note for Firefox for Android to be more specific about the incomplete behavior. This also appends a bug link and removes the partial flag.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

The previous note implied that only `blob:` and `data:` URIs could be downloaded. The new note is more specific and references https://bugzilla.mozilla.org/show_bug.cgi?id=1845642.

The [spec for this behavior](https://html.spec.whatwg.org/multipage/links.html#downloading-resources:attr-hyperlink-download:~:text=If%20the%20user%20agent%20needs%20a%20filename) is a quite complex "should" procedure, so I don't think this merits a partial implementation.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/issues/16069
- https://github.com/mdn/browser-compat-data/pull/25691
- https://bugzilla.mozilla.org/show_bug.cgi?id=1845642

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
