### PR TITLE
Add `ignores_find_in_page` to `inert` global attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -747,7 +747,7 @@
         "ignores_find_in_page": {
           "__compat": {
             "description": "Element is ignored for the purposes of find-in-page.",
-            "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-inert",
+            "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees",
             "tags": [
               "web-features:inert"
             ],

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -747,7 +747,6 @@
         "ignores_find_in_page": {
           "__compat": {
             "description": "Element is ignored for the purposes of find-in-page.",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inert",
             "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-inert",
             "tags": [
               "web-features:inert"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -743,6 +743,46 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "ignores_find_in_page": {
+          "__compat": {
+            "description": "Element is ignored for the purposes of find-in-page.",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inert",
+            "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-inert",
+            "tags": [
+              "web-features:inert"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "124"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "120"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/269909"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "inputmode": {


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds subfeature `ignores_find_in_page` to `html.global_attributes.inert`, duplicated from `api.HTMLElement.inert`.

#### Test results and supporting details


#### Related issues

Fixes #25983.
