### PR TITLE
Update Edge data for api.HTMLElement.contentEditable.plaintext-only

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -822,7 +822,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "136"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -362,7 +362,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "136"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `contentEditable.plaintext-only` member of the `HTMLElement` API. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable#pasting_content_into_contenteditable
