### PR TITLE
Chrome 1 / Safari 1.1 added `border-collapse` CSS property

### DIFF
--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -31,11 +31,9 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "1.1"
             },
-            "safari_ios": {
-              "version_added": "3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "2.2"
@@ -72,9 +70,7 @@
               "safari": {
                 "version_added": "1.1"
               },
-              "safari_ios": {
-                "version_added": "3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
@@ -110,9 +106,7 @@
               "safari": {
                 "version_added": "1.1"
               },
-              "safari_ios": {
-                "version_added": "3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -55,12 +55,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -70,9 +70,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "3"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
@@ -91,12 +93,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -106,9 +108,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "3"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -108,7 +108,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1.1"
               },
               "safari_ios": {
                 "version_added": "3"

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -70,7 +70,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1.1"
               },
               "safari_ios": {
                 "version_added": "3"


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `border-collapse` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/border-collapse
