### PR TITLE
`import(…, { with: { type: "json" } })` is standard track

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -954,7 +954,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -905,6 +905,7 @@
         "trailing_commas_in_dynamic_import": {
           "__compat": {
             "description": "Trailing comma in dynamic import",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-import-call-runtime-semantics-evaluation",
             "support": {
               "chrome": {
                 "version_added": "91"

--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -154,7 +154,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -105,6 +105,7 @@
         "options_parameter": {
           "__compat": {
             "description": "The `options` parameter",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-import-calls",
             "support": {
               "chrome": {
                 "version_added": "91"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The options argument for `import()` is just as standardized as the rest of import attributes.

#### Test results and supporting details

https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-import-call-runtime-semantics-evaluation

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Discovered via https://github.com/web-platform-dx/web-features/pull/2564

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
