### PR TITLE
Data for legacy version of webextension.api.userScripts

### DIFF
--- a/webextensions/api/userScripts_legacy.json
+++ b/webextensions/api/userScripts_legacy.json
@@ -34,7 +34,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "68",
-                "notes": "For extension using Manifest V3, see [`userScripts.RegisteredUserScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript)."
+                "notes": "Only available for use in extensions using Manifest V2. For extension using Manifest V3, see [`userScripts.RegisteredUserScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript)."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -54,7 +54,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "68",
-                  "notes": "For extension using Manifest V3, see [`userScripts.unregister`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/unregister)."
+                  "notes": "Only available for use in extensions using Manifest V2. For extension using Manifest V3, see [`userScripts.unregister`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/unregister)."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -96,7 +96,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "68",
-                "notes": "For extension using Manifest V3, see [`userScripts.register`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register)."
+                "notes": "Only available for use in extensions using Manifest V2. For extension using Manifest V3, see [`userScripts.register`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register)."
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/api/userScripts_legacy.json
+++ b/webextensions/api/userScripts_legacy.json
@@ -11,7 +11,10 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "68",
-              "notes": "Only available for use in extensions using Manifest V2."
+              "notes": [
+                "Only available for use in extensions using Manifest V2.",
+                "An alternative version of this API is available for use with Manifest V3. See [`userScritps`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts)."
+              ]
             },
             "firefox_android": "mirror",
             "opera": "mirror",
@@ -30,7 +33,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "68"
+                "version_added": "68",
+                "notes": "For extension using Manifest V3, see [`userScritps.RegisteredUserScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript)."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -49,7 +53,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "68"
+                  "version_added": "68",
+                  "notes": "For extension using Manifest V3, see [`userScritps.unregister`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/unregister)."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -90,7 +95,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "68"
+                "version_added": "68",
+                "notes": "For extension using Manifest V3, see [`userScritps.register`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/registert)."
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/api/userScripts_legacy.json
+++ b/webextensions/api/userScripts_legacy.json
@@ -13,7 +13,7 @@
               "version_added": "68",
               "notes": [
                 "Only available for use in extensions using Manifest V2.",
-                "An alternative version of this API is available for use with Manifest V3. See [`userScritps`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts)."
+                "An alternative version of this API is available for use with Manifest V3. See [`userScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts)."
               ]
             },
             "firefox_android": "mirror",
@@ -34,7 +34,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "68",
-                "notes": "For extension using Manifest V3, see [`userScritps.RegisteredUserScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript)."
+                "notes": "For extension using Manifest V3, see [`userScripts.RegisteredUserScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript)."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -54,7 +54,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "68",
-                  "notes": "For extension using Manifest V3, see [`userScritps.unregister`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/unregister)."
+                  "notes": "For extension using Manifest V3, see [`userScripts.unregister`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/unregister)."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -96,7 +96,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "68",
-                "notes": "For extension using Manifest V3, see [`userScritps.register`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/registert)."
+                "notes": "For extension using Manifest V3, see [`userScripts.register`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register)."
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/api/userScripts_legacy.json
+++ b/webextensions/api/userScripts_legacy.json
@@ -1,0 +1,121 @@
+{
+  "webextensions": {
+    "api": {
+      "userScripts_legacy": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "68",
+              "notes": "Only available for use in extensions using Manifest V2."
+            },
+            "firefox_android": "mirror",
+            "opera": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror"
+          }
+        },
+        "RegisteredUserScript": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "unregister": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        },
+        "onBeforeScript": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "register": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "98"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/api/userScripts_legacy.json
+++ b/webextensions/api/userScripts_legacy.json
@@ -3,6 +3,7 @@
     "api": {
       "userScripts_legacy": {
         "__compat": {
+          "description": "userScripts (Legacy)",
           "support": {
             "chrome": {
               "version_added": false
@@ -22,6 +23,7 @@
         },
         "RegisteredUserScript": {
           "__compat": {
+            "description": "RegisteredUserScript (Legacy)",
             "support": {
               "chrome": {
                 "version_added": false
@@ -40,6 +42,7 @@
           },
           "unregister": {
             "__compat": {
+              "description": "unregister (Legacy)",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -60,6 +63,7 @@
         },
         "onBeforeScript": {
           "__compat": {
+            "description": "onBeforeScript (Legacy)",
             "support": {
               "chrome": {
                 "version_added": false
@@ -79,6 +83,7 @@
         },
         "register": {
           "__compat": {
+            "description": "register (Legacy)",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/manifest/user_scripts.json
+++ b/webextensions/manifest/user_scripts.json
@@ -11,7 +11,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "68",
-              "notes": "Only available for use in extensions using Manifest V2."
+              "notes": "Required for the legacy version of [`userScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy), which is only available for extensions using Manifest V2."
             },
             "firefox_android": "mirror",
             "opera": "mirror",

--- a/webextensions/manifest/user_scripts.json
+++ b/webextensions/manifest/user_scripts.json
@@ -6,16 +6,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts",
           "support": {
             "chrome": {
-              "version_added": "≤78"
+              "version_added": false
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "68"
+              "version_added": "68",
+              "notes": "Only available for use in extensions using Manifest V2."
             },
             "firefox_android": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "safari": {
               "version_added": false
             },
@@ -26,16 +25,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤78"
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {
                 "version_added": "68"
               },
               "firefox_android": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
#### Summary

Initial PR for addressing the compatibility data needs of [Bug 1943050](https://bugzilla.mozilla.org/show_bug.cgi?id=1943050) Enable userScripts API by default. This PR creates the compatibility data to complement the documentation changes in https://github.com/mdn/content/pull/37975:

- addition of a userScripts_legacy.json file (being a copy of the original userScripts.json with a note about the legacy version availability in Manifest V2 only)
- update to user_scripts.json to note its applicability to Manifest V2 only.
