### PR TITLE
Firefox Android also supports VideoColorSpace API

### DIFF
--- a/api/VideoColorSpace.json
+++ b/api/VideoColorSpace.json
@@ -16,9 +16,7 @@
           "firefox": {
             "version_added": "130"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -56,9 +54,7 @@
             "firefox": {
               "version_added": "130"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -96,9 +92,7 @@
             "firefox": {
               "version_added": "130"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -136,9 +130,7 @@
             "firefox": {
               "version_added": "130"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -176,9 +168,7 @@
             "firefox": {
               "version_added": "130"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -216,9 +206,7 @@
             "firefox": {
               "version_added": "130"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -256,9 +244,7 @@
             "firefox": {
               "version_added": "130"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `VideoColorSpace` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/VideoColorSpace
