### PR TITLE
enhance(scripts/update-browser-releases): update Opera releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "typescript": "~5.7.2",
         "web-features": "^2.15.0",
         "web-specs": "^3.0.0",
+        "xml2js": "^0.6.2",
         "yargs": "~17.7.0"
       },
       "engines": {
@@ -7066,6 +7067,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8131,6 +8139,30 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "typescript": "~5.7.2",
     "web-features": "^2.15.0",
     "web-specs": "^3.0.0",
+    "xml2js": "^0.6.2",
     "yargs": "~17.7.0"
   },
   "scripts": {

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -5,6 +5,7 @@ import yargs from 'yargs';
 import { updateChromiumReleases } from './chrome.js';
 import { updateEdgeReleases } from './edge.js';
 import { updateFirefoxReleases } from './firefox.js';
+import { updateOperaReleases } from './opera.js';
 import { updateSafariReleases } from './safari.js';
 
 const argv = yargs(process.argv.slice(2))
@@ -26,6 +27,11 @@ const argv = yargs(process.argv.slice(2))
   })
   .option('firefox', {
     describe: 'Update Mozilla Firefox',
+    type: 'boolean',
+    group: 'Engine selection:',
+  })
+  .option('opera', {
+    describe: 'Update Opera',
     type: 'boolean',
     group: 'Engine selection:',
   })
@@ -65,12 +71,14 @@ const updateAllBrowsers =
     argv['webview'] ||
     argv['firefox'] ||
     argv['edge'] ||
+    argv['opera'] ||
     argv['safari']
   );
 const updateChrome = argv['chrome'] || updateAllBrowsers;
 const updateWebview = argv['webview'] || updateAllBrowsers;
 const updateFirefox = argv['firefox'] || updateAllBrowsers;
 const updateEdge = argv['edge'] || updateAllBrowsers;
+const updateOpera = argv['opera'] || updateAllBrowsers;
 const updateSafari = argv['safari'] || updateAllBrowsers;
 const updateAllDevices =
   argv['alldevices'] || !(argv['mobile'] || argv['desktop']);
@@ -163,6 +171,25 @@ const options = {
     firefoxScheduleURL:
       'https://whattrainisitnow.com/api/release/schedule/?version=',
   },
+  opera_desktop: {
+    browserName: 'Opera for Desktop',
+    bcdFile: './browsers/opera.json',
+    bcdBrowserName: 'opera',
+    skippedReleases: [],
+    releaseFeedURL: 'https://blogs.opera.com/desktop/category/stable-2/feed/',
+    titleVersionPattern: /^Opera (\d+)$/,
+    descriptionEngineVersionPattern: /Chromium (\d+)/,
+  },
+  opera_android: {
+    browserName: 'Opera for Android',
+    bcdFile: './browsers/opera_android.json',
+    bcdBrowserName: 'opera_android',
+    skippedReleases: [],
+    releaseFeedURL: 'https://forums.opera.com/category/20.rss',
+    releaseFilterCreator: ['abitkulova'],
+    titleVersionPattern: /^Opera for Android (\d+)$/,
+    descriptionEngineVersionPattern: /Chromium (\d+)/,
+  },
   safari_desktop: {
     browserName: 'Safari for Desktop',
     bcdFile: './browsers/safari.json',
@@ -221,6 +248,16 @@ if (updateFirefox && updateDesktop) {
 
 if (updateFirefox && updateMobile) {
   const add = await updateFirefoxReleases(options.firefox_android);
+  result += (result && add ? '\n' : '') + add;
+}
+
+if (updateOpera && updateDesktop) {
+  const add = await updateOperaReleases(options.opera_desktop);
+  result += (result && add ? '\n' : '') + add;
+}
+
+if (updateOpera && updateMobile) {
+  const add = await updateOperaReleases(options.opera_android);
   result += (result && add ? '\n' : '') + add;
 }
 

--- a/scripts/update-browser-releases/opera.ts
+++ b/scripts/update-browser-releases/opera.ts
@@ -1,0 +1,170 @@
+import fs from 'node:fs/promises';
+
+import stringify from '../lib/stringify-and-order-properties.js';
+
+import {
+  createOrUpdateBrowserEntry,
+  getRSSItems,
+  RSSItem,
+  updateBrowserEntry,
+} from './utils';
+
+interface Release {
+  version: string;
+  date: string;
+  releaseNote: string;
+  channel: 'current';
+  engine: 'Blink';
+  engineVersion: string;
+}
+
+/**
+ * Extracts the latest release from the items.
+ * @param items the RSS items.
+ * @param titleVersionPattern the pattern to match the title and extract the version.
+ * @param descriptionEngineVersionPattern the pattern to match the description and extract the engine version.
+ * @returns the latest release, if found, otherwise null.
+ */
+const findRelease = (
+  items: RSSItem[],
+  titleVersionPattern: RegExp,
+  descriptionEngineVersionPattern: RegExp,
+): Release | null => {
+  const item = items.find(
+    (item) =>
+      titleVersionPattern.test(item.title) &&
+      descriptionEngineVersionPattern.test(item.description),
+  );
+
+  if (!item) {
+    return null;
+  }
+
+  const version = (
+    item.title.match(titleVersionPattern) as RegExpMatchArray
+  )[1];
+  const date = new Date(item.pubDate).toISOString().split('T')[0];
+  const releaseNote = item.link;
+  const engineVersion = (
+    item.description.match(descriptionEngineVersionPattern) as RegExpMatchArray
+  )[1];
+
+  return {
+    version,
+    date,
+    releaseNote,
+    channel: 'current',
+    engine: 'Blink',
+    engineVersion,
+  };
+};
+
+/**
+ * Converts a message into a GFM noteblock.
+ * @param type the type of the noteblock.
+ * @param message the message of the noteblock.
+ * @returns the message as a GFM noteblock.
+ */
+const gfmNoteblock = (type: 'INFO' | 'WARN', message: string) =>
+  `> [!${type}]\n${message
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n')}`;
+
+/**
+ * Updates the JSON files listing the Opera browser releases.
+ * @param options The list of options for this type of Safari.
+ * @returns The log of what has been generated (empty if nothing)
+ */
+export const updateOperaReleases = async (options) => {
+  const browser = options.bcdBrowserName;
+
+  const isDesktop = browser === 'opera';
+
+  let result = '';
+
+  const items = await getRSSItems(options.releaseFeedURL);
+
+  const release = findRelease(
+    items.filter((item) =>
+      options.releaseFilterCreator?.includes(item['dc:creator'] ?? true),
+    ),
+    options.titleVersionPattern,
+    options.descriptionEngineVersionPattern,
+  );
+
+  if (!release) {
+    return gfmNoteblock(
+      'INFO',
+      `**${options.browserName}**: No release announcement found among ${items.length} items in [this RSS feed](<${options.releaseFeedURL}>).`,
+    );
+  }
+
+  const file = await fs.readFile(`${options.bcdFile}`, 'utf-8');
+  const data = JSON.parse(file.toString());
+
+  const current = structuredClone(
+    data.browsers[browser].releases[release.version],
+  );
+
+  if (isDesktop && !current) {
+    return gfmNoteblock(
+      'WARN',
+      `Latest stable **${options.browserName}** release **${release.version}** not yet tracked.`,
+    );
+  }
+
+  result += createOrUpdateBrowserEntry(
+    data,
+    browser,
+    release.version,
+    release.channel,
+    release.engine,
+    release.engineVersion,
+    release.date,
+    release.releaseNote,
+  );
+
+  // Set previous release to "retired".
+  const previousVersion = String(Number(release.version) - 1);
+  result += updateBrowserEntry(
+    data,
+    browser,
+    previousVersion,
+    undefined,
+    'retired',
+    undefined,
+    undefined,
+  );
+
+  if (isDesktop) {
+    // 1. Set next release to "beta".
+    result += createOrUpdateBrowserEntry(
+      data,
+      browser,
+      String(Number(release.version) + 1),
+      'beta',
+      release.engine,
+      String(Number(release.engineVersion) + 1),
+    );
+
+    // 2. Add another release as "nightly".
+    result += createOrUpdateBrowserEntry(
+      data,
+      browser,
+      String(Number(release.version) + 2),
+      'nightly',
+      release.engine,
+      String(Number(release.engineVersion) + 2),
+    );
+  }
+
+  await fs.writeFile(`./${options.bcdFile}`, stringify(data) + '\n');
+
+  // Returns the log
+  if (result) {
+    result = `### Updates for ${options.browserName}${result}`;
+  }
+
+  return result;
+};

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -2,6 +2,17 @@
  * See LICENSE file for more information. */
 
 import chalk from 'chalk-template';
+import xml2js from 'xml2js';
+
+const USER_AGENT =
+  'MDN-Browser-Release-Update-Bot/1.0 (+https://developer.mozilla.org/)';
+
+export interface RSSItem {
+  title: string;
+  pubDate: string;
+  description: string;
+  link: string;
+}
 
 /**
  * newBrowserEntry - Add a new browser entry in the JSON list
@@ -81,4 +92,93 @@ export const updateBrowserEntry = (
   }
 
   return result;
+};
+
+/**
+ *
+ * @param json
+ * @param browser
+ * @param version
+ * @param status
+ * @param engine
+ * @param engineVersion
+ * @param releaseDate
+ * @param releaseNotesURL
+ */
+export const createOrUpdateBrowserEntry = (
+  json,
+  browser,
+  version,
+  status: 'retired' | 'current' | 'beta' | 'nightly',
+  engine: string | undefined,
+  engineVersion: string | undefined,
+  releaseDate: string | undefined = undefined,
+  releaseNotesURL: string | undefined = undefined,
+) => {
+  if (json.browsers[browser].releases[version]) {
+    return updateBrowserEntry(
+      json,
+      browser,
+      version,
+      releaseDate,
+      status,
+      releaseNotesURL,
+      engineVersion,
+    );
+  }
+
+  return newBrowserEntry(
+    json,
+    browser,
+    version,
+    status,
+    engine,
+    releaseDate,
+    releaseNotesURL,
+    engineVersion,
+  );
+};
+
+/**
+ * Fetches an RSS feed, using a typical RSS user agent.
+ * @param url The URL of the RSS feed.
+ * @returns Promise
+ */
+const fetchRSS = async (url: string) => {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': USER_AGENT,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return await response.text();
+};
+
+/**
+ * Parses an RSS feed into a JSON object.
+ * @param rssText The content of the RSS feed.
+ * @returns the RSS items.
+ */
+const parseRSS = async (rssText: string): Promise<RSSItem[]> => {
+  const parser = new xml2js.Parser({ explicitArray: false });
+
+  const result = await parser.parseStringPromise(rssText);
+
+  return result.rss.channel.item;
+};
+
+/**
+ * Fetches and parses an RSS feed.
+ * @param url The URL of the RSS feed.
+ * @returns the RSS items.
+ */
+export const getRSSItems = async (url): Promise<RSSItem[]> => {
+  const rssText = await fetchRSS(url);
+  const items = await parseRSS(rssText);
+
+  return Array.isArray(items) ? items : [items];
 };

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -95,15 +95,16 @@ export const updateBrowserEntry = (
 };
 
 /**
- *
- * @param json
- * @param browser
- * @param version
- * @param status
- * @param engine
- * @param engineVersion
- * @param releaseDate
- * @param releaseNotesURL
+ * Creates or updates a browser entry, depending on whether it already exists.
+ * @param json json file to update
+ * @param browser the entry name where to add it in the bcd file
+ * @param version the version to add
+ * @param status the status
+ * @param engine the name of the negine
+ * @param engineVersion the version of the engine
+ * @param releaseDate the release date
+ * @param releaseNotesURL url of the release notes
+ * @returns Text describing what has been updated
  */
 export const createOrUpdateBrowserEntry = (
   json,


### PR DESCRIPTION
#### Summary

Adds an Opera release update script based on these RSS feeds:

1. https://blogs.opera.com/desktop/category/stable-2/feed/ (for Desktop)
2. https://forums.opera.com/category/20.rss (for Mobile)

#### Test results and supporting details

Ran `npm run update-browser-releases -- --opera` on this branch (which intentionally doesn't include 12cf843e27d9439f0b024062fce93b0718c2df06):

- ✅ It updated the Opera release.
- :x: Currently, it doesn't update the Opera Android release, because the [corresponding announcement post](https://forums.opera.com/topic/75836/opera-for-android-87) has an additional comment, which is returned in the RSS feed **instead** of the original post (but it worked 1h ago, probably due to caching).

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
