### PR TITLE
Safari TP supports focus with focusVisible parameter

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1556,7 +1556,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Safari Tech Preview supports the focusVisible option of the focus method.

#### Test results and supporting details

See https://webkit.org/blog/16445/release-notes-for-safari-technology-preview-212/

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes #25765
