### PR TITLE
Update Chrome/Edge data for overscroll-behavior-y CSS property

### DIFF
--- a/css/properties/overscroll-behavior-y.json
+++ b/css/properties/overscroll-behavior-y.json
@@ -51,7 +51,9 @@
                 "version_added": "63"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "18"
+              },
               "firefox": {
                 "version_added": "59"
               },
@@ -85,10 +87,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "63"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "18"
+              },
               "firefox": {
                 "version_added": "59"
               },
@@ -122,7 +126,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "63"
               },
               "chrome_android": "mirror",
               "edge": [


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `overscroll-behavior-y` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/overscroll-behavior-y
