### PR TITLE
Chrome 134 WebGPU subgroups feature support

### DIFF
--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -537,6 +537,47 @@
           }
         }
       },
+      "feature_subgroups": {
+        "__compat": {
+          "description": "`subgroups` feature",
+          "spec_url": "https://gpuweb.github.io/gpuweb/#subgroups",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "134"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "feature_texture-compression-astc": {
         "__compat": {
           "description": "`texture-compression-astc` feature",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 134 supports the WebGPU subgroups feature — see https://developer.chrome.com/blog/new-in-webgpu-134#improve_machine-learning_workloads_with_subgroups and https://chromestatus.com/feature/5126409856221184 for full details.

This PR adds a data point for the `subgroups` feature under `GPUSupportedFeatures`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
