### PR TITLE
Update spec link for `vertical-align` from css2 to css inline

### DIFF
--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -4,7 +4,7 @@
       "vertical-align": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/vertical-align",
-          "spec_url": "https://drafts.csswg.org/css2/#propdef-vertical-align",
+          "spec_url": "https://drafts.csswg.org/css-inline/#propdef-vertical-align",
           "tags": [
             "web-features:vertical-align"
           ],
@@ -44,7 +44,7 @@
         },
         "baseline": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css2/#valdef-vertical-align-baseline",
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-alignment-baseline-baseline",
             "tags": [
               "web-features:vertical-align"
             ],
@@ -83,7 +83,7 @@
         },
         "bottom": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css2/#valdef-vertical-align-bottom",
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-shift-bottom",
             "tags": [
               "web-features:vertical-align"
             ],
@@ -122,7 +122,7 @@
         },
         "middle": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css2/#valdef-vertical-align-middle",
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-alignment-baseline-middle",
             "tags": [
               "web-features:vertical-align"
             ],
@@ -161,7 +161,7 @@
         },
         "sub": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css2/#valdef-vertical-align-sub",
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-shift-sub",
             "tags": [
               "web-features:vertical-align"
             ],
@@ -200,7 +200,7 @@
         },
         "super": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css2/#valdef-vertical-align-super",
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-shift-super",
             "tags": [
               "web-features:vertical-align"
             ],
@@ -239,7 +239,7 @@
         },
         "text-bottom": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css2/#valdef-vertical-align-text-bottom",
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-alignment-baseline-text-bottom",
             "tags": [
               "web-features:vertical-align"
             ],
@@ -278,7 +278,7 @@
         },
         "text-top": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css2/#valdef-vertical-align-text-top",
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-alignment-baseline-text-top",
             "tags": [
               "web-features:vertical-align"
             ],
@@ -317,7 +317,7 @@
         },
         "top": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css2/#valdef-vertical-align-top",
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-shift-top",
             "tags": [
               "web-features:vertical-align"
             ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the spec lin for css3 - css inline module should be used than css2 link

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
