### PR TITLE
Remove `javascript.builtins.Error.cause.displayed_in_console`

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -286,7 +286,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "93"
+                "version_added": "93",
+                "notes": "Before version 125, default console logging for `Error` objects does not print the cause."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -308,7 +309,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15",
-                "notes": "The cause of an error is not shown in the developer console."
+                "notes": "Default console logging for `Error` objects does not print the cause."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -307,7 +307,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "The cause of an error is not shown in the developer console."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -318,46 +319,6 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
-            }
-          },
-          "displayed_in_console": {
-            "__compat": {
-              "description": "Cause is displayed in console",
-              "support": {
-                "chrome": {
-                  "version_added": "125"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.13"
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "91"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "16.9.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror",
-                "webview_ios": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": false
-              }
             }
           }
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`javascript.builtins.Error.cause.displayed_in_console` can never be incompatible because the contents of the console aren't inspectable.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This is a weird thing. The appearance of the console is [implementation-defined](https://infra.spec.whatwg.org/#implementation-defined) by specification. Arguably, the console _output_ can look however a vendor wants it to look and it'd be standard behavior.

But unlike, say, the default stylesheet or a sensitive feature's permissions UI, the output of the console is not inspectable by a web page in any browser in any case. That is to say, there are no methods to _read_ the console, only to write to it. You could never build a web application that depends on the output of the console. It's definitionally compatible because no browser exposes it to developer code or ordinary users (e.g., there's no way to trigger the appearance of the console).

That said, lots of stuff can be up to the implementer and still "incompatible" for developers, if they're too divergent. I get this. I think it's worth noting that Safari is alone in failing to print this information, so I've moved that information into the parent feature's notes.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Discovered in the course of https://github.com/web-platform-dx/web-features/pull/2564. This is one of the first keys where I've wanted to not exist that wasn't already on the road to removal.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
