### PR TITLE
Mark Firefox as fully supporting `@starting-style`

### DIFF
--- a/css/at-rules/starting-style.json
+++ b/css/at-rules/starting-style.json
@@ -18,7 +18,6 @@
             "firefox": {
               "version_added": "129",
               "impl_url": "https://bugzil.la/1834877",
-              "partial_implementation": true,
               "notes": "Does not yet support animating from `display: none`"
             },
             "firefox_android": "mirror",

--- a/css/at-rules/starting-style.json
+++ b/css/at-rules/starting-style.json
@@ -16,9 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "129",
-              "impl_url": "https://bugzil.la/1834877",
-              "notes": "Does not yet support animating from `display: none`"
+              "version_added": "129"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
See https://github.com/web-platform-dx/web-features/issues/2839

This feature is supported in Firefox, and we don't believe the noted missing functionality is sufficient to make it unusable for authors. In addition the transition from `display:none` is already covered by the `is_transitionable` key: https://github.com/mdn/browser-compat-data/blob/e8988baea037d5a8be014a60d9d928cf7e899f81/css/properties/display.json#L618-L655 so we have an existing record of the gap.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
