### PR TITLE
Deno 2.1 supports javascript.builtins.Intl.Locale.getWeekInfo

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -653,9 +653,16 @@
                   }
                 ],
                 "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.19"
-                },
+                "deno": [
+                  {
+                    "version_added": "2.1"
+                  },
+                  {
+                    "alternative_name": "weekInfo",
+                    "version_added": "1.19",
+                    "notes": "Implemented as an accessor property."
+                  }
+                ],
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `Locale.getWeekInfo` member of the `Intl` JavaScript builtin. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code:

```

const he = new Intl.Locale("he"); he.getWeekInfo();

```

Additional Notes: This fixes #24459, fixes #22134.
