### PR TITLE
Update Edge data for Selection API

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -263,7 +263,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": "55"
@@ -299,7 +299,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": "55"
@@ -472,7 +472,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": "55"
@@ -715,7 +715,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": "55"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `Selection` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Selection
