### PR TITLE
WebView iOS also supports css.types.color.color-mix

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -204,9 +204,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": {
-                "version_added": false
-              }
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView iOS/iPadOS for the `color-mix` member of the `color` CSS value type. This fixes #25451, which contains the supporting evidence for this change.

Additional Notes: The collector has a typo which is causing the test to not pass.  This will be fixed.
