### PR TITLE
Bug-1869171-alarms.create now async function BCD note

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -105,10 +105,12 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "From Firefox 138, can be called asynchronously."
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "From Firefox 138, can be called asynchronously."
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
#### Summary
Addresses the dev-doc-needed requirements of [Bug 1869171](https://bugzilla.mozilla.org/show_bug.cgi?id=1869171) "`alarms.create` is not declared as an async function" by adding a note to `alarms.create`.

### Related issues and pull requests

Related to changes to MDN content in https://github.com/mdn/content/pull/38834
