### PR TITLE
Bump range cutoff date to four years ago

### DIFF
--- a/lint/linter/test-versions.ts
+++ b/lint/linter/test-versions.ts
@@ -21,7 +21,7 @@ const now = new Date();
 
 /* The latest date a range's release can correspond to */
 const rangeCutoffDate = new Date(
-  now.getFullYear() - 3,
+  now.getFullYear() - 4,
   now.getMonth(),
   now.getDate(),
 );


### PR DESCRIPTION
This PR bumps the range cutoff date to four years back (from three years).  Requires #25962 to be merged first.
