### PR TITLE
Update Edge data for WebGLRenderingContext API

### DIFF
--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -1260,9 +1260,7 @@
                 "version_added": "60"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "79"
               },
@@ -6954,9 +6952,7 @@
                 "version_added": "60"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "79"
               },
@@ -7093,9 +7089,7 @@
                 "version_added": "60"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "79"
               },
@@ -7232,9 +7226,7 @@
                 "version_added": "60"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "79"
               },
@@ -7371,9 +7363,7 @@
                 "version_added": "60"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "79"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `WebGLRenderingContext` API. Since SharedArrayBuffer wasn't supported before Edge 79, so features that depend on it can't be supported.
