### PR TITLE
ci(workflows): install lefthook hooks via CI=false

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -44,6 +44,9 @@ jobs:
           git config user.name mdn-bot
 
       - name: Install
+        env:
+          # Temporary workaround to install lefthook hooks.
+          CI: false
         run: npm ci
 
       - name: Release

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -34,6 +34,9 @@ jobs:
           git config user.name mdn-bot
 
       - name: Install
+        env:
+          # Temporary workaround to install lefthook hooks.
+          CI: false
         run: npm ci
 
       - name: Update

--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -35,6 +35,9 @@ jobs:
           git config user.name mdn-bot
 
       - name: Install
+        env:
+          # Temporary workaround to install lefthook hooks.
+          CI: false
         run: npm ci
 
       - name: Update tags

--- a/.github/workflows/update-webdriver-bidi-data.yml
+++ b/.github/workflows/update-webdriver-bidi-data.yml
@@ -32,6 +32,9 @@ jobs:
           git config user.name mdn-bot
 
       - name: Install
+        env:
+          # Temporary workaround to install lefthook hooks.
+          CI: false
         run: npm ci
 
       - name: Update data


### PR DESCRIPTION
#### Summary

Ensures that the pre-commit hook runs in CI, which they no longer do since migrating from husky to lefthook (d3183ea0cc3290c141289d4e3b93db38bafc6e64).

#### Test results and supporting details

The verbose alternative would be to explicitly run:

```
git add .
npx lefthook run pre-commit
```

#### Related issues

See:

- https://github.com/evilmartians/lefthook/pull/1001
