### PR TITLE
WebView Android 120 also supports unprefixed mask-clip CSS property

### DIFF
--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -41,10 +41,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "2"
-            },
+            "webview_android": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2"
+              }
+            ],
             "webview_ios": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `mask-clip` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/mask-clip
