### PR TITLE
Chrome 125 + Safari 18.2 support startViewTransition() with object

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8310,7 +8310,10 @@
       "startViewTransition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/startViewTransition",
-          "spec_url": "https://drafts.csswg.org/css-view-transitions/#dom-document-startviewtransition",
+          "spec_url": [
+            "https://drafts.csswg.org/css-view-transitions-1/#dom-document-startviewtransition",
+            "https://drafts.csswg.org/css-view-transitions-2/#dom-document-startviewtransition"
+          ],
           "tags": [
             "web-features:view-transitions"
           ],
@@ -8343,6 +8346,45 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "accepts_options": {
+          "__compat": {
+            "description": "Accepts options object",
+            "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#dictdef-startviewtransitionoptions",
+            "tags": [
+              "web-features:view-transitions"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1860854"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
#### Summary

Adds `startViewTransition()` subfeature for accepting an options object.

#### Test results and supporting details

Chromium impl: https://chromestatus.com/feature/5089552511533056
WebKit impl: https://github.com/WebKit/WebKit/commit/c6cadba6b01325cd2e8a3b35d8f0ef440ea97429 (in [620.1.2](https://github.com/WebKit/WebKit/blob/c6cadba6b01325cd2e8a3b35d8f0ef440ea97429/Configurations/Version.xcconfig#L24-L26) before Safari 18.2)

#### Related issues

See:

- https://github.com/mdn/mdn/issues/643
