### PR TITLE
Add Firefox/Safari impl_urls for `overflow-clip-margin`

### DIFF
--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -55,7 +55,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1661582"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -92,7 +93,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1661582"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -129,7 +131,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1661582"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -29,7 +29,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/236153"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -66,7 +67,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/236153"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -104,7 +106,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/236153"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -142,7 +145,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/236153"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

- Add Firefox impl_url for `overflow-clip-margin: <visual-box>`.
- Add Safari impl_url for `overflow-clip-margin`.

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/issues/19333#issuecomment-2685650735

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/19333.