### PR TITLE
Safari 18 only partially implements `content-visibility: auto`

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -61,7 +61,10 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18"
+                "version_added": "18",
+                "impl_url": "https://webkit.org/b/283846",
+                "partial_implementation": true,
+                "notes": "Skipped content is not findable via find-in-page."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Safari does not fully implement [`content-visibility: auto` according to the spec](https://drafts.csswg.org/css-contain/#valdef-content-visibility-auto):

> Unlike [hidden](https://drafts.csswg.org/css-contain/#valdef-content-visibility-hidden), the [skipped contents](https://drafts.csswg.org/css-contain/#skips-its-contents) _must_ still be available as normal to user-agent features such as find-in-page, tab order navigation, etc., and must be focusable and selectable as normal.

Since [Safari 18 introduced this feature](https://webkit.org/blog/15865/webkit-features-in-safari-18-0/#content-visibility), any website that already use `content-visibility: auto` as a progressive enhancement are broken for find-in-page.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

It doesn’t seem possible to automate testing of the find-in-page feature of browsers, so this has to be manually tested. There’s a reduced test included in the WebKit bug URL below. Visit it in Safari and follow the instructions in the content of the test.


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[WebKit Bug 283846](https://bugs.webkit.org/show_bug.cgi?id=283846)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

- https://github.com/web-platform-dx/web-features/issues/2585

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
