### PR TITLE
enhance(scripts/update-browser-releases): update in parallel + separate sections

### DIFF
--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -219,62 +219,31 @@ const options = {
   },
 };
 
-let result = '';
+const results = await Promise.all([
+  ...(updateChrome && [
+    updateDesktop && updateChromiumReleases(options.chrome_desktop),
+    updateMobile && updateChromiumReleases(options.chrome_android),
+  ]),
+  updateWebview &&
+    updateMobile &&
+    updateChromiumReleases(options.webview_android),
+  updateEdge && updateDesktop && updateEdgeReleases(options.edge_desktop),
+  ...(updateFirefox && [
+    updateDesktop && updateFirefoxReleases(options.firefox_desktop),
+    updateMobile && updateFirefoxReleases(options.firefox_android),
+  ]),
+  ...(updateOpera && [
+    updateDesktop && updateOperaReleases(options.opera_desktop),
+    updateMobile && updateOperaReleases(options.opera_android),
+  ]),
+  ...(updateSafari && [
+    updateDesktop && updateSafariReleases(options.safari_desktop),
+    updateMobile && updateSafariReleases(options.safari_ios),
+    updateMobile && updateSafariReleases(options.webview_ios),
+  ]),
+]);
 
-if (updateChrome && updateDesktop) {
-  const add = await updateChromiumReleases(options.chrome_desktop);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateChrome && updateMobile) {
-  const add = await updateChromiumReleases(options.chrome_android);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateWebview && updateMobile) {
-  const add = await updateChromiumReleases(options.webview_android);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateEdge && updateDesktop) {
-  const add = await updateEdgeReleases(options.edge_desktop);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateFirefox && updateDesktop) {
-  const add = await updateFirefoxReleases(options.firefox_desktop);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateFirefox && updateMobile) {
-  const add = await updateFirefoxReleases(options.firefox_android);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateOpera && updateDesktop) {
-  const add = await updateOperaReleases(options.opera_desktop);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateOpera && updateMobile) {
-  const add = await updateOperaReleases(options.opera_android);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateSafari && updateDesktop) {
-  const add = await updateSafariReleases(options.safari_desktop);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateSafari && updateMobile) {
-  const add = await updateSafariReleases(options.safari_ios);
-  result += (result && add ? '\n' : '') + add;
-}
-
-if (updateSafari && updateMobile) {
-  const add = await updateSafariReleases(options.webview_ios);
-  result += (result && add ? '\n' : '') + add;
-}
+const result = results.filter(Boolean).join('\n');
 
 if (result) {
   console.log(result);

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -243,7 +243,7 @@ const results = await Promise.all([
   ]),
 ]);
 
-const result = results.filter(Boolean).join('\n');
+const result = results.filter(Boolean).join('\n\n');
 
 if (result) {
   console.log(result);

--- a/scripts/update-browser-releases/opera.ts
+++ b/scripts/update-browser-releases/opera.ts
@@ -65,7 +65,7 @@ const findRelease = (
  * @param message the message of the noteblock.
  * @returns the message as a GFM noteblock.
  */
-const gfmNoteblock = (type: 'INFO' | 'WARN', message: string) =>
+const gfmNoteblock = (type: 'NOTE' | 'WARN', message: string) =>
   `> [!${type}]\n${message
     .split('\n')
     .map((line) => `> ${line}`)
@@ -95,7 +95,7 @@ export const updateOperaReleases = async (options) => {
 
   if (!release) {
     return gfmNoteblock(
-      'INFO',
+      'NOTE',
       `**${options.browserName}**: No release announcement found among ${items.length} items in [this RSS feed](<${options.releaseFeedURL}>).`,
     );
   }


### PR DESCRIPTION
#### Summary

Updates all browsers in parallel (using `Promise.all()`), and separates the update outputs by two new lines, separating them in paragraphs, so that the `[!NOTE]` blocks (returned by the Opera updater) are properly displayed.

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/pull/26120.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
