### PR TITLE
Safari 18.4 supports Iterator constructor

### DIFF
--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -78,8 +78,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/248650"
+                "version_added": "18.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
The tests for the in mdn-bcd-collector don't work: https://github.com/openwebdocs/mdn-bcd-collector/issues/2275

Instead the second example in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Iterator#examples was pasted into Safari 18.4 Web Inspector to confirm it works.