### PR TITLE
Update the browser version of the CSS gradient `single_color_stop` feature

### DIFF
--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -247,7 +247,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "preview"
+                  "version_added": "135"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -260,11 +260,11 @@
                 },
                 "oculus": "mirror",
                 "opera": {
-                  "version_added": false
+                  "version_added": "mirror"
                 },
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "18.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -582,7 +582,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "preview"
+                  "version_added": "135"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -595,11 +595,11 @@
                 },
                 "oculus": "mirror",
                 "opera": {
-                  "version_added": false
+                  "version_added": "mirror"
                 },
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "18.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1039,7 +1039,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "preview"
+                  "version_added": "135"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -1052,11 +1052,11 @@
                 },
                 "oculus": "mirror",
                 "opera": {
-                  "version_added": false
+                  "version_added": "mirror"
                 },
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "18.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -259,9 +259,7 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "mirror"
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "18.4"
@@ -594,9 +592,7 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "mirror"
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "18.4"
@@ -1051,9 +1047,7 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "mirror"
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "18.4"


### PR DESCRIPTION
#### Summary
- Chrome 135: https://chromiumdash.appspot.com/commit/de30a22358e9ae8d4688d0e51de8d27c69cc4f91
- Safari 18.4: https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#CSS:~:text=Added%20support%20for%20gradients%20with%20only%20one%20stop
