### PR TITLE
ci(workflows): add initial pr-review-companion

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -1,7 +1,7 @@
 name: PR Review Companion
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   # Post comment in pull request.

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -1,0 +1,91 @@
+name: PR Review Companion
+
+on:
+  pull_request:
+
+permissions:
+  # Post comment in pull request.
+  pull-requests: write
+
+concurrency:
+  group: pr-review-companion-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: flat-diff
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Diff (by change)
+        run: npm run diff:flat -- $PR_NUMBER
+        env:
+          FORCE_COLOR: 3
+
+      - name: Diff (by change, mirroring applied)
+        run: npm run diff:flat -- $PR_NUMBER --mirror
+        env:
+          FORCE_COLOR: 3
+
+      - name: Diff (by feature)
+        run: npm run diff:flat -- $PR_NUMBER --no-group
+        env:
+          FORCE_COLOR: 3
+
+      - name: Diff (by feature, mirroring applied)
+        run: npm run diff:flat -- $PR_NUMBER --no-group --mirror
+        env:
+          FORCE_COLOR: 3
+
+      - name: Determine job url
+        run: |
+          job_id=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '.jobs[0].id')
+          echo "JOB_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${job_id}?pr=$PR_NUMBER" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Post message in PR
+        run: |
+          AUTHOR="github-actions"
+          MARKER="<!-- pr-review-companion -->"
+          BODY="${MARKER}
+
+          ${COMMENT}"
+
+          COMMENT_ID=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --comments --json comments \
+            --jq ".comments | sort_by(.createdAt) | map(select(.author.login == \"$AUTHOR\" and (.body | contains(\"$MARKER\")))) | .[0].id")
+          if [ -n "$COMMENT_ID" ]; then
+            gh api graphql -f query='
+                mutation($id:ID!, $body:String!) {
+                  updateIssueComment(input:{id:$id, body:$body}) {
+                    issueComment {
+                      id
+                    }
+                  }
+                }' -f id="$COMMENT_ID" -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$BODY"
+          fi
+        env:
+          COMMENT: |
+            _Tip_: Review these changes [grouped by change][1] (recommended for most PRs), or [grouped by feature][2] (for large PRs).
+
+            [1]: ${{ env.JOB_URL }}#step:5:1
+            [2]: ${{ env.JOB_URL }}#step:7:1
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
#### Summary

Adds a new experimental `pr-review-companion` workflow that (for now) runs the `diff:flat` script from the [`flat-diff`](https://github.com/mdn/browser-compat-data/compare/main...flat-diff) branch (see https://github.com/mdn/browser-compat-data/pull/25352), and posts a comment in the PR, to make it easier for reviewers to understand the changes.

#### Test results and supporting details


#### Related issues

Initial work for https://github.com/mdn/browser-compat-data/issues/26517.
