### PR TITLE
Firefox 15 added `border-image-repeat` CSS property

### DIFF
--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -57,7 +57,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "15"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -176,7 +176,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "15"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `border-image-repeat` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/border-image-repeat
