### PR TITLE
Chrome 134 adds SharedStorageWorkletGlobalScope.interestGroups

### DIFF
--- a/api/SharedStorageWorkletGlobalScope.json
+++ b/api/SharedStorageWorkletGlobalScope.json
@@ -37,6 +37,40 @@
           "deprecated": false
         }
       },
+      "interestGroups": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworkletglobalscope-interestgroups",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "register": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorageWorkletGlobalScope/register",


### PR DESCRIPTION
#### Summary

Chrome 134 supports SharedStorageWorkletGlobalScope.interestGroup. (The collector doesn't support these worklets yet.)

#### Test results and supporting details

https://chromestatus.com/feature/5074536530444288

#### Related issues

https://github.com/mdn/browser-compat-data/pull/25866#issuecomment-2640832400