### PR TITLE
Firefox 137 ships Atomics.pause

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -485,8 +485,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1937805"
+                "version_added": "137"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This wasn't previously detected as shipping in the first Firefox 137 beta, we reported the issue, and now it has been fixed to ship for real: https://bugzilla.mozilla.org/show_bug.cgi?id=1937805#c8

Yay, we're doing QA for web platform features!