### PR TITLE
Updates for Chrome 136 beta

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1918,14 +1918,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "136"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/CaptureController.json
+++ b/api/CaptureController.json
@@ -80,6 +80,186 @@
           }
         }
       },
+      "decreaseZoomLevel": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-surface-control/#dom-capturecontroller-decreasezoomlevel",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "forwardWheel": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-surface-control/#dom-capturecontroller-forwardwheel",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getSupportedZoomLevels": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-surface-control/#dom-capturecontroller-getsupportedzoomlevels",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "increaseZoomLevel": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-surface-control/#dom-capturecontroller-increasezoomlevel",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resetZoomLevel": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-surface-control/#dom-capturecontroller-resetzoomlevel",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setFocusBehavior": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CaptureController/setFocusBehavior",
@@ -90,6 +270,79 @@
           "support": {
             "chrome": {
               "version_added": "109"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "zoomLevel": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-surface-control/#dom-capturecontroller-zoomlevel",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "zoomlevelchange_event": {
+        "__compat": {
+          "description": "`zoomlevelchange` event",
+          "spec_url": "https://w3c.github.io/mediacapture-surface-control/#dom-capturecontroller-onzoomlevelchange",
+          "support": {
+            "chrome": {
+              "version_added": "136"
             },
             "chrome_android": {
               "version_added": false

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -215,6 +215,40 @@
           }
         }
       },
+      "isFallbackAdapter": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-isfallbackadapter",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "subgroupMaxSize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapterInfo/subgroupMaxSize",

--- a/api/IdentityCredential.json
+++ b/api/IdentityCredential.json
@@ -39,6 +39,42 @@
           "deprecated": false
         }
       },
+      "configURL": {
+        "__compat": {
+          "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identitycredential-configurl",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "disconnect_static": {
         "__compat": {
           "description": "`disconnect()` static method",

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1456,14 +1456,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "136"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -253,8 +253,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40589293"
+              "version_added": "136"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -291,8 +290,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40589293"
+              "version_added": "136"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -389,7 +389,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "136"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -467,7 +467,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "136"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/dynamic-range-limit.json
+++ b/css/properties/dynamic-range-limit.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-color-hdr/#the-dynamic-range-limit-property",
           "support": {
             "chrome": {
-              "version_added": "135"
+              "version_added": "136"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -34,12 +34,12 @@
             "deprecated": false
           }
         },
-        "constrained-high": {
+        "constrained": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-constrained-high",
+            "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-constrained",
             "support": {
               "chrome": {
-                "version_added": "135"
+                "version_added": "136"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -68,12 +68,12 @@
             }
           }
         },
-        "high": {
+        "no-limit": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-high",
+            "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-no-limit",
             "support": {
               "chrome": {
-                "version_added": "135"
+                "version_added": "136"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -107,7 +107,7 @@
             "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-standard",
             "support": {
               "chrome": {
-                "version_added": "135"
+                "version_added": "136"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/print-color-adjust.json
+++ b/css/properties/print-color-adjust.json
@@ -9,14 +9,19 @@
             "web-features:print-color-adjust"
           ],
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "17",
-              "notes": [
-                "Chrome does not print backgrounds of the [`&lt;body&gt;`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element. If this property is set to `exact` for the `&lt;body&gt;` element, it will apply only to its descendants.",
-                "Before version 26, if background images are clipped (for example, when using `background-image` sprites) and `-webkit-print-color-adjust` is set to `exact`, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See [bug 40219905](https://crbug.com/40219905)."
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "136"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "17",
+                "notes": [
+                  "Chrome does not print backgrounds of the [`&lt;body&gt;`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element. If this property is set to `exact` for the `&lt;body&gt;` element, it will apply only to its descendants.",
+                  "Before version 26, if background images are clipped (for example, when using `background-image` sprites) and `-webkit-print-color-adjust` is set to `exact`, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See [bug 40219905](https://crbug.com/40219905)."
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "prefix": "-webkit-",
@@ -87,7 +92,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "136"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -124,7 +129,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "136"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -208,8 +208,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/353856236"
+                "version_added": "136"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.11 found new features shipping in Chrome 136 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 23 features as shipping in Chrome 136:

- api.CanvasRenderingContext2D.lang
- api.CaptureController.decreaseZoomLevel
- api.CaptureController.forwardWheel
- api.CaptureController.getSupportedZoomLevels
- api.CaptureController.increaseZoomLevel
- api.CaptureController.resetZoomLevel
- api.CaptureController.zoomLevel
- api.CaptureController.zoomlevelchange_event
- api.GPUAdapterInfo.isFallbackAdapter
- api.IdentityCredential.configURL
- api.OffscreenCanvasRenderingContext2D.lang
- api.SVGAElement.rel
- api.SVGAElement.relList
- api.SVGGeometryElement.isPointInFill.point_parameter_DOMPoint
- api.SVGGeometryElement.isPointInStroke.point_parameter_DOMPoint
- css.properties.dynamic-range-limit
- css.properties.dynamic-range-limit.constrained
- css.properties.dynamic-range-limit.no-limit
- css.properties.dynamic-range-limit.standard
- css.properties.print-color-adjust
- css.properties.print-color-adjust.economy
- css.properties.print-color-adjust.exact
- javascript.builtins.RegExp.escape

See also the 136 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-136-beta

Notes:

- For CSS dynamic-range-limit, there was some value renaming going on, see https://issues.chromium.org/issues/40277822#comment26. I updated the data accordingly.
- For SVGAElement.rel and reLlist there is https://chromestatus.com/feature/5066982694846464 which says Chrome 135, but I think that might be wrong. I don't see it working in 135.

cc @rachelandrew 