### PR TITLE
Chrome 93 also maintains CSS `accent-color` contrast for legibility

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -83,10 +83,12 @@
             ],
             "support": {
               "chrome": {
+                "version_added": "93"
+              },
+              "chrome_android": {
                 "version_added": false,
                 "impl_url": "https://crbug.com/343503163"
               },
-              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "92"
@@ -108,7 +110,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 93 also supports the subfeature introduced in https://github.com/mdn/browser-compat-data/pull/26493, just not on Android.

#### Test results and supporting details

See [this comment](https://github.com/mdn/browser-compat-data/pull/26493#discussion_r2044226952) by @lukewarlow.

Verified in Chrome 93, and latest Chrome Android version.

#### Related issues

Follow-up to:

- https://github.com/mdn/browser-compat-data/pull/26493
