### PR TITLE
Safari 17 fixed a bug with pseudo elements in the 3D rendering context

### DIFF
--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -50,7 +50,8 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "9"
+                "version_added": "9",
+                "notes": "Before Safari 17, `::before` and `::after` pseudo elements were not included in the 3D rendering context (see [bug 256430](https://webkit.org/b/256430))."
               },
               {
                 "prefix": "-webkit-",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari 17 fixed a bug with pseudo elements in the 3D rendering context

#### Test results and supporting details

- BCD issue: https://github.com/mdn/browser-compat-data/issues/19472
- WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=256430

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/19472.