### PR TITLE
Update Edge data for api.Document.hasUnpartitionedCookieAccess

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5165,9 +5165,7 @@
               "version_added": "125"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `hasUnpartitionedCookieAccess` member of the `Document` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/hasUnpartitionedCookieAccess
