### PR TITLE
Update Opera data for EXT_texture_norm16 API

### DIFF
--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -21,9 +21,7 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": false
-          },
+          "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
             "version_added": "16"


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `EXT_texture_norm16` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/EXT_texture_norm16
