### PR TITLE
FF138 Notification.actions in nightly

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -251,7 +251,7 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF138 supports [`Notification.actions`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/actions) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1225110

This adds the feature. Note that `maxActions` was also part of above issue, but feature for that was added in  #26371

Related docs can be tracked in https://github.com/mdn/content/issues/38886