### PR TITLE
Chrome 133 supports scroll-state container queries

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -50,7 +50,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1931980"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -39,6 +39,143 @@
             "deprecated": false
           }
         },
+        "scroll-state_queries": {
+          "__compat": {
+            "description": "Scroll-state queries",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#scroll-state-container",
+            "support": {
+              "chrome": {
+                "version_added": "133"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "scrollable": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-conditional-5/#scrollable",
+              "support": {
+                "chrome": {
+                  "version_added": "133"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "snapped": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-conditional-5/#snapped",
+              "support": {
+                "chrome": {
+                  "version_added": "133"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "stuck": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-conditional-5/#stuck",
+              "support": {
+                "chrome": {
+                  "version_added": "133"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
         "style_queries_for_custom_properties": {
           "__compat": {
             "description": "Style queries for custom properties",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 133 supports scroll-state container queries. See https://chromestatus.com/feature/5072263730167808.

A data point for the `container-type` property `scroll-state` value has already been added previously.

This PR adds data for `@container` at-rule support for scroll-state queries. I've added a separate sub-data point for the `scrollable`, `snapped`, and `stuck` features. Even though they are all implemented in Chrome at the same time, I think it is a good reminder of the available subfeatures, and other browsers could easily implement them at different rates.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I used the following demos to test the different types of scroll-state container query:

- `scrollable`: https://scroll-state-scrollable-container-query.glitch.me/ (when the document is scrolled downwards (so it able to be scrolled upwards), a back-to-top link should appear)
- `snapped`: https://scroll-state-snapped-container-query.glitch.me/ (when a child element snaps to its scroll snap container parent, it should have different styling applied)
- `stuck`: https://scroll-state-stuck-container-query.glitch.me/ (when a `position: sticky` heading sticks to the top of the screen, it should have different styling applied)

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
