### PR TITLE
Remove api.MLOperand.MLNumber from BCD

### DIFF
--- a/api/MLOperand.json
+++ b/api/MLOperand.json
@@ -47,55 +47,6 @@
           "standard_track": true,
           "deprecated": false
         }
-      },
-      "MLNumber": {
-        "__compat": {
-          "spec_url": "https://www.w3.org/TR/webnn/#api-mlnumber-typedef",
-          "tags": [
-            "web-features:webnn"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "132",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-machine-learning-neural-network",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the `MLNumber` member of the `MLOperand` API from BCD. This feature is a type (ex. a dictionary, enum, mixin, constant or WebIDL typedef) that we have explicitly stated not to document separately from the feature(s) that depend on it, as they are virtually invisible to the end developer.
