### PR TITLE
Add `details` support data for webextensions.api.webRequest

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1505,6 +1505,27 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "54"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "challenger": {
               "__compat": {
                 "support": {
@@ -2022,6 +2043,29 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "46"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "cookieStoreId": {
               "__compat": {
                 "support": {
@@ -2547,6 +2591,29 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "46"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "cookieStoreId": {
               "__compat": {
                 "support": {
@@ -2962,6 +3029,29 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "cookieStoreId": {
               "__compat": {
                 "support": {
@@ -3375,6 +3465,29 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "cookieStoreId": {
               "__compat": {
                 "support": {
@@ -3871,6 +3984,29 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "cookieStoreId": {
               "__compat": {
                 "support": {
@@ -4327,6 +4463,29 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "cookieStoreId": {
               "__compat": {
                 "support": {
@@ -4836,6 +4995,29 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "cookieStoreId": {
               "__compat": {
                 "support": {
@@ -5328,6 +5510,29 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            },
             "cookieStoreId": {
               "__compat": {
                 "support": {
@@ -5502,7 +5707,7 @@
                 }
               }
             },
-            "requestId": {
+            "requestHeaders": {
               "__compat": {
                 "support": {
                   "chrome": {
@@ -5527,7 +5732,7 @@
                 }
               }
             },
-            "requestHeaders": {
+            "requestId": {
               "__compat": {
                 "support": {
                   "chrome": {


### PR DESCRIPTION
#### Summary

Adding the `"__compat"` directive to the `details` object for all the events in the `webRequest` API. Without this these details are not presented on MDN.

#### Related issues

Undertaken to support [Bug 1602005](https://bugzilla.mozilla.org/show_bug.cgi?id=1602005) webRequest.onHeadersReceived: more object "details" properties than in the documentation
