### PR TITLE
Firefox 138 adds `webextensions.api.webRequest.ResourceType.json`

### DIFF
--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -455,6 +455,25 @@
               }
             }
           },
+          "json": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "138"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "main_frame": {
             "__compat": {
               "support": {

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -463,7 +463,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "138"
+                  "version_added": "138",
+                  "notes": "The \"json\" property is supported from Firefox 135, but requests of this type are only available from Firefox 138."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -406,7 +406,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "138"
+                  "version_added": "138",
+                  "notes": "The \"json\" property is supported from Firefox 135, but requests of this type are only available from Firefox 138."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -406,7 +406,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "138"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -398,6 +398,25 @@
               }
             }
           },
+          "json": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "main_frame": {
             "__compat": {
               "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This adds `json` to `webextensions.api.webRequest.ResourceType`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The test code is defined in Firefox source-code: https://phabricator.services.mozilla.com/D230563, but import attribution support on Firefox is blocking this.

Also, `declarativeNetRequest.ResourceType` should be confirmed in the future.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

fixes #26016
refs https://github.com/mdn/content/pull/38305
