### PR TITLE
Add Chrome notes about `Clear-Site-Data: cache` issues

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -88,9 +88,17 @@
               "web-features:clear-site-data"
             ],
             "support": {
-              "chrome": {
-                "version_added": "61"
-              },
+              "chrome": [
+                {
+                  "version_added": "65",
+                  "notes": "Setting this value may increase response duration (see [bug 40233601](https://crbug.com/40233601)."
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "63",
+                  "notes": "Setting this value may prevent a page from fully load (see [bug 41343050](https://crbug.com/41343050)."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"


### PR DESCRIPTION
#### Summary

Add Chrome notes about issues with `Clear-Site-Data: cache`.

Also reflects that Chrome 63 temporarily [disabled the feature](https://chromiumdash.appspot.com/commit/63d6097e91187b1f6cb171b7e44d88ab0a91124c), before [re-enabling it](https://chromiumdash.appspot.com/commit/d0976380e9c7cbf22f4689b640d1e260b10daddc) in Chrome 65.

#### Test results and supporting details

See Chrome bugs:

- [Clear-Site-Data cache deletion can be slow and break loading](https://crbug.com/41343050)
- [Clear-Site-Data cache deletion is still slow](https://crbug.com/40233601)

#### Related issues

Fixes #26268.
