### PR TITLE
Safari 7 supported CSS `-webkit-text-decoration-skip: {auto,none}`

### DIFF
--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -12,7 +12,7 @@
             "chrome": {
               "version_added": "57",
               "version_removed": "64",
-              "notes": "Only supports the deprecated `ink` value."
+              "notes": "Only supported the deprecated `ink` value."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -24,25 +24,15 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "44",
-              "version_removed": "50",
-              "notes": "Only supports the deprecated `ink` value."
-            },
-            "opera_android": {
-              "version_added": "43",
-              "version_removed": "46",
-              "notes": "Only supports the deprecated `ink` value."
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "12.1",
-                "notes": "Supports only `none`, `auto`, and `objects` values."
+                "version_added": "12.1"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "7",
-                "notes": "Supports only `none`, `auto`, and `objects` values."
+                "version_added": "7"
               }
             ],
             "safari_ios": "mirror",
@@ -79,7 +69,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -116,7 +106,40 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "7"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "objects": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -119,39 +119,6 @@
               "deprecated": false
             }
           }
-        },
-        "objects": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `text-decoration-skip` CSS property. This fixes the data based upon the notes.
