### PR TITLE
FF136 HTTP Referer sent on page refresh

### DIFF
--- a/http/headers/Refresh.json
+++ b/http/headers/Refresh.json
@@ -14,7 +14,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "From version 136 the HTTP `Referer` header is sent following a refresh that redirects to another page (if permitted)"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF136 adds support for sending the HTTP `Referer` header (if permitted by the referrer policy) on page refresh caused by `Refresh` header or equivalent `<meta>` in https://bugzilla.mozilla.org/show_bug.cgi?id=1928291#c9

This matches spec, and also chrome and Safari behaviour. It matters because some sites rely on it - specifically Twitch.

I have chosen to add as a note to the `Refresh`, because that is where the behaviour that is relied upon is changed (i.e. where you might look). It could be a subfeature.. But I think it this is the right place.
Happy to change that if you have another opinion.

Related docs work tracked in https://github.com/mdn/content/issues/37944