### PR TITLE
Firefox Nightly supports `PerformanceEventTiming.interactionId`

### DIFF
--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -89,14 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.performance.event_timing.enable_interactionid",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -89,7 +89,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.performance.event_timing.enable_interactionid",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF138 added support for [`PerformanceEventTiming.interactionId`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming/interactionId) behind a pref in https://bugzilla.mozilla.org/show_bug.cgi?id=1934683

This adds the subfeature. 

Related docs work can be tracked in https://github.com/mdn/content/issues/38885

