### PR TITLE
fix(linter): fix property order issues in browser files

### DIFF
--- a/lint/fixer/property-order.ts
+++ b/lint/fixer/property-order.ts
@@ -11,10 +11,6 @@ import stringifyAndOrderProperties from '../../scripts/lib/stringify-and-order-p
  * @param filename The name of the file to fix
  */
 const fixPropertyOrder = (filename: string): void => {
-  if (filename.includes('/browsers/')) {
-    return;
-  }
-
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = stringifyAndOrderProperties(actual);
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Ensures that property order issues in browser files are not only reported by `npm run lint`, but also fixed by `npm run lint:fix`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #25826.