### PR TITLE
chore: migrate to import attributes

### DIFF
--- a/lint/linter/test-schema.ts
+++ b/lint/linter/test-schema.ts
@@ -8,8 +8,8 @@ import betterAjvErrors from 'better-ajv-errors';
 
 import { Linter, Logger, LinterData } from '../utils.js';
 
-import compatDataSchema from './../../schemas/compat-data.schema.json' assert { type: 'json' };
-import browserDataSchema from './../../schemas/browsers.schema.json' assert { type: 'json' };
+import compatDataSchema from './../../schemas/compat-data.schema.json' with { type: 'json' };
+import browserDataSchema from './../../schemas/browsers.schema.json' with { type: 'json' };
 
 const ajv = new Ajv({ allErrors: true });
 // We use 'fast' because as a side effect that makes the "uri" format more lax.

--- a/lint/linter/test-spec-urls.ts
+++ b/lint/linter/test-spec-urls.ts
@@ -2,7 +2,7 @@
  * See LICENSE file for more information. */
 
 import chalk from 'chalk-template';
-import specData from 'web-specs' assert { type: 'json' };
+import specData from 'web-specs' with { type: 'json' };
 
 import { Linter, Logger, LinterData } from '../utils.js';
 import { CompatStatement } from '../../types/types.js';


### PR DESCRIPTION
This PR switches our import assertions with import attributes.  Since we have our `.nvmrc` set to NodeJS v20 and require 20+, we are already requiring only NodeJS versions that support import attributes.
