### PR TITLE
Update Webview Android data for JS builtins

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -194,7 +194,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1067,7 +1067,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1220,7 +1220,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1377,7 +1377,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1430,7 +1430,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1581,7 +1581,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1634,7 +1634,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1687,7 +1687,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1942,7 +1942,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -2239,7 +2239,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -2292,7 +2292,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -193,7 +193,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1064,7 +1066,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1372,7 +1376,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1423,7 +1429,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1572,7 +1580,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1623,7 +1633,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1674,7 +1686,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -2277,7 +2291,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -43,7 +43,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4"
             },
             "webview_ios": "mirror"
           },
@@ -96,7 +96,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -341,7 +341,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -443,7 +443,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -776,7 +776,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -969,7 +969,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -1173,7 +1173,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -1281,7 +1281,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -1485,7 +1485,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -1536,7 +1536,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -1744,7 +1744,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -1946,7 +1946,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -2243,7 +2243,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -43,7 +43,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "webview_ios": "mirror"
           },
@@ -96,7 +96,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -340,9 +340,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -442,9 +440,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -775,9 +771,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -968,9 +962,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1172,9 +1164,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1226,7 +1216,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },
@@ -1280,9 +1270,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1484,9 +1472,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1535,9 +1521,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1743,9 +1727,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1021,7 +1021,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1225,7 +1225,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1581,7 +1581,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1785,7 +1785,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1839,7 +1839,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },
@@ -1892,7 +1892,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "webview_ios": "mirror"
             },

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -43,7 +43,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "webview_ios": "mirror"
           },
@@ -95,7 +95,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "1"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -245,9 +247,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -353,9 +353,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -417,9 +415,7 @@
                 "notes": "Also supported in Safari for iOS 4.2, but not on DOM objects."
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -570,9 +566,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -677,9 +671,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -779,9 +771,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -881,9 +871,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1032,7 +1020,9 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1079,9 +1069,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1132,9 +1120,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1185,9 +1171,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1240,7 +1224,9 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1344,9 +1330,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1497,9 +1481,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1598,7 +1580,9 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1702,9 +1686,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -1802,7 +1784,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1854,7 +1838,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1905,7 +1891,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -243,7 +243,9 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -349,7 +351,9 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -411,7 +415,9 @@
                 "notes": "Also supported in Safari for iOS 4.2, but not on DOM objects."
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -562,7 +568,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -667,7 +675,9 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -767,7 +777,9 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -867,7 +879,9 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1063,7 +1077,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1114,7 +1130,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1165,7 +1183,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1322,7 +1342,9 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1473,7 +1495,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -1676,7 +1700,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "≤4"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -42,7 +42,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": "≤4"
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2794,7 +2794,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤4"
               },
               "webview_ios": "mirror"
             },

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -42,7 +42,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": "≤4"
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -43,7 +43,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "webview_ios": "mirror"
           },
@@ -95,7 +95,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "1"
+              },
               "webview_ios": "mirror"
             },
             "status": {
@@ -2795,9 +2797,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤4"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR updates JavaScript builtins support version of Webview Android. Most changes are changing `≤37` or `mirror` to `≤4`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I wrote a simple tool to determine if the value is `undefined` to check if the browser supports this feature (only implemented 3 checks so far). Which is available at [SessionHu/check-js-feat](https://github.com/SessionHu/check-js-feat).
Then I run the server on my another device and open the page on the old Android 4.2 TV with an browser which using Android System Webview.
Here is the result photo (UserAgent on the top, support features in green background, unsupport in red. And I cannot take screenshot on that device):

<details><summary>here 3 photos shot on phone camera</summary>

![IMG_20250210_115227](https://github.com/user-attachments/assets/5ca313c0-14cf-40b3-b5ee-6c7f1fc2ae34)
![IMG_20250210_115341](https://github.com/user-attachments/assets/5226f7d4-f422-4f53-96bc-bba2d881583b)
![IMG_20250210_115403](https://github.com/user-attachments/assets/26300788-aa40-4100-9d39-7153010ac52b)

</details>

Although the system version is `4.2.1` instead of `4` according to the `navigator.userAgent` and System Settings. I believe it has the same behavior as 4. Because I did not find Android Webview 4.2 release in [/browsers/webview_android.json](https://github.com/mdn/browser-compat-data/blob/main/browsers/webview_android.json).

I also do some other tests on that device. But test code were already removed before this PR opened.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Not fond yet
