### PR TITLE
Magnetometer: entire API is behind a flag in Chromium

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -472,7 +472,14 @@
           "description": "`magnetometer` permission",
           "support": {
             "chrome": {
-              "version_added": "62"
+              "version_added": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -491,9 +498,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -867,7 +867,14 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "66"
+                  "version_added": "66",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-generic-sensor-extra-classes",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -886,9 +893,7 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": false
-                }
+                "webview_android": "mirror"
               },
               "status": {
                 "experimental": true,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The rest of Magnetometer API is behind a flag in Chromium; these features would have no effect without the flag turned on.

#### Test results and supporting details

via @foolip in https://github.com/web-platform-dx/web-features/issues/2631

> In Chromium the features is controlled by a flag which is off by default: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/runtime_enabled_features.json5;l=3940-3943;drc=bdbfc851687b28b24b80bccbc4c027bfe05a701b

I didn't check the version numbers—I figured it doesn't matter that much, but plausible that these things appeared after the initial `Magnetometer` API.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/pull/2614/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
