### PR TITLE
fix(workflows/pr-reviewdog): run fix on PR head, not main

### DIFF
--- a/.github/workflows/pr-reviewdog.yml
+++ b/.github/workflows/pr-reviewdog.yml
@@ -4,17 +4,16 @@ on:
   pull_request_target:
     branches: ["main"]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   fix:
     name: Fix
     runs-on: ubuntu-latest
+    permissions: {}
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -40,6 +39,7 @@ jobs:
     needs: fix
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
 
     steps:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Run `npm run fix` on the PR head, not on main.

#### Test results and supporting details

This explains two things:

1. Since introducing reviewdog in BCD, it didn't actually comment on any PR, even when it was expected.
2. Today, it posted unrelated review comments like [this one](https://github.com/mdn/browser-compat-data/pull/26135#discussion_r1983666659), suggesting to add an `mdn_url` where the PR already included it.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
