### PR TITLE
NodeJS 23 supports javascript.builtins.Intl.DurationFormat

### DIFF
--- a/javascript/builtins/Intl/DurationFormat.json
+++ b/javascript/builtins/Intl/DurationFormat.json
@@ -26,7 +26,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "23.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -70,7 +70,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "23.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -114,7 +114,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "23.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -158,7 +158,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "23.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -202,7 +202,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "23.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -246,7 +246,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "23.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `DurationFormat` member of the `Intl` JavaScript builtin. This fixes #26249, which contains the supporting evidence for this change.
