### PR TITLE
Updates for Chrome 134 beta

### DIFF
--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -215,6 +215,82 @@
           }
         }
       },
+      "subgroupMaxSize": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-subgroupmaxsize",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "134",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "subgroupMinSize": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-subgroupminsize",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "134",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "vendor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapterInfo/vendor",

--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -156,6 +156,40 @@
           }
         }
       },
+      "closedBy": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-closedby",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "open": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/open",
@@ -189,6 +223,40 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestClose": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-requestclose",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1026,6 +1026,40 @@
           }
         }
       },
+      "getContextAttributes": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-canvas-getcontextattributes",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getImageData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getImageData",

--- a/api/PaintRenderingContext2D.json
+++ b/api/PaintRenderingContext2D.json
@@ -654,7 +654,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "65"
+              "version_added": "134"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SharedStorage.json
+++ b/api/SharedStorage.json
@@ -75,6 +75,40 @@
           }
         }
       },
+      "batchUpdate": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-batchupdate",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorage/clear",

--- a/api/SharedStorageAppendMethod.json
+++ b/api/SharedStorageAppendMethod.json
@@ -1,0 +1,73 @@
+{
+  "api": {
+    "SharedStorageAppendMethod": {
+      "__compat": {
+        "spec_url": "https://wicg.github.io/shared-storage/#sharedstorageappendmethod",
+        "support": {
+          "chrome": {
+            "version_added": "134"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "SharedStorageAppendMethod": {
+        "__compat": {
+          "description": "`SharedStorageAppendMethod()` constructor",
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageappendmethod-sharedstorageappendmethod",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/SharedStorageClearMethod.json
+++ b/api/SharedStorageClearMethod.json
@@ -1,0 +1,73 @@
+{
+  "api": {
+    "SharedStorageClearMethod": {
+      "__compat": {
+        "spec_url": "https://wicg.github.io/shared-storage/#sharedstorageclearmethod",
+        "support": {
+          "chrome": {
+            "version_added": "134"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "SharedStorageClearMethod": {
+        "__compat": {
+          "description": "`SharedStorageClearMethod()` constructor",
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageclearmethod-sharedstorageclearmethod",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/SharedStorageDeleteMethod.json
+++ b/api/SharedStorageDeleteMethod.json
@@ -1,0 +1,73 @@
+{
+  "api": {
+    "SharedStorageDeleteMethod": {
+      "__compat": {
+        "spec_url": "https://wicg.github.io/shared-storage/#sharedstoragedeletemethod",
+        "support": {
+          "chrome": {
+            "version_added": "134"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "SharedStorageDeleteMethod": {
+        "__compat": {
+          "description": "`SharedStorageDeleteMethod()` constructor",
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstoragedeletemethod-sharedstoragedeletemethod",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/SharedStorageModifierMethod.json
+++ b/api/SharedStorageModifierMethod.json
@@ -1,0 +1,38 @@
+{
+  "api": {
+    "SharedStorageModifierMethod": {
+      "__compat": {
+        "spec_url": "https://wicg.github.io/shared-storage/#sharedstoragemodifiermethod",
+        "support": {
+          "chrome": {
+            "version_added": "134"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/SharedStorageSetMethod.json
+++ b/api/SharedStorageSetMethod.json
@@ -1,0 +1,73 @@
+{
+  "api": {
+    "SharedStorageSetMethod": {
+      "__compat": {
+        "spec_url": "https://wicg.github.io/shared-storage/#sharedstoragesetmethod",
+        "support": {
+          "chrome": {
+            "version_added": "134"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "SharedStorageSetMethod": {
+        "__compat": {
+          "description": "`SharedStorageSetMethod()` constructor",
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstoragesetmethod-sharedstoragesetmethod",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/dynamic-range-limit.json
+++ b/css/properties/dynamic-range-limit.json
@@ -1,21 +1,17 @@
 {
-  "html": {
-    "elements": {
-      "dialog": {
+  "css": {
+    "properties": {
+      "dynamic-range-limit": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dialog",
-          "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element",
-          "tags": [
-            "web-features:dialog"
-          ],
+          "spec_url": "https://drafts.csswg.org/css-color-hdr/#the-dynamic-range-limit-property",
           "support": {
             "chrome": {
-              "version_added": "37"
+              "version_added": "134"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "98"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -25,7 +21,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.4"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -33,14 +29,14 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         },
-        "closedby": {
+        "constrained-high": {
           "__compat": {
-            "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-dialog-closedby",
+            "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-constrained-high",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -72,19 +68,17 @@
             }
           }
         },
-        "open": {
+        "high": {
           "__compat": {
-            "tags": [
-              "web-features:dialog"
-            ],
+            "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-high",
             "support": {
               "chrome": {
-                "version_added": "37"
+                "version_added": "134"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "98"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +88,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -102,7 +96,41 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "standard": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-standard",
+            "support": {
+              "chrome": {
+                "version_added": "134"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/has-slotted.json
+++ b/css/selectors/has-slotted.json
@@ -11,7 +11,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "134"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -34,7 +34,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.8 found new features shipping in Chrome 134 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 23 features as shipping in Chrome 134:

- api.GPUAdapterInfo.subgroupMaxSize
- api.GPUAdapterInfo.subgroupMinSize
- api.HTMLDialogElement.closedBy
- api.HTMLDialogElement.requestClose
- api.OffscreenCanvasRenderingContext2D.getContextAttributes
- api.PaintRenderingContext2D.imageSmoothingQuality
- api.SharedStorage.batchUpdate
- api.SharedStorageAppendMethod
- api.SharedStorageAppendMethod.SharedStorageAppendMethod
- api.SharedStorageClearMethod
- api.SharedStorageClearMethod.SharedStorageClearMethod
- api.SharedStorageDeleteMethod
- api.SharedStorageDeleteMethod.SharedStorageDeleteMethod
- api.SharedStorageModifierMethod
- api.SharedStorageSetMethod
- api.SharedStorageSetMethod.SharedStorageSetMethod
- css.properties.dynamic-range-limit
- css.properties.dynamic-range-limit.constrained-high
- css.properties.dynamic-range-limit.high
- css.properties.dynamic-range-limit.standard
- css.selectors.has-slotted
- html.elements.dialog.closedby
- html.elements.meta.name.application-title

See also the 134 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-134-beta

Note: The Web Locks integration to Shared Storage doesn't seem to be mentioned in @rachelandrew's post but from the collector it looks like it is shipping?! Is chromestatus outdated? https://chromestatus.com/feature/5133950203461632 Could also be a beta-only exposure. Thoughts, Rachel?