### PR TITLE
Update Edge data for api.SVGElement.focus.options_preventScroll_parameter

### DIFF
--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -367,7 +367,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": "68"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `focus.options_preventScroll_parameter` member of the `SVGElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SVGElement/focus/options_preventScroll_parameter
