### PR TITLE
Update Error.isError with Deno info

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -408,7 +408,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

Update Error.isError with Deno info.

#### Test results and supporting details

```sh
deno upgrade --version 2.1.10
deno eval "console.log(Error.isError(new Error()))" # TypeError: Error.isError is not a function
deno upgrade --version 2.2.0
deno eval "console.log(Error.isError(new Error()))" # true
```

#### Related issues

N/A