### PR TITLE
Change Firefox support for Partitioned cookie attribute to false.

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -136,7 +136,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The partitioned cookie attribute was unshipped in Firefox because of a login regression. It will be re-supported soon but for now we should change the support to false.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Bugzilla bug with the regression: https://bugzilla.mozilla.org/show_bug.cgi?id=1923663
Phabricator patch that disables CHIPS: https://phabricator.services.mozilla.com/D225712

