### PR TITLE
Bug 1949955 userScripts API enabled on mobile

### DIFF
--- a/webextensions/api/userScripts.json
+++ b/webextensions/api/userScripts.json
@@ -18,7 +18,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "138"
             },
             "opera": "mirror",
             "safari": {
@@ -39,7 +39,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -61,7 +61,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -81,7 +81,7 @@
                   "version_added": "136"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "138"
                 },
                 "opera": "mirror",
                 "safari": {
@@ -104,7 +104,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -126,7 +126,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -148,7 +148,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -168,7 +168,7 @@
                   "version_added": "136"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "138"
                 },
                 "opera": "mirror",
                 "safari": {
@@ -191,7 +191,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -213,7 +213,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -235,7 +235,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -258,7 +258,7 @@
                 "notes": "An incompatible version of this function is available for Manifest V2. See [userScripts (Legacy)](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy/register)."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -280,7 +280,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -302,7 +302,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {
@@ -324,7 +324,7 @@
                 "version_added": "136"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "138"
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
#### Summary

Update the version added information for Firefox for Android to indicate the availability of the userScripts API in version 138 (to address the dev-doc-needed requirement of [Bug 1949955](https://bugzilla.mozilla.org/show_bug.cgi?id=1949955) Enable userScripts API by default on mobile)

#### Related issues

Corresponding release note added in https://github.com/mdn/content/pull/38672