### PR TITLE
Mark dialog.requestClose() as supported in Safari 18.4

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -249,7 +249,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -257,7 +257,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mark dialog.requestClose() as supported in Safari 18.4

Unmark as experimental now it has 2 implementations.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#:~:text=for%20dialog.-,requestClose,-().%20(143388390)

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
