### PR TITLE
Bug-1538451 add `commands.openShortcutSettings`

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -232,6 +232,27 @@
             }
           }
         },
+        "openShortcutSettings": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "137"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "reset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/reset",


### PR DESCRIPTION
#### Summary

Addresses the dev-docs needed request for [Bug 1538451](https://bugzilla.mozilla.org/show_bug.cgi?id=1538451) _Make extension shortcut management page accessible by a link/URL for a WebExtension_ by adding `commands.openShortcutSettings`.

#### Related issues

Related MDN documentation changes in https://github.com/mdn/content/pull/38234