### PR TITLE
Chrome Android doesn't support SpeechRecognition.continuous

### DIFF
--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -221,7 +221,11 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "33",
+              "partial_implementation": true,
+              "notes": "The property can be set, but it has no effect (see [bug 41297427](https://crbug.com/41297427))."
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `continuous` property of `SpeechRecognition` can be set on Chrome Android, but it has no effect.

#### Test results and supporting details

See:

- https://github.com/mdn/browser-compat-data/issues/25794#issuecomment-2619493257
- https://issues.chromium.org/issues/41297427

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25794#issuecomment-2642818996.
