### PR TITLE
Chrome/Safari only partially support source option for popover API

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2453,6 +2453,7 @@
         "source": {
           "__compat": {
             "description": "`source` option",
+            "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-showpopoveroptions-source",
             "tags": [
               "web-features:popover"
             ],
@@ -2460,7 +2461,7 @@
               "chrome": {
                 "version_added": "133",
                 "partial_implementation": true,
-                "notes": "This doesn't apply the focus ordering change. See [bug 383343310](https://crbug.com/383343310)."
+                "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 383343310](https://crbug.com/383343310)."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2477,7 +2478,7 @@
               "safari": {
                 "version_added": "preview",
                 "partial_implementation": true,
-                "notes": "This doesn't apply the focus ordering change. See [bug 286575](https://webkit.org/b/286575)."
+                "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 286575](https://webkit.org/b/286575)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2956,6 +2957,7 @@
         "source": {
           "__compat": {
             "description": "`source` option",
+            "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-showpopoveroptions-source",
             "tags": [
               "web-features:popover"
             ],
@@ -2963,7 +2965,7 @@
               "chrome": {
                 "version_added": "133",
                 "partial_implementation": true,
-                "notes": "This doesn't apply the focus ordering change. See [bug 383343310](https://crbug.com/383343310)."
+                "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 383343310](https://crbug.com/383343310)."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2980,7 +2982,7 @@
               "safari": {
                 "version_added": "preview",
                 "partial_implementation": true,
-                "notes": "This doesn't apply the focus ordering change. See [bug 286575](https://webkit.org/b/286575)."
+                "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 286575](https://webkit.org/b/286575)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2458,7 +2458,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "133"
+                "version_added": "133",
+                "partial_implementation": true,
+                "notes": "This doesn't apply the focus ordering change. See [bug 383343310](https://crbug.com/383343310)."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2473,7 +2475,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview",
+                "partial_implementation": true,
+                "notes": "This doesn't apply the focus ordering change. See [bug 286575](https://webkit.org/b/286575)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2957,7 +2961,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "133"
+                "version_added": "133",
+                "partial_implementation": true,
+                "notes": "This doesn't apply the focus ordering change. See [bug 383343310](https://crbug.com/383343310)."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2972,7 +2978,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview",
+                "partial_implementation": true,
+                "notes": "This doesn't apply the focus ordering change. See [bug 286575](https://webkit.org/b/286575)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Also mark Chrome support as partial due to missing focus behavior

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Mark Safari Tech Preview as partially supporting source option for popover API

Also mark Chrome support as partial due to missing focus behavior

#### Test results and supporting details

Manually tested STP support by running https://wpt.live/html/semantics/popovers/imperative-invokers.html

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
