### PR TITLE
Firefox 41/66 added CSS `inset*: auto`

### DIFF
--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -138,7 +138,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "41"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -138,7 +138,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "41"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -138,7 +138,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "41"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -138,7 +138,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "41"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -138,7 +138,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "41"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -138,7 +138,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "41"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/inset.json
+++ b/css/properties/inset.json
@@ -131,7 +131,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "66"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `auto` member of the `inset` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/inset/auto
