### PR TITLE
Update Edge data for api.MediaStreamTrack.applyConstraints

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -92,7 +92,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "≤15"
               },
               "firefox": {
                 "version_added": false
@@ -134,9 +134,7 @@
                 "version_added": "67"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": [
                 {
                   "version_added": "55"
@@ -181,9 +179,7 @@
                 "version_added": "59"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -223,7 +219,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "43",
@@ -306,9 +302,7 @@
                 "version_added": "59"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "50"
               },
@@ -348,7 +342,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "50"
@@ -389,7 +383,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "50"
@@ -430,7 +424,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "70"
@@ -471,7 +465,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "50"
@@ -511,9 +505,7 @@
                 "version_added": "59"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "50"
               },
@@ -591,9 +583,7 @@
                 "version_added": "67"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": [
                 {
                   "version_added": "55"
@@ -677,7 +667,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -718,7 +708,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -794,7 +784,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -835,7 +825,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "50"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `applyConstraints` member of the `MediaStreamTrack` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaStreamTrack/applyConstraints
