### PR TITLE
chore(schemas/browsers): make engine_version required if engine is set

### DIFF
--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -127,6 +127,9 @@
         }
       },
       "required": ["status"],
+      "dependencies": {
+        "engine": ["engine_version"]
+      },
       "additionalProperties": false
     }
   },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Makes the `engine_version` required if `engine` is set.

#### Test results and supporting details

It does not seem to change the build output, so I don't think this is a breaking change.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22843.
