### PR TITLE
Chrome 52 supports `d` CSS property

### DIFF
--- a/css/properties/d.json
+++ b/css/properties/d.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `d` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/d
