### PR TITLE
NodeJS 22 supports `Iterator()` constructor

### DIFF
--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -72,7 +72,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "22.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR updates and corrects version values for NodeJS for the `Iterator` JavaScript builtin constructor. This fixes #26210, which contains the supporting evidence for this change (but was closed accidentally when a partial fix was merged).

#### Test results and supporting details

#26210

#### Related issues

Fixes #26210

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
