### PR TITLE
Firefox 92 maintains CSS `accent-color` contrast for legibility

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -25,9 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.4",
-              "partial_implementation": true,
-              "notes": "Safari does not adjust the color of glyphs (such as checkmarks) on form controls to maintain contrast. See [bug 244233](https://webkit.org/b/244233)."
+              "version_added": "15.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -71,6 +69,45 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "maintains_contrast": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui/#:~:text=must%20maintain%20contrast%20for%20legibility%20of%20the%20control",
+            "tags": [
+              "web-features:accent-color"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/343503163"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "92"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/244233"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -76,7 +76,8 @@
         },
         "maintains_contrast": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-ui/#:~:text=must%20maintain%20contrast%20for%20legibility%20of%20the%20control",
+             "description": "Maintains contrast",
+             "spec_url": "https://drafts.csswg.org/css-ui/#:~:text=must%20maintain%20contrast%20for%20legibility%20of%20the%20control",
             "tags": [
               "web-features:accent-color"
             ],

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -76,8 +76,8 @@
         },
         "maintains_contrast": {
           "__compat": {
-             "description": "Maintains contrast",
-             "spec_url": "https://drafts.csswg.org/css-ui/#:~:text=must%20maintain%20contrast%20for%20legibility%20of%20the%20control",
+            "description": "Maintains contrast",
+            "spec_url": "https://drafts.csswg.org/css-ui/#:~:text=must%20maintain%20contrast%20for%20legibility%20of%20the%20control",
             "tags": [
               "web-features:accent-color"
             ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a subfeature `maintains_contrast` to CSS `accent-color`, which is only supported by Firefox.

#### Test results and supporting details

Tested with https://accent-color.glitch.me/ in Firefox 92 using BrowserStack Live.

Bugs:

- Chrome: [Checkbox's checkmark doesn't invert in response to accent-color on android](https://crbug.com/343503163)
- Safari: [accent-color: white makes checkbox checkmark invisible](https://webkit.org/b/244233)

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26073.
Fixes https://github.com/mdn/browser-compat-data/issues/26381.