### PR TITLE
Update Firefox Android data for CSSNestedDeclarations API

### DIFF
--- a/api/CSSNestedDeclarations.json
+++ b/api/CSSNestedDeclarations.json
@@ -16,9 +16,7 @@
           "firefox": {
             "version_added": "132"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -55,9 +53,7 @@
             "firefox": {
               "version_added": "132"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `CSSNestedDeclarations` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSNestedDeclarations
