### PR TITLE
Update MediaStreamTrackProcessor spec_url and mark Chrome constructor support as partial

### DIFF
--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "94",
             "partial_implementation": true,
-            "notes": "Chrome incorrectly exposes this interface only on the Window scope, rather than the DedicatedWorker scope as defined in the spec."
+            "notes": "Exposed on `Window` instead of `DedicatedWorker`."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -51,7 +51,7 @@
             "chrome": {
               "version_added": "94",
               "partial_implementation": true,
-              "notes": "Chrome incorrectly exposes this constructor only on the Window scope, rather than the DedicatedWorker scope as defined in the spec."
+              "notes": "Exposed on `Window` instead of `DedicatedWorker`."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -91,7 +91,7 @@
             "chrome": {
               "version_added": "94",
               "partial_implementation": true,
-              "notes": "Chrome incorrectly exposes this readable only on the Window scope, rather than the DedicatedWorker scope as defined in the spec."
+              "notes": "Exposed on `Window` instead of `DedicatedWorker`."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -89,9 +89,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "94",
-              "partial_implementation": true,
-              "notes": "Exposed on `Window` instead of `DedicatedWorker`."
+              "version_added": "94"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -3,7 +3,7 @@
     "MediaStreamTrackProcessor": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackProcessor",
-        "spec_url": "https://w3c.github.io/mediacapture-transform/#track-processor-interface",
+        "spec_url": "https://w3c.github.io/mediacapture-transform/#mediastreamtrackprocessor",
         "tags": [
           "web-features:insertable-streams"
         ],
@@ -49,7 +49,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "94"
+              "version_added": "94",
+              "partial_implementation": true,
+              "notes": "Chrome incorrectly exposes this constructor only on the Window scope, rather than the DedicatedWorker scope as defined in the spec."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -87,7 +89,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "94"
+              "version_added": "94",
+              "partial_implementation": true,
+              "notes": "Chrome incorrectly exposes this readable only on the Window scope, rather than the DedicatedWorker scope as defined in the spec."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary
- Have MediaStreamTrackProcessor members inherit partial support in chrome, for visibility
- ~Add mdn links to VideoTrackGenerator~

#### Test results and supporting details

`npm test` verified JSON, but complains of missing mdn links for VideoTrackGenerator (coming in https://github.com/mdn/content/pull/39124).

couldn't get `npm run stats` to work, so hopefully things look OK.

Spec: https://w3c.github.io/mediacapture-transform/
