### PR TITLE
WebView iOS also supports `column-width: auto`

### DIFF
--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -130,7 +130,8 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView iOS/iPadOS for the `auto` member of the `column-width` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/column-width/auto
