### PR TITLE
MediaSource API is not available in Safari iOS on iPhone

### DIFF
--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -45,9 +45,7 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": {
-            "version_added": false
-          }
+          "webview_ios": "mirror"
         },
         "status": {
           "experimental": false,
@@ -284,12 +282,15 @@
             "safari": {
               "version_added": "18"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "18",
+              "impl_url": "https://webkit.org/b/200147",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": {
-              "version_added": false
-            }
+            "webview_ios": "mirror"
           },
           "status": {
             "experimental": false,
@@ -472,12 +473,15 @@
             "safari": {
               "version_added": "18"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "18",
+              "impl_url": "https://webkit.org/b/200147",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": {
-              "version_added": false
-            }
+            "webview_ios": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `MediaSource` API. This propogates the note to the newly-supported features, as well as corrects the data for WebView iOS (which was collected with the collector using only an iPhone).
