### PR TITLE
Update Edge data for api.OfflineAudioContext.OfflineAudioContext.options_parameter

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -118,9 +118,7 @@
                 "version_added": "62"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "57"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `OfflineAudioContext.options_parameter` member of the `OfflineAudioContext` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/OfflineAudioContext/OfflineAudioContext/options_parameter
