### PR TITLE
ci(issue-regex-labeler): include title

### DIFF
--- a/.github/workflows/issue-regex-labeler.yml
+++ b/.github/workflows/issue-regex-labeler.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: github/issue-labeler@v3.4
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/issue-regex-labeler.yml
           enable-versioned-regex: 0
+          include-title: 1
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### Summary

Configures the `github/issue-labeler` action to [include the title in the regex target](https://github.com/github/issue-labeler?tab=readme-ov-file#example-including-the-issue-title-in-the-regex-target).

#### Test results and supporting details

This should help issues to get labeled correctly.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
