### PR TITLE
Add data point for GPUTexture.createView() usage option

### DIFF
--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -161,6 +161,50 @@
               "deprecated": false
             }
           }
+        },
+        "usage": {
+          "__compat": {
+            "description": "<code>usage</code> option",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputextureviewdescriptor-usage",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "132",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "132"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "depthOrArrayLayers": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 132 supports a new option, `usage`, in the descriptor of the `GPUTexture.createView()` method. This allows you to limit the view usage to a subset of the usages set on the source texture.

See https://developer.chrome.com/blog/new-in-webgpu-132#texture_view_usage and https://chromestatus.com/feature/5155252832305152 for more information.

This PR adds a data point for the new option.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
