### PR TITLE
Additional Chrome `browsingData.RemovalOptions` properties

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -325,6 +325,25 @@
               }
             }
           },
+          "excludeOrigin": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "74"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "hostnames": {
             "__compat": {
               "support": {
@@ -342,6 +361,25 @@
                 "firefox_android": {
                   "version_added": "85"
                 },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "origin": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "74"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
                   "version_added": false


### PR DESCRIPTION
#### Summary

Adds browser compatibility data for the `origin` and `excludeOrigin` properties of `browsingData.RemovalOptions` introduced into Chrome in release 74.

#### Related issues

Provides for the browser compatibility data requirements of https://github.com/mdn/content/issues/27629. Related documentation changes in https://github.com/mdn/content/pull/38902