### PR TITLE
Firefox 122 supports webauthn value in HTML form autocomplete attr

### DIFF
--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -241,7 +241,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "122"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -259,7 +259,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION

#### Summary

Firefox 122 supports `webauthn` token in `autocomplete` attr in forms, e.g.,

```html
<input type="text" name="username" autocomplete="username webauthn" ...>
```

#### Test results and supporting details

- https://bugzilla.mozilla.org/show_bug.cgi?id=1824215
- https://wpt.fyi/results/html/semantics/forms/the-form-element/form-autocomplete.html?label=master&label=stable&product=chrome&product=firefox&product=safari&aligned
- https://wpt.live/html/semantics/forms/the-form-element/form-autocomplete.html

#### Related issues

Fixes #26176
