### PR TITLE
FF137 SVG discard element disabled behind pref

### DIFF
--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -12,7 +12,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "137",
+            "version_added": "136",
             "flags": [
               {
                 "type": "preference",

--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -12,7 +12,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "137"
+            "version_added": "137",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "svg.discard.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "ie": {

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -13,7 +13,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137"
+              "version_added": "137",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "svg.discard.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "137",
+              "version_added": "136",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
FF has disabled the [`<discard>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/discard) element behind a pref in https://bugzilla.mozilla.org/show_bug.cgi?id=1954608

This was supposed to be added in 137 nightly and release in 138 but is still in discussion specification wise. 