### PR TITLE
Edge Legacy only partially supported HTTP `Origin` header

### DIFF
--- a/http/headers/Origin.json
+++ b/http/headers/Origin.json
@@ -16,10 +16,16 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "notes": "Before Edge 79, this header was not sent with `POST` requests."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true,
+                "notes": "Not sent with `POST` requests"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "70"

--- a/http/headers/Origin.json
+++ b/http/headers/Origin.json
@@ -33,6 +33,7 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "70",
                 "partial_implementation": true,
                 "notes": "Not sent with `POST` requests, see [bug 446344](https://bugzil.la/446344)."
               }

--- a/http/headers/Origin.json
+++ b/http/headers/Origin.json
@@ -22,6 +22,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "79",
                 "partial_implementation": true,
                 "notes": "Not sent with `POST` requests"
               }


### PR DESCRIPTION
Firefox data considers the implementation without POST partial, while Edge data didn't.

It's a little better to do it like the Firefox one because this way the web UI will annotate the Edge version with the release date.
