### PR TITLE
Magnetometer: entire API is behind a flag in Chromium (again)

### DIFF
--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -795,7 +795,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "66"
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-generic-sensor-extra-classes",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -814,9 +821,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I missed a key in https://github.com/mdn/browser-compat-data/pull/25897. This fixes the omission.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

As before:

> In Chromium the features is controlled by a flag which is off by default: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/runtime_enabled_features.json5;l=3940-3943;drc=bdbfc851687b28b24b80bccbc4c027bfe05a701b

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Previously: https://github.com/mdn/browser-compat-data/pull/25897
- Previously: https://github.com/web-platform-dx/web-features/pull/2614
- Discovered in: https://github.com/web-platform-dx/web-features/pull/2639

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
