### PR TITLE
Mark the Iterator() constructor as not supported

### DIFF
--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -57,7 +57,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "122"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "deno": {
@@ -65,14 +65,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "131"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "22.0.0"
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
The data comes from these PRs:
https://github.com/mdn/browser-compat-data/pull/21998 https://github.com/mdn/browser-compat-data/pull/24332 https://github.com/mdn/browser-compat-data/pull/26285

In Chrome and Node.js, invoking `new Iterator()` throws a TypeError with the message "Abstract class Iterator not directly constructable". In Firefox, the message is "Iterator constructor can't be used directly".

Since the constructor can't be used directly, saying that it is supported seems unhelpful. Possibly the entry should be removed.