### PR TITLE
Update Chrome Android data for CSSMarginRule API

### DIFF
--- a/api/CSSMarginRule.json
+++ b/api/CSSMarginRule.json
@@ -10,9 +10,7 @@
           "chrome": {
             "version_added": "131"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -48,9 +46,7 @@
             "chrome": {
               "version_added": "131"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -87,9 +83,7 @@
             "chrome": {
               "version_added": "131"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `CSSMarginRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSMarginRule
