### PR TITLE
Data for `tab.group`, `tab.unGroup`, and additions of `groupId`

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -748,7 +748,8 @@
                   "version_added": "138"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Always -1 as tab groups are not supported in Firefox for Android"
                 },
                 "opera": "mirror",
                 "safari": {
@@ -4026,7 +4027,7 @@
             }
           }
         },
-        "unGroup": {
+        "ungroup": {
           "__compat": {
             "support": {
               "chrome": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -737,6 +737,27 @@
               }
             }
           },
+          "groupId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "88"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "138"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "height": {
             "__compat": {
               "support": {
@@ -2269,6 +2290,27 @@
             }
           }
         },
+        "group": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "88"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "138"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "hide": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/hide",
@@ -2895,6 +2937,27 @@
                 }
               }
             },
+            "groupId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "88"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "138"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "mutedInfo": {
               "__compat": {
                 "support": {
@@ -3373,6 +3436,27 @@
                   "firefox_android": {
                     "version_added": "57",
                     "version_removed": "79"
+                  },
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "groupId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "88"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "138"
+                  },
+                  "firefox_android": {
+                    "version_added": false
                   },
                   "opera": "mirror",
                   "safari": {
@@ -3937,6 +4021,27 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "16.4"
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "unGroup": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "88"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "138"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3133,6 +3133,27 @@
               }
             },
             "properties": {
+              "groupId": {
+                "__compat": {
+                  "support": {
+                    "chrome": {
+                      "version_added": false
+                    },
+                    "edge": "mirror",
+                    "firefox": {
+                      "version_added": "138"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": "mirror",
+                    "safari": {
+                      "version_added": false
+                    },
+                    "safari_ios": "mirror"
+                  }
+                }
+              },
               "isArticle": {
                 "__compat": {
                   "support": {


### PR DESCRIPTION
#### Summary

Data for `tab.group`, `tab.unGroup`, and additions of `groupId` to `tab.query`, `tab.Tab`, and `tab.onUpdated`.

Addresses the changes implemented in:
- [Bug 1959713](https://bugzilla.mozilla.org/show_bug.cgi?id=1959713) - Implement tabs.Tab.groupId (this bug)
- [Bug 1959715](https://bugzilla.mozilla.org/show_bug.cgi?id=1959715) - Support groupId in tabs.query
- [Bug 1959714](https://bugzilla.mozilla.org/show_bug.cgi?id=1959714) - Implement tabs.group() and tabs.ungroup()
- [Bug 1959716](https://bugzilla.mozilla.org/show_bug.cgi?id=1959716) - Implement groupId in tabs.onUpdated

#### Related issues

Related content changes on MDN made in https://github.com/mdn/content/pull/39145
