### PR TITLE
Bug-1951166 `page_action` support in `menus` API for MV3

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -203,7 +203,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "53"
+                  "version_added": "53",
+                  "notes": "Available for use in Manifest V3 from Firefox 138."
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
#### Summary

Added a note to indicate the availability of `page_action` as a `ContextType` in the `menus` API from Firefox 138 (to address the dev-doc-needed requirement of [Bug 1951166](https://bugzilla.mozilla.org/show_bug.cgi?id=1951166) page_action missing from MV3 menus.json)

#### Related issues

Corresponding release note added in https://github.com/mdn/content/pull/38674