### PR TITLE
Update Deno data for javascript.builtins.Intl.DurationFormat

### DIFF
--- a/javascript/builtins/Intl/DurationFormat.json
+++ b/javascript/builtins/Intl/DurationFormat.json
@@ -15,7 +15,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.46"
               },
               "edge": "mirror",
               "firefox": {
@@ -59,7 +59,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.46"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -103,7 +103,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.46"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -147,7 +147,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.46"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -191,7 +191,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.46"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -235,7 +235,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.46"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Deno for the `DurationFormat` member of the `Intl` JavaScript builtin. This fixes #24460, which contains the supporting evidence for this change.
