### PR TITLE
Add missing api.Window.postMessage.options_delegate_parameter feature

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4321,6 +4321,40 @@
             "deprecated": false
           }
         },
+        "options_delegate_parameter": {
+          "__compat": {
+            "description": "`options.delegate` parameter",
+            "support": {
+              "chrome": {
+                "version_added": "100"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "options_includeUserActivation_parameter": {
           "__compat": {
             "description": "`options.includeUserActivation` parameter",


### PR DESCRIPTION
This PR adds the missing `postMessage.options_delegate_parameter` member of the `Window` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/postMessage/options_delegate_parameter
