### PR TITLE
Fix typo in Firefox notes about `StorageArea.getBytesInUse()`

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -154,7 +154,7 @@
                   "version_added": "78",
                   "notes": [
                     "Supported by the `sync` and, from Firefox 131, `session` storage areas.",
-                    "Not implemented in `local`, see [bug 138583](https://bugzil.la/138583)"
+                    "Not implemented in `local`, see [bug 1385832](https://bugzil.la/1385832)"
                   ]
                 },
                 "firefox_android": {
@@ -441,7 +441,7 @@
                 },
                 "firefox": {
                   "version_added": false,
-                  "impl_url": "https://bugzil.la/1385832"
+                  "impl_url": "https://bugzil.la/13858322"
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Corrects a Firefox bug number in the notes about `StorageArea.getBytesInUse()` support.

#### Test results and supporting details

:x: Wrong bug: 138583

> Profile cannot be found if Drive was mounted after starting Mozilla

✅ Correct bug: 1385832

> getBytesInUse() is not supported in `local` and `managed` storage areas

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26010.