### PR TITLE
Update Chromium data for `webextensions.api.menus` (esp. `OnClickData.srcUrl`)

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -512,7 +512,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.create",
-                "version_added": "≤58",
+                "version_added": "6",
                 "notes": "Items that don't specify 'contexts' do not inherit contexts from their parents."
               },
               "edge": "mirror",
@@ -664,7 +664,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.onClicked",
-                "version_added": "≤58"
+                "version_added": "≤21"
               },
               "edge": "mirror",
               "firefox": [
@@ -802,7 +802,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.remove",
-                "version_added": "≤58"
+                "version_added": "6"
               },
               "edge": "mirror",
               "firefox": [
@@ -835,7 +835,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.removeAll",
-                "version_added": "≤58"
+                "version_added": "6"
               },
               "edge": "mirror",
               "firefox": [
@@ -867,7 +867,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.update",
-                "version_added": "≤58"
+                "version_added": "6"
               },
               "edge": "mirror",
               "firefox": [

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -464,7 +464,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤95"
+                  "version_added": "≤38"
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -464,7 +464,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤38"
+                  "version_added": "7"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `OnClickData.srcUrl` member of the `menus` Web Extensions interface. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://source.chromium.org/chromium/chromium/src/+/641efff1566c569f02d395f872d4c4f5c965d217

Additional Notes: This commit does not seem to add the feature itself, but it provides evidence that the feature was around during that time.
