### PR TITLE
fix(issue-templates): use correct "needs triage" label

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -1,7 +1,7 @@
 name: "Data problem"
 title: "<NAME THE FEATURE> - <SUMMARIZE THE PROBLEM>"
 description: Report incorrect, incomplete, or missing data
-labels: ["needs-triage"]
+labels: ["needs triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,6 +1,6 @@
 name: "Enhancement"
 description: An enhancement to BCD's infrastructure
-labels: ["needs-triage", "enhancement"]
+labels: ["needs triage", "enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/infra-problem.yml
+++ b/.github/ISSUE_TEMPLATE/infra-problem.yml
@@ -1,6 +1,6 @@
 name: "Infrastructure/Linter Problem"
 description: Report issues with infrastructure, including scripts and linters
-labels: ["needs-triage"]
+labels: ["needs triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the issue templates to use the correct `needs triage` label, which is the one we use in the MDN org across repos ( `needs-triage` doesn't exist).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
