### PR TITLE
Safari 18.4 supports Wake Lock API in Home Screen Web Apps

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -6110,11 +6110,16 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": {
-              "version_added": "16.4",
-              "partial_implementation": true,
-              "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
-            },
+            "safari_ios": [
+              {
+                "version_added": "18.4"
+              },
+              {
+                "version_added": "16.4",
+                "partial_implementation": true,
+                "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
+              }
+            ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -26,10 +26,16 @@
           "safari": {
             "version_added": "16.4"
           },
-          "safari_ios": {
-            "version_added": "16.4",
-            "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
-          },
+          "safari_ios": [
+            {
+              "version_added": "18.4"
+            },
+            {
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
+            }
+          ],
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
           "webview_ios": "mirror"
@@ -66,11 +72,16 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": {
-              "version_added": "16.4",
-              "partial_implementation": true,
-              "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
-            },
+            "safari_ios": [
+              {
+                "version_added": "18.4"
+              },
+              {
+                "version_added": "16.4",
+                "partial_implementation": true,
+                "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
+              }
+            ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -26,11 +26,16 @@
           "safari": {
             "version_added": "16.4"
           },
-          "safari_ios": {
-            "version_added": "16.4",
-            "partial_implementation": true,
-            "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
-          },
+          "safari_ios": [
+            {
+              "version_added": "18.4"
+            },
+            {
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
+            }
+          ],
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
           "webview_ios": "mirror"
@@ -67,11 +72,16 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": {
-              "version_added": "16.4",
-              "partial_implementation": true,
-              "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
-            },
+            "safari_ios": [
+              {
+                "version_added": "18.4"
+              },
+              {
+                "version_added": "16.4",
+                "partial_implementation": true,
+                "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
+              }
+            ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -110,11 +120,16 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": {
-              "version_added": "16.4",
-              "partial_implementation": true,
-              "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
-            },
+            "safari_ios": [
+              {
+                "version_added": "18.4"
+              },
+              {
+                "version_added": "16.4",
+                "partial_implementation": true,
+                "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
+              }
+            ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -152,11 +167,16 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": {
-              "version_added": "16.4",
-              "partial_implementation": true,
-              "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
-            },
+            "safari_ios": [
+              {
+                "version_added": "18.4"
+              },
+              {
+                "version_added": "16.4",
+                "partial_implementation": true,
+                "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
+              }
+            ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -194,11 +214,16 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": {
-              "version_added": "16.4",
-              "partial_implementation": true,
-              "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
-            },
+            "safari_ios": [
+              {
+                "version_added": "18.4"
+              },
+              {
+                "version_added": "16.4",
+                "partial_implementation": true,
+                "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
+              }
+            ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"


### PR DESCRIPTION
See https://bugs.webkit.org/show_bug.cgi?id=254545#c65