### PR TITLE
Update metadata for SpeechGrammar API

### DIFF
--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -3,7 +3,6 @@
     "SpeechGrammar": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammar",
-        "spec_url": "https://webaudio.github.io/web-speech-api/#speechreco-speechgrammar",
         "tags": [
           "web-features:speech-recognition"
         ],
@@ -43,9 +42,9 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "SpeechGrammar": {
@@ -88,16 +87,15 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
       "src": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammar/src",
-          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechgrammar-src",
           "tags": [
             "web-features:speech-recognition"
           ],
@@ -136,16 +134,15 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
       "weight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammar/weight",
-          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechgrammar-weight",
           "tags": [
             "web-features:speech-recognition"
           ],
@@ -184,9 +181,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
This PR updates and corrects the metadata (spec URLs, descriptions, statuses, etc.) for the `SpeechGrammar` API.

Additional Notes: Removed from spec in https://github.com/WebAudio/web-speech-api/pull/117.
