### PR TITLE
Safari only partially supports top-level await

### DIFF
--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -78,7 +78,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15"
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "Doesn't support multiple modules simultaneously importing a module containing a top-level await (see [bug 242740](https://webkit.org/b/242740))."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marks Safari's implementation of top-level await as partial, because it doesn't support

> _multiple modules simultaneously importing a module containing a top-level await._ 

#### Test results and supporting details

This was reported in https://github.com/mdn/browser-compat-data/issues/20426 and https://github.com/mdn/browser-compat-data/issues/26075.

Upstream bug: https://bugs.webkit.org/show_bug.cgi?id=242740

The wording was taken from @shvaikalesh's [WebKit PR addressing the issue](https://github.com/WebKit/WebKit/pull/24122) (not yet merged) .

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20426.