### PR TITLE
feat(schemas)!: improve TypeScript definitions for array values

### DIFF
--- a/lint/fixer/flags.ts
+++ b/lint/fixer/flags.ts
@@ -50,7 +50,11 @@ export const removeIrrelevantFlags = (
   if (result.length == 1) {
     return result[0];
   }
-  return result;
+  return result as [
+    SimpleSupportStatement,
+    SimpleSupportStatement,
+    ...SimpleSupportStatement[],
+  ];
 };
 
 /**

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -60,7 +60,7 @@
           "items": {
             "$ref": "#/definitions/flag_statement"
           },
-          "tsType": "FlagStatement[]"
+          "tsType": "[FlagStatement, ...FlagStatement[]]"
         },
         "impl_url": {
           "anyOf": [
@@ -76,7 +76,7 @@
             }
           ],
           "description": "An optional changeset/commit URL for the revision which implemented the feature in the source code, or the URL to the bug tracking the implementation, for the associated browser.",
-          "tsType": "string | string[]",
+          "tsType": "string | [string, string, ...string[]]",
           "errorMessage": {
             "pattern": "impl_url must be a link to a browser commit or bug URL. URLs must be in shortened form (ex. bugs.chromium.org -> crbug.com). Note: `npm run fix` may resolve these issues."
           }
@@ -99,7 +99,7 @@
               }
             }
           ],
-          "tsType": "string | string[]"
+          "tsType": "string | [string, string, ...string[]]"
         }
       },
       "required": ["version_added"],
@@ -147,7 +147,7 @@
         },
         { "const": "mirror" }
       ],
-      "tsType": "SimpleSupportStatement | SimpleSupportStatement[]"
+      "tsType": "SimpleSupportStatement | [SimpleSupportStatement, SimpleSupportStatement, ...SimpleSupportStatement[]]"
     },
 
     "status_block": {
@@ -237,13 +237,13 @@
             }
           ],
           "description": "An optional URL or array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must contain a fragment identifier.",
-          "tsType": "string | string[]"
+          "tsType": "string | [string, string, ...string[]]"
         },
         "tags": {
           "description": "An optional array of strings allowing to assign tags to the feature.",
           "type": "array",
           "minItems": 1,
-          "tsType": "string[]"
+          "tsType": "[string, ...string[]]"
         },
         "source_file": {
           "type": "string",

--- a/scripts/build/mirror.ts
+++ b/scripts/build/mirror.ts
@@ -13,7 +13,7 @@ import { InternalSupportBlock } from '../../types/index.js';
 
 const { browsers } = bcd;
 
-type Notes = string | string[] | null;
+type Notes = string | [string, string, ...string[]] | null;
 
 /**
  */
@@ -204,7 +204,11 @@ export const bumpSupport = (
         return newData[0];
 
       default:
-        return newData;
+        return newData as [
+          SimpleSupportStatement,
+          SimpleSupportStatement,
+          ...SimpleSupportStatement[],
+        ];
     }
   }
 

--- a/scripts/migrations/002-remove-webview-flags.ts
+++ b/scripts/migrations/002-remove-webview-flags.ts
@@ -39,7 +39,11 @@ export const removeWebViewFlags = (
         } else if (result.length == 1) {
           value.support.webview_android = result[0];
         } else {
-          value.support.webview_android = result;
+          value.support.webview_android = result as [
+            SimpleSupportStatement,
+            SimpleSupportStatement,
+            ...SimpleSupportStatement[],
+          ];
         }
       } else if (value.support.webview_android.flags !== undefined) {
         value.support.webview_android = { version_added: false };

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -5,7 +5,11 @@ import esMain from 'es-main';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-import { BrowserName, Identifier } from '../types/types.js';
+import {
+  BrowserName,
+  Identifier,
+  SimpleSupportStatement,
+} from '../types/types.js';
 import { InternalSupportStatement } from '../types/index.js';
 import dataFolders from '../scripts/lib/data-folders.js';
 import bcd from '../index.js';
@@ -68,7 +72,10 @@ export function* iterateFeatures(
               continue;
             }
             for (const browser of browsers) {
-              let browserData = comp[browser];
+              let browserData:
+                | SimpleSupportStatement
+                | SimpleSupportStatement[]
+                | undefined = comp[browser];
 
               if (!browserData) {
                 if (values.length == 0 || values.includes('null')) {


### PR DESCRIPTION
#### Summary

Refines our TypeScript array types to account for `minItems`.

E.g. `string | [string, string, ...string[]]` guarantees that if the value is an array, then the first two values are `string`, rather than `string | undefined`.

> [!IMPORTANT]
> This is a **breaking change**. 

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
