### PR TITLE
Safari iOS 17 supports MouseEvent.movement{X,Y}

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -255,7 +255,9 @@
             "safari": {
               "version_added": "1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
@@ -726,16 +728,9 @@
                 "version_removed": "8"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "8"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "8"
-              }
-            ],
+            "safari_ios": {
+              "version_added": "17"
+            },
             "samsunginternet_android": [
               {
                 "version_added": "3.0"


### PR DESCRIPTION
Before, these properties were not exposed.


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari iOS only exposed `MouseEvent.movement{X,Y}` from version 17.

#### Test results and supporting details

See:
- https://bugs.webkit.org/show_bug.cgi?id=255207
- https://github.com/mdn/browser-compat-data/issues/19339#issuecomment-1772432594

The v17 change log mentions:

> Fixed missing movementX and movementY in pointermove events. (108112600)

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/19339.