### PR TITLE
Chrome Android also supports CSS font-variant-emoji values

### DIFF
--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -62,9 +62,7 @@
               "chrome": {
                 "version_added": "131"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -101,9 +99,7 @@
               "chrome": {
                 "version_added": "131"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -140,9 +136,7 @@
               "chrome": {
                 "version_added": "131"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -179,9 +173,7 @@
               "chrome": {
                 "version_added": "131"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
This PR tries to fix the strange behavior of the compatibility table, which shows that Chrome Android supports this CSS property, but does not support any value of the property (which makes no sense).

![Image](https://github.com/user-attachments/assets/09a7fe17-f2b4-439d-b43d-2401e681b1c6)

The same error happens with WebView Android and Opera Android, but in this case, I have no idea how to fix it (this is my first PR on mdn).

**Reference:**
https://chromestatus.com/feature/6566092561973248