### PR TITLE
Update Chrome/Firefox/Safari data for `break-inside` CSS property

### DIFF
--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -67,12 +67,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "65"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -82,7 +82,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -103,12 +103,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "65"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -118,7 +118,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -139,7 +139,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -154,7 +154,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -175,7 +175,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -190,7 +190,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -118,7 +118,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -118,7 +118,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10"
+                "version_added": "3"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `break-inside` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/break-inside
