### PR TITLE
Firefox 103-122 didn't support `backdrop-filter` with some GPUs

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -24,7 +24,8 @@
               }
             ],
             "firefox": {
-              "version_added": "103"
+              "version_added": "103",
+              "notes": "Before Firefox 123, the property was not supported on systems with unknown GPU vendor (see bug [1868737](https://bugzil.la/1868737#c12))."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds note about Firefox 103 to 122 not supporting `backdrop-filter` on systems with unknown GPU vendor.

#### Test results and supporting details

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1868737#c12

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/19052.