### PR TITLE
Firefox 136 & Chrome/Safari Preview support gradients with single color stop and 0-1 positions

### DIFF
--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -237,6 +237,43 @@
                 "deprecated": false
               }
             }
+          },
+          "singleposition": {
+            "__compat": {
+              "description": "Single color stop and 0-1 positions",
+              "tags": [
+                "web-features:conic-gradients"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "preview"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "136"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": false,
+                "opera": false,
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "preview"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": false,
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "linear-gradient": {
@@ -523,6 +560,43 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "singleposition": {
+            "__compat": {
+              "description": "Single color stop and 0-1 positions",
+              "tags": [
+                "web-features:gradients"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "preview"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "136"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": false,
+                "opera": false,
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "preview"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": false,
                 "webview_android": "mirror",
                 "webview_ios": "mirror"
               },
@@ -940,6 +1014,43 @@
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "singleposition": {
+            "__compat": {
+              "description": "Single color stop and 0-1 positions",
+              "tags": [
+                "web-features:gradients"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "preview"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "136"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": false,
+                "opera": false,
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "preview"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": false,
                 "webview_android": "mirror",
                 "webview_ios": "mirror"
               },

--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -573,9 +573,10 @@
               }
             }
           },
-          "singleposition": {
+          "single_color_stop": {
             "__compat": {
               "description": "Single color stop and 0-1 positions",
+              "spec_url": "https://drafts.csswg.org/css-images-4/#color-stop-syntax",
               "tags": [
                 "web-features:gradients"
               ],
@@ -1029,9 +1030,10 @@
               }
             }
           },
-          "singleposition": {
+          "single_color_stop": {
             "__compat": {
               "description": "Single color stop and 0-1 positions",
+              "spec_url": "https://drafts.csswg.org/css-images-4/#color-stop-syntax",
               "tags": [
                 "web-features:gradients"
               ],

--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -241,6 +241,7 @@
           "single_color_stop": {
             "__compat": {
               "description": "Single color stop and 0-1 positions",
+              "spec_url": "https://drafts.csswg.org/css-images-4/#color-stop-syntax",
               "tags": [
                 "web-features:conic-gradients"
               ],

--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -238,7 +238,7 @@
               }
             }
           },
-          "singleposition": {
+          "single_color_stop": {
             "__compat": {
               "description": "Single color stop and 0-1 positions",
               "tags": [

--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -257,14 +257,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "oculus": false,
-                "opera": false,
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": false
+                },
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "preview"
                 },
                 "safari_ios": "mirror",
-                "samsunginternet_android": false,
+                "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
                 "webview_ios": "mirror"
               },
@@ -589,14 +591,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "oculus": false,
-                "opera": false,
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": false
+                },
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "preview"
                 },
                 "safari_ios": "mirror",
-                "samsunginternet_android": false,
+                "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
                 "webview_ios": "mirror"
               },
@@ -1043,14 +1047,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "oculus": false,
-                "opera": false,
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": false
+                },
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "preview"
                 },
                 "safari_ios": "mirror",
-                "samsunginternet_android": false,
+                "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
                 "webview_ios": "mirror"
               },


### PR DESCRIPTION
#### Summary

- Added BCD for single color stop with 0-1 positions for:
  - `linear-gradient()`
  - `conic-gradient()`
  - `radial-gradient()`

#### Test results and supporting details

- used https://codepen.io/CodeRedDigital/pen/qEBaeav to test, tested in:
  - Firefox Beta - passed
  - Chrome:
    - Beta - failed
    - Dev - failed
    - Canary - passed
  - Edge:
    - Beta - failed
    - Dev - failed
    - Canary - passed
  - Safari - failed
  - Safari TP - passed
  - Samsung internet - failed

#### Related issues

- [Allow gradients with a single color stop and 0-1 positions](https://github.com/mdn/content/issues/37937)
- [Content PR](https://github.com/mdn/content/pull/38343)
- [Firefox Release PR](https://github.com/mdn/content/pull/38342)
