### PR TITLE
Update all browsers data for SVGPathElement API

### DIFF
--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -1160,12 +1160,12 @@
           "spec_url": "https://svgwg.org/specs/paths/#__svg__SVGPathElement__getPointAtLength",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1175,7 +1175,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1194,12 +1194,12 @@
           "spec_url": "https://svgwg.org/specs/paths/#__svg__SVGPathElement__getTotalLength",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1209,7 +1209,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1228,12 +1228,12 @@
           "spec_url": "https://svgwg.org/specs/paths/#__svg__SVGPathElement__pathLength",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1243,7 +1243,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `SVGPathElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SVGPathElement
