### PR TITLE
Chrome/Edge 134 support experimental `<meta name="application-title">`

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -375,6 +375,39 @@
               "deprecated": false
             }
           },
+          "application-title": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "134"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
+          },
           "color-scheme": {
             "__compat": {
               "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Edge just shipped, in Chromium, a new name that can be used with `<meta>` tags. This name is `application-title` and is used to provide text content (via the `content` attribute) that should be displayed in an installed application's title bar.

Installed application: a web app that's been installed as a standalone app on desktop operating systems that support it. For example, when installing a PWA from Microsoft Edge, on Windows.

This new meta tag makes it easy for developers to control the content that appears in the standalone app window's title bar. Developers can still use the `<title>` element (still works), but using `<meta name="application-title" content="...">` provides an additional mechanism just for when the app is installed, which can help avoid UX issues (learn more from the explainer linked below).

This BCD PR adds the compat data for the new meta name.

There's no spec yet as this is gated behind having more implementer interest. But the feature has shipped in Chrome and Edge, and other Chromium-based browsers, starting with 134.

#### Test results and supporting details

Explainer: https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/DocumentSubtitle/explainer.md

HTML spec discussion: https://github.com/whatwg/html/issues/8909
