### PR TITLE
Safari iOS 18.3. fully supports popover

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2306,11 +2306,17 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": {
-              "version_added": "17",
-              "partial_implementation": true,
-              "notes": "On iOS and iPadOS, popovers are not dismissed when the user taps outside of the popover area, see [bug 267688](https://webkit.org/b/267688)."
-            },
+            "safari_ios": [
+              {
+                "version_added": "18.3"
+              },
+              {
+                "version_added": "17",
+                "version_removed": "18.3",
+                "partial_implementation": true,
+                "notes": "On iOS and iPadOS, popovers are not dismissed when the user taps outside of the popover area, see [bug 267688](https://webkit.org/b/267688)."
+              }
+            ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"


### PR DESCRIPTION
The major bug with light dismiss has been addressed.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Popover attribute is now fully supported on iOS Safari as of 18.3.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See https://developer.apple.com/documentation/safari-release-notes/safari-18_3-release-notes#Web-API

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
