### PR TITLE
Update all browsers data for fill-opacity CSS property

### DIFF
--- a/css/properties/fill-opacity.json
+++ b/css/properties/fill-opacity.json
@@ -10,10 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `fill-opacity` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/fill-opacity
