### PR TITLE
Fix Safari iOS data for MouseEvent.{client,movement}X

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -255,9 +255,7 @@
             "safari": {
               "version_added": "1"
             },
-            "safari_ios": {
-              "version_added": "17"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
@@ -648,16 +646,9 @@
                 "version_removed": "8"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "8"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "8"
-              }
-            ],
+            "safari_ios": {
+              "version_added": "17"
+            },
             "samsunginternet_android": [
               {
                 "version_added": "3.0"


### PR DESCRIPTION
#### Summary

Fixes a mistake in https://github.com/mdn/browser-compat-data/pull/26053, which accidentally updated `MouseEvent.clientX` instead of `MouseEvent.movementX`.

Reverts the `clientX` changes, and applies them to `movementX` instead.

#### Test results and supporting details

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26103.
