### PR TITLE
`<meter>` element: update Edge support data

### DIFF
--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "12"
+            "version_added": "13"
           },
           "firefox": {
             "version_added": "16"

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -11,7 +11,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "16"
@@ -54,7 +54,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "16"
@@ -98,7 +98,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "16"
@@ -143,7 +143,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "16"
@@ -188,7 +188,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "16"
@@ -232,7 +232,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "16"
@@ -276,7 +276,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "16"


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This makes the data for the `<meter>` element and API more consistent for Edge.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I was able to make an educated guess on the starting version 13 from these [release highlights](https://blogs.windows.com/msedgedev/2015/11/16/introducing-edgehtml-13-our-first-platform-update-for-microsoft-edge/) from Microsoft. Manual testing in Edge 18, 17, and 14 showed that the `labels` API was the only part that landed later.

#### Related issues

This will make things make more sense for https://github.com/web-platform-dx/web-features/pull/1419.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
