### PR TITLE
Update init.priority in fetch global for Firefox 132

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -367,7 +367,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "132"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

fetchPriority was enabled in FF 132, but this option on the fetch global was missed

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1854077

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Other APIs were updated in https://github.com/mdn/browser-compat-data/pull/24518, including RequestInit which Fetch uses
