### PR TITLE
NodeJS 22 supports javascript.builtins.Iterator.from

### DIFF
--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -423,7 +423,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "22.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `from` member of the `Iterator` JavaScript builtin. This fixes #26210, which contains the supporting evidence for this change.
