### PR TITLE
Safari doesn't reflect the font-weight of the Canvas context font

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1240,7 +1240,9 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "The `font-weight` can be set, but is not reflected back (see [bug 288486](https://webkit.org/b/288486))."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1239,11 +1239,17 @@
             "opera_android": {
               "version_added": "≤12.1"
             },
-            "safari": {
-              "version_added": "4",
-              "partial_implementation": true,
-              "notes": "The `font-weight` can be set, but is not reflected back (see [bug 288486](https://webkit.org/b/288486))."
-            },
+            "safari": [
+              {
+                "version_added": "18.4"
+              },
+              {
+                "version_added": "4",
+                "version_removed": "18.4",
+                "partial_implementation": true,
+                "notes": "The `font-weight` can be set, but is not reflected back (see [bug 288486](https://webkit.org/b/288486))."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1247,7 +1247,7 @@
                 "version_added": "4",
                 "version_removed": "18.4",
                 "partial_implementation": true,
-                "notes": "The `font-weight` can be set, but is not reflected back (see [bug 288486](https://webkit.org/b/288486))."
+                "notes": "The `font-weight` can be set, but is not reflected back (see [bug 284115](https://webkit.org/b/284115))."
               }
             ],
             "safari_ios": "mirror",

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -897,11 +897,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "16.4",
-              "partial_implementation": true,
-              "notes": "The `font-weight` can be set, but is not reflected back (see [bug 288486](https://webkit.org/b/288486))."
-            },
+            "safari": [
+              {
+                "version_added": "18.4"
+              },
+              {
+                "version_added": "16.4",
+                "version_removed": "18.4",
+                "partial_implementation": true,
+                "notes": "The `font-weight` can be set, but is not reflected back (see [bug 288486](https://webkit.org/b/288486))."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -898,7 +898,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "The `font-weight` can be set, but is not reflected back (see [bug 288486](https://webkit.org/b/288486))."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -905,7 +905,7 @@
                 "version_added": "16.4",
                 "version_removed": "18.4",
                 "partial_implementation": true,
-                "notes": "The `font-weight` can be set, but is not reflected back (see [bug 288486](https://webkit.org/b/288486))."
+                "notes": "The `font-weight` can be set, but is not reflected back (see [bug 284115](https://webkit.org/b/284115))."
               }
             ],
             "safari_ios": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The font-weight can be set on the `font` property, but it doesn't reflect back.

#### Test results and supporting details

- WebKit bug: https://github.com/mdn/browser-compat-data/issues/19348
- BCD issue: https://bugs.webkit.org/show_bug.cgi?id=288486

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/19348.
