### PR TITLE
Safari iOS data also supports unprefixed mask-border CSS property

### DIFF
--- a/css/properties/mask-border-outset.json
+++ b/css/properties/mask-border-outset.json
@@ -35,10 +35,7 @@
                 "version_added": "3.1"
               }
             ],
-            "safari_ios": {
-              "alternative_name": "-webkit-mask-box-image-outset",
-              "version_added": "3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/css/properties/mask-border-repeat.json
+++ b/css/properties/mask-border-repeat.json
@@ -35,10 +35,7 @@
                 "version_added": "3.1"
               }
             ],
-            "safari_ios": {
-              "alternative_name": "-webkit-mask-box-image-repeat",
-              "version_added": "3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/css/properties/mask-border-slice.json
+++ b/css/properties/mask-border-slice.json
@@ -35,10 +35,7 @@
                 "version_added": "3.1"
               }
             ],
-            "safari_ios": {
-              "alternative_name": "-webkit-mask-box-image-slice",
-              "version_added": "3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/css/properties/mask-border-source.json
+++ b/css/properties/mask-border-source.json
@@ -35,10 +35,7 @@
                 "version_added": "3.1"
               }
             ],
-            "safari_ios": {
-              "alternative_name": "-webkit-mask-box-image-source",
-              "version_added": "3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/css/properties/mask-border-width.json
+++ b/css/properties/mask-border-width.json
@@ -35,10 +35,7 @@
                 "version_added": "3.1"
               }
             ],
-            "safari_ios": {
-              "alternative_name": "-webkit-mask-box-image-width",
-              "version_added": "3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/css/properties/mask-border.json
+++ b/css/properties/mask-border.json
@@ -35,10 +35,7 @@
                 "version_added": "3.1"
               }
             ],
-            "safari_ios": {
-              "alternative_name": "-webkit-mask-box-image",
-              "version_added": "3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `mask-border` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/mask-border
