### PR TITLE
Add spec for CSS `::column` pseudo-element

### DIFF
--- a/css/selectors/column.json
+++ b/css/selectors/column.json
@@ -4,6 +4,7 @@
       "column": {
         "__compat": {
           "description": "`::column`",
+          "spec_url": "https://drafts.csswg.org/css-multicol-2/#column-pseudo",
           "support": {
             "chrome": {
               "version_added": "135"
@@ -30,7 +31,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         },
@@ -63,7 +64,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

BCD already contains support data for the `::column` pseudo-element, but we couldn't find the spec initially, so we thought it was non-standard. We've now found it in the multi-col level 2 spec, so this PR adds the `spec_url` and updates the `standard_track` appropriately.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
