### PR TITLE
Chrome 134 supports customizable `<select>` element

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -113,6 +113,44 @@
             }
           }
         },
+        "base": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-base",
+            "tags": [
+              "web-features:appearance"
+            ],
+            "support": {
+              "chrome": {
+                "alternative_name": "base-select",
+                "version_added": "134"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "button": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-button",

--- a/css/selectors/checkmark.json
+++ b/css/selectors/checkmark.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "selectors": {
+      "checkmark": {
+        "__compat": {
+          "description": "`::checkmark`",
+          "spec_url": "https://drafts.csswg.org/css-forms-1/#styling-checkmarks-the-checkmark-pseudo-element",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/picker-icon.json
+++ b/css/selectors/picker-icon.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "selectors": {
+      "picker-icon": {
+        "__compat": {
+          "description": "`::picker-icon`",
+          "spec_url": "https://drafts.csswg.org/css-forms-1/#picker-opener-icon-the-picker-icon-pseudo-element",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/picker.json
+++ b/css/selectors/picker.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "selectors": {
+      "picker": {
+        "__compat": {
+          "description": "`::picker()`",
+          "spec_url": "https://drafts.csswg.org/css-forms-1/#the-picker-pseudo-element",
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/selectedcontent.json
+++ b/html/elements/selectedcontent.json
@@ -1,0 +1,39 @@
+{
+  "html": {
+    "elements": {
+      "selectedcontent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

## Summary

Chrome 134 supports customizable `<select>` elements (see https://chromestatus.com/feature/5737365999976448).

This includes a multitude of sub-features; this PR adds data for the new ones we haven't already got data for, which are as follows:

- The `<selectedcontent>` element
- The `::picker()` pseudo-element
- The `::picker-icon` pseudo-element
- The `::checkmark` pseudo-element
- The `appearance` property `base-select` value (which is currently specified as `base`, but I think this might change soon).

<s>I'm setting this as a draft for now because BCD doesn't recognize the [CSS Form Control Styling Level 1](https://drafts.csswg.org/css-forms-1/) as a valid spec. I've filed an issue to ask if I can get it added to `browser-specs`: see https://github.com/w3c/browser-specs/issues/1723</s> - UPDATE, this issue got fixed.

<!-- ✍️ In a sentence or two, describe your changes. -->

## Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

## Related issues

MDN content: https://github.com/mdn/content/pull/38470

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
