### PR TITLE
Firefox 136 already supports ARIA Attribute Reflection

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -905,7 +905,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1322,7 +1322,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1397,7 +1397,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1472,7 +1472,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1547,7 +1547,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1622,7 +1622,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1848,7 +1848,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2113,7 +2113,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -466,7 +466,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -541,7 +541,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -616,7 +616,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -691,7 +691,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -766,7 +766,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -992,7 +992,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1257,7 +1257,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1919102#c9 and other posts the aria reflected elements that appeared in the 137 release note were either added or pushed back into 136. This changes the items that were updated in #26118:

api.Element.ariaActiveDescendantElement
api.Element.ariaControlsElements
api.Element.ariaDescribedByElements
api.Element.ariaDetailsElements
api.Element.ariaErrorMessageElements
api.Element.ariaFlowToElements
api.Element.ariaLabelledByElements
api.Element.ariaOwnsElements
api.ElementInternals.ariaActiveDescendantElement
api.ElementInternals.ariaControlsElements
api.ElementInternals.ariaDescribedByElements
api.ElementInternals.ariaDetailsElements
api.ElementInternals.ariaErrorMessageElements
api.ElementInternals.ariaFlowToElements
api.ElementInternals.ariaLabelledByElements
api.ElementInternals.ariaOwnsElements

Can you confirm ?

Related docs work to be tracked in https://github.com/mdn/content/issues/38402