### PR TITLE
Shift the range cutoff to three years back

### DIFF
--- a/lint/linter/test-versions.ts
+++ b/lint/linter/test-versions.ts
@@ -4,7 +4,7 @@
 import { compare, validate } from 'compare-versions';
 import chalk from 'chalk-template';
 
-import { Linter, Logger, LinterData, twoYearsAgo } from '../utils.js';
+import { Linter, Logger, LinterData } from '../utils.js';
 import {
   BrowserName,
   SimpleSupportStatement,
@@ -16,6 +16,15 @@ import {
 } from '../../types/index';
 import bcd from '../../index.js';
 const { browsers } = bcd;
+
+const now = new Date();
+
+/* The latest date a range's release can correspond to */
+const rangeCutoffDate = new Date(
+  now.getFullYear() - 3,
+  now.getMonth(),
+  now.getDate(),
+);
 
 const browserTips: Record<string, string> = {
   nodejs:
@@ -181,10 +190,10 @@ const checkVersions = (
           if (
             !releaseData ||
             !releaseData.release_date ||
-            new Date(releaseData.release_date) > twoYearsAgo
+            new Date(releaseData.release_date) > rangeCutoffDate
           ) {
             logger.error(
-              chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Ranged values are only allowed for browser versions released two years or earlier (on or before ${twoYearsAgo}). Ranged values are also not allowed for browser versions without a known release date.`,
+              chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Ranged values are only allowed for browser versions released on or before ${rangeCutoffDate.toDateString()}. (Ranged values are also not allowed for browser versions without a known release date.)`,
             );
           }
         }

--- a/lint/utils.ts
+++ b/lint/utils.ts
@@ -12,15 +12,6 @@ export interface LintOptions {
   only?: string[];
 }
 
-const now = new Date();
-
-/* The date, exactly two years ago */
-export const twoYearsAgo = new Date(
-  now.getFullYear() - 2,
-  now.getMonth(),
-  now.getDate(),
-);
-
 const INVISIBLES_MAP: Readonly<Record<string, string>> = Object.freeze(
   Object.assign(Object.create(null), {
     '\0': '\\0', // ␀ (0x00)


### PR DESCRIPTION
This PR shifts the range cutoff date from two years to three years, as we are able to do so.  In the process, this PR also performs some slight refactoring to move the related variable from another file (since it's not used anywhere else), as well as updating the message to improve the date displayed and make future updating easier.
