### PR TITLE
Update Opera data for EXT_disjoint_timer_query_webgl2 API

### DIFF
--- a/api/EXT_disjoint_timer_query_webgl2.json
+++ b/api/EXT_disjoint_timer_query_webgl2.json
@@ -26,9 +26,7 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": false
-          },
+          "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
             "version_added": false
@@ -70,9 +68,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `EXT_disjoint_timer_query_webgl2` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/EXT_disjoint_timer_query_webgl2
