### PR TITLE
Remove color-interpolation partial implementation flag

### DIFF
--- a/css/properties/color-interpolation.json
+++ b/css/properties/color-interpolation.json
@@ -11,8 +11,6 @@
           "support": {
             "chrome": {
               "version_added": "≤80",
-              "partial_implementation": true,
-              "notes": "Only the default value of `sRGB` is implemented"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -28,8 +26,6 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "≤13.1",
-              "partial_implementation": true,
-              "notes": "Only the default value of `sRGB` is implemented"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/color-interpolation.json
+++ b/css/properties/color-interpolation.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80",
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1",
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR removes the partial implementation flags for the color-interpolation CSS property, for both Chrome and Safari. 

The reason for this is:

1. The property _is_ supported on those browsers.
2. Not all values are supported though, but the supported/unsupported values are already tracked in the same BCD file as sub-features. So there's no need to show the parent feature as partially supported when that information is already tracked elsewhere.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #26198.
