### PR TITLE
Mark `picture-in-picture` directive as supported in Edge

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1094,9 +1094,7 @@
                 "chrome_android": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false,
                   "impl_url": "https://bugzil.la/1463402"

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1006,9 +1006,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false,
                 "impl_url": "https://bugzil.la/1463402"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

1. other Picture-in-Picture APi features are also supported in Edge
2. it is supported in latest version for Edge
3. no evidence indicate it is has different support status as Edge

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
