### PR TITLE
Chrome 1 already supported `max-height`

### DIFF
--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -13,7 +13,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 1 already supported `max-height`

#### Test results and supporting details

See evidence in [this comment](https://github.com/mdn/browser-compat-data/issues/19302#issuecomment-2666514782).

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/19302.