### PR TITLE
Chrome 1 / Edge ≤15 / Safari ≤4 added `display: table-caption`

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1171,10 +1171,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1186,7 +1188,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1171,7 +1171,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -1188,7 +1188,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `table-caption` member of the `display` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/display/table-caption
