### PR TITLE
Chrome 1 / Edge ≤15 / Firefox 1.5 / Safari 4 added stroke CSS properties

### DIFF
--- a/css/properties/stroke-color.json
+++ b/css/properties/stroke-color.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤12.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-color.json
+++ b/css/properties/stroke-color.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤12.1"
+              "version_added": "11.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-dasharray.json
+++ b/css/properties/stroke-dasharray.json
@@ -17,7 +17,7 @@
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -55,7 +55,7 @@
                 "version_added": "≤15"
               },
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/stroke-dasharray.json
+++ b/css/properties/stroke-dasharray.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -48,7 +48,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -65,7 +65,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/stroke-dasharray.json
+++ b/css/properties/stroke-dasharray.json
@@ -10,10 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,12 +48,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,7 +65,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/stroke-dashoffset.json
+++ b/css/properties/stroke-dashoffset.json
@@ -17,7 +17,7 @@
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-dashoffset.json
+++ b/css/properties/stroke-dashoffset.json
@@ -10,10 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-dashoffset.json
+++ b/css/properties/stroke-dashoffset.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-linecap.json
+++ b/css/properties/stroke-linecap.json
@@ -17,7 +17,7 @@
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -55,7 +55,7 @@
                 "version_added": "≤15"
               },
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +94,7 @@
                 "version_added": "≤15"
               },
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -133,7 +133,7 @@
                 "version_added": "≤15"
               },
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/stroke-linecap.json
+++ b/css/properties/stroke-linecap.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -48,7 +48,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -65,7 +65,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -87,7 +87,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -104,7 +104,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -126,7 +126,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -143,7 +143,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/stroke-linecap.json
+++ b/css/properties/stroke-linecap.json
@@ -10,10 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,12 +48,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,7 +65,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -83,12 +87,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -98,7 +104,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -120,12 +126,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -135,7 +143,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/stroke-linejoin.json
+++ b/css/properties/stroke-linejoin.json
@@ -17,7 +17,7 @@
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -55,7 +55,7 @@
                 "version_added": "≤15"
               },
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +94,7 @@
                 "version_added": "≤15"
               },
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -133,7 +133,7 @@
                 "version_added": "≤15"
               },
               "firefox": {
-                "version_added": "≤4"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/stroke-linejoin.json
+++ b/css/properties/stroke-linejoin.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -48,7 +48,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -65,7 +65,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -87,7 +87,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -104,7 +104,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -126,7 +126,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -143,7 +143,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤5.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/stroke-linejoin.json
+++ b/css/properties/stroke-linejoin.json
@@ -10,10 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,12 +48,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,7 +65,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -83,12 +87,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -98,7 +104,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -120,12 +126,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -135,7 +143,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "≤5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/stroke-miterlimit.json
+++ b/css/properties/stroke-miterlimit.json
@@ -17,7 +17,7 @@
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-miterlimit.json
+++ b/css/properties/stroke-miterlimit.json
@@ -10,10 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-miterlimit.json
+++ b/css/properties/stroke-miterlimit.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-opacity.json
+++ b/css/properties/stroke-opacity.json
@@ -17,7 +17,7 @@
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-opacity.json
+++ b/css/properties/stroke-opacity.json
@@ -10,10 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-opacity.json
+++ b/css/properties/stroke-opacity.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-width.json
+++ b/css/properties/stroke-width.json
@@ -17,7 +17,7 @@
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/stroke-width.json
+++ b/css/properties/stroke-width.json
@@ -10,10 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke-width.json
+++ b/css/properties/stroke-width.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke.json
+++ b/css/properties/stroke.json
@@ -10,12 +10,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "≤4"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/stroke.json
+++ b/css/properties/stroke.json
@@ -10,14 +10,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "≤4"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `stroke` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/stroke
