### PR TITLE
NodeJS 21 supports transferable ArrayBuffer

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -235,7 +235,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "21.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -515,7 +515,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "21.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -559,7 +559,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "21.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

NodeJS 21 supports javascript.builtins.ArrayBuffer.{detached,transfer,transferToFixedLength}

This PR updates and corrects version values for NodeJS for the members `detached`, `transfer`, `transferToFixedLength` of `ArrayBuffer` JavaScript instances. This fixes #26213, which contains the supporting evidence for this change.

#### Test results and supporting details

#26213

#### Related issues

Fixes #26213