### PR TITLE
Add `html.elements.area.attributionsrc`

### DIFF
--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -79,6 +79,40 @@
             }
           }
         },
+        "attributionsrc": {
+          "__compat": {
+            "spec_url": "https://wicg.github.io/attribution-reporting-api/#element-attrdef-area-attributionsrc",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "coords": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/image-maps.html#attr-area-coords",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

BCD has a key for `api.HTMLAreaElement.attributionsrc`, which reflects an HTML attribute. The HTML attribute was not represented in `html.elements.area`. This PR fills in the missing data.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

[Chrome Platform Status says](https://chromestatus.com/feature/6547509428879360) this attribute being included on `<area>` is a formalization of a Chromium implementation detail. While exposed from Chrome 133, the attribute itself worked since Chrome 125, when `<a attributionsrc>` shipped.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://chromestatus.com/feature/6547509428879360
- https://issues.chromium.org/issues/379275911
- `api.HTMLAreaElement.attributionsrc` was added in https://github.com/mdn/browser-compat-data/pull/25674
- Discovered in the course of https://github.com/web-platform-dx/web-features/pull/2605

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
