### PR TITLE
Firefox Nightly supports `Clear-Site-Data: cache`

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -95,11 +95,17 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": {
-                "version_added": "63",
-                "version_removed": "94",
-                "impl_url": "https://bugzil.la/1838506"
-              },
+              "firefox": [
+                {
+                  "version_added": "preview",
+                  "impl_url": "https://bugzil.la/1942272"
+                },
+                {
+                  "version_added": "63",
+                  "version_removed": "94",
+                  "impl_url": "https://bugzil.la/1838506"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -97,8 +97,7 @@
               },
               "firefox": [
                 {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1942272"
+                  "version_added": "preview"
                 },
                 {
                   "version_added": "63",


### PR DESCRIPTION
FF136 supports [`Clear-Site-Data: cache`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1942272 (and also clearing of cache in the `*` wildcard).

This adds preview feature to the `cache` subfeature. No need to update the `*` wildcard - the expectation is that will clear everything based on the other features that are supported.

Related docs work can be tracked in https://github.com/mdn/content/issues/37946