### PR TITLE
Update Edge data for HTMLCanvasElement API

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -380,7 +380,7 @@
                 },
                 "chrome_android": "mirror",
                 "edge": {
-                  "version_added": "≤79"
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "30"
@@ -852,9 +852,7 @@
                   "version_added": "32"
                 },
                 "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "≤79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "30"
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `HTMLCanvasElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLCanvasElement
