### PR TITLE
ci(release): comment in release PR after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,19 @@ jobs:
               client_payload: {}
             })
             console.log(result);
+
+      - name: Comment in release PR
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$JOB_STATUS" = "success" ]; then
+            BODY="Release was successfully published by [this run]($RUN_URL)."
+          else
+            BODY="@mdn/bcd-releasers Failed to publish release (see [this run]($RUN_URL)."
+          fi
+
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --state merged --search "$GITHUB_SHA" --json number --jq '.[0].number')
+
+          gh pr comment --repo "$GITHUB_REPOSITORY" "$PR_NUMBER" --body "$BODY"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Comment in the release PR after release is published, pinging `@mdn/bcd-releasers` (@caugner + @Elchi3) in case of a failure.

#### Test results and supporting details

Ensures that a failed BCD release gets noticed right away.

(Tested locally [here](https://github.com/mdn/browser-compat-data/pull/26313#issuecomment-2776220172).)

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26382.
