### PR TITLE
FileSystemObserver is not yet part of File System standard

### DIFF
--- a/api/FileSystemObserver.json
+++ b/api/FileSystemObserver.json
@@ -30,7 +30,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": false
         }
       },
@@ -65,7 +65,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -100,7 +100,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -135,7 +135,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `FileSystemObserver` interface has been implemented in Chromium 133+ (desktop-only) and is already included in the BCD. However, it is not yet merged into the File System standard (see https://github.com/whatwg/fs/pull/165), so I'm setting it to `standard_track: false` for now in this PR, to avoid confusion. I'll set it back again when it is merged.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
