### PR TITLE
Chrome Android doesn't support PWA `protocol_handlers`

### DIFF
--- a/html/manifest/protocol_handlers.json
+++ b/html/manifest/protocol_handlers.json
@@ -62,9 +62,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "83"
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false
@@ -103,9 +101,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "83"
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/html/manifest/protocol_handlers.json
+++ b/html/manifest/protocol_handlers.json
@@ -12,7 +12,9 @@
             "chrome": {
               "version_added": "96"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -29,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -50,7 +50,9 @@
               "chrome": {
                 "version_added": "96"
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -63,17 +65,13 @@
               "opera": {
                 "version_added": "83"
               },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {
@@ -93,7 +91,9 @@
               "chrome": {
                 "version_added": "96"
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -106,17 +106,13 @@
               "opera": {
                 "version_added": "83"
               },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Updates `protocol_handlers` compat data to reflect reality. It's only supported on Chrome desktop, Edge desktop and desktop derivatives (Opera untested).

I think it's a mistake to mark this API as "mirrored" on `webview_android`, but the pre-commit scripts and `npm test` say it's an error not to do so. It doesn't make sense for this API to ever be supported on Android webview as it relates to installing progressive web apps, which requires a standalone browser. I hope your tooling and `not-webview-exposed.txt` will properly mark this API as not available if it ever does get added to Chrome Android.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I tested the API on the following platforms:
- Chrome desktop – works
- Edge desktop – works
- Firefox desktop – doesn't work
- Chrome Android – doesn't work
- Samsung Internet Android – doesn't work

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Supporting information:

- https://chromestatus.com/feature/5151703944921088

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

- Fixes #26107

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
