### PR TITLE
Chrome 133 supports HTML `popover="hint"` attribute value

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2326,6 +2326,44 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "popover_hint": {
+          "__compat": {
+            "description": "`hint` value",
+            "spec_url": "https://html.spec.whatwg.org/multipage/popover.html#attr-popover-hint",
+            "tags": [
+              "web-features:popover"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "133"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "showPopover": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2327,7 +2327,7 @@
             "deprecated": false
           }
         },
-        "popover_hint": {
+        "hint": {
           "__compat": {
             "description": "`hint` value",
             "spec_url": "https://html.spec.whatwg.org/multipage/popover.html#attr-popover-hint",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1020,6 +1020,44 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "popover_hint": {
+          "__compat": {
+            "description": "`hint` value",
+            "spec_url": "https://html.spec.whatwg.org/multipage/popover.html#attr-popover-hint",
+            "tags": [
+              "web-features:popover"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "133"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "slot": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1021,7 +1021,7 @@
             "deprecated": false
           }
         },
-        "popover_hint": {
+        "hint": {
           "__compat": {
             "description": "`hint` value",
             "spec_url": "https://html.spec.whatwg.org/multipage/popover.html#attr-popover-hint",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 133 supports the `popover` attribute `hint` value, which creates popovers that do not light-dismiss `auto` popovers when shown. This is useful for situations where, for example, you have toolbar buttons that can be pressed to show UI popovers, but you also want to reveal tooltips when the buttons are hovered, without dismissing the UI popovers.

This PR adds data points for the HTML `popover` attribute `hint` value and the `hint` value of the `HTMLElement.popover` DOM API equivalent.

See https://chromestatus.com/feature/5073251081912320 for the data source.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
