### PR TITLE
Fix HTTP shared dictionary compression header spec URL

### DIFF
--- a/http/headers/Dictionary-ID.json
+++ b/http/headers/Dictionary-ID.json
@@ -3,8 +3,7 @@
     "headers": {
       "Dictionary-ID": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Dictionary-ID",
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-use-as-dictionary",
+          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-dictionary-id",
           "support": {
             "chrome": {
               "version_added": "130"

--- a/http/headers/Dictionary-ID.json
+++ b/http/headers/Dictionary-ID.json
@@ -3,6 +3,7 @@
     "headers": {
       "Dictionary-ID": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Dictionary-ID",
           "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-dictionary-id",
           "support": {
             "chrome": {


### PR DESCRIPTION
#### Summary

Minor PR to fix up spec URL for Dictionary-ID. Found while working on:

-[ ] https://github.com/mdn/content/pull/38948
