### PR TITLE
FF137 SVG <discard> element

### DIFF
--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -31,7 +31,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": true
+          "deprecated": false
         }
       }
     }

--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "137"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -29,7 +29,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "136"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -32,7 +32,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "137"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
SVG `<discard>` element is present in FF136, but behind a nightly-enabled pref `svg.discard.enabled` - see https://bugzilla.mozilla.org/show_bug.cgi?id=1069931. Ditto corresponding API `SVGDiscardElement`

This modifies the feature to preview.

Related docs work can be tracked in https://github.com/mdn/content/issues/37939