### PR TITLE
Chrome 98 / Firefox 103 / Safari 17 support `AggregateError` serialization

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -173,7 +173,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -142,7 +142,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "98",
+                "notes": "`AggregateError` serializes to the `Error` type, without additional properties."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -151,7 +152,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "103",
-                "notes": "Serialized properties: `name`, `message`, `cause`, `errors`."
+                "notes": "`AggregateError` serializes to the `AggregateError` type, with properties `name`, `message`, `cause`, and `errors`."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -164,7 +165,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I wasn't super satisfied with merging https://github.com/mdn/browser-compat-data/pull/25744 as is. This completes the work I suggested in the original description, following the discussion.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I tested this manually in BrowserStack, with the test code mentioned in the previous PR.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://github.com/mdn/browser-compat-data/pull/25744

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
