### PR TITLE
Firefox 136 supports `hyphenate-limit-chars` CSS property behind pref

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -489,12 +489,8 @@
             "chrome": {
               "version_added": "132"
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -510,7 +506,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {
@@ -529,12 +527,8 @@
             "chrome": {
               "version_added": "132"
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -550,7 +544,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {
@@ -569,12 +565,8 @@
             "chrome": {
               "version_added": "132"
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -590,7 +582,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/css/properties/hyphenate-limit-chars.json
+++ b/css/properties/hyphenate-limit-chars.json
@@ -15,7 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1521723"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/hyphenate-limit-chars.json
+++ b/css/properties/hyphenate-limit-chars.json
@@ -15,7 +15,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "136",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.hyphenate-limit-chars.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "impl_url": "https://bugzil.la/1521723"
             },
             "firefox_android": "mirror",

--- a/css/properties/hyphenate-limit-chars.json
+++ b/css/properties/hyphenate-limit-chars.json
@@ -22,8 +22,7 @@
                   "name": "layout.css.hyphenate-limit-chars.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "impl_url": "https://bugzil.la/1521723"
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/hyphenate-limit-chars.json
+++ b/css/properties/hyphenate-limit-chars.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136",
+              "version_added": "preview",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
#### Summary

- added bcd for hyphenate-limit-chars for firefox

#### Test results and supporting details

- tested in FF Nightly
- tested in FF Developer edition
- tested in FF Beta

#### Related issues

- [Firefox release PR](https://github.com/mdn/content/pull/38212)