### PR TITLE
Trusted Types - FF updates and missing entries in TT spec

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8985,6 +8985,53 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "line_param_accepts_TrustedHTML": {
+          "__compat": {
+            "description": "`line` parameter accepts `TrustedHTML` type",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/writeln",
+            "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln",
+            "tags": [
+              "web-features:dom",
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                "version_added": "133",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "xmlEncoding": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -8899,7 +8899,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "text_param_accepts_TrustedHTML": {
@@ -8943,9 +8943,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/api/Document.json
+++ b/api/Document.json
@@ -9074,7 +9074,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/Document.json
+++ b/api/Document.json
@@ -8910,7 +8910,6 @@
               "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#:~:text=if%20value%20is%20a%20trustedhtml%20object"
             ],
             "tags": [
-              "web-features:dom",
               "web-features:trusted-types"
             ],
             "support": {
@@ -9040,7 +9039,6 @@
             "description": "Accepts `TrustedHTML` instances",
             "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln",
             "tags": [
-              "web-features:dom",
               "web-features:trusted-types"
             ],
             "support": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -8902,9 +8902,9 @@
             "deprecated": true
           }
         },
-        "text_param_accepts_TrustedHTML": {
+        "accepts_TrustedHTML": {
           "__compat": {
-            "description": "`text` parameter accepts `TrustedHTML` type",
+            "description": "Accepts `TrustedHTML` instances",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/write",
             "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-write",
             "tags": [
@@ -9033,9 +9033,9 @@
             "deprecated": false
           }
         },
-        "line_param_accepts_TrustedHTML": {
+        "accepts_TrustedHTML": {
           "__compat": {
-            "description": "`text` parameter accepts `TrustedHTML` type",
+            "description": "Accepts `TrustedHTML` instances",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/writeln",
             "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln",
             "tags": [

--- a/api/Document.json
+++ b/api/Document.json
@@ -8905,7 +8905,6 @@
         "accepts_TrustedHTML": {
           "__compat": {
             "description": "Accepts `TrustedHTML` instances",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/write",
             "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-write",
             "tags": [
               "web-features:dom",

--- a/api/Document.json
+++ b/api/Document.json
@@ -8905,14 +8905,17 @@
         "accepts_TrustedHTML": {
           "__compat": {
             "description": "Accepts `TrustedHTML` instances",
-            "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-write",
+            "spec_url": [
+              "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document-write-steps",
+              "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#:~:text=if%20value%20is%20a%20trustedhtml%20object"
+            ],
             "tags": [
               "web-features:dom",
               "web-features:trusted-types"
             ],
             "support": {
               "chrome": {
-                "version_added": "83"
+                "version_added": "86"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -9035,7 +9038,6 @@
         "accepts_TrustedHTML": {
           "__compat": {
             "description": "Accepts `TrustedHTML` instances",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/writeln",
             "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln",
             "tags": [
               "web-features:dom",
@@ -9043,7 +9045,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "83"
+                "version_added": "86"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/Document.json
+++ b/api/Document.json
@@ -8899,7 +8899,54 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
+          }
+        },
+        "text_param_accepts_TrustedHTML": {
+          "__compat": {
+            "description": "`text` parameter accepts `TrustedHTML` type",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/write",
+            "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-write",
+            "tags": [
+              "web-features:dom",
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -8988,7 +9035,7 @@
         },
         "line_param_accepts_TrustedHTML": {
           "__compat": {
-            "description": "`line` parameter accepts `TrustedHTML` type",
+            "description": "`text` parameter accepts `TrustedHTML` type",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/writeln",
             "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln",
             "tags": [
@@ -9001,7 +9048,7 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
+              "firefox": {
                 "version_added": "133",
                 "flags": [
                   {
@@ -9010,7 +9057,7 @@
                     "value_to_set": "true"
                   }
                 ]
-              ],
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -6263,6 +6263,53 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "accepts_TrustedHtml": {
+          "__compat": {
+            "description": "Can be set with a `TrustedHtml`",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/innerHTML",
+            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
+            "tags": [
+              "web-features:dom",
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "135",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "input_event": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -6269,7 +6269,6 @@
             "description": "Can be set with a `TrustedHTML` instance",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
             "tags": [
-              "web-features:dom",
               "web-features:trusted-types"
             ],
             "support": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -6267,7 +6267,6 @@
         "accepts_TrustedHTML": {
           "__compat": {
             "description": "Can be set with a `TrustedHTML` instance",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/innerHTML",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
             "tags": [
               "web-features:dom",

--- a/api/Element.json
+++ b/api/Element.json
@@ -6264,9 +6264,9 @@
             "deprecated": false
           }
         },
-        "accepts_TrustedHtml": {
+        "accepts_TrustedHTML": {
           "__compat": {
-            "description": "Can be set with a `TrustedHtml`",
+            "description": "Can be set with a `TrustedHTML` instance",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/innerHTML",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
             "tags": [

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1830,7 +1830,6 @@
             "description": "Can be set with `TrustedScript` instances in `HTMLScriptElement`.",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
             "tags": [
-              "web-features:script",
               "web-features:trusted-types"
             ],
             "support": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1824,6 +1824,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "scripts_accept_TrustedScript": {
+          "__compat": {
+            "description": "Can be set with `TrustedScript` instances in `HTMLScriptElement`.",
+            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
+            "tags": [
+              "web-features:script",
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "135",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "inputMode": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -417,6 +417,53 @@
           }
         }
       },
+      "innerText": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
+          "tags": [
+            "web-features:script",
+            "web-features:trusted-types"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "integrity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/integrity",
@@ -870,6 +917,53 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "textContent": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
+          "tags": [
+            "web-features:script",
+            "web-features:trusted-types"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -692,6 +692,53 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "accepts_TrustedScriptUrl": {
+          "__compat": {
+            "description": "Can be set with a `TrustedScriptUrl`",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/src",
+            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-src",
+            "tags": [
+              "web-features:script",
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "135",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "supports_static": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -696,7 +696,6 @@
         "accepts_TrustedScriptURL": {
           "__compat": {
             "description": "Can be set with a `TrustedScriptURL` instance",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/src",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-src",
             "tags": [
               "web-features:script",
@@ -828,7 +827,6 @@
         "accepts_TrustedScript": {
           "__compat": {
             "description": "Can be set with a `TrustedScript` instance",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/text",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-text",
             "tags": [
               "web-features:script",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -777,6 +777,53 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "accepts_TrustedScript": {
+          "__compat": {
+            "description": "Can be set with a `TrustedScript`",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/text",
+            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-text",
+            "tags": [
+              "web-features:script",
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "135",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "type": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -417,53 +417,6 @@
           }
         }
       },
-      "innerText": {
-        "__compat": {
-          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
-          "tags": [
-            "web-features:script",
-            "web-features:trusted-types"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "83"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "integrity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/integrity",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -740,9 +740,9 @@
             "deprecated": false
           }
         },
-        "accepts_TrustedScriptUrl": {
+        "accepts_TrustedScriptURL": {
           "__compat": {
-            "description": "Can be set with a `TrustedScriptUrl`",
+            "description": "Can be set with a `TrustedScriptURL` instance",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/src",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-src",
             "tags": [
@@ -874,7 +874,7 @@
         },
         "accepts_TrustedScript": {
           "__compat": {
-            "description": "Can be set with a `TrustedScript`",
+            "description": "Can be set with a `TrustedScript` instance",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/text",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-text",
             "tags": [

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -698,7 +698,6 @@
             "description": "Can be set with a `TrustedScriptURL` instance",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-src",
             "tags": [
-              "web-features:script",
               "web-features:trusted-types"
             ],
             "support": {
@@ -829,7 +828,6 @@
             "description": "Can be set with a `TrustedScript` instance",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-text",
             "tags": [
-              "web-features:script",
               "web-features:trusted-types"
             ],
             "support": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -873,53 +873,6 @@
           }
         }
       },
-      "textContent": {
-        "__compat": {
-          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
-          "tags": [
-            "web-features:script",
-            "web-features:trusted-types"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "83"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/type",

--- a/api/Node.json
+++ b/api/Node.json
@@ -1402,7 +1402,6 @@
             "description": "Can be set with `TrustedScript` instances in `HTMLScriptElement`.",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
             "tags": [
-              "web-features:script",
               "web-features:trusted-types"
             ],
             "support": {

--- a/api/Node.json
+++ b/api/Node.json
@@ -1396,6 +1396,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "scripts_accept_TrustedScript": {
+          "__compat": {
+            "description": "Can be set with `TrustedScript` instances in `HTMLScriptElement`.",
+            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
+            "tags": [
+              "web-features:script",
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "135",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -500,7 +500,6 @@
             "description": "Can be set with a `TrustedHTML` instance",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
             "tags": [
-              "web-features:dom",
               "web-features:trusted-types"
             ],
             "support": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -495,9 +495,9 @@
             "deprecated": false
           }
         },
-        "accepts_TrustedHtml": {
+        "accepts_TrustedHTML": {
           "__compat": {
-            "description": "Can be set with a `TrustedHtml`",
+            "description": "Can be set with a `TrustedHTML` instance",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/innerHTML",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
             "tags": [

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -494,6 +494,53 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "accepts_TrustedHtml": {
+          "__compat": {
+            "description": "Can be set with a `TrustedHtml`",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/innerHTML",
+            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
+            "tags": [
+              "web-features:dom",
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "135",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "mode": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -498,7 +498,6 @@
         "accepts_TrustedHTML": {
           "__compat": {
             "description": "Can be set with a `TrustedHTML` instance",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/innerHTML",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
             "tags": [
               "web-features:dom",

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -105,7 +105,6 @@
       "code_param_accepts_trustedScript": {
         "__compat": {
           "description": "`code` parameter can be set with a `TrustedScript` instance",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setInterval",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
           "tags": [
             "web-features:setinterval",

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -102,6 +102,53 @@
           }
         }
       },
+      "code_param_accepts_trustedScript": {
+        "__compat": {
+          "description": "`code` parameter can be set with a `TrustedScript` instance",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setInterval",
+          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
+          "tags": [
+            "web-features:setinterval",
+            "web-features:trusted-types"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "supports_parameters_for_callback": {
         "__compat": {
           "description": "Supports parameters for callback",
@@ -141,53 +188,6 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "trustedScript_param": {
-        "__compat": {
-          "description": "`trustedScript` parameter of type `TrustedScript`",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setInterval",
-          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
-          "tags": [
-            "web-features:setinterval",
-            "web-features:trusted-types"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "83"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -154,6 +154,7 @@
         "__compat": {
           "description": "`trustedScript` parameter of type `TrustedScript`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setInterval",
+          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
           "tags": [
             "web-features:setinterval",
             "web-features:trusted-types"

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -149,6 +149,52 @@
             "deprecated": false
           }
         }
+      },
+      "trustedScript_param": {
+        "__compat": {
+          "description": "`trustedScript` parameter of type `TrustedScript`",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setInterval",
+          "tags": [
+            "web-features:setinterval",
+            "web-features:trusted-types"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -107,7 +107,6 @@
           "description": "`code` parameter can be set with a `TrustedScript` instance",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
           "tags": [
-            "web-features:setinterval",
             "web-features:trusted-types"
           ],
           "support": {

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -154,6 +154,7 @@
         "__compat": {
           "description": "`trustedScript` parameter of type `TrustedScript`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setTimeout",
+          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
           "tags": [
             "web-features:setinterval",
             "web-features:trusted-types"

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -105,7 +105,6 @@
       "code_param_accepts_trustedScript": {
         "__compat": {
           "description": "`code` parameter can be set with a `TrustedScript` instance",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setTimeout",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
           "tags": [
             "web-features:setinterval",

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -102,6 +102,53 @@
           }
         }
       },
+      "code_param_accepts_trustedScript": {
+        "__compat": {
+          "description": "`code` parameter can be set with a `TrustedScript` instance",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setTimeout",
+          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
+          "tags": [
+            "web-features:setinterval",
+            "web-features:trusted-types"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "supports_parameters_for_callback": {
         "__compat": {
           "description": "Supports parameters for callback",
@@ -141,53 +188,6 @@
             "webview_android": {
               "version_added": "≤37"
             },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "trustedScript_param": {
-        "__compat": {
-          "description": "`trustedScript` parameter of type `TrustedScript`",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setTimeout",
-          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
-          "tags": [
-            "web-features:setinterval",
-            "web-features:trusted-types"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "83"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -149,6 +149,52 @@
             "deprecated": false
           }
         }
+      },
+      "trustedScript_param": {
+        "__compat": {
+          "description": "`trustedScript` parameter of type `TrustedScript`",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setTimeout",
+          "tags": [
+            "web-features:setinterval",
+            "web-features:trusted-types"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -107,7 +107,6 @@
           "description": "`code` parameter can be set with a `TrustedScript` instance",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
           "tags": [
-            "web-features:setinterval",
             "web-features:trusted-types"
           ],
           "support": {

--- a/api/_globals/trustedTypes.json
+++ b/api/_globals/trustedTypes.json
@@ -14,7 +14,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "135",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.security.trusted_types.enabled",
+                "value_to_set": "true"
+              }
+            ],
             "impl_url": "https://bugzil.la/1508286"
           },
           "firefox_android": "mirror",


### PR DESCRIPTION
FF has added more support for trusted types behind a flag. This adds those updates.

Also it adds some missing entries, primarily for the methods and properties that will now _accept_ trusted types. Some of this is a bit weird so I've added comments inline explaining how/why I did stuff.

- FF135 The `Document.write()` and `writeln()` accept {{domxref("TrustedHTML")}} objects as parameters, in addition to strings. https://bugzilla.mozilla.org/show_bug.cgi?id=1906301 - I tested version support for Chrome using https://wpt.live/trusted-types/Document-write.html
- The `HTMLScriptElement.text`, `innerText`, and `textContent`  properties now accept `TrustedScript` as a setter,  while `HTMLScriptElement.src` accepts `TrustedScriptURL` in https://bugzilla.mozilla.org/show_bug.cgi?id=1905706
  - Note, the `innerText` and `textContext` were formerly inherited from HTMLElement and Node respectively. 
- FF135 supports `setTimeout` and `setInterval` taking a trustedtype  - as a proxy for code in a script. But it isn't in the spec other than broadly referred to. I have added info though, because it is a compat issue - it should be listed in https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks
- FF supports the global `trustedTypes` - you need to have that for anything to work. I have added this as though added in FF135. It might have appeared earlier, but not useful - I'm OK with it since all of that will change when this gets released.
- `Element.innerHTML` and the shadow versions arent speced with alternative IDL saying it can take a trusted type, but there are examples which show that, and wpt tests, and they are mentioned in https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks - which I have used for the spec url.



The spec mentions some other cases such as [Element.outerHTML](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-outerhtml) setters, and functions that create a new same-origin [Document](https://dom.spec.whatwg.org/#document) with caller-controlled markup like [parseFromString()](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring). Have not added that, because I haven't tested it.
