### PR TITLE
Update Firefox data for css.properties.clip-path.view-box

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -352,7 +352,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "54"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `view-box` member of the `clip-path` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/clip-path/view-box
