### PR TITLE
FF138 Set-Login HTTP header

### DIFF
--- a/http/headers/Set-Login.json
+++ b/http/headers/Set-Login.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -32,7 +32,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF138 adds support for the [`Set-Login`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Login) HTTP response header in https://bugzilla.mozilla.org/show_bug.cgi?id=1945573.

This adds a subfeature. Note that this is part of the `NavigatorLogin` additions that were done in https://github.com/mdn/browser-compat-data/pull/26371

Related docs work can be tracked in https://github.com/mdn/content/issues/38949