### PR TITLE
Info for the new HTML CanvasRenderingContext2D lang attribute

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1919,7 +1919,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "135"
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1912,7 +1912,6 @@
       },
       "lang": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lang",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-lang",
           "tags": [
             "web-features:canvas-2d"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1910,6 +1910,44 @@
           }
         }
       },
+      "lang": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lang",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-lang",
+          "tags": [
+            "web-features:canvas-2d"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "135"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "letterSpacing": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/letterSpacing",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1949,7 +1949,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1923,8 +1923,8 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "Enabled"
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
                 }
               ]
             },

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1448,6 +1448,44 @@
           }
         }
       },
+      "lang": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lang",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-lang",
+          "tags": [
+            "web-features:offscreen-canvas"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "135"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "letterSpacing": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/letterSpacing",

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1450,7 +1450,6 @@
       },
       "lang": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lang",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-lang",
           "tags": [
             "web-features:offscreen-canvas"

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1457,7 +1457,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "135"
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1487,7 +1487,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1461,8 +1461,8 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "Enabled"
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
                 }
               ]
             },


### PR DESCRIPTION
#### Summary

Add BCD info for the newly added HTML CanvasRenderingContext2D lang attribute (and also OffscreenCanvasRenderingContext2D).

#### Test results and supporting details

Spec PR: https://github.com/whatwg/html/pull/10873

Chrome Intent: https://chromestatus.com/feature/5066778773028864

WPT Tests:
   * https://wpt.fyi/results/html/canvas/element/manual/text?label=master&label=experimental
     * canvas.2d.lang.dynamic.html
     * canvas.2d.lang.empty.canvas.tentative.html
     * canvas.2d.lang.inherit.canvas.tentative.html
     * canvas.2d.lang.inherit.disconnected.canvas.tentative.html
     * canvas.2d.lang.inherit.document.disconnected.canvas.tentative.html
     * canvas.2d.lang.inherit.document.tentative.html
     * canvas.2d.lang.tentative.html

   * https://wpt.fyi/results/html/canvas/offscreen/manual/text?label=master&label=experimental
     * canvas.2d.offscreen.lang.inherit.tentative.html
     * canvas.2d.offscreen.lang.tentative.html
     * canvas.2d.offscreen.transferred.lang.inherit.document.tentative.html
     * canvas.2d.offscreen.transferred.lang.inherit.tentative.html
     * canvas.2d.offscreen.transferred.lang.tentative.html
     * canvas.2d.offscreen.worker.lang.inherit.tentative.html
     * canvas.2d.offscreen.worker.lang.tentative.html
   * https://wpt.fyi/results/html/canvas/element/text?label=master&label=experimental
     * 2d.text.lang.valid.html
     * 2d.text.lang.default.html
   * https://wpt.fyi/results/html/canvas/offscreen/text?label=master&label=experimental
     * 2d.text.lang.valid.html
     * 2d.text.lang.default.html

#### Related issues
