### PR TITLE
Update Chrome/Safari data for baseline-shift CSS property

### DIFF
--- a/css/properties/baseline-shift.json
+++ b/css/properties/baseline-shift.json
@@ -12,7 +12,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -48,7 +48,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -63,7 +63,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -85,7 +85,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -100,7 +100,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -122,7 +122,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -137,7 +137,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `baseline-shift` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/baseline-shift
