### PR TITLE
Safari 18.4 supports CSP Reporting API

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -35,7 +35,7 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": "18.4"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
@@ -78,7 +78,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -122,7 +122,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -166,7 +166,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -210,7 +210,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -254,7 +254,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -298,7 +298,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -342,7 +342,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -386,7 +386,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -430,7 +430,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -474,7 +474,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -518,7 +518,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -562,7 +562,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "18.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
#26380 by @Elchi3  added support for Reporting API for Safari 18.4 for #26361 for @yoavweiss 

But that PR didn't include the CSP Reporting that this was implemented for so this is still marked as "preview" instead of 18.4.

#### Test results and supporting details

See https://github.com/WebKit/WebKit/pull/3613

and

https://wpt.fyi/results/content-security-policy/reporting-api?label=stable&label=master&aligned

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#26380

#26361

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
