### PR TITLE
`webassembly.jsStringBuiltins`: show support in Chrome for Android

### DIFF
--- a/webassembly/jsStringBuiltins.json
+++ b/webassembly/jsStringBuiltins.json
@@ -10,9 +10,7 @@
           "chrome": {
             "version_added": "130"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": "134"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This shows Chrome for Android as supporting wasm JS string builtins.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This data was untouched in the course of https://github.com/mdn/browser-compat-data/pull/25391; I believe it was error rather than an intentional omission, given the reported [support in Chrome Platform Status](https://chromestatus.com/feature/6695587390423040). See https://github.com/mdn/browser-compat-data/pull/25706 for past errors along these lines.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/25391
- https://github.com/mdn/browser-compat-data/pull/25706
- Discovered in the course of https://github.com/web-platform-dx/web-features/pull/2579/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
