### PR TITLE
Update `api.Permissions.permission_accessibility-events` status and Chrome 131 removal

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -109,9 +109,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -84,7 +84,8 @@
           "description": "`accessibility-events` permission",
           "support": {
             "chrome": {
-              "version_added": "62"
+              "version_added": "62",
+              "version_removed": "131"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This updates the status for `api.Permissions.permission_accessibility-events` and shows its removal from Chrome.

#### Test results and supporting details

Thanks to help from @dontcallmedom in the WebDX chat, I learned that this permission was part of a now-deprecated [Accessibility Object Model (AOM) Phase 2 specification](https://wicg.github.io/aom/spec/phase2.html#privacy-concerns). This is no longer the case; see the [contemporary AOM spec](https://wicg.github.io/aom/spec) and [its phase 2 specification](https://wicg.github.io/aom/spec/input-events.html#privacy) for comparison. 

Because the originating spec is not in good standing, I wasn't able to add it to `spec_url`. I've still marked this feature as deprecated and non-standard track. The linter obliges us to set it to non-experimental, too.

Thanks to @caugner in https://github.com/mdn/browser-compat-data/issues/25854#issuecomment-2638199486, I learned that this feature has been removed from Chrome 131 ([commit](https://chromiumdash.appspot.com/commit/41da4aa10c42b36665b50c076274ab0dff0261e3)). Given the text of [bug 369945541](https://issues.chromium.org/issues/369945541), I think it's likely that this was _always_ behind a flag, so—removal is an option here—but I don't think it's worth the time to go find out if this is true, since this feature will get removed in November 2026 anyway.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Fixes https://github.com/mdn/browser-compat-data/issues/25854
- Prompted by https://github.com/web-platform-dx/web-features/pull/2614
- Key to be added to https://github.com/web-platform-dx/web-features/pull/2566

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
