### PR TITLE
Update Edge data for api.Range.collapse.toStart_parameter_optional

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -232,7 +232,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": "25"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `collapse.toStart_parameter_optional` member of the `Range` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Range/collapse/toStart_parameter_optional
