### PR TITLE
On Chrome Android, the `(hover: hover)` media query sometimes matches incorrectly

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -815,7 +815,8 @@
                 "notes": "Before Chrome 41, the implementation was buggy and reported `(hover: none)` on non-touch-based computers with a mouse/trackpad. See [bug 40397980](https://crbug.com/40397980)."
               },
               "chrome_android": {
-                "version_added": "50"
+                "version_added": "50",
+                "notes": "Some Android devices, such as Samsung devices, incorrectly match the `(hover: hover)` media query. See [bug 41445959](https://crbug.com/41445959)."
               },
               "edge": {
                 "version_added": "12"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -816,7 +816,7 @@
               },
               "chrome_android": {
                 "version_added": "50",
-                "notes": "Some Android devices, such as Samsung devices, incorrectly match the `(hover: hover)` media query. See [bug 41445959](https://crbug.com/41445959)."
+                "notes": "On some Android devices, such as certain Samsung models, the `(hover: hover)` media query may incorrectly match. See [bug 41445959](https://crbug.com/41445959)."
               },
               "edge": {
                 "version_added": "12"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add a note about samsung devices incorrectly matching `(hover: hover)`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

fixes #21515

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
