### PR TITLE
Update Chrome/Firefox data for `text-orientation` CSS property

### DIFF
--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -58,12 +58,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤48"
+                "version_added": "48"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "41"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -96,7 +96,7 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "48"
+                  "version_added": "12"
                 },
                 {
                   "alternative_name": "sideways-right",
@@ -144,12 +144,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤48"
+                "version_added": "12"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "41"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -15,7 +15,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "11"
+                "version_added": "12"
               }
             ],
             "chrome_android": "mirror",

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -58,12 +58,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "≤48"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤50"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -96,7 +96,7 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "25"
+                  "version_added": "48"
                 },
                 {
                   "alternative_name": "sideways-right",
@@ -144,12 +144,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "≤48"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤50"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `text-orientation` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-orientation
