### PR TITLE
[Schema] Merge browser accepts_* fields into accepts array

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -5,8 +5,7 @@
       "type": "desktop",
       "preview_name": "Canary",
       "pref_url": "chrome://flags",
-      "accepts_flags": true,
-      "accepts_webextensions": true,
+      "accepts": ["flags", "webextensions"],
       "releases": {
         "1": {
           "release_date": "2008-12-11",

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -5,8 +5,7 @@
       "type": "mobile",
       "upstream": "chrome",
       "pref_url": "chrome://flags",
-      "accepts_flags": true,
-      "accepts_webextensions": false,
+      "accepts": ["flags"],
       "releases": {
         "18": {
           "release_date": "2012-06-27",

--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -3,8 +3,7 @@
     "deno": {
       "name": "Deno",
       "type": "server",
-      "accepts_flags": true,
-      "accepts_webextensions": false,
+      "accepts": ["flags"],
       "releases": {
         "1.0": {
           "release_date": "2020-05-13",

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -5,8 +5,7 @@
       "type": "desktop",
       "upstream": "chrome",
       "pref_url": "about:flags",
-      "accepts_flags": true,
-      "accepts_webextensions": true,
+      "accepts": ["flags", "webextensions"],
       "releases": {
         "12": {
           "release_date": "2015-07-29",

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -5,8 +5,7 @@
       "type": "desktop",
       "preview_name": "Nightly",
       "pref_url": "about:config",
-      "accepts_flags": true,
-      "accepts_webextensions": true,
+      "accepts": ["flags", "webextensions"],
       "releases": {
         "1": {
           "release_date": "2004-11-09",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -5,8 +5,7 @@
       "type": "mobile",
       "upstream": "firefox",
       "pref_url": "about:config",
-      "accepts_flags": false,
-      "accepts_webextensions": true,
+      "accepts": ["webextensions"],
       "releases": {
         "4": {
           "release_date": "2011-03-29",

--- a/browsers/ie.json
+++ b/browsers/ie.json
@@ -3,8 +3,7 @@
     "ie": {
       "name": "Internet Explorer",
       "type": "desktop",
-      "accepts_flags": false,
-      "accepts_webextensions": false,
+      "accepts": [],
       "releases": {
         "1": {
           "release_date": "1995-08-16",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -3,8 +3,7 @@
     "nodejs": {
       "name": "Node.js",
       "type": "server",
-      "accepts_flags": true,
-      "accepts_webextensions": false,
+      "accepts": ["flags"],
       "releases": {
         "0.10.0": {
           "release_date": "2013-03-11",

--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -5,8 +5,7 @@
       "type": "xr",
       "upstream": "chrome_android",
       "pref_url": "chrome://flags",
-      "accepts_flags": true,
-      "accepts_webextensions": false,
+      "accepts": ["flags"],
       "releases": {
         "5.0": {
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-50",

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -5,8 +5,7 @@
       "type": "desktop",
       "upstream": "chrome",
       "pref_url": "opera://flags",
-      "accepts_flags": true,
-      "accepts_webextensions": true,
+      "accepts": ["flags", "webextensions"],
       "releases": {
         "2": {
           "release_date": "1996-07-14",

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -4,8 +4,7 @@
       "name": "Opera Android",
       "type": "mobile",
       "upstream": "chrome_android",
-      "accepts_flags": false,
-      "accepts_webextensions": false,
+      "accepts": [],
       "releases": {
         "10.1": {
           "release_date": "2010-11-09",

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -4,8 +4,7 @@
       "name": "Safari",
       "type": "desktop",
       "preview_name": "TP",
-      "accepts_flags": true,
-      "accepts_webextensions": true,
+      "accepts": ["flags", "webextensions"],
       "releases": {
         "1": {
           "release_date": "2003-06-23",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -4,8 +4,7 @@
       "name": "Safari on iOS",
       "type": "mobile",
       "upstream": "safari",
-      "accepts_flags": true,
-      "accepts_webextensions": true,
+      "accepts": ["flags", "webextensions"],
       "releases": {
         "1": {
           "release_date": "2007-06-29",

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -4,8 +4,7 @@
       "name": "Samsung Internet",
       "type": "mobile",
       "upstream": "chrome_android",
-      "accepts_flags": false,
-      "accepts_webextensions": false,
+      "accepts": [],
       "releases": {
         "1.0": {
           "release_date": "2013-04-27",

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -4,8 +4,7 @@
       "name": "WebView Android",
       "type": "mobile",
       "upstream": "chrome_android",
-      "accepts_flags": false,
-      "accepts_webextensions": false,
+      "accepts": [],
       "releases": {
         "1": {
           "release_date": "2008-09-23",

--- a/browsers/webview_ios.json
+++ b/browsers/webview_ios.json
@@ -4,8 +4,7 @@
       "name": "WebView on iOS",
       "type": "mobile",
       "upstream": "safari_ios",
-      "accepts_flags": false,
-      "accepts_webextensions": false,
+      "accepts": [],
       "releases": {
         "1": {
           "release_date": "2007-06-29",

--- a/lint/linter/test-browsers-data.test.ts
+++ b/lint/linter/test-browsers-data.test.ts
@@ -20,8 +20,7 @@ describe('test-browsers-data', () => {
     const data: BrowserStatement = {
       name: 'Node.js',
       type: 'server',
-      accepts_flags: true,
-      accepts_webextensions: false,
+      accepts: ['flags'],
       releases: {
         '20.6.0': {
           release_date: '2023-09-04',
@@ -43,8 +42,7 @@ describe('test-browsers-data', () => {
     const data: BrowserStatement = {
       name: 'Firefox',
       type: 'desktop',
-      accepts_flags: true,
-      accepts_webextensions: true,
+      accepts: ['flags', 'webextensions'],
       releases: {
         '1': { status: 'nightly' },
         '2': { status: 'nightly' },
@@ -59,8 +57,7 @@ describe('test-browsers-data', () => {
     const data: BrowserStatement = {
       name: 'Node.js',
       type: 'server',
-      accepts_flags: true,
-      accepts_webextensions: false,
+      accepts: ['flags'],
       releases: {
         '1': { status: 'nightly' },
         '2': { status: 'nightly' },
@@ -76,8 +73,7 @@ describe('test-browsers-data', () => {
       name: 'Safari iOS',
       type: 'mobile',
       upstream: browser,
-      accepts_flags: false,
-      accepts_webextensions: false,
+      accepts: [],
       releases: {},
     };
 
@@ -91,8 +87,7 @@ describe('test-browsers-data', () => {
       name: 'Safari iOS',
       type: 'mobile',
       upstream: 'unknown' as any,
-      accepts_flags: false,
-      accepts_webextensions: false,
+      accepts: [],
       releases: {},
     };
 
@@ -107,8 +102,7 @@ describe('test-browsers-data', () => {
       type: 'desktop',
       upstream: 'chrome',
       pref_url: 'opera://flags',
-      accepts_flags: true,
-      accepts_webextensions: true,
+      accepts: ['flags', 'webextensions'],
       releases: {
         '97': {
           status: 'retired',

--- a/lint/linter/test-browsers-presence.ts
+++ b/lint/linter/test-browsers-presence.ts
@@ -35,14 +35,16 @@ const processData = (
             ? ['server']
             : []),
         ].includes(browsers[b].type) &&
-        (category !== 'webextensions' || browsers[b].accepts_webextensions),
+        (category !== 'webextensions' ||
+          browsers[b].accepts.includes('webextensions')),
     );
     const requiredBrowsers = (
       Object.keys(browsers) as (keyof typeof browsers)[]
     ).filter(
       (b) =>
         browsers[b].type == 'desktop' &&
-        (category !== 'webextensions' || browsers[b].accepts_webextensions),
+        (category !== 'webextensions' ||
+          browsers[b].accepts.includes('webextensions')),
     );
 
     const undefEntries = definedBrowsers.filter(

--- a/lint/linter/test-mirror.ts
+++ b/lint/linter/test-mirror.ts
@@ -23,7 +23,9 @@ const checkMirroring = (
 ): void => {
   const browsersToCheck = Object.keys(browsers)
     .filter((b) =>
-      category === 'webextensions' ? browsers[b].accepts_webextensions : !!b,
+      category === 'webextensions'
+        ? browsers[b].accepts.includes('webextensions')
+        : !!b,
     )
     .filter((b) => browsers[b].upstream) as BrowserName[];
 

--- a/lint/linter/test-versions.ts
+++ b/lint/linter/test-versions.ts
@@ -132,7 +132,9 @@ const checkVersions = (
   logger: Logger,
 ): void => {
   const browsersToCheck = Object.keys(browsers).filter((b) =>
-    category === 'webextensions' ? browsers[b].accepts_webextensions : !!b,
+    category === 'webextensions'
+      ? browsers[b].accepts.includes('webextensions')
+      : !!b,
   ) as BrowserName[];
 
   for (const browser of browsersToCheck) {
@@ -202,7 +204,10 @@ const checkVersions = (
         }
       }
 
-      if ('flags' in statement && !browsers[browser].accepts_flags) {
+      if (
+        'flags' in statement &&
+        !browsers[browser].accepts?.includes('flags')
+      ) {
         logger.error(
           chalk`This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.`,
         );

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -16,8 +16,7 @@ Below is an example of the browser data:
       "type": "desktop",
       "preview_name": "Nightly",
       "pref_url": "about:config",
-      "accepts_flags": true,
-      "accepts_webextensions": true,
+      "accepts" ["flags", "webextensions"],
       "releases": {
         "1.5": {
           "release_date": "2005-11-29",
@@ -46,13 +45,14 @@ The `type` string is a required property which indicates the platform category t
 
 The `upstream` string is an optional property which indicates the upstream browser updates are derived from. For example, Firefox Android's upstream browser is Firefox (desktop), and Edge's upstream browser is Chrome. This is used for mirroring data between browsers. Valid options are any browser defined in the data.
 
-### `accepts_flags`
+### `accepts`
 
-An optional boolean indicating whether the browser supports flags. If it is set to `false`, flag data will not be allowed for that browser.
+An optional array indicating which additional features the browser supports. Possible items are:
 
-### `accepts_webextensions`
+- `flags` - if the browser supports flags.
+- `webextensions` - if the browser supports web extensions.
 
-An optional boolean indicating whether the browser supports web extensions. A `true` value will allow this browser to be defined in web extensions support.
+The value is used to determine if support data for this feature can be added for the browser.
 
 ### `pref_url`
 

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -72,13 +72,11 @@
           "type": "string",
           "description": "URL of the page where feature flags can be changed (e.g. 'about:config' for Firefox or 'chrome://flags' for Chrome)."
         },
-        "accepts_flags": {
-          "type": "boolean",
-          "description": "Whether the browser supports user-toggleable flags that enable or disable features."
-        },
-        "accepts_webextensions": {
-          "type": "boolean",
-          "description": "Whether the browser supports extensions."
+        "accepts": {
+          "type": "array",
+          "additionalProperties": { "$ref": "#/definitions/accepts_value" },
+          "description": "The additional features the browser supports.",
+          "tsType": "AcceptsValue[]"
         },
         "releases": {
           "type": "object",
@@ -87,14 +85,26 @@
           "tsType": "{ [version: string]: ReleaseStatement };"
         }
       },
-      "required": [
-        "name",
-        "type",
-        "releases",
-        "accepts_flags",
-        "accepts_webextensions"
-      ],
+      "required": ["name", "type", "releases", "accepts"],
       "additionalProperties": false
+    },
+
+    "accepts_value": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "const": "flags",
+            "description": "User-toggleable flags that enable or disable features."
+          },
+          {
+            "const": "webextensions",
+            "description": "Extensions."
+          }
+        ]
+      },
+      "uniqueItems": true,
+      "tsType": "\"flags\" | \"webextensions\""
     },
 
     "release_statement": {

--- a/scripts/build/mirror.ts
+++ b/scripts/build/mirror.ts
@@ -210,7 +210,7 @@ export const bumpSupport = (
 
   const newData: SimpleSupportStatement = copyStatement(sourceData);
 
-  if (!browsers[destination].accepts_flags && newData.flags) {
+  if (!browsers[destination].accepts?.includes('flags') && newData.flags) {
     // Remove flag data if the target browser doesn't accept flags
     return { version_added: false };
   }

--- a/scripts/lib/stringify-and-order-properties.ts
+++ b/scripts/lib/stringify-and-order-properties.ts
@@ -19,8 +19,7 @@ const propOrder = {
       'upstream',
       'preview_name',
       'pref_url',
-      'accepts_flags',
-      'accepts_webextensions',
+      'accepts',
       'releases',
     ],
     release: [

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -75,7 +75,7 @@ export function* iterateFeatures(
                   if (
                     !(
                       identifier.startsWith('webextensions.') &&
-                      bcd.browsers[browser].accepts_webextensions
+                      bcd.browsers[browser].accepts?.includes('webextensions')
                     )
                   ) {
                     continue;


### PR DESCRIPTION
#### Summary

Merges the `accepts_flags` and `accepts_webextensions` fields in the browser schema into a single `accepts` array that accepts the enum values `flags` and `webextensions`.

#### Test results and supporting details

Prepares for https://github.com/mdn/browser-compat-data/pull/25804, which adds `webdriver-bidi`.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
