### PR TITLE
Updates for Firefox 136 beta

### DIFF
--- a/api/CookieChangeEvent.json
+++ b/api/CookieChangeEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "136"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -52,7 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -90,7 +90,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -166,7 +166,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "136"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -56,7 +56,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -94,7 +94,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -131,7 +131,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "136"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -149,7 +149,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -170,7 +170,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -246,7 +246,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -322,7 +322,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -359,7 +359,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "136"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -377,7 +377,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -317,7 +317,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -334,7 +334,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -827,7 +827,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "136"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -1,0 +1,39 @@
+{
+  "api": {
+    "SVGDiscardElement": {
+      "__compat": {
+        "spec_url": "https://svgwg.org/specs/animations/#InterfaceSVGDiscardElement",
+        "support": {
+          "chrome": {
+            "version_added": "34",
+            "version_removed": "81"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "136"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": true
+        }
+      }
+    }
+  }
+}

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -477,7 +477,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -495,7 +495,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Window.json
+++ b/api/Window.json
@@ -999,7 +999,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1018,7 +1018,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/open.json
+++ b/css/selectors/open.json
@@ -27,7 +27,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -45,7 +45,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -136,7 +136,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -158,7 +158,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -364,7 +364,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "preview"
+                "version_added": "136"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Intl/DurationFormat.json
+++ b/javascript/builtins/Intl/DurationFormat.json
@@ -19,7 +19,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "136"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -63,7 +63,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "136"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -107,7 +107,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "136"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -151,7 +151,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "136"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -195,7 +195,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "136"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "136"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -1,17 +1,13 @@
 {
-  "css": {
-    "selectors": {
-      "has-slotted": {
+  "svg": {
+    "elements": {
+      "discard": {
         "__compat": {
-          "description": "`:has-slotted`",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:has-slotted",
-          "spec_url": "https://drafts.csswg.org/css-scoping/#the-has-slotted-pseudo",
-          "tags": [
-            "web-features:has-slotted"
-          ],
+          "spec_url": "https://svgwg.org/specs/animations/#DiscardElement",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "34",
+              "version_removed": "81"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -34,9 +30,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.8 found new features shipping in Firefox 136 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 28 features as shipping in Firefox 136:

- api.CookieChangeEvent
- api.CookieChangeEvent.CookieChangeEvent
- api.CookieChangeEvent.changed
- api.CookieChangeEvent.deleted
- api.CookieStore
- api.CookieStore.change_event
- api.CookieStore.delete
- api.CookieStore.delete.partitioned_option
- api.CookieStore.get
- api.CookieStore.getAll
- api.CookieStore.set
- api.CookieStore.set.partitioned_option
- api.HTMLElement.autocorrect
- api.HTMLElement.contentEditable.plaintext-only
- api.SVGDiscardElement
- api.ServiceWorkerGlobalScope.cookieStore
- api.Window.cookieStore
- css.selectors.has-slotted
- css.selectors.open
- html.global_attributes.autocorrect
- html.global_attributes.contenteditable.plaintext-only
- javascript.builtins.Intl.DurationFormat
- javascript.builtins.Intl.DurationFormat.DurationFormat
- javascript.builtins.Intl.DurationFormat.format
- javascript.builtins.Intl.DurationFormat.formatToParts
- javascript.builtins.Intl.DurationFormat.resolvedOptions
- javascript.builtins.Intl.DurationFormat.supportedLocalesOf
- svg.elements.discard

See also https://github.com/mdn/mdn/issues/632 and https://www.mozilla.org/en-US/firefox/136.0beta/releasenotes/