### PR TITLE
Move symbol support subfeatures into constructor/methods

### DIFF
--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -152,7 +152,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1863140"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -241,7 +242,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1863140"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -134,49 +134,49 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "symbol_as_target": {
-          "__compat": {
-            "description": "Non-registered symbol as target",
-            "tags": [
-              "web-features:snapshot:ecmascript-2023",
-              "web-features:weak-references"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "109"
+          },
+          "symbol_as_target": {
+            "__compat": {
+              "description": "Non-registered symbol as target",
+              "tags": [
+                "web-features:snapshot:ecmascript-2023",
+                "web-features:weak-references"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "109"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.28"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "20.0.0"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
               },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.28"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "20.0.0"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "16.4"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },
@@ -222,6 +222,50 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "symbol_as_target": {
+            "__compat": {
+              "description": "Non-registered symbol as target",
+              "tags": [
+                "web-features:snapshot:ecmascript-2023",
+                "web-features:weak-references"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "109"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.28"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "20.0.0"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -89,6 +89,50 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "symbol_as_target": {
+            "__compat": {
+              "description": "Non-registered symbol as target",
+              "tags": [
+                "web-features:snapshot:ecmascript-2023",
+                "web-features:weak-references"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "109"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.28"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "20.0.0"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "deref": {
@@ -123,50 +167,6 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "14.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "symbol_as_target": {
-          "__compat": {
-            "description": "Non-registered symbol as target",
-            "tags": [
-              "web-features:snapshot:ecmascript-2023",
-              "web-features:weak-references"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "109"
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.28"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "20.0.0"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -107,7 +107,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1863140"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Moves the `Non-registered symbol as target` subfeatures:

- from `WeakRef` to the constructor (`WeakRef.WeakRef`)
- from `FinalizationRegistry` to the methods (`FinalizationRegistry.{register,unregister}`)

Also adds the [Firefox impl_url](https://bugzilla.mozilla.org/show_bug.cgi?id=1863140).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26132.
