### PR TITLE
Ff136 Error.captureStackTrace() and Error.stackTraceLimit

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -683,6 +683,48 @@
             }
           }
         },
+        "stackTraceLimit": {
+          "__compat": {
+            "tags": [
+              "web-features:javascript"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "17"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.17.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "11.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/toString",

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -230,9 +230,6 @@
         },
         "captureStackTrace": {
           "__compat": {
-            "tags": [
-              "web-features:javascript"
-            ],
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -685,9 +682,6 @@
         },
         "stackTraceLimit": {
           "__compat": {
-            "tags": [
-              "web-features:javascript"
-            ],
             "support": {
               "chrome": {
                 "version_added": "3"

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -228,6 +228,56 @@
             }
           }
         },
+        "captureStackTrace": {
+          "__compat": {
+            "tags": [
+              "web-features:javascript"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "17"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "136",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.error_capture_stack_trace",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1886820"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.17.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17.3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "cause": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/cause",

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -235,7 +235,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "17"
+                "version_added": "3"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -690,7 +690,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "17"
+                "version_added": "3"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
`Error.captureStackTrace()` and `Error.stackTraceLimit` are defacto standard method/property, along with Error.stack. They are not yet standardized, but are planned to be. 

This adds subfeatures for each of them.

Should we add a spec link for Error.stack to https://github.com/tc39/proposal-error-stacks ?

Related docs work can be tracked in https://github.com/mdn/content/issues/37930