### PR TITLE
Updates for Firefox 138 beta

### DIFF
--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -36,6 +36,40 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "port": {
+        "__compat": {
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioworklet-port",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2438,7 +2438,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2461,7 +2461,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/NavigatorLogin.json
+++ b/api/NavigatorLogin.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "138"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -31,7 +31,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -47,7 +47,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -67,7 +67,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -844,7 +844,7 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -865,7 +865,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -89,7 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -253,7 +253,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "138"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -668,7 +668,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "138"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -3874,7 +3874,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3892,7 +3892,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -105,7 +105,7 @@
               },
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "138"
                 },
                 {
                   "version_added": "63",

--- a/http/headers/Origin-Agent-Cluster.json
+++ b/http/headers/Origin-Agent-Cluster.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -241,15 +241,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "136",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.error_capture_stack_trace",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1886820"
+                "version_added": "138"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -420,7 +412,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "138"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.9 found new features shipping in Firefox 138 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 13 features as shipping in Firefox 138:

- api.AudioWorklet.port
- api.Navigator.login
- api.NavigatorLogin
- api.NavigatorLogin.setStatus
- api.Notification.maxActions_static
- api.RTCCertificate.getFingerprints
- api.RTCRtpSender.getParameters.return_object_property_degradationPreference
- api.RTCRtpSender.setParameters.parameters_degradationPreference_parameter
- api.Window.originAgentCluster
- http.headers.Clear-Site-Data.cache
- http.headers.Origin-Agent-Cluster
- javascript.builtins.Error.captureStackTrace
- javascript.builtins.Error.isError

See also https://github.com/mdn/mdn/issues/661 and https://www.mozilla.org/en-US/firefox/138.0beta/releasenotes/
