### PR TITLE
WebView iOS also supports HTML ul compact attribute

### DIFF
--- a/html/elements/ul.json
+++ b/html/elements/ul.json
@@ -66,7 +66,8 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView iOS/iPadOS for the `compact` member of the `ul` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/ul/compact
