### PR TITLE
HTTP responses for status codes that should have no body

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -121,7 +121,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "1"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1",

--- a/http/status.json
+++ b/http/status.json
@@ -109,6 +109,48 @@
           }
         }
       },
+      "204": {
+        "__compat": {
+          "description": "204 (No Content)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/204",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.204",
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "notes": "This status code describes a HTTP response with no body. If a server erroneously includes data after the headers, Chrome tolerates up to 4 bytes of invalid data. See [Chromium issue 1934](https://codereview.chromium.org/1934)."
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "1"
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "This status code describes a HTTP response with no body. If a server erroneously includes data after the headers, Firefox tolerates in excess of a kilobyte of invalid data. See [Bug 1356614](https://bugzil.la/1356614"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "4"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "2"
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "308": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/308",

--- a/http/status.json
+++ b/http/status.json
@@ -125,7 +125,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "This status code describes a HTTP response with no body. If a server erroneously includes data after the headers, Firefox tolerates in excess of a kilobyte of invalid data. See [Bug 1356614](https://bugzil.la/1356614"
+              "notes": "This status code describes a HTTP response with no body. If a server erroneously includes data after the headers, Firefox tolerates in excess of a kilobyte of invalid data. See [Bug 1356614](https://bugzil.la/1356614)"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

HTTP responses with 204, 304, (1XX) should not contain content (a body). For historical / legacy reasons, browsers have tolerated junk data in <=HTTP/1.1 that precedes the status line because servers occasionally included content in responses that should not have a body. HTTP spec versions after 1.1 are strict / explicit in forbidding content in these cases.

I'm removing compat info from prose in MDN docs, and putting this into compat data instead, as this seems the most appropriate place for this to live on.

204 (No Content) is the most obvious place, but I'm open to alternatives somewhere (outside of `http/status.json`?)

#### Related issues

- [ ] https://github.com/mdn/content/pull/37928
- https://bugzilla.mozilla.org/show_bug.cgi?id=1356614