### PR TITLE
Chrome Android doesn't really partially support SpeechRecognition.continuous

### DIFF
--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -222,9 +222,9 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": "33",
-              "partial_implementation": true,
-              "notes": "The property can be set, but it has no effect (see [bug 41297427](https://crbug.com/41297427))."
+              "version_added": false,
+              "impl_url": "https://crbug.com/41297427",
+              "notes": "The property can be set, but has no effect."
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `continuous` property of `SpeechRecognition` can be set on Chrome Android, but it has no effect.

(Missed a local change in the previous PR.)

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixup for:

- https://github.com/mdn/browser-compat-data/pull/25878