### PR TITLE
fix(scripts/update-browser-releases): avoid unreleased Chrome Stable

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk-template';
 
 import stringify from '../lib/stringify-and-order-properties.js';
 
-import { newBrowserEntry, updateBrowserEntry } from './utils.js';
+import { gfmNoteblock, newBrowserEntry, updateBrowserEntry } from './utils.js';
 
 /**
  * getReleaseNotesURL - Guess the URL of the release notes
@@ -121,8 +121,10 @@ export const updateChromiumReleases = async (options) => {
       data[value].releaseDate = releaseDate; // Remove the time part;
 
       if (key === 'current' && Date.now() < Date.parse(releaseDate)) {
-        console.debug(`Ignoring unreleased Chrome ${version} stable release`);
-        return '';
+        return gfmNoteblock(
+          'NOTE',
+          `**${options.browserName}**: Ignoring current version ${version}, which is not yet released (stable date is ${releaseDate}).`,
+        );
       }
 
       // Update the JSON in memory

--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -122,7 +122,7 @@ export const updateChromiumReleases = async (options) => {
 
       if (key === 'current' && Date.now() < Date.parse(releaseDate)) {
         console.debug(`Ignoring unreleased Chrome ${version} stable release`);
-        return;
+        return '';
       }
 
       // Update the JSON in memory

--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -111,10 +111,19 @@ export const updateChromiumReleases = async (options) => {
   for (const [key, value] of channels) {
     // Extract the useful data
     const versionData = versions[value];
+
     if (versionData) {
+      const version = versionData.version.toString();
+      const releaseDate = versionData.stable_date.substring(0, 10);
+
       data[value] = {};
-      data[value].version = versionData.version.toString();
-      data[value].releaseDate = versionData.stable_date.substring(0, 10); // Remove the time part;
+      data[value].version = version;
+      data[value].releaseDate = releaseDate; // Remove the time part;
+
+      if (key === 'current' && Date.now() < Date.parse(releaseDate)) {
+        console.debug(`Ignoring unreleased Chrome ${version} stable release`);
+        return;
+      }
 
       // Update the JSON in memory
       let releaseNotesURL;

--- a/scripts/update-browser-releases/opera.ts
+++ b/scripts/update-browser-releases/opera.ts
@@ -5,6 +5,7 @@ import stringify from '../lib/stringify-and-order-properties.js';
 import {
   createOrUpdateBrowserEntry,
   getRSSItems,
+  gfmNoteblock,
   RSSItem,
   updateBrowserEntry,
 } from './utils';
@@ -58,18 +59,6 @@ const findRelease = (
     engineVersion,
   };
 };
-
-/**
- * Converts a message into a GFM noteblock.
- * @param type the type of the noteblock.
- * @param message the message of the noteblock.
- * @returns the message as a GFM noteblock.
- */
-const gfmNoteblock = (type: 'NOTE' | 'WARN', message: string) =>
-  `> [!${type}]\n${message
-    .split('\n')
-    .map((line) => `> ${line}`)
-    .join('\n')}`;
 
 /**
  * Updates the JSON files listing the Opera browser releases.

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -183,3 +183,15 @@ export const getRSSItems = async (url): Promise<RSSItem[]> => {
 
   return Array.isArray(items) ? items : [items];
 };
+
+/**
+ * Converts a message into a GFM noteblock.
+ * @param type the type of the noteblock.
+ * @param message the message of the noteblock.
+ * @returns the message as a GFM noteblock.
+ */
+export const gfmNoteblock = (type: 'NOTE' | 'WARN', message: string) =>
+  `> [!${type}]\n${message
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n')}`;


### PR DESCRIPTION
#### Summary

Prevents the `update-browser-releases` script from advancing the Chrome Stable release before it's actually released.

(A few days before the Chrome Stable release, Chrome Status already returns it as the stable release.)

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/commit/fb16a4c36926ab1ec4b6aa6e284740a53ccf3851

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
