### PR TITLE
added release note for ::details-content to experimental and 138

### DIFF
--- a/css/selectors/details-content.json
+++ b/css/selectors/details-content.json
@@ -16,7 +16,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.details-content.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1901037"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

- added release note for `::details-content` in:
  - Firefox experimental releases
  - Firefox 138 release in experimental section

#### Test results and supporting details

- Tested with the flag: `layout.css.details-content.enabled` in:
  - Nightly
  - Developer edition
  - Beta

#### Related issues

- [Content PR](https://github.com/mdn/content/pull/38953)
- [Firefox Release PR](https://github.com/mdn/content/pull/38954)
