### PR TITLE
Firefox Nightly now supports Temporal by default

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -3052,14 +3052,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -3052,7 +3052,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -3052,7 +3052,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -27,7 +27,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "impl_url": "https://bugzil.la/1946823"
+              "impl_url": "https://bugzil.la/1912511"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -27,14 +27,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "javascript.options.experimental.temporal",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1912511"
+              "impl_url": "https://bugzil.la/1912757"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -27,7 +27,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "impl_url": "https://bugzil.la/1912757"
+              "impl_url": "https://bugzil.la/1946823"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1088,7 +1088,7 @@
                 "firefox": {
                   "version_added": "preview",
                   "impl_url": [
-                    "https://bugzil.la/1912757",
+                    "https://bugzil.la/1946823",
                     "https://bugzil.la/1942850"
                   ],
                   "notes": "Currently toLocaleString() returns a string representing this duration in the ISO 8601 format and does not respect `locales` and `options`"
@@ -1144,7 +1144,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1197,7 +1197,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1250,7 +1250,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1303,7 +1303,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1356,7 +1356,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1409,7 +1409,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1088,7 +1088,7 @@
                 "firefox": {
                   "version_added": "preview",
                   "impl_url": [
-                    "https://bugzil.la/1946823",
+                    "https://bugzil.la/1912511",
                     "https://bugzil.la/1942850"
                   ],
                   "notes": "Currently toLocaleString() returns a string representing this duration in the ISO 8601 format and does not respect `locales` and `options`"
@@ -1144,7 +1144,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1197,7 +1197,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1250,7 +1250,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1303,7 +1303,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1356,7 +1356,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1409,7 +1409,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -87,14 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,14 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -207,14 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -267,14 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -327,14 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -387,14 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -447,14 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -507,14 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -567,14 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -627,14 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -687,14 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -747,14 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -807,14 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -867,14 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,14 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -987,14 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1047,14 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1107,14 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1167,14 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1227,15 +1087,8 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
                   "impl_url": [
-                    "https://bugzil.la/1912511",
+                    "https://bugzil.la/1912757",
                     "https://bugzil.la/1942850"
                   ],
                   "notes": "Currently toLocaleString() returns a string representing this duration in the ISO 8601 format and does not respect `locales` and `options`"
@@ -1291,14 +1144,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1351,14 +1197,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1411,14 +1250,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1471,14 +1303,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1531,14 +1356,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1591,14 +1409,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -87,14 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,14 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -207,14 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -267,14 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -327,14 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -387,14 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -447,14 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -507,14 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -567,14 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -627,14 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -687,14 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -747,14 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -807,14 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -867,14 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,14 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -987,14 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1047,14 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1107,14 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -86,14 +79,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -146,14 +132,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -206,14 +185,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -266,14 +238,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -326,14 +291,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -386,14 +344,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,7 +79,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,7 +132,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,7 +185,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,7 +238,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,7 +291,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,7 +344,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,7 +79,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,7 +132,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,7 +185,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,7 +238,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,7 +291,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,7 +344,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1140,7 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1193,7 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1246,7 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1299,7 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1352,7 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1405,7 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1458,7 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1511,7 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1564,7 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1617,7 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1670,7 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1723,7 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1776,7 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1829,7 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -87,14 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,14 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -207,14 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -267,14 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -327,14 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -387,14 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -447,14 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -507,14 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -567,14 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -627,14 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -687,14 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -747,14 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -807,14 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -867,14 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,14 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -987,14 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1047,14 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1107,14 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1167,14 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1227,14 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1287,14 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1347,14 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1407,14 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1467,14 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1527,14 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1587,14 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1647,14 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1707,14 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1767,14 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1827,14 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1887,14 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1947,14 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2007,14 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2067,14 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1140,7 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1193,7 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1246,7 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1299,7 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1352,7 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1405,7 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1458,7 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1511,7 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1564,7 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1617,7 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1670,7 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1723,7 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1776,7 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1829,7 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1140,7 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1193,7 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1246,7 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1299,7 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1352,7 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1405,7 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1458,7 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1511,7 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1564,7 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1617,7 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1670,7 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1723,7 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1776,7 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1829,7 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1882,7 +1882,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1935,7 +1935,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1988,7 +1988,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2041,7 +2041,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2094,7 +2094,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2147,7 +2147,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2200,7 +2200,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1140,7 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1193,7 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1246,7 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1299,7 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1352,7 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1405,7 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1458,7 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1511,7 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1564,7 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1617,7 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1670,7 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1723,7 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1776,7 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1829,7 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1882,7 +1882,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1935,7 +1935,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1988,7 +1988,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2041,7 +2041,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2094,7 +2094,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2147,7 +2147,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2200,7 +2200,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -87,14 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,14 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -207,14 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -267,14 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -327,14 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -387,14 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -447,14 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -507,14 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -567,14 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -627,14 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -687,14 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -747,14 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -807,14 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -867,14 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,14 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -987,14 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1047,14 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1107,14 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1167,14 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1227,14 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1287,14 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1347,14 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1407,14 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1467,14 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1527,14 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1587,14 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1647,14 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1707,14 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1767,14 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1827,14 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1887,14 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1947,14 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2007,14 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2067,14 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2127,14 +1882,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2187,14 +1935,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2247,14 +1988,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2307,14 +2041,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2367,14 +2094,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2427,14 +2147,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2487,14 +2200,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -87,14 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,14 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -207,14 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -267,14 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -327,14 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -387,14 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -447,14 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -507,14 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -567,14 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -627,14 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -687,14 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -747,14 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -87,14 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,14 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -207,14 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -267,14 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -327,14 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -387,14 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -447,14 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -507,14 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -567,14 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -627,14 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -687,14 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -747,14 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -807,14 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -867,14 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,14 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -987,14 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1047,14 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1107,14 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1167,14 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1227,14 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -87,14 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,14 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -207,14 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -267,14 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -327,14 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -387,14 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -447,14 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -507,14 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -567,14 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -627,14 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -687,14 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -747,14 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -807,14 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -867,14 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,14 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -987,14 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1047,14 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1107,14 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1167,14 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1227,14 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1287,14 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1347,14 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1407,14 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1467,14 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1140,7 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1193,7 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1246,7 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1299,7 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1140,7 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1193,7 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1246,7 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1299,7 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912757"
+                "impl_url": "https://bugzil.la/1946823"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1140,7 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1193,7 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1246,7 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1299,7 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1352,7 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1405,7 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1458,7 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1511,7 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1564,7 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1617,7 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1670,7 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1723,7 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1776,7 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1829,7 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1882,7 +1882,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1935,7 +1935,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1988,7 +1988,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2041,7 +2041,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2094,7 +2094,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2147,7 +2147,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2200,7 +2200,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2253,7 +2253,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2306,7 +2306,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2359,7 +2359,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2412,7 +2412,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2465,7 +2465,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2518,7 +2518,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2571,7 +2571,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2624,7 +2624,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2677,7 +2677,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2730,7 +2730,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912757"
+                  "impl_url": "https://bugzil.la/1946823"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -27,7 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "impl_url": "https://bugzil.la/1946823"
+                "impl_url": "https://bugzil.la/1912511"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -80,7 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -133,7 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -186,7 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -292,7 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -345,7 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -398,7 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -451,7 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -504,7 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -557,7 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -610,7 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -663,7 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -716,7 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -769,7 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -822,7 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -875,7 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -928,7 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -981,7 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1034,7 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1087,7 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1140,7 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1193,7 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1246,7 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1299,7 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1352,7 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1405,7 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1458,7 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1511,7 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1564,7 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1617,7 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1670,7 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1723,7 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1776,7 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1829,7 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1882,7 +1882,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1935,7 +1935,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1988,7 +1988,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2041,7 +2041,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2094,7 +2094,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2147,7 +2147,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2200,7 +2200,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2253,7 +2253,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2306,7 +2306,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2359,7 +2359,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2412,7 +2412,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2465,7 +2465,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2518,7 +2518,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2571,7 +2571,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2624,7 +2624,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2677,7 +2677,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2730,7 +2730,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1946823"
+                  "impl_url": "https://bugzil.la/1912511"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -27,14 +27,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.temporal",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1912511"
+                "impl_url": "https://bugzil.la/1912757"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -87,14 +80,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,14 +133,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -207,14 +186,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -267,14 +239,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -327,14 +292,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -387,14 +345,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -447,14 +398,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -507,14 +451,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -567,14 +504,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -627,14 +557,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -687,14 +610,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -747,14 +663,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -807,14 +716,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -867,14 +769,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,14 +822,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -987,14 +875,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1047,14 +928,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1107,14 +981,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1167,14 +1034,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1227,14 +1087,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1287,14 +1140,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1347,14 +1193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1407,14 +1246,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1467,14 +1299,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1527,14 +1352,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1587,14 +1405,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1647,14 +1458,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1707,14 +1511,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1767,14 +1564,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1827,14 +1617,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1887,14 +1670,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1947,14 +1723,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2007,14 +1776,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2067,14 +1829,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2127,14 +1882,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2187,14 +1935,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2247,14 +1988,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2307,14 +2041,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2367,14 +2094,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2427,14 +2147,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2487,14 +2200,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2547,14 +2253,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2607,14 +2306,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2667,14 +2359,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2727,14 +2412,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2787,14 +2465,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2847,14 +2518,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2907,14 +2571,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2967,14 +2624,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -3027,14 +2677,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -3087,14 +2730,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.temporal",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1912511"
+                  "impl_url": "https://bugzil.la/1912757"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
#### Summary

- Removed Flag for Firefox Nightly and updated the `imp_url` for:
  - `Temporal` API
  - `Temporal.Duration`
  - `Temporal.Instant`
  - `Temporal.Now`
  - `Temporal.PlainDate`
  - `Temporal.PlainDateTime`
  - `Temporal.PlainMonthDay`
  - `Temporal.PlainTime`
  - `Temporal.PlainYearMonth`
  - `Temporal.ZonedDateTime`
  - `Date.toTemporalInstant`

#### Test results and supporting details

- Tested in Firefox Nightly with the flag: `javascript.options.experimental.temporal`, using the following test codepens:
  - [`Temporal.Duration`](https://codepen.io/CodeRedDigital/pen/jENvKmd)
  - [`Temporal.Instant`](https://codepen.io/CodeRedDigital/pen/qEWMKPq)
  - [`Temporal.Now`](https://codepen.io/CodeRedDigital/pen/EaYeRQK)
  - [`Temporal.PlainDate`](https://codepen.io/CodeRedDigital/pen/RNbYrEK)
  - [`Temporal.PlainDateTime`](https://codepen.io/CodeRedDigital/pen/vEBzrQd)
  - [`Temporal.PlainMonthDay`](https://codepen.io/CodeRedDigital/pen/YPKOwgp)
  - [`Temporal.PlainTime`](https://codepen.io/CodeRedDigital/pen/WbegyPB)
  - [`Temporal.PlainYearMonth`](https://codepen.io/CodeRedDigital/pen/ByBOVeM)
  - [`Temporal.ZonedDateTime`](https://codepen.io/CodeRedDigital/pen/vEBzaBr)
  - [`Date.toTemporalInstant()`](https://codepen.io/CodeRedDigital/pen/zxOeEQb?editors=0011)

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/38628)
- [Enable Temporal on Nightly #38404](https://github.com/mdn/content/issues/38404)