### PR TITLE
Update Edge data for exceptionsFinal WebAssembly feature

### DIFF
--- a/webassembly/exceptionsFinal.json
+++ b/webassembly/exceptionsFinal.json
@@ -12,7 +12,10 @@
             "version_added": false
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": "16",
+            "version_removed": "79"
+          },
           "firefox": {
             "version_added": "131"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `exceptionsFinal` WebAssembly feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/exceptionsFinal
