### PR TITLE
WebView iOS also supports `-webkit-inner-spin-button` CSS selector

### DIFF
--- a/css/selectors/-webkit-inner-spin-button.json
+++ b/css/selectors/-webkit-inner-spin-button.json
@@ -27,9 +27,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": {
-              "version_added": false
-            }
+            "webview_ios": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView iOS/iPadOS for the `-webkit-inner-spin-button` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/-webkit-inner-spin-button
