### PR TITLE
Node.js 0.10.0 already supported `Error.captureStackTrace()`

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -256,7 +256,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "16.17.0"
+                "version_added": "1.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -256,7 +256,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "1.0.0"
+                "version_added": "0.10.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Node.js support statement for Error.captureStackTrace()`.

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/issues/26271#issuecomment-2747643056 for the evidence.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26271.
