### PR TITLE
Add spec urls for moveBefore()

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5787,6 +5787,7 @@
       },
       "moveBefore": {
         "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-parentnode-movebefore",
           "tags": [
             "web-features:move-before"
           ],

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -328,6 +328,7 @@
       },
       "moveBefore": {
         "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-parentnode-movebefore",
           "tags": [
             "web-features:move-before"
           ],

--- a/api/Element.json
+++ b/api/Element.json
@@ -7353,6 +7353,7 @@
       },
       "moveBefore": {
         "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-parentnode-movebefore",
           "tags": [
             "web-features:move-before"
           ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `moveBefore()` method (available on `Document`, `DocumentFragment`, and `Element`) was already added to BCD, but the `spec_url` field was missing. This PR adds the `spec_url` in. 

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
