### PR TITLE
Update Chrome Android data for FileSystemObserver API

### DIFF
--- a/api/FileSystemObserver.json
+++ b/api/FileSystemObserver.json
@@ -6,7 +6,9 @@
           "chrome": {
             "version_added": "133"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,7 +41,9 @@
             "chrome": {
               "version_added": "133"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -72,7 +76,9 @@
             "chrome": {
               "version_added": "133"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -105,7 +111,9 @@
             "chrome": {
               "version_added": "133"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `FileSystemObserver` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemObserver
