### PR TITLE
Add deno data for `console.{profile,profileEnd,timeStamp}`

### DIFF
--- a/api/_globals/console.json
+++ b/api/_globals/console.json
@@ -972,7 +972,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.29"
             },
             "edge": {
               "version_added": "12"
@@ -1028,7 +1028,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.29"
             },
             "edge": {
               "version_added": "12"
@@ -1358,7 +1358,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.29"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

these methods are added in v1.28.2, via https://github.com/denoland/deno/pull/16724

see https://github.com/denoland/deno/releases/tag/v1.28.2

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

manually test for v1.28.0 and v1.29.0:

![image](https://github.com/user-attachments/assets/ea036dd2-8a53-4bd4-8ac2-e2fef899746e)

![image](https://github.com/user-attachments/assets/32cdbd9f-c198-4fcc-b3ef-b1482d4fce77)

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25022

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
