### PR TITLE
Chrome 129 supports Web Share on macOS

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -555,7 +555,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "128"
+                "version_added": "129"
               },
               {
                 "version_added": "89",
@@ -5278,7 +5278,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "128"
+                "version_added": "129"
               },
               {
                 "version_added": "89",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -553,11 +553,16 @@
             "web-features:share"
           ],
           "support": {
-            "chrome": {
-              "version_added": "89",
-              "partial_implementation": true,
-              "notes": "Only supported on ChromeOS and Windows, see [bug 40542648](https://crbug.com/40542648) and [bug 40729163](https://crbug.com/40729163)."
-            },
+            "chrome": [
+              {
+                "version_added": "128"
+              },
+              {
+                "version_added": "89",
+                "partial_implementation": true,
+                "notes": "Only supported on ChromeOS and Windows, see [bug 40542648](https://crbug.com/40542648) and [bug 40729163](https://crbug.com/40729163)."
+              }
+            ],
             "chrome_android": {
               "version_added": "75"
             },
@@ -5271,11 +5276,16 @@
             "web-features:share"
           ],
           "support": {
-            "chrome": {
-              "version_added": "89",
-              "partial_implementation": true,
-              "notes": "Only supported on ChromeOS and Windows, see [bug 40542648](https://crbug.com/40542648) and [bug 40729163](https://crbug.com/40729163)."
-            },
+            "chrome": [
+              {
+                "version_added": "128"
+              },
+              {
+                "version_added": "89",
+                "partial_implementation": true,
+                "notes": "Only supported on ChromeOS and Windows, see [bug 40542648](https://crbug.com/40542648) and [bug 40729163](https://crbug.com/40729163)."
+              }
+            ],
             "chrome_android": {
               "version_added": "61"
             },


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/26397