### PR TITLE
fix(workflows): assign explicit permissions + pin 3rd party actions

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -11,7 +11,7 @@ jobs:
   close-issues-if-invalid:
     runs-on: ubuntu-latest
     steps:
-      - uses: queengooborg/invalid-issue-closer@v1.5.4
+      - uses: queengooborg/invalid-issue-closer@d79a4ae7685cfab213be15f0e39fbd4533e3d822 # v1.5.4
         id: spam-check
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -21,7 +21,7 @@ jobs:
             This issue has been identified as spam and has been automatically closed and locked.  Do not use this repository for posting spam.
           normalize-newlines: true
           body-is-blank: true
-      - uses: queengooborg/invalid-issue-closer@v1.5.4
+      - uses: queengooborg/invalid-issue-closer@d79a4ae7685cfab213be15f0e39fbd4533e3d822 # v1.5.4
         if: steps.spam-check.outputs.was-closed == 'false'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-regex-labeler.yml
+++ b/.github/workflows/issue-regex-labeler.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   issue-labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,7 +21,7 @@ jobs:
     needs: label-py-path
     runs-on: ubuntu-latest
     steps:
-      - uses: codelytv/pr-size-labeler@v1
+      - uses: codelytv/pr-size-labeler@1c3422395d899286d5ee2c809fd5aed264d5eb9b # v1.10.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           github_api_url: "https://api.github.com"

--- a/.github/workflows/ping-other-repos.yml
+++ b/.github/workflows/ping-other-repos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Ping w3c/mdn-spec-links
         # This is one of many possible repos we can ping. When adding other
         # repos, you can follow this w3c/mdn-spec-links one as an example.
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.SIDESHOWBARKER }}
           repository: w3c/mdn-spec-links

--- a/.github/workflows/pr-reviewdog.yml
+++ b/.github/workflows/pr-reviewdog.yml
@@ -51,7 +51,7 @@ jobs:
           name: diff
 
       - name: Setup
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
         with:
           reviewdog_version: latest
 

--- a/.github/workflows/pr-reviewdog.yml
+++ b/.github/workflows/pr-reviewdog.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     branches: ["main"]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   fix:
     name: Fix

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -34,7 +34,7 @@ jobs:
           npm run update-browser-releases -- --all >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
           token: ${{ secrets.GH_TOKEN }} # need the rights to create and edit PRs
           commit-message: Update browser releases

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - "package-lock.json"
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   update-mdn-urls:
     if: github.repository == 'mdn/browser-compat-data' && github.event.pull_request.user.login == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/npm_and_yarn/ddbeck/mdn-content-inventory-')

--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -44,7 +44,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
           token: ${{ secrets.GH_TOKEN }} # need the rights to create and edit PRs
           commit-message: Update web-features tags

--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "30 4 * * 1-5"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-web-features:
     if: github.repository == 'mdn/browser-compat-data'


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Assign explicit workflow permissions, and pin 3rd party actions.

#### Test results and supporting details

This resolves 12 CodeQL alerts of medium severity (see [here](https://github.com/mdn/browser-compat-data/security/code-scanning?query=pr%3A25793+tool%3ACodeQL+is%3Aopen) for those with access).

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
