### PR TITLE
Clarify auto-generation of background service worker

### DIFF
--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -109,7 +109,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "Does not auto-generate a background service worker when combined with `scripts`."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -132,7 +133,10 @@
               },
               "firefox": {
                 "version_added": "48",
-                "notes": "Before Firefox 50, when the debugger is open, scripts are not always loaded in the order given in the array."
+                "notes": [
+                  "Before Firefox 50, when the debugger is open, scripts are not always loaded in the order given in the array.",
+                  "Does not auto-generate a background service worker when combined with `preferred_environment`."
+                ]
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

This PR addresses the following feedback raised in another PR.

> @rebloor can we add a note stating Firefox does not support generating a `service_worker` based in the `scripts` key? This is something currently only supported by Apple.

_Originally posted by @carlosjeurissen in https://github.com/mdn/browser-compat-data/issues/25808#issuecomment-2627793381_
            

#### Test results and supporting details

N/A

#### Related issues

- #25808
- [Bugzilla 1930334: Implement background.preferred_environment](https://bugzilla.mozilla.org/show_bug.cgi?id=1930334)
