### PR TITLE
Edge 93 supports `EXT_frag_depth` + `EXT_shader_texture_lod`

### DIFF
--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -12,10 +12,15 @@
             "version_added": "38"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "12",
-            "version_removed": "79"
-          },
+          "edge": [
+            {
+              "version_added": "93"
+            },
+            {
+              "version_added": "17",
+              "version_removed": "79"
+            }
+          ],
           "firefox": {
             "version_added": "47"
           },

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -12,10 +12,15 @@
             "version_added": "38"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "17",
-            "version_removed": "79"
-          },
+          "edge": [
+            {
+              "version_added": "93"
+            },
+            {
+              "version_added": "17",
+              "version_removed": "79"
+            }
+          ],
           "firefox": {
             "version_added": "47"
           },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Edge 93 supports `EXT_frag_depth` + `EXT_shader_texture_lod`.

#### Test results and supporting details

Tested with BrowserStack Live on Windows 11:

- ✅ Edge 93
- :x: Edge 92

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26484.
