### PR TITLE
Firefox 137 deprecates afterscriptexecute and beforescriptexecute events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -368,7 +368,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -748,7 +748,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -230,7 +230,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -3298,7 +3298,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
FF137 is adding deprecation warnings for [`Document.afterscriptexecute` event](https://developer.mozilla.org/en-US/docs/Web/API/Document/afterscriptexecute_event), [`Document.beforescriptexecute` event](https://developer.mozilla.org/en-US/docs/Web/API/Document/beforescriptexecute_event), [`Element.afterscriptexecute` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/afterscriptexecute_event), and [`Element.beforescriptexecute` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforescriptexecute_event), in https://bugzilla.mozilla.org/show_bug.cgi?id=1949373

This is part of a usage test, on the way to unimplementation in https://bugzilla.mozilla.org/show_bug.cgi?id=1584269

This PR just marks the APIs as deprecated.