### PR TITLE
Chrome 132 support for WebGPU float32-blendable feature

### DIFF
--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -333,14 +333,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-unsafe-webgpu",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "132"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 132 supports the `float32-blendable` WebGPU feature — see https://chromestatus.com/feature/5173655901044736, and see https://developer.chrome.com/blog/new-in-webgpu-132#32-bit_float_textures_blending for more details.

This PR updates the data point for that feature.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
