### PR TITLE
WebView Android also supports unprefixed text-align CSS property values

### DIFF
--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -96,10 +96,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": "37"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -236,10 +233,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": "37"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -338,10 +332,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": "37"
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `text-align` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-align
