### PR TITLE
Update Chrome/Safari data for css.properties.alignment-baseline.alphabetic

### DIFF
--- a/css/properties/alignment-baseline.json
+++ b/css/properties/alignment-baseline.json
@@ -48,7 +48,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -63,7 +63,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `alphabetic` member of the `alignment-baseline` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/alignment-baseline/alphabetic
