### PR TITLE
Chrome 67 enables AmbientLightSensor via `#enable-generic-sensor-extra-classes`

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -8,26 +8,28 @@
           "web-features:ambient-light"
         ],
         "support": {
-          "chrome": {
-            "version_added": "56",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#enable-experimental-web-platform-features",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          {
-            "version_added": "67",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#enable-generic-sensor-extra-classes",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "chrome": [
+            {
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "67",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -13,6 +13,16 @@
             "flags": [
               {
                 "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          {
+            "version_added": "62",
+            "flags": [
+              {
+                "type": "preference",
                 "name": "#enable-generic-sensor-extra-classes",
                 "value_to_set": "Enabled"
               }
@@ -58,7 +68,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -103,7 +113,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
               ],

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -13,7 +13,7 @@
             "flags": [
               {
                 "type": "preference",
-                "name": "#enable-experimental-web-platform-features",
+                "name": "#enable-generic-sensor-extra-classes",
                 "value_to_set": "Enabled"
               }
             ]
@@ -58,7 +58,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
+                  "name": "#enable-generic-sensor-extra-classes",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -103,7 +103,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
+                  "name": "#enable-generic-sensor-extra-classes",
                   "value_to_set": "Enabled"
                 }
               ],

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -19,7 +19,7 @@
             ]
           },
           {
-            "version_added": "62",
+            "version_added": "67",
             "flags": [
               {
                 "type": "preference",

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -65,16 +65,28 @@
             "web-features:ambient-light"
           ],
           "support": {
-            "chrome": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-generic-sensor-extra-classes",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -110,17 +122,29 @@
             "web-features:ambient-light"
           ],
           "support": {
-            "chrome": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ],
-              "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
-            },
+            "chrome": [
+              {
+                "version_added": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-generic-sensor-extra-classes",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                 "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -142,7 +142,8 @@
                     "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "Enabled"
                   }
-                ]
+                ],
+                "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
               }
             ],
             "chrome_android": "mirror",

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -132,7 +132,7 @@
                     "value_to_set": "Enabled"
                   }
                 ],
-                 "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
+                "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
               },
               {
                 "version_added": "56",

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -10,21 +10,21 @@
         "support": {
           "chrome": [
             {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
               "version_added": "67",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
               ]


### PR DESCRIPTION
Fixes #25832 

More info:
https://developer.chrome.com/docs/capabilities/web-apis/generic-sensor