### PR TITLE
Mark `:hover`'s element support as standard

### DIFF
--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -88,7 +88,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -103,7 +103,7 @@
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12",
-                "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the `:hover` state until the pointer is moved. See [bug 5381673](https://developer.microsoft.com/microsoft-edge/platform/issues/5381673/)."
+                "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the `:hover` state until the pointer is moved."
               },
               "firefox": {
                 "version_added": "1"
@@ -135,7 +135,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

these two entries are marked as non-standard since it is originally added via https://github.com/mdn/browser-compat-data/pull/783, however, this should regard as standard

also remove a not-existed edge's issue link

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://developer.mozilla.org/en-US/docs/Web/CSS/:hover

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
