### PR TITLE
Mark Safari Tech Preview as supporting dialog.requestClose()

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -248,7 +248,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add Safari Tech Preview support for dialog.requestClose()

#### Test results and supporting details

Not in release notes but it's in Safari TP 213 see the commit range at https://webkit.org/blog/16461/release-notes-for-safari-technology-preview-213/

https://commits.webkit.org/289352@main

I also tested manually by running the relevant WPTs in STP 213.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
