### PR TITLE
Correctly attribute `getUserSettings` to `browserAction`

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -355,6 +355,48 @@
             }
           }
         },
+        "getUserSettings": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getUserSettings",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "returns_userSettings_isOnToolbar_property": {
+            "__compat": {
+              "description": "`userSettings.isOnToolbar` in returned object",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "116"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        },
         "isEnabled": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/isEnabled",

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -107,48 +107,6 @@
             }
           }
         },
-        "getUserSettings": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getUserSettings",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "116"
-              },
-              "firefox_android": "mirror",
-              "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
-            }
-          },
-          "returns_userSettings_isOnToolbar_property": {
-            "__compat": {
-              "description": "`userSettings.isOnToolbar` in returned object",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "116"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          }
-        },
         "hide": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/hide",


### PR DESCRIPTION
#### Summary

https://github.com/mdn/browser-compat-data/pull/22081 accidentally added the data to `pageAction` instead of `browserAction`.

#### Related issues

Fixes #26522
