### PR TITLE
Opera Android / Samsung Internet / WebView Android also support unprefixed mask-image CSS property

### DIFF
--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -45,10 +45,15 @@
               "prefix": "-webkit-",
               "version_added": "15"
             },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera_android": [
+              {
+                "version_added": "80"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "15.4"
@@ -60,15 +65,17 @@
               }
             ],
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "prefix": "-webkit-",
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "2",
-              "notes": "Initially, Android supported only `-webkit-` prefixed values for gradients (such as `-webkit-linear-gradient()`). Later, support for unprefixed values was added."
-            },
+            "samsunginternet_android": "mirror",
+            "webview_android": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2",
+                "notes": "Initially, Android supported only `-webkit-` prefixed values for gradients (such as `-webkit-linear-gradient()`). Later, support for unprefixed values was added."
+              }
+            ],
             "webview_ios": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `mask-image` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/mask-image
