### PR TITLE
fix(dependabot): remove emoji from label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,4 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "infra :building_construction:"
+      - "infra"


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

We removed emojis from labels, but the Dependabot config still referenced a label with an emoji.

Dependabot [posts a warning](https://github.com/mdn/browser-compat-data/pull/26251#issuecomment-2735096730) about the missing label in every Dependabot PRs for GitHub Actions.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
