### PR TITLE
Chrome 100 supports Sec-CH-UA-WoW64, 124 supports Sec-CH-UA-Form-Factors client hints

### DIFF
--- a/http/headers/Sec-CH-UA-Form-Factors.json
+++ b/http/headers/Sec-CH-UA-Form-Factors.json
@@ -1,0 +1,46 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Form-Factors": {
+        "__compat": {
+          "description": "`Sec-CH-UA-Form-Factors` request header",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-form-factors",
+          "tags": [
+            "web-features:ua-client-hints"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "124"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/Sec-CH-UA-WoW64.json
+++ b/http/headers/Sec-CH-UA-WoW64.json
@@ -1,0 +1,46 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-WoW64": {
+        "__compat": {
+          "description": "`Sec-CH-UA-WoW64` request header",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-wow64",
+          "tags": [
+            "web-features:ua-client-hints"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "23.0"
+            },
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

Adding some BCD entries for missing client hints headers.

#### Test results and supporting details

Tested using https://browserleaks.com/client-hints with:

- Fx Nightly / Stable
- Samsung internet (27) on Android
- Safari

chromestatus:

- [Feature: Sec-CH-UA-Form-Factors client hint](https://chromestatus.com/feature/5162545698045952)
- [Feature: Sec-CH-UA-WoW64 Client Hint](https://chromestatus.com/feature/5682026601512960)

#### Related issues

- [ ] https://github.com/mdn/content/pull/37547
- [x] https://github.com/mdn/browser-compat-data/pull/11235