### PR TITLE
Chrome 133 + Safari TP support multiple import maps

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -674,6 +674,40 @@
                   "deprecated": false
                 }
               }
+            },
+            "multiple_import_maps": {
+              "__compat": {
+                "description": "Multiple import maps",
+                "support": {
+                  "chrome": {
+                    "version_added": "133"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "preview"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           },
           "module": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -678,6 +678,7 @@
             "multiple_import_maps": {
               "__compat": {
                 "description": "Multiple import maps",
+                "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#:~:text=multiple%20import%20maps",
                 "support": {
                   "chrome": {
                     "version_added": "133"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds a data point for multiple import maps support, which was documented by @yoavweiss in https://github.com/mdn/content/pull/37739.

It has the following support:

- Chrome 133+: https://chromestatus.com/feature/5121916248260608
- WebKit Nightly branch: https://bugs.webkit.org/show_bug.cgi?id=279025

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Spec PR: https://github.com/whatwg/html/pull/10528

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
