### PR TITLE
Add load_event on HTMLElement

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2012,6 +2012,7 @@
       "load_event": {
         "__compat": {
           "description": "`load` event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/load_event",
           "spec_url": "https://w3c.github.io/uievents/#event-type-load",
           "tags": [
             "web-features:dom"
@@ -2032,11 +2033,11 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "4"
+              "version_added": "5.5"
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "4"
+              "version_added": "8"
             },
             "opera_android": {
               "version_added": "10.1"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2009,6 +2009,53 @@
           }
         }
       },
+      "load_event": {
+        "__compat": {
+          "description": "`load` event",
+          "spec_url": "https://w3c.github.io/uievents/#event-type-load",
+          "tags": [
+            "web-features:dom"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "4"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "4"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "1.3"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "nonce": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/nonce",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -716,6 +716,7 @@
         "__compat": {
           "description": "`command` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/command_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-command",
           "tags": [
             "web-features:invoker-commands"
           ],
@@ -1453,7 +1454,10 @@
         "__compat": {
           "description": "`error` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/error_event",
-          "spec_url": "https://w3c.github.io/uievents/#event-type-error",
+          "spec_url": [
+            "https://w3c.github.io/uievents/#event-type-error",
+            "https://html.spec.whatwg.org/multipage/indices.html#event-error"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2013,7 +2017,11 @@
         "__compat": {
           "description": "`load` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/load_event",
-          "spec_url": "https://w3c.github.io/uievents/#event-type-load",
+          "spec_url": [
+            "https://w3c.github.io/uievents/#event-type-load",
+            "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onload",
+            "https://html.spec.whatwg.org/multipage/indices.html#event-load"
+          ],
           "tags": [
             "web-features:dom"
           ],


### PR DESCRIPTION
#### Summary

Adds `api.HTMLElement.load_event`.

#### Test results and supporting details

Copied from `api.Window.load_event`.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/19595.
