### PR TITLE
Safari iOS lacks support for beforeunload event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -374,7 +374,8 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/219102"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
@@ -457,7 +458,9 @@
               "safari": {
                 "version_added": "9.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"


### PR DESCRIPTION
#### Summary

Safari iOS doesn't support the `beforeunload` event.

#### Test results and supporting details

Evidence is in https://github.com/mdn/browser-compat-data/issues/24394.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24394.
