### PR TITLE
Chrome 1 / Edge ≤14 / Firefox 3 / Safari 4 added `text-anchor` CSS property

### DIFF
--- a/css/properties/text-anchor.json
+++ b/css/properties/text-anchor.json
@@ -10,12 +10,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "≤4"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -25,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/text-anchor.json
+++ b/css/properties/text-anchor.json
@@ -10,14 +10,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤15"
             },
             "firefox": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -27,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤5.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/text-anchor.json
+++ b/css/properties/text-anchor.json
@@ -14,7 +14,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤15"
+              "version_added": "≤14"
             },
             "firefox": {
               "version_added": "3"


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `text-anchor` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-anchor
