### PR TITLE
Mark `font-stretch` as deprecated

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -613,7 +613,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -38,7 +38,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "percentage": {
@@ -76,7 +76,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -84,9 +84,9 @@
             }
           }
         },
-        "font_stretch_support": {
+        "font-width_keyword_values": {
           "__compat": {
-            "description": "Support for `font-stretch` values in shorthand",
+            "description": "`font-width` keyword values in shorthand",
             "tags": [
               "web-features:font-stretch"
             ],

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -1434,7 +1434,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The spec calls this a "legacy" alias, so I took this to mean it's now deprecated.

#### Test results and supporting details

https://drafts.csswg.org/css-fonts-4/#font-stretch-prop

It feels a little weird to mark this up, given the strong support for the old name. But given our guidelines, that's how this ought to be.

I didn't make the change for the SVG attribute or `css.properties.font.font_stretch_support`, since I was less clear on how to handle those based on the spec. Guidance or suggestions welcome.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

See the corresponding change in web-features: https://github.com/web-platform-dx/web-features/pull/2707.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
