### PR TITLE
Update Samsung Internet / WebView Android data for GeolocationCoordinates API

### DIFF
--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -84,10 +84,7 @@
               "version_removed": "13.4"
             }
           ],
-          "samsunginternet_android": {
-            "alternative_name": "Coordinates",
-            "version_added": "1.0"
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": [
             {
               "version_added": "79"
@@ -133,9 +130,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects version values for Samsung Internet for the `GeolocationCoordinates` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/GeolocationCoordinates
