### PR TITLE
Chrome 135 doesn't ship abs() and sign()

### DIFF
--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -11,7 +11,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "135"
+              "version_added": false,
+              "impl_url": "https://crbug.com/40253181"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -11,7 +11,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "135"
+              "version_added": false,
+              "impl_url": "https://crbug.com/40253181"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/26396

See https://issues.chromium.org/issues/40253181#comment12
"Turned out we still have some places of math mess left to fix."
