### PR TITLE
Safari 16.4 supports Reporting-Endpoints header

### DIFF
--- a/http/headers/Reporting-Endpoints.json
+++ b/http/headers/Reporting-Endpoints.json
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -44,7 +44,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/26361

See https://github.com/WebKit/WebKit/pull/3613