### PR TITLE
Bug-1771328 Persist WebExtensions menus fix note

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -519,7 +519,8 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": "Before version 128, menus didn't persist across extension restart in Manifest V3 extensions with a non-persistent background context."
                 },
                 {
                   "alternative_name": "contextMenus.create",


### PR DESCRIPTION
#### Summary

Provide a note in support of [Bug 1771328](https://bugzilla.mozilla.org/show_bug.cgi?id=1771328) Restarting manifest v3 extension removes its context menu entry

#### Related issues

Update to release notes in https://github.com/mdn/content/pull/38814
