### PR TITLE
Revert ResponseStart updates

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -588,16 +588,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/finalResponseHeadersStart",
           "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-finalresponseheadersstart",
           "support": {
-            "chrome": [
-              {
-                "version_added": "133"
-              },
-              {
-                "alternative_name": "responseStart",
-                "version_added": "115",
-                "version_removed": "133"
-              }
-            ],
+            "chrome": {
+              "version_added": "133"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -1012,21 +1005,9 @@
             "web-features:resource-timing"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "133"
-              },
-              {
-                "version_added": "115",
-                "version_removed": "133",
-                "partial_implementation": true,
-                "notes": "Returns the time of the final response, even if an interim response is available."
-              },
-              {
-                "version_added": "85",
-                "version_removed": "115"
-              }
-            ],
+            "chrome": {
+              "version_added": "85"
+            },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -1006,7 +1006,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "85"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This reverts most of #25733 

The aim of that PR (as well as adding `finalResponseHeadersStart`) was to try to explain that Chrome diverged in it's definition of `responseStart` for sites using Early Hints. However, in hindsight, I think the updates are causing more confusion than help.

MDN currently shows this:

<img width="797" alt="image" src="https://github.com/user-attachments/assets/ff8250da-b332-486a-a830-e6c2f77f3130" />

This suggests the header was only added in 133 (it wasn't it was supported since 85 with a slight change in definition for some sites).

It also suggests it's not supported yet in Opera, Opera Android, and Samsung internet when that's not the case.

All in all, I think my intent to help developers has caused more issues than it solved, and we should instead treat this as a small oddity in Chrome 115-132 that doesn't require documenting in BCD (like some bugs aren't unless major issues).

Additionally, I incorrectly noted this was available from Chrome 87, when it was actually available from Chrome 43 so that was a typo.

It's also causing confusion in downstream dependencies:

https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1891

Similarly I think the noting of `finalResponseHeadersStart` as being available earlier, with the alternative name of `responseStart` is more confusing than helpful so also removing that.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

N/A - see https://github.com/mdn/browser-compat-data/pull/25733

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

https://github.com/mdn/browser-compat-data/pull/25733
