### PR TITLE
Mark Safari 16.4 as supporting html.elements.form.autocomplete.webauthn

### DIFF
--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -251,7 +251,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marked Safari 16.4 as supporting webauthn autocomplete

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Related issues

See #26323 for discussions about the issue

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
