### PR TITLE
Chrome 42 / Firefox 69 / Safari 9 added `y` CSS property

### DIFF
--- a/css/properties/y.json
+++ b/css/properties/y.json
@@ -10,12 +10,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "42"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "69"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "9"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `y` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/y
