### PR TITLE
Update Chrome/Firefox/Safari data for `break-after` CSS property

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -118,7 +118,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -154,7 +154,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -190,7 +190,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -226,7 +226,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -262,7 +262,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -298,7 +298,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -597,7 +597,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -854,7 +854,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -890,7 +890,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -926,7 +926,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -72,7 +72,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "65"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -103,12 +103,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "65"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -118,7 +118,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -139,12 +139,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "65"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -154,7 +154,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -175,7 +175,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -190,7 +190,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -211,7 +211,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -226,7 +226,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -247,7 +247,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -262,7 +262,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -283,12 +283,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "65"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -298,7 +298,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -582,12 +582,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "65"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -597,7 +597,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -839,7 +839,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -854,7 +854,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -875,12 +875,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "65"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -890,7 +890,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -911,7 +911,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -926,7 +926,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `break-after` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/break-after
