### PR TITLE
fix(scripts/release): improve major release handling

### DIFF
--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -61,7 +61,7 @@ const commitAndPR = async (
     git stash
     git switch -C ${branch} origin/main
     git stash pop
-    git add package.json package-lock.json RELEASE_NOTES.md
+    git add package.json package-lock.json RELEASE_NOTES.md release_notes/
   `);
 
   console.log(chalk`{blue Committing changes...}`);

--- a/scripts/release/notes.ts
+++ b/scripts/release/notes.ts
@@ -20,7 +20,7 @@ export const getNotes = (
   thisVersion: string,
   changes: Changes,
   stats: Stats,
-  versionBump: string,
+  versionBump: 'major' | 'minor' | 'patch',
 ): string =>
   [
     `## [${thisVersion}](https://github.com/mdn/browser-compat-data/releases/tag/${thisVersion})`,

--- a/scripts/release/notes.ts
+++ b/scripts/release/notes.ts
@@ -33,7 +33,9 @@ export const getNotes = (
     '',
     ...(versionBump !== 'patch'
       ? [
-          '### Notable changes',
+          versionBump === 'major'
+            ? '### Breaking changes'
+            : '### Notable changes',
           '',
           '<!-- TODO: Fill me out with the appropriate information about breaking changes or new backwards-compatible additions! -->',
           '',

--- a/scripts/release/notes.ts
+++ b/scripts/release/notes.ts
@@ -62,7 +62,7 @@ export const addNotes = async (
 
   // If we are doing a major version bump, move old changelog results to another file
   if (versionBump === 'major') {
-    const lastMajorVersion = lastVersion.split('.')[0];
+    const lastMajorVersion = lastVersion.split('.')[0].replace(/^v/, '');
     const olderVersionsHeader = '## Older Versions';
 
     const oldChangelog =


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes the following issues related to major releases, observed in https://github.com/mdn/browser-compat-data/commit/3d5d48bb33ff0879ca1883db4eb8392d40bf5c88:

1. The "Older releases" section referred to `vv5` instead of `v5`.
2. The previous release notes (`release_notes/v5.md`) were not included in the release commit.
3. The section was called "Notable changes" instead of "Breaking changes".

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

See:

- https://github.com/mdn/browser-compat-data/pull/26291