### PR TITLE
Bug-1958596 `dark_theme` manifest key support

### DIFF
--- a/webextensions/manifest/dark_theme.json
+++ b/webextensions/manifest/dark_theme.json
@@ -1,0 +1,969 @@
+{
+  "webextensions": {
+    "manifest": {
+      "dark_theme": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤59"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror"
+          }
+        },
+        "colors": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤61"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "bookmark_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤62",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "button_background_active": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "button_background_hover": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "frame": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤61",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "frame_inactive": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤62",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "frame_incognito": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤62",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "frame_incognito_inactive": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤62",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "icons": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "icons_attention": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "ntp_background": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤62",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "ntp_header": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤62",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "ntp_link": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤62",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "ntp_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤62",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "popup": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "popup_highlight": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "popup_highlight_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "popup_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "tab_background_separator": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68",
+                  "notes": "Deprecated in Firefox 89. For details, see the [Changes to themeable areas of Firefox in version 89](https://blog.mozilla.org/addons/2021/04/19/changes-to-themeable-areas-of-firefox-in-version-89/) blog post ."
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "tab_background_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤65",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "tab_line": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "tab_loading": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "tab_selected": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "tab_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤61",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤61",
+                  "notes": "The CSS color form is not supported for this property."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_bottom_separator": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_field": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_field_border": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_field_border_focus": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_field_focus": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_field_highlight": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_field_highlight_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_field_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_field_text_focus": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_top_separator": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "toolbar_vertical_separator": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        },
+        "images": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤67"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "additional_backgrounds": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "theme_frame": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤76"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "68"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        },
+        "properties": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤67"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "color_scheme": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "100"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "content_color_scheme": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "100"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/manifest/dark_theme.json
+++ b/webextensions/manifest/dark_theme.json
@@ -221,7 +221,7 @@
               }
             }
           },
-           "ntp_text": {
+          "ntp_text": {
             "__compat": {
               "support": {
                 "chrome": {

--- a/webextensions/manifest/dark_theme.json
+++ b/webextensions/manifest/dark_theme.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤59"
+              "version_added": false
             },
             "edge": "mirror",
             "firefox": {
@@ -27,7 +27,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤61"
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {
@@ -49,8 +49,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤62",
-                  "notes": "The CSS color form is not supported for this property."
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -115,8 +114,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61",
-                  "notes": "The CSS color form is not supported for this property."
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -139,8 +137,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤62",
-                  "notes": "The CSS color form is not supported for this property."
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -149,50 +146,6 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
-          "frame_incognito": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "≤62",
-                  "notes": "The CSS color form is not supported for this property."
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
-          "frame_incognito_inactive": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "≤62",
-                  "notes": "The CSS color form is not supported for this property."
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
                 "opera": {
                   "version_added": false
                 },
@@ -249,8 +202,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤62",
-                  "notes": "The CSS color form is not supported for this property."
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -269,56 +221,11 @@
               }
             }
           },
-          "ntp_header": {
+           "ntp_text": {
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤62",
-                  "notes": "The CSS color form is not supported for this property."
-                },
-                "edge": "mirror",
-                "firefox": {
                   "version_added": false
-                },
-                "firefox_android": "mirror",
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
-          "ntp_link": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "≤62",
-                  "notes": "The CSS color form is not supported for this property."
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "opera": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
-          "ntp_text": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "≤62",
-                  "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -447,8 +354,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤65",
-                  "notes": "The CSS color form is not supported for this property."
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -534,8 +440,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61",
-                  "notes": "The CSS color form is not supported for this property."
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -558,8 +463,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61",
-                  "notes": "The CSS color form is not supported for this property."
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -835,7 +739,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤67"
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {
@@ -878,7 +782,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤76"
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -902,7 +806,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤67"
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/manifest/dark_theme.json
+++ b/webextensions/manifest/dark_theme.json
@@ -314,28 +314,6 @@
               }
             }
           },
-          "tab_background_separator": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "68",
-                  "notes": "Deprecated in Firefox 89. For details, see the [Changes to themeable areas of Firefox in version 89](https://blog.mozilla.org/addons/2021/04/19/changes-to-themeable-areas-of-firefox-in-version-89/) blog post ."
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "tab_background_text": {
             "__compat": {
               "support": {

--- a/webextensions/manifest/dark_theme.json
+++ b/webextensions/manifest/dark_theme.json
@@ -14,9 +14,7 @@
             "firefox_android": {
               "version_added": false
             },
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "safari": {
               "version_added": false
             },
@@ -36,9 +34,7 @@
               "firefox_android": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -58,9 +54,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -123,9 +117,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -146,9 +138,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -211,9 +201,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -234,9 +222,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -363,9 +349,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -449,9 +433,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -472,9 +454,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -748,9 +728,7 @@
               "firefox_android": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -791,9 +769,7 @@
                 "firefox_android": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -815,9 +791,7 @@
               "firefox_android": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
#### Summary

Adds browser compatibility data for the dark_theme manifest key introduced in Firefox 68 ([Bug 1525762](https://bugzilla.mozilla.org/show_bug.cgi?id=1525762)) response to comment on [Comment 15](https://bugzilla.mozilla.org/show_bug.cgi?id=1958596#c15)  on [Bug 1958596](https://bugzilla.mozilla.org/show_bug.cgi?id=1958596)

#### Related issues

- related developer documentation in https://github.com/mdn/content/pull/39122
- related extension workshop theme documentation in https://github.com/mozilla/extension-workshop/pull/2050
