### PR TITLE
Add Firefox/Safari impl_url for import attribute with `{type: 'css'}`

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1676,7 +1676,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1720570"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1689,7 +1690,8 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/227967"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Adds links to import attributes e.g. `with {type: 'css'}`

These bugs are identical to those added in #22881 when the specification was not yet settled

cc @jogibear9988 @captainbrosset