### PR TITLE
test-spec-urls.ts - exception for Error.captureStackTrace()

### DIFF
--- a/lint/linter/test-spec-urls.ts
+++ b/lint/linter/test-spec-urls.ts
@@ -31,6 +31,11 @@ const specsExceptions = [
   // if they have been integrated into a real spec
   'https://w3c.github.io/webrtc-extensions/',
 
+  // This is being used to develop Error.captureStackTrace() standard
+  // Need to be checked after some time to see if integrated
+  // into a real spec
+  'https://github.com/tc39/proposal-error-capturestacktrace',
+  
   // Proposals for WebAssembly
   'https://github.com/WebAssembly/spec/blob/main/proposals',
   'https://github.com/WebAssembly/exception-handling/blob/main/proposals',


### PR DESCRIPTION
Moz are chasing standardization of `Error.captureStackTrace()` in https://github.com/tc39/proposal-error-capturestacktrace. It is only stage 1. Creating this as requested in https://github.com/mdn/browser-compat-data/pull/26399#pullrequestreview-2742649175 by @Elchi3 

Hope I got this right.

