### PR TITLE
RTCRtpSender degradationPreference not deprecated

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -246,6 +246,7 @@
           "__compat": {
             "description": "`degradationPreference` property in returned object",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getParameters#degradationpreference",
+            "spec_url": "https://w3c.github.io/mst-content-hint/#dom-rtcrtpsendparameters-degradationpreference",
             "support": {
               "chrome": {
                 "version_added": "83"
@@ -273,7 +274,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -661,6 +662,7 @@
           "__compat": {
             "description": "`parameters.degradationPreference` parameter",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/setParameters#degradationpreference",
+            "spec_url": "https://w3c.github.io/mst-content-hint/#dom-rtcrtpsendparameters-degradationpreference",
             "support": {
               "chrome": {
                 "version_added": "83"
@@ -688,7 +690,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
FF138 adds support for `degradationPreference` in [`RTCRtpSender.setParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters#degradationpreference) and [`RTCRtpSender.getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/getParameters#degradationpreference).

This adds a spec_url, and marks this `"deprecated": false`. As noted in https://bugzilla.mozilla.org/show_bug.cgi?id=1329847#c7 that is wrong - the spec moved, and probably this was assumed to be deprecated due to that fact.

Related docs work can be tracked in https://github.com/mdn/content/issues/38880