### PR TITLE
Safari 10 also supports `ReadableStreamDefaultReader` constructor

### DIFF
--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -89,7 +89,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
The compat data was updated in #24553, but we forgot to also update the constructor's data.