### PR TITLE
Safari TP 216 supports `text-wrap: pretty`

### DIFF
--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -138,7 +138,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
See https://webkit.org/blog/16547/better-typography-with-text-wrap-pretty/