### PR TITLE
Samsung Internet also supports unprefixed `min-width: fit-content`

### DIFF
--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -182,10 +182,7 @@
                 }
               ],
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "5.0"
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Samsung Internet for the `fit-content` member of the `min-width` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/min-width/fit-content
