### PR TITLE
feat(lint): check + fix overlapping version ranges

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -14,6 +14,7 @@
             },
             {
               "version_added": "30",
+              "version_removed": "32",
               "partial_implementation": true,
               "notes": "Available only on macOS."
             }

--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -37,6 +37,7 @@
             },
             {
               "version_added": "11.1",
+              "version_removed": "12.1",
               "partial_implementation": true,
               "notes": "Even though `window.AbortController` is defined, it doesn't really abort `fetch` requests. See [bug 174980](https://webkit.org/b/174980)."
             }
@@ -90,6 +91,7 @@
               },
               {
                 "version_added": "11.1",
+                "version_removed": "12.1",
                 "partial_implementation": true,
                 "notes": "Even though `window.AbortController` is defined, it doesn't really abort `fetch` requests. See [bug 174980](https://webkit.org/b/174980)."
               }
@@ -161,6 +163,7 @@
               },
               {
                 "version_added": "11.1",
+                "version_removed": "12.1",
                 "partial_implementation": true,
                 "notes": "Even though `window.AbortController` is defined, it doesn't really abort `fetch` requests. See [bug 174980](https://webkit.org/b/174980)."
               }
@@ -264,6 +267,7 @@
               },
               {
                 "version_added": "11.1",
+                "version_removed": "12.1",
                 "partial_implementation": true,
                 "notes": "Even though `window.AbortController` is defined, it doesn't really abort `fetch` requests. See [bug 174980](https://webkit.org/b/174980)."
               }

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "15.7.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `buffer` module."
             },

--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -35,6 +35,7 @@
             },
             {
               "version_added": "15.4.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `worker_threads` module."
             }

--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/CSSGroupingRule.json
+++ b/api/CSSGroupingRule.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "3",
+              "version_removed": "14.1",
               "partial_implementation": true,
               "notes": "The `CSSGroupingRule` interface itself is not present, but many of the methods are available on various interfaces such as the [`CSSMediaRule`](https://developer.mozilla.org/docs/Web/API/CSSMediaRule) and [`CSSPageRule`](https://developer.mozilla.org/docs/Web/API/CSSPageRule) interfaces."
             }

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -280,6 +280,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "54",
                 "partial_implementation": true,
                 "notes": "The options parameter only supports `ignoreSearch`, and `cacheName`."
               }

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -457,6 +457,7 @@
               },
               {
                 "version_added": "90",
+                "version_removed": "112",
                 "partial_implementation": true,
                 "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function."
               }
@@ -474,6 +475,7 @@
               },
               {
                 "version_added": "15",
+                "version_removed": "16.1",
                 "partial_implementation": true,
                 "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function."
               }

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -29,6 +29,7 @@
             },
             {
               "version_added": "17.0.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -39,6 +39,7 @@
             },
             {
               "version_added": "15.0.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `crypto` module."
             }

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "15.0.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `crypto` module."
             }
@@ -116,6 +117,7 @@
               },
               {
                 "version_added": "1.12",
+                "version_removed": "1.13",
                 "partial_implementation": true,
                 "notes": "The only supported value for this property is `true`."
               }

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -29,6 +29,7 @@
             },
             {
               "version_added": "17.0.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/Document.json
+++ b/api/Document.json
@@ -4593,6 +4593,7 @@
               },
               {
                 "version_added": "13.1",
+                "version_removed": "14",
                 "partial_implementation": true,
                 "notes": "Implements an older version of the specification, see [bug 179536](https://webkit.org/b/179536)."
               }
@@ -6728,6 +6729,7 @@
               },
               {
                 "version_added": "8",
+                "version_removed": "9",
                 "partial_implementation": true,
                 "notes": "`querySelectorAll()` is supported, but only for CSS 2.1 selectors."
               }
@@ -6779,6 +6781,7 @@
               },
               {
                 "version_added": "8",
+                "version_removed": "9",
                 "partial_implementation": true,
                 "notes": "`querySelectorAll()` is supported, but only for CSS 2.1 selectors."
               }
@@ -8561,13 +8564,14 @@
                 "version_added": "62"
               },
               {
-                "version_added": "33",
+                "prefix": "webkit",
+                "version_added": "13",
                 "partial_implementation": true,
                 "notes": "The `onvisibilitychange` event handler property is not supported."
               },
               {
-                "prefix": "webkit",
-                "version_added": "13",
+                "version_added": "33",
+                "version_removed": "62",
                 "partial_implementation": true,
                 "notes": "The `onvisibilitychange` event handler property is not supported."
               }
@@ -8579,6 +8583,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "18",
                 "partial_implementation": true,
                 "notes": "The `onvisibilitychange` event handler property is not supported."
               }
@@ -8598,13 +8603,14 @@
                 "version_added": "49"
               },
               {
-                "version_added": "20",
+                "prefix": "webkit",
+                "version_added": "15",
                 "partial_implementation": true,
                 "notes": "The `onvisibilitychange` event handler property is not supported."
               },
               {
-                "prefix": "webkit",
-                "version_added": "15",
+                "version_added": "20",
+                "version_removed": "49",
                 "partial_implementation": true,
                 "notes": "The `onvisibilitychange` event handler property is not supported."
               },
@@ -8620,13 +8626,14 @@
                 "version_added": "46"
               },
               {
-                "version_added": "20",
+                "prefix": "webkit",
+                "version_added": "14",
                 "partial_implementation": true,
                 "notes": "The `onvisibilitychange` event handler property is not supported."
               },
               {
-                "prefix": "webkit",
-                "version_added": "14",
+                "version_added": "20",
+                "version_removed": "46",
                 "partial_implementation": true,
                 "notes": "The `onvisibilitychange` event handler property is not supported."
               },
@@ -8643,11 +8650,13 @@
               },
               {
                 "version_added": "14",
+                "version_removed": "14.1",
                 "partial_implementation": true,
                 "notes": "Doesn't fire the `visibilitychange` event when navigating away from a document, so also include code to check for the `pagehide` event (which does fire for that case in all current browsers). See [bug 116769](https://webkit.org/b/116769), [bug 151234](https://webkit.org/b/151234), [bug 151610](https://webkit.org/b/151610), and [bug 194897](https://webkit.org/b/194897)."
               },
               {
                 "version_added": "10.1",
+                "version_removed": "14",
                 "partial_implementation": true,
                 "notes": [
                   "Doesn't fire the `visibilitychange` event when navigating away from a document, so also include code to check for the `pagehide` event (which does fire for that case in all current browsers). See [bug 116769](https://webkit.org/b/116769), [bug 151234](https://webkit.org/b/151234), [bug 151610](https://webkit.org/b/151610), and [bug 194897](https://webkit.org/b/194897).",
@@ -8656,6 +8665,7 @@
               },
               {
                 "version_added": "7",
+                "version_removed": "10.1",
                 "partial_implementation": true,
                 "notes": [
                   "Doesn't fire the `visibilitychange` event when navigating away from a document, so also include code to check for the `pagehide` event (which does fire for that case in all current browsers). See [bug 116769](https://webkit.org/b/116769), [bug 151234](https://webkit.org/b/151234), [bug 151610](https://webkit.org/b/151610), and [bug 194897](https://webkit.org/b/194897).",

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -429,6 +429,7 @@
               },
               {
                 "version_added": "8",
+                "version_removed": "9",
                 "partial_implementation": true,
                 "notes": "`querySelectorAll()` is supported, but only for CSS 2.1 selectors."
               }
@@ -482,6 +483,7 @@
               },
               {
                 "version_added": "8",
+                "version_removed": "9",
                 "partial_implementation": true,
                 "notes": "`querySelectorAll()` is supported, but only for CSS 2.1 selectors."
               }

--- a/api/Element.json
+++ b/api/Element.json
@@ -8359,6 +8359,7 @@
               },
               {
                 "version_added": "8",
+                "version_removed": "9",
                 "partial_implementation": true,
                 "notes": "`querySelector()` is supported, but only for CSS 2.1 selectors."
               }
@@ -8410,6 +8411,7 @@
               },
               {
                 "version_added": "8",
+                "version_removed": "9",
                 "partial_implementation": true,
                 "notes": "`querySelectorAll()` is supported, but only for CSS 2.1 selectors."
               }
@@ -11052,6 +11054,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "13.1",
                 "partial_implementation": true,
                 "notes": "The event handler exists but will never be called."
               }
@@ -11102,6 +11105,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "13.1",
                 "partial_implementation": true,
                 "notes": "The event handler exists but will never be called."
               }

--- a/api/File.json
+++ b/api/File.json
@@ -39,6 +39,7 @@
             },
             {
               "version_added": "19.2.0",
+              "version_removed": "20.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `buffer` module."
             },

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -163,6 +163,7 @@
               },
               {
                 "version_added": "35",
+                "version_removed": "120",
                 "partial_implementation": true,
                 "notes": "Prior to version 120, this method returned `false` instead of `true` for nonexistent or locally installed fonts. See [bug 40893726](https://crbug.com/40893726)."
               }

--- a/api/HID.json
+++ b/api/HID.json
@@ -58,6 +58,7 @@
               },
               {
                 "version_added": "117",
+                "version_removed": "131",
                 "partial_implementation": true,
                 "notes": "WebExtension service workers only."
               }

--- a/api/HIDConnectionEvent.json
+++ b/api/HIDConnectionEvent.json
@@ -99,6 +99,7 @@
               },
               {
                 "version_added": "117",
+                "version_removed": "131",
                 "partial_implementation": true,
                 "notes": "WebExtension service workers only."
               }

--- a/api/HIDDevice.json
+++ b/api/HIDDevice.json
@@ -58,6 +58,7 @@
               },
               {
                 "version_added": "117",
+                "version_removed": "131",
                 "partial_implementation": true,
                 "notes": "WebExtension service workers only."
               }

--- a/api/HIDInputReportEvent.json
+++ b/api/HIDInputReportEvent.json
@@ -58,6 +58,7 @@
               },
               {
                 "version_added": "117",
+                "version_removed": "131",
                 "partial_implementation": true,
                 "notes": "WebExtension service workers only."
               }

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -424,6 +424,7 @@
                   },
                   {
                     "version_added": "75",
+                    "version_removed": "81",
                     "partial_implementation": true,
                     "notes": "ChromeOS only"
                   }
@@ -638,6 +639,7 @@
                   },
                   {
                     "version_added": "75",
+                    "version_removed": "81",
                     "partial_implementation": true,
                     "notes": "ChromeOS only"
                   }
@@ -931,6 +933,7 @@
                   },
                   {
                     "version_added": "75",
+                    "version_removed": "81",
                     "partial_implementation": true,
                     "notes": "ChromeOS only"
                   }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2677,6 +2677,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "18",
                 "partial_implementation": true,
                 "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See [issue 4365703](https://developer.microsoft.com/microsoft-edge/platform/issues/4365703/) for details."
               }

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3239,11 +3239,13 @@
               },
               {
                 "version_added": "131",
+                "version_removed": "132",
                 "partial_implementation": true,
                 "notes": "In Chrome for Android 131, if a user selects a directory, the browser crashes (see [bug 376834374](https://crbug.com/376834374))."
               },
               {
                 "version_added": "18",
+                "version_removed": "131",
                 "partial_implementation": true,
                 "notes": "The property reflects the attribute, but users cannot choose a directory, only individual files (see [bug 40248532](https://crbug.com/40248532)."
               }
@@ -3272,6 +3274,7 @@
               },
               {
                 "version_added": "11.3",
+                "version_removed": "18.4",
                 "partial_implementation": true,
                 "notes": "The property can be set, but has no effect (see [bug 271705](https://webkit.org/b/271705))."
               }

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3042,6 +3042,7 @@
               },
               {
                 "version_added": "52",
+                "version_removed": "108",
                 "partial_implementation": true,
                 "notes": "Support added for `MediaStream` objects (see [bug 41186131](https://crbug.com/41186131))."
               }

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -62,6 +62,7 @@
               },
               {
                 "version_added": "23",
+                "version_removed": "32",
                 "partial_implementation": true,
                 "notes": "The `oncuechange` event handler property is not supported."
               }
@@ -84,6 +85,7 @@
               },
               {
                 "version_added": "15",
+                "version_removed": "19",
                 "partial_implementation": true,
                 "notes": "The `oncuechange` event handler property is not supported."
               },
@@ -98,6 +100,7 @@
               },
               {
                 "version_added": "14",
+                "version_removed": "19",
                 "partial_implementation": true,
                 "notes": "The `oncuechange` event handler property is not supported."
               },
@@ -112,6 +115,7 @@
               },
               {
                 "version_added": "6",
+                "version_removed": "10",
                 "partial_implementation": true,
                 "notes": "The `oncuechange` event handler property is not supported."
               }

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -199,6 +199,7 @@
                 },
                 {
                   "version_added": "130",
+                  "version_removed": "132",
                   "partial_implementation": true,
                   "notes": "Returns a `NotFoundError` exception for unrecoverable read errors, and a `DataError` for transient read errors."
                 }

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -115,6 +115,7 @@
               },
               {
                 "version_added": "39",
+                "version_removed": "116",
                 "partial_implementation": true,
                 "notes": "`enumerateDevices()` only returns input devices."
               }

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "11.7.0",
+              "version_removed": "15.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `worker_threads` module."
             }

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "14.7.0",
+              "version_removed": "15.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `worker_threads` module."
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -559,6 +559,7 @@
               },
               {
                 "version_added": "89",
+                "version_removed": "129",
                 "partial_implementation": true,
                 "notes": "Only supported on ChromeOS and Windows, see [bug 40542648](https://crbug.com/40542648) and [bug 40729163](https://crbug.com/40729163)."
               }
@@ -1632,6 +1633,7 @@
               },
               {
                 "version_added": "80",
+                "version_removed": "84",
                 "partial_implementation": true,
                 "notes": "Supports checking of Android app installation."
               }
@@ -5272,6 +5274,7 @@
               },
               {
                 "version_added": "89",
+                "version_removed": "129",
                 "partial_implementation": true,
                 "notes": "Only supported on ChromeOS and Windows, see [bug 40542648](https://crbug.com/40542648) and [bug 40729163](https://crbug.com/40729163)."
               }
@@ -6116,6 +6119,7 @@
               },
               {
                 "version_added": "16.4",
+                "version_removed": "18.4",
                 "partial_implementation": true,
                 "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
               }

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -37,6 +37,7 @@
             },
             {
               "version_added": "8.5.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `perf_hooks` module."
             }
@@ -88,6 +89,7 @@
               },
               {
                 "version_added": "11.7.0",
+                "version_removed": "19.0.0",
                 "partial_implementation": true,
                 "notes": "Available as a part of the `perf_hooks` module."
               }

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "16.0.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `perf_hooks` module."
             }

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "16.7.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `perf_hooks` module."
             },

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -26,6 +26,7 @@
             },
             {
               "version_added": "8.5.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `perf_hooks` module."
             }

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -26,6 +26,7 @@
             },
             {
               "version_added": "16.7.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `perf_hooks` module."
             },

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -28,6 +28,7 @@
             },
             {
               "version_added": "18.2.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `perf_hooks` module."
             },

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -357,6 +357,7 @@
               },
               {
                 "version_added": "10",
+                "version_removed": "11",
                 "partial_implementation": true,
                 "notes": "Returns values in screen pixels instead of CSS document pixels."
               }
@@ -528,6 +529,7 @@
               },
               {
                 "version_added": "10",
+                "version_removed": "11",
                 "partial_implementation": true,
                 "notes": "Returns an integer enumeration instead of a string."
               }
@@ -632,6 +634,7 @@
               },
               {
                 "version_added": "10",
+                "version_removed": "11",
                 "partial_implementation": true,
                 "notes": "Returns 0 instead of 0.5 on hardware that doesn't support pressure."
               }
@@ -847,6 +850,7 @@
               },
               {
                 "version_added": "10",
+                "version_removed": "11",
                 "partial_implementation": true,
                 "notes": "Returns values in screen pixels instead of CSS document pixels."
               }

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -216,6 +216,7 @@
                 },
                 {
                   "version_added": "46",
+                  "version_removed": "128",
                   "partial_implementation": true,
                   "notes": "The property is defined but not implemented/used."
                 }
@@ -632,6 +633,7 @@
                 },
                 {
                   "version_added": "46",
+                  "version_removed": "128",
                   "partial_implementation": true,
                   "notes": "The property is defined but not implemented/used."
                 }

--- a/api/ReadableByteStreamController.json
+++ b/api/ReadableByteStreamController.json
@@ -38,6 +38,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -29,6 +29,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -29,6 +29,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -37,6 +37,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -37,6 +37,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/Request.json
+++ b/api/Request.json
@@ -1102,6 +1102,7 @@
               },
               {
                 "version_added": "11.1",
+                "version_removed": "14.1",
                 "partial_implementation": true,
                 "notes": "The method exists but always rejects with `NotSupportedError`. See [bug 215671](https://webkit.org/b/215671)."
               }

--- a/api/Response.json
+++ b/api/Response.json
@@ -595,6 +595,7 @@
               },
               {
                 "version_added": "10.1",
+                "version_removed": "14.1",
                 "partial_implementation": true,
                 "notes": "The method exists but always rejects with `NotSupportedError`. See [bug 215671](https://webkit.org/b/215671)."
               }

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -105,6 +105,7 @@
               },
               {
                 "version_added": "78",
+                "version_removed": "110",
                 "partial_implementation": true,
                 "notes": "Only supported on `SVGGraphicsElement`."
               }

--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -105,6 +105,7 @@
               },
               {
                 "version_added": "15",
+                "version_removed": "15.4",
                 "partial_implementation": true,
                 "notes": "Property is not set for `<button>` elements. See [bug 229660](https://webkit.org/b/229660)."
               }

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "15.0.0",
+              "version_removed": "19.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `crypto` module."
             }
@@ -769,6 +770,7 @@
               },
               {
                 "version_added": "1.15",
+                "version_removed": "1.18",
                 "partial_implementation": true,
                 "notes": "Not supported: ECDSA, ECDH."
               },

--- a/api/SyncManager.json
+++ b/api/SyncManager.json
@@ -54,14 +54,13 @@
               },
               {
                 "version_added": "49",
+                "version_removed": "61",
                 "partial_implementation": true,
                 "notes": "Only available in the `Window` and `ServiceWorker` global scopes."
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -22,6 +22,7 @@
             },
             {
               "version_added": "18",
+              "version_removed": "19",
               "partial_implementation": true,
               "notes": "Implemented a slightly different version of the spec."
             }
@@ -36,6 +37,7 @@
             },
             {
               "version_added": "8.3.0",
+              "version_removed": "11.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `util` module."
             }
@@ -80,6 +82,7 @@
               },
               {
                 "version_added": "18",
+                "version_removed": "19",
                 "partial_implementation": true,
                 "notes": "Implemented a slightly different version of the spec."
               }
@@ -175,6 +178,7 @@
               },
               {
                 "version_added": "18",
+                "version_removed": "19",
                 "partial_implementation": true,
                 "notes": "Implemented a slightly different version of the spec."
               }
@@ -226,6 +230,7 @@
               },
               {
                 "version_added": "18",
+                "version_removed": "19",
                 "partial_implementation": true,
                 "notes": "Implemented a slightly different version of the spec."
               }

--- a/api/TextDecoderStream.json
+++ b/api/TextDecoderStream.json
@@ -29,6 +29,7 @@
             },
             {
               "version_added": "16.6.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -29,6 +29,7 @@
             },
             {
               "version_added": "8.3.0",
+              "version_removed": "11.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `util` module."
             }

--- a/api/TextEncoderStream.json
+++ b/api/TextEncoderStream.json
@@ -29,6 +29,7 @@
             },
             {
               "version_added": "16.6.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -29,6 +29,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/TransformStreamDefaultController.json
+++ b/api/TransformStreamDefaultController.json
@@ -37,6 +37,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/URL.json
+++ b/api/URL.json
@@ -38,6 +38,7 @@
             },
             {
               "version_added": "6.13.0",
+              "version_removed": "10.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `url` module."
             }
@@ -113,6 +114,7 @@
               },
               {
                 "version_added": "6",
+                "version_removed": "14.1",
                 "partial_implementation": true,
                 "notes": "Before Safari 14.1, calling the `URL` constructor with a base URL whose value is `undefined` caused Safari to throw a `TypeError`, see [bug 216841](https://webkit.org/b/216841)."
               }

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -32,6 +32,7 @@
             },
             {
               "version_added": "7.5.0",
+              "version_removed": "10.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `url` module."
             },
@@ -338,6 +339,7 @@
               },
               {
                 "version_added": "10.1",
+                "version_removed": "14",
                 "partial_implementation": true,
                 "notes": "Removing a non-existent query parameter doesn't remove `?` from the URL. See [bug 193022](https://webkit.org/b/193022)."
               }

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -254,14 +254,13 @@
               },
               {
                 "version_added": "61",
+                "version_removed": "62",
                 "partial_implementation": true,
                 "notes": "The `onresize` event handler property is not supported."
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "91"
             },
@@ -278,9 +277,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },
@@ -346,14 +343,13 @@
               },
               {
                 "version_added": "61",
+                "version_removed": "62",
                 "partial_implementation": true,
                 "notes": "The `onscroll` event handler property is not supported."
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "91"
             },
@@ -370,9 +366,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
           },
@@ -398,6 +392,7 @@
               },
               {
                 "version_added": "114",
+                "version_removed": "126",
                 "partial_implementation": true,
                 "notes": "The `onscrollend` event handler property is not supported. See [bug 325307785](https://crbug.com/325307785)."
               }

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -32,6 +32,7 @@
             },
             {
               "version_added": "16.4",
+              "version_removed": "18.4",
               "partial_implementation": true,
               "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
             }
@@ -78,6 +79,7 @@
               },
               {
                 "version_added": "16.4",
+                "version_removed": "18.4",
                 "partial_implementation": true,
                 "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
               }

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -32,6 +32,7 @@
             },
             {
               "version_added": "16.4",
+              "version_removed": "18.4",
               "partial_implementation": true,
               "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
             }
@@ -78,6 +79,7 @@
               },
               {
                 "version_added": "16.4",
+                "version_removed": "18.4",
                 "partial_implementation": true,
                 "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
               }
@@ -126,6 +128,7 @@
               },
               {
                 "version_added": "16.4",
+                "version_removed": "18.4",
                 "partial_implementation": true,
                 "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
               }
@@ -173,6 +176,7 @@
               },
               {
                 "version_added": "16.4",
+                "version_removed": "18.4",
                 "partial_implementation": true,
                 "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
               }
@@ -220,6 +224,7 @@
               },
               {
                 "version_added": "16.4",
+                "version_removed": "18.4",
                 "partial_implementation": true,
                 "notes": "Does not work in standalone Home Screen Web Apps. See [bug 254545](https://webkit.org/b/254545#c32)."
               }

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -664,6 +664,7 @@
               },
               {
                 "version_added": "11.7.0",
+                "version_removed": "12.5.0",
                 "partial_implementation": true,
                 "notes": "Takes an optional callback parameter to be executed when the worker has terminated."
               }

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "16.5.0",
+              "version_removed": "18.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the `stream/web` module."
             }

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -25,6 +25,7 @@
             },
             {
               "version_added": "5",
+              "version_removed": "7",
               "partial_implementation": true,
               "notes": "Implemented via `ActiveXObject('Microsoft.XMLHTTP')`"
             }
@@ -670,6 +671,7 @@
               },
               {
                 "version_added": "5",
+                "version_removed": "11",
                 "partial_implementation": true,
                 "notes": "Implemented via `ActiveXObject`"
               }

--- a/api/_globals/console.json
+++ b/api/_globals/console.json
@@ -135,6 +135,7 @@
               },
               {
                 "version_added": "0.10.0",
+                "version_removed": "10.0.0",
                 "partial_implementation": true,
                 "notes": "Throws error when assertion fails."
               }
@@ -563,6 +564,7 @@
               },
               {
                 "version_added": "8.0.0",
+                "version_removed": "9.3.0",
                 "partial_implementation": true,
                 "notes": "Does not use Logger to log data."
               }

--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "8.5.0",
+              "version_removed": "16.0.0",
               "partial_implementation": true,
               "notes": "Available as a part of the <code>perf_hooks</code> module."
             }
@@ -84,6 +85,7 @@
               },
               {
                 "version_added": "11.7.0",
+                "version_removed": "16.0.0",
                 "partial_implementation": true,
                 "notes": "Available as a part of the <code>perf_hooks</code> module."
               }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1365,6 +1365,7 @@
                   },
                   {
                     "version_added": "111",
+                    "version_removed": "129",
                     "partial_implementation": true,
                     "notes": "Only supports SVG images, not iframes."
                   }
@@ -1595,6 +1596,7 @@
                 },
                 {
                   "version_added": "63",
+                  "version_removed": "102",
                   "partial_implementation": true,
                   "notes": "Only supports range notations where the feature name comes before any value `(width &#62; 500px)`"
                 }
@@ -1643,6 +1645,7 @@
                 },
                 {
                   "version_added": "3.5",
+                  "version_removed": "8",
                   "partial_implementation": true,
                   "notes": "Supports [`<integer>`](https://developer.mozilla.org/docs/Web/CSS/integer) values only."
                 }

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -325,6 +325,7 @@
                 },
                 {
                   "version_added": "1",
+                  "version_removed": "80",
                   "partial_implementation": true,
                   "notes": "See [bug 1481615](https://bugzil.la/1481615)."
                 }
@@ -412,6 +413,7 @@
                 },
                 {
                   "version_added": "1",
+                  "version_removed": "54",
                   "partial_implementation": true,
                   "notes": "Doesn't work with `<input type=\"checkbox\">` and `<input type=\"radio\">`."
                 }

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -279,6 +279,7 @@
                 },
                 {
                   "version_added": "3",
+                  "version_removed": "120",
                   "partial_implementation": true,
                   "notes": "The `text` value is only supported by `-webkit-background-clip` (and not by `background-clip`; see [bug 40229927](https://crbug.com/40229927))."
                 }
@@ -290,6 +291,7 @@
                 },
                 {
                   "version_added": "79",
+                  "version_removed": "120",
                   "partial_implementation": true,
                   "notes": "The `text` value is only supported by `-webkit-background-clip` (and not by `background-clip`; see [bug 40229927](https://crbug.com/40229927))."
                 },
@@ -322,6 +324,7 @@
                 },
                 {
                   "version_added": "4",
+                  "version_removed": "14",
                   "partial_implementation": true,
                   "notes": "The `text` value is only supported by `-webkit-background-clip` (and not by `background-clip`)."
                 }

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -86,6 +86,7 @@
                 },
                 {
                   "version_added": "22",
+                  "version_removed": "130",
                   "partial_implementation": true,
                   "notes": "This value was only supported with the -webkit- prefix."
                 }
@@ -132,6 +133,7 @@
                 },
                 {
                   "version_added": "22",
+                  "version_removed": "130",
                   "partial_implementation": true,
                   "notes": "This value was only supported with the -webkit- prefix."
                 }

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -25,6 +25,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "79",
                 "partial_implementation": true,
                 "notes": "Only supports clip paths defined by `url()`."
               }

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -444,6 +444,7 @@
                 },
                 {
                   "version_added": "6",
+                  "version_removed": "8",
                   "partial_implementation": true,
                   "notes": "Until Internet Explorer 8, `inline-block` is only for natural inline elements."
                 }

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -146,6 +146,7 @@
                 },
                 {
                   "version_added": "≤72",
+                  "version_removed": "81",
                   "partial_implementation": true,
                   "notes": "Before Firefox 81, overflow with `column-reverse` was unsupported. See [bug 1042151](https://bugzil.la/1042151)."
                 }
@@ -231,6 +232,7 @@
                 },
                 {
                   "version_added": "≤72",
+                  "version_removed": "81",
                   "partial_implementation": true,
                   "notes": "Before Firefox 81, overflow with `column-reverse` was unsupported. See [bug 1042151](https://bugzil.la/1042151)."
                 }

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -95,6 +95,7 @@
                 },
                 {
                   "version_added": "55",
+                  "version_removed": "88",
                   "partial_implementation": true,
                   "notes": "Only supported on macOS."
                 }

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -611,6 +611,7 @@
                 },
                 {
                   "version_added": "7",
+                  "version_removed": "15",
                   "partial_implementation": true,
                   "notes": "Until version 15, only decimal numbers display."
                 }
@@ -621,6 +622,7 @@
                 },
                 {
                   "version_added": "10.1",
+                  "version_removed": "14",
                   "partial_implementation": true,
                   "notes": "Until version 15, only decimal numbers display."
                 }

--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -15,6 +15,7 @@
               },
               {
                 "version_added": "35",
+                "version_removed": "123",
                 "partial_implementation": true,
                 "notes": "Does not affect stroked HTML text, see [bug 41372165](https://crbug.com/41372165)"
               }
@@ -37,6 +38,7 @@
               },
               {
                 "version_added": "8",
+                "version_removed": "11",
                 "partial_implementation": true,
                 "notes": "Does not affect stroked HTML text, see [bug 168601](https://webkit.org/b/168601)"
               }

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -430,11 +430,13 @@
                 },
                 {
                   "version_added": "121",
+                  "version_removed": "124",
                   "partial_implementation": true,
                   "notes": "Supported for select, button, textarea and textual input elements."
                 },
                 {
                   "version_added": "119",
+                  "version_removed": "121",
                   "partial_implementation": true,
                   "notes": "Only supported for select and button elements."
                 }
@@ -457,6 +459,7 @@
                 },
                 {
                   "version_added": "16.5",
+                  "version_removed": "17.4",
                   "partial_implementation": true,
                   "notes": "Support for range sliders, textual inputs, and textareas only"
                 }

--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -16,6 +16,7 @@
               },
               {
                 "version_added": "112",
+                "version_removed": "120",
                 "partial_implementation": true,
                 "notes": "Does not support nested rules that start with a type selector."
               }
@@ -38,6 +39,7 @@
               },
               {
                 "version_added": "16.5",
+                "version_removed": "17.2",
                 "partial_implementation": true,
                 "notes": "Does not support nested rules that start with a type selector."
               }

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -16,6 +16,7 @@
               },
               {
                 "version_added": "90",
+                "version_removed": "125",
                 "partial_implementation": true,
                 "notes": "Uses a dashed-ident (such as `:--foo`) instead of `:state()`."
               }

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -157,6 +157,7 @@
                   },
                   {
                     "version_added": "16.4",
+                    "version_removed": "18",
                     "partial_implementation": true,
                     "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified as percentages with units (`%`)."
                   }
@@ -390,6 +391,7 @@
                   },
                   {
                     "version_added": "119",
+                    "version_removed": "125",
                     "partial_implementation": true,
                     "notes": "`s` and `l` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `s` and `l` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%). See [bug 330096624](https://crbug.com/330096624)."
                   }
@@ -412,6 +414,7 @@
                   },
                   {
                     "version_added": "16.4",
+                    "version_removed": "18",
                     "partial_implementation": true,
                     "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified with units (`deg` for `h`, `%` for `s` and `l`)."
                   }
@@ -555,6 +558,7 @@
                   },
                   {
                     "version_added": "119",
+                    "version_removed": "125",
                     "partial_implementation": true,
                     "notes": "`w` and `b` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `w` and `b` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%). See [bug 330096624](https://crbug.com/330096624)."
                   }
@@ -577,6 +581,7 @@
                   },
                   {
                     "version_added": "16.4",
+                    "version_removed": "18",
                     "partial_implementation": true,
                     "notes": "Implementation based on older spec version. As a result, calculations with channel values do not work correctly, requiring values to be specified with units (`deg` for `h`, `%` for `w` and `b`)."
                   }
@@ -812,6 +817,7 @@
                   },
                   {
                     "version_added": "16.4",
+                    "version_removed": "18",
                     "partial_implementation": true,
                     "notes": "Implementation based on older spec version. As a result, calculations with `h` channel values do not work correctly, requiring values to be specified with units (`deg`)."
                   }
@@ -1091,6 +1097,7 @@
                   },
                   {
                     "version_added": "119",
+                    "version_removed": "122",
                     "partial_implementation": true,
                     "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2). See [bug 40940488](https://crbug.com/40940488)."
                   }
@@ -1212,6 +1219,7 @@
                   },
                   {
                     "version_added": "119",
+                    "version_removed": "122",
                     "partial_implementation": true,
                     "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2). See [bug 40940488](https://crbug.com/40940488)."
                   }
@@ -1234,6 +1242,7 @@
                   },
                   {
                     "version_added": "16.4",
+                    "version_removed": "18",
                     "partial_implementation": true,
                     "notes": "Implementation based on older spec version. As a result, calculations with `h` channel values do not work correctly, requiring values to be specified with units (`deg`)."
                   }
@@ -1420,6 +1429,7 @@
                   },
                   {
                     "version_added": "119",
+                    "version_removed": "122",
                     "partial_implementation": true,
                     "notes": "Channel values incorrectly resolve to numbers between 0-1 rather than 0-255. As a result, channel value calculations require values to be specified as decimal percentage equivalents (e.g. 0.3 for 30%, which would be equivalent to a 76.5 `<number>` value). See [bug 41490327](https://crbug.com/41490327)."
                   }
@@ -1442,6 +1452,7 @@
                   },
                   {
                     "version_added": "16.4",
+                    "version_removed": "18",
                     "partial_implementation": true,
                     "notes": "Implementation based on older spec version. As a result, channel value calculations do not work correctly, requiring values to be specified as percentages with units (e.g. 30%, which would be equivalent to a 76.5 `<number>` value). See [bug 267647](https://webkit.org/b/267647)."
                   }

--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -654,6 +654,7 @@
                   },
                   {
                     "version_added": "46",
+                    "version_removed": "55",
                     "partial_implementation": true,
                     "notes": "Accepted only in `-webkit-linear-gradient()` and `-moz-linear-gradient()`, not `linear-gradient()`."
                   }
@@ -1541,6 +1542,7 @@
                   },
                   {
                     "version_added": "46",
+                    "version_removed": "55",
                     "partial_implementation": true,
                     "notes": "Accepted only in `-webkit-repeating-linear-gradient()` and `-moz-repeating-linear-gradient()`, not `repeating-linear-gradient()`."
                   }

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -23,6 +23,7 @@
               },
               {
                 "version_added": "3.5",
+                "version_removed": "8",
                 "partial_implementation": true,
                 "notes": "Supports [`<integer>`](https://developer.mozilla.org/docs/Web/CSS/integer) values only."
               }

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -206,6 +206,7 @@
                 },
                 {
                   "version_added": "13",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": [
                     "Until Edge 14 (build 14357), attempting to download data URIs caused Edge to crash ([bug 7160092](https://developer.microsoft.com/microsoft-edge/platform/issues/7160092/)).",

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -64,6 +64,7 @@
                 },
                 {
                   "version_added": "12",
+                  "version_removed": "79",
                   "partial_implementation": true,
                   "notes": "Does not work with nested fieldsets. For example: `<fieldset disabled><fieldset><!--Still enabled--></fieldset></fieldset>`"
                 }

--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -1565,6 +1565,7 @@
                 },
                 {
                   "version_added": "131",
+                  "version_removed": "132",
                   "partial_implementation": true,
                   "notes": [
                     "In Chrome for Android 131, choosing a directory crashes the browser (see [bug 376834374](https://crbug.com/376834374)).",

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -113,6 +113,7 @@
                   },
                   {
                     "version_added": "≤67",
+                    "version_removed": "124",
                     "partial_implementation": true,
                     "notes": "Vertical orientation available by setting the non-standard `-webkit-appearance: slider-vertical` style on the `input` element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
                   }
@@ -129,6 +130,7 @@
                   },
                   {
                     "version_added": "≤72",
+                    "version_removed": "120",
                     "impl_url": [
                       "https://bugzil.la/840820",
                       "https://bugzil.la/981916"
@@ -152,6 +154,7 @@
                   },
                   {
                     "version_added": "3.1",
+                    "version_removed": "16.5",
                     "partial_implementation": true,
                     "notes": "Vertical orientation available by setting the non-standard `-webkit-appearance: slider-vertical` style on the `input` element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
                   }
@@ -163,6 +166,7 @@
                   },
                   {
                     "version_added": "5",
+                    "version_removed": "16.5",
                     "partial_implementation": true,
                     "notes": "Vertical orientation available by setting the non-standard `-webkit-appearance: slider-vertical` style on the `input` element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
                   }

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -19,6 +19,7 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "65",
                 "partial_implementation": true,
                 "notes": "Implements the `HTMLDivElement` interface."
               }

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -774,6 +774,7 @@
                   },
                   {
                     "version_added": "105",
+                    "version_removed": "109",
                     "partial_implementation": true,
                     "notes": "Initial support included same-origin prerendering only."
                   }
@@ -784,6 +785,7 @@
                   },
                   {
                     "version_added": "103",
+                    "version_removed": "109",
                     "partial_implementation": true,
                     "notes": "Initial support included same-origin prerendering only."
                   }
@@ -871,6 +873,7 @@
                     },
                     {
                       "version_added": "121",
+                      "version_removed": "127",
                       "partial_implementation": true,
                       "notes": "Supported for `prefetch` only."
                     }

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -229,6 +229,7 @@
                 },
                 {
                   "version_added": "31",
+                  "version_removed": "50",
                   "partial_implementation": true,
                   "notes": "Before Firefox 50, setting the `src` didn't work, though it didn't raise an error."
                 }

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -244,6 +244,7 @@
                 },
                 {
                   "version_added": "23",
+                  "version_removed": "50",
                   "partial_implementation": true,
                   "notes": "Before Firefox 50, ping attributes of &lt;a&gt; elements weren't covered by connect-src."
                 }
@@ -487,6 +488,7 @@
                 },
                 {
                   "version_added": "33",
+                  "version_removed": "58",
                   "partial_implementation": true,
                   "notes": "Before Firefox 58, `frame-ancestors` is ignored in `Content-Security-Policy-Report-Only`."
                 }

--- a/http/headers/No-Vary-Search.json
+++ b/http/headers/No-Vary-Search.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "121",
+                "version_removed": "127",
                 "partial_implementation": true,
                 "notes": "Supported for navigation prefetch cache only."
               }

--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -199,6 +199,7 @@
                 },
                 {
                   "version_added": "12",
+                  "version_removed": "13",
                   "partial_implementation": true,
                   "notes": "Treats `SameSite=None` and invalid values as `Strict` in macOS before 10.15 Catalina. See [bug 198181](https://webkit.org/b/198181)."
                 }
@@ -209,6 +210,7 @@
                 },
                 {
                   "version_added": "12.2",
+                  "version_removed": "13",
                   "partial_implementation": true,
                   "notes": "Treats `SameSite=None` and invalid values as `Strict` in iOS before 13. See [bug 198181](https://webkit.org/b/198181)."
                 }

--- a/http/headers/X-Content-Type-Options.json
+++ b/http/headers/X-Content-Type-Options.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "64",
                 "partial_implementation": true,
                 "notes": "Not supported for stylesheets."
               }

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1990,6 +1990,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the function silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2482,6 +2482,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the function silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }
@@ -2692,6 +2693,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the function silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }
@@ -2902,6 +2904,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the function silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Intl/Collator.json
+++ b/javascript/builtins/Intl/Collator.json
@@ -84,6 +84,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the `Collator` instance silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }
@@ -552,6 +553,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -84,6 +84,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the `DateTimeFormat` instance silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }
@@ -120,6 +121,7 @@
                     },
                     {
                       "version_added": "57",
+                      "version_removed": "91",
                       "partial_implementation": true,
                       "notes": "The fallback symbol property has description `IntlFallback`."
                     }
@@ -144,6 +146,7 @@
                     },
                     {
                       "version_added": "8.0.0",
+                      "version_removed": "16.0.0",
                       "partial_implementation": true,
                       "notes": "The fallback symbol property has description `IntlFallback`."
                     }
@@ -198,6 +201,7 @@
                     },
                     {
                       "version_added": "0.12.0",
+                      "version_removed": "13.0.0",
                       "partial_implementation": true,
                       "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the `DateTimeFormat` instance silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                     }
@@ -1089,6 +1093,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Intl/ListFormat.json
+++ b/javascript/builtins/Intl/ListFormat.json
@@ -79,6 +79,7 @@
                   },
                   {
                     "version_added": "12.0.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the `ListFormat` instance silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }
@@ -277,6 +278,7 @@
                   },
                   {
                     "version_added": "12.0.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -113,6 +113,7 @@
                     },
                     {
                       "version_added": "57",
+                      "version_removed": "91",
                       "partial_implementation": true,
                       "notes": "The fallback symbol property has description `IntlFallback`."
                     }
@@ -137,6 +138,7 @@
                     },
                     {
                       "version_added": "8.0.0",
+                      "version_removed": "16.0.0",
                       "partial_implementation": true,
                       "notes": "The fallback symbol property has description `IntlFallback`."
                     }
@@ -191,6 +193,7 @@
                     },
                     {
                       "version_added": "0.12.0",
+                      "version_removed": "13.0.0",
                       "partial_implementation": true,
                       "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the `NumberFormat` instance silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                     }
@@ -1234,6 +1237,7 @@
                       },
                       {
                         "version_added": "0.12.0",
+                        "version_removed": "13.0.0",
                         "partial_implementation": true,
                         "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the `NumberFormat` instance silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                       }
@@ -1610,6 +1614,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Intl/PluralRules.json
+++ b/javascript/builtins/Intl/PluralRules.json
@@ -80,6 +80,7 @@
                   },
                   {
                     "version_added": "10.0.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the `PluralRules` instance silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Intl/RelativeTimeFormat.json
+++ b/javascript/builtins/Intl/RelativeTimeFormat.json
@@ -118,6 +118,7 @@
                     },
                     {
                       "version_added": "12.0.0",
+                      "version_removed": "13.0.0",
                       "partial_implementation": true,
                       "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the `RelativeTimeFormat` instance silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                     }
@@ -436,6 +437,7 @@
                   },
                   {
                     "version_added": "12.0.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -980,6 +980,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the function silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -395,6 +395,7 @@
                 },
                 {
                   "version_added": "8",
+                  "version_removed": "9",
                   "partial_implementation": true,
                   "notes": "In Internet Explorer 8, this was only supported on DOM objects and with some non-standard behaviors. This was later fixed in Internet Explorer 9."
                 }
@@ -656,6 +657,7 @@
                 },
                 {
                   "version_added": "8",
+                  "version_removed": "9",
                   "partial_implementation": true,
                   "notes": "In Internet Explorer 8, this was only supported on DOM objects and with some non-standard behaviors. This was later fixed in Internet Explorer 9."
                 }

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1309,6 +1309,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the function silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }
@@ -2430,6 +2431,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the function silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }
@@ -2545,6 +2547,7 @@
                   },
                   {
                     "version_added": "0.12.0",
+                    "version_removed": "13.0.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for `en-US` is available by default. When other locales are specified, the function silently falls back to `en-US`. To make full ICU (locale) data available before version 13, see [Node.js documentation on the `--with-intl` option](https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js) and how to provide the data."
                   }

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -222,6 +222,7 @@
                 },
                 {
                   "version_added": "12",
+                  "version_removed": "12.1",
                   "partial_implementation": true,
                   "notes": "No support for an undefined description."
                 }

--- a/lint/common/overlap.ts
+++ b/lint/common/overlap.ts
@@ -1,0 +1,144 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import chalk from 'chalk-template';
+import { compareVersions } from 'compare-versions';
+
+import { Logger, createStatementGroupKey } from '../utils.js';
+import {
+  BrowserName,
+  SimpleSupportStatement,
+  SupportStatement,
+} from '../../types/types.js';
+import compareStatements from '../../scripts/lib/compare-statements.js';
+
+/**
+ * Groups statements by group key.
+ * @param data The support statements to group.
+ * @returns the statement groups
+ */
+const groupByStatementKey = (data: SimpleSupportStatement[]) => {
+  const groups = new Map<string, SimpleSupportStatement[]>();
+
+  for (const support of data) {
+    const key = createStatementGroupKey(support);
+    const group = groups.get(key);
+    if (group) {
+      group.push(support);
+    } else {
+      groups.set(key, [support]);
+    }
+  }
+  return groups;
+};
+
+/**
+ * Formats a support statement as a simplified JSON-like version range.
+ * @param support The statement to format
+ * @returns The formatted range
+ */
+const formatRange = (support: SimpleSupportStatement): string => {
+  const result: string[] = [];
+  if (support.version_added) {
+    result.push(`added: ${support.version_added}`);
+  }
+  if (support.version_removed) {
+    result.push(`removed: ${support.version_removed}`);
+  }
+
+  return `{ ${result.join(', ')} }`;
+};
+
+/**
+ * Process data and check to make sure there aren't support statements whose version ranges overlap.
+ * @param data The data to test
+ * @param browser The name of the browser
+ * @param options The check options
+ * @param options.logger The logger to output errors to
+ * @param options.fix Whether the statements should be fixed (if possible)
+ * @returns the data (with fixes, if specified)
+ */
+export const checkOverlap = (
+  data: SupportStatement,
+  browser: BrowserName,
+  { logger, fix = false }: { logger?: Logger; fix?: boolean },
+): SupportStatement => {
+  if (!Array.isArray(data)) {
+    // If there's only one statement, skip since this is a linter for multiple statements
+    return data;
+  }
+
+  const filteredData = data.filter((support) => !support.flags);
+
+  const groups = groupByStatementKey(filteredData);
+
+  for (const [groupKey, groupData] of groups.entries()) {
+    const statements = groupData.slice().sort(compareStatements).reverse();
+
+    for (let i = 0; i < statements.length - 1; i++) {
+      const current = statements.at(i) as SimpleSupportStatement;
+      const next = statements.at(i + 1) as SimpleSupportStatement;
+
+      if (!statementsOverlap(current, next)) {
+        continue;
+      }
+
+      let fixed = false;
+      if (fix) {
+        if (
+          typeof current.version_removed === 'undefined' &&
+          next.version_added !== 'preview'
+        ) {
+          current.version_removed = next.version_added;
+          fixed = true;
+        }
+      }
+
+      if (!fixed && logger) {
+        logger.error(
+          chalk`{bold ${browser}} statements overlap for {bold ${groupKey}}: ` +
+            `[${formatRange(next)}, ${formatRange(current)}]`,
+        );
+      }
+    }
+  }
+
+  return data;
+};
+
+/**
+ * Checks if the support statements overlap in terms of their version ranges.
+ * @param current the current statement.
+ * @param next the chronologically following statement.
+ * @returns Whether the support statements overlap.
+ */
+const statementsOverlap = (
+  current: SimpleSupportStatement,
+  next: SimpleSupportStatement,
+): boolean => {
+  if (typeof current.version_removed === 'string') {
+    // If previous has no removed version, we always have an overlap.
+
+    if (next.version_added === 'preview') {
+      // Feature got re-introduced.
+      return false;
+    }
+
+    if (
+      typeof next.version_added === 'string' &&
+      compareVersions(current.version_removed, next.version_added) <= 0
+    ) {
+      // No overlap.
+      return false;
+    }
+  } else if (
+    next.version_added === 'preview' &&
+    current.partial_implementation === true
+  ) {
+    // Stable has partial support.
+    // Preview has full support.
+    return false;
+  }
+
+  return true;
+};

--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -23,6 +23,7 @@ import fixLinks from './fixer/links.js';
 import fixMDNURLs from './fixer/mdn-urls.js';
 import fixStatus from './fixer/status.js';
 import fixMirror from './fixer/mirror.js';
+import fixOverlap from './fixer/overlap.js';
 import { LintOptions } from './utils.js';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -34,6 +35,7 @@ const FIXES = Object.freeze({
   mdn_urls: fixMDNURLs,
   status: fixStatus,
   mirror: fixMirror,
+  overlap: fixOverlap,
   browser_order: fixBrowserOrder,
   feature_order: fixFeatureOrder,
   property_order: fixPropertyOrder,

--- a/lint/fixer/overlap.test.ts
+++ b/lint/fixer/overlap.test.ts
@@ -1,0 +1,94 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import assert from 'node:assert/strict';
+
+import { checkOverlap } from '../common/overlap.js';
+import { SupportStatement } from '../../types/types.js';
+
+const tests: { input: SupportStatement; output?: SupportStatement }[] = [
+  // Use version_added from following as version_removed of previous.
+  {
+    input: [
+      {
+        version_added: '3',
+      },
+      {
+        version_added: '1',
+      },
+    ],
+    output: [
+      {
+        version_added: '3',
+      },
+      {
+        version_added: '1',
+        version_removed: '3',
+      },
+    ],
+  },
+  // Don't touch open-ended stable/preview side-by-side.
+  {
+    input: [
+      {
+        version_added: 'preview',
+      },
+      {
+        version_added: '1',
+      },
+    ],
+  },
+  // Don't touch flag data.
+  {
+    input: [
+      {
+        version_added: '126',
+        flags: [
+          {
+            name: '#web-machine-learning-neural-network',
+            type: 'preference',
+            value_to_set: 'Enabled',
+          },
+        ],
+        notes: 'Supported on CPUs, GPUs and NPUs on macOS.',
+      },
+      {
+        version_added: '121',
+        flags: [
+          {
+            name: '#web-machine-learning-neural-network',
+            type: 'preference',
+            value_to_set: 'Enabled',
+          },
+        ],
+        notes: 'Supported on GPUs and NPUs on Windows.',
+      },
+      {
+        version_added: '116',
+        flags: [
+          {
+            name: '#web-machine-learning-neural-network',
+            type: 'preference',
+            value_to_set: 'Enabled',
+          },
+        ],
+        notes: 'Supported on CPUs on Windows, ChromeOS and Linux.',
+      },
+    ],
+  },
+];
+
+describe('fix -> overlap', () => {
+  let i = 1;
+  for (const test of tests) {
+    it(`Test #${i}`, () => {
+      const result = checkOverlap(test.input, 'firefox', {
+        fix: true,
+      });
+
+      assert.deepStrictEqual(result, test.output ?? test.input);
+    });
+
+    i += 1;
+  }
+});

--- a/lint/fixer/overlap.ts
+++ b/lint/fixer/overlap.ts
@@ -1,0 +1,57 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import fs from 'node:fs';
+
+import { BrowserName, CompatStatement } from '../../types/types.js';
+import { IS_WINDOWS } from '../utils.js';
+import { checkOverlap as checkOverlap } from '../common/overlap.js';
+
+/**
+ * Return a new "support_block" object whose support statements have
+ * been updated to avoid overlapping version ranges.
+ * @param key The key in the object
+ * @param value The value of the key
+ * @returns The new value
+ */
+export const processStatement = (
+  key: string,
+  value: CompatStatement,
+): CompatStatement => {
+  if (key === '__compat') {
+    for (const browser of Object.keys(value.support) as BrowserName[]) {
+      const supportData = value.support[browser];
+      if (Array.isArray(supportData)) {
+        value.support[browser] = checkOverlap(supportData, browser, {
+          fix: true,
+        });
+      }
+    }
+  }
+  return value;
+};
+
+/**
+ * Fix issues with statement order throughout the BCD files
+ * @param filename The name of the file to fix
+ */
+const fixOverlap = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
+  let actual = fs.readFileSync(filename, 'utf-8').trim();
+  let expected = JSON.stringify(JSON.parse(actual, processStatement), null, 2);
+
+  if (IS_WINDOWS) {
+    // prevent false positives from git.core.autocrlf on Windows
+    actual = actual.replace(/\r/g, '');
+    expected = expected.replace(/\r/g, '');
+  }
+
+  if (actual !== expected) {
+    fs.writeFileSync(filename, expected + '\n', 'utf-8');
+  }
+};
+
+export default fixOverlap;

--- a/lint/linter/index.ts
+++ b/lint/linter/index.ts
@@ -13,6 +13,7 @@ export { default as testMirror } from './test-mirror.js';
 export { default as testMultipleStatements } from './test-multiple-statements.js';
 export { default as testNotes } from './test-notes.js';
 export { default as testObsolete } from './test-obsolete.js';
+export { default as testOverlap } from './test-overlap.js';
 export { default as testPrefix } from './test-prefix.js';
 export { default as testSchema } from './test-schema.js';
 export { default as testSpecURLs } from './test-spec-urls.js';

--- a/lint/linter/test-multiple-statements.ts
+++ b/lint/linter/test-multiple-statements.ts
@@ -3,7 +3,12 @@
 
 import chalk from 'chalk-template';
 
-import { Linter, Logger, LinterData } from '../utils.js';
+import {
+  Linter,
+  Logger,
+  LinterData,
+  createStatementGroupKey,
+} from '../utils.js';
 import { BrowserName, SupportStatement } from '../../types/types.js';
 
 /**
@@ -31,11 +36,7 @@ const processData = (
       continue;
     }
 
-    const statementKey = d.prefix
-      ? `prefix: ${d.prefix}`
-      : d.alternative_name
-        ? `alt. name: ${d.alternative_name}`
-        : 'normal name';
+    const statementKey = createStatementGroupKey(d);
 
     if (statements.includes(statementKey)) {
       logger.error(

--- a/lint/linter/test-overlap.test.ts
+++ b/lint/linter/test-overlap.test.ts
@@ -1,0 +1,180 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import assert from 'node:assert/strict';
+
+import { Logger } from '../utils.js';
+import { CompatStatement } from '../../types/types.js';
+
+import test from './test-overlap.js';
+
+describe('overlap', () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    logger = new Logger('test', 'test');
+  });
+
+  it('should skip processing when data is not an array', () => {
+    const data: CompatStatement = {
+      support: {
+        chrome: {
+          version_added: '1',
+          version_removed: '2',
+        },
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 0);
+  });
+
+  it('should log error when statements overlap', () => {
+    const data: CompatStatement = {
+      support: {
+        firefox: [
+          { version_added: '2' },
+          { version_added: '1', version_removed: '3' },
+        ],
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 1);
+    assert.ok(logger.messages[0].message.includes('statements overlap'));
+  });
+
+  it('should log error when overlapping statements are not sorted', () => {
+    const data: CompatStatement = {
+      support: {
+        firefox: [
+          { version_added: '1', version_removed: '3' },
+          { version_added: '2' },
+        ],
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 1);
+    assert.ok(logger.messages[0].message.includes('statements overlap'));
+  });
+
+  it('should log error when statements with same prefix overlap', () => {
+    const data: CompatStatement = {
+      support: {
+        firefox: [
+          { prefix: '-moz', version_added: '1', version_removed: '3' },
+          { prefix: '-moz', version_added: '2' },
+        ],
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 1);
+    assert.ok(logger.messages[0].message.includes('statements overlap'));
+  });
+
+  it('should log error when statements with same alternative name overlap', () => {
+    const data: CompatStatement = {
+      support: {
+        firefox: [
+          {
+            alternative_name: 'MozObject',
+            version_added: '1',
+            version_removed: '3',
+          },
+          { alternative_name: 'MozObject', version_added: '2' },
+        ],
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 1);
+    assert.ok(logger.messages[0].message.includes('statements overlap'));
+  });
+
+  it('should log error when there are two statements without version_added', () => {
+    const data: CompatStatement = {
+      support: {
+        firefox: [
+          {
+            version_added: '133',
+          },
+          {
+            version_added: '131',
+          },
+        ],
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 1);
+    assert.ok(logger.messages[0].message.includes('statements overlap'));
+  });
+
+  it('should log error when there are two statements without version_added incl. preview', () => {
+    const data: CompatStatement = {
+      support: {
+        firefox: [
+          {
+            version_added: 'preview',
+          },
+          {
+            version_added: '131',
+          },
+        ],
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 1);
+    assert.ok(logger.messages[0].message.includes('statements overlap'));
+  });
+
+  it('should ignore when partial support in stable and full support in preview overlap', () => {
+    const data: CompatStatement = {
+      support: {
+        firefox: [
+          {
+            version_added: 'preview',
+          },
+          {
+            version_added: '43',
+            partial_implementation: true,
+          },
+        ],
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 0);
+  });
+
+  it('should ignore preview version without overlap', () => {
+    const data: CompatStatement = {
+      support: {
+        firefox: [
+          {
+            version_added: 'preview',
+          },
+          {
+            version_added: '131',
+            version_removed: '133',
+          },
+        ],
+      },
+    };
+
+    test.check(logger, { data });
+
+    assert.equal(logger.messages.length, 0);
+  });
+});

--- a/lint/linter/test-overlap.ts
+++ b/lint/linter/test-overlap.ts
@@ -1,0 +1,25 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import { Linter, Logger, LinterData } from '../utils.js';
+import { BrowserName, SupportStatement } from '../../types/types.js';
+import { checkOverlap } from '../common/overlap.js';
+
+export default {
+  name: 'Overlap',
+  description: 'Ensure there are no statements with overlapping version ranges',
+  scope: 'feature',
+  /**
+   * Test the data
+   * @param logger The logger to output errors to
+   * @param root The data to test
+   * @param root.data The data to test
+   */
+  check: (logger: Logger, { data }: LinterData) => {
+    for (const [browser, support] of Object.entries(data.support)) {
+      checkOverlap(support as SupportStatement, browser as BrowserName, {
+        logger,
+      });
+    }
+  },
+} as Linter;

--- a/lint/utils.test.ts
+++ b/lint/utils.test.ts
@@ -3,7 +3,13 @@
 
 import assert from 'node:assert/strict';
 
-import { escapeInvisibles, jsonDiff } from './utils.js';
+import { SimpleSupportStatement } from '../types/types.js';
+
+import {
+  createStatementGroupKey,
+  escapeInvisibles,
+  jsonDiff,
+} from './utils.js';
 
 describe('utils', () => {
   it('`escapeInvisibles()` works correctly', () => {
@@ -71,5 +77,46 @@ describe('utils', () => {
       ),
       null,
     );
+  });
+
+  it('createStatementGroupKey() works correctly', () => {
+    const tests: Record<string, SimpleSupportStatement> = {
+      'normal name': {
+        version_added: '1',
+      },
+      'alt. name: foobar': {
+        version_added: '2',
+        alternative_name: 'foobar',
+      },
+      'prefix: -moz-': {
+        version_added: '3',
+        prefix: '-moz-',
+      },
+      'preference: #service-worker-payment-apps': {
+        version_added: '4',
+        flags: [
+          {
+            type: 'preference',
+            name: '#service-worker-payment-apps',
+            value_to_set: 'Enabled',
+          },
+        ],
+      },
+      'alt. name: foobar / preference: #service-worker-payment-apps': {
+        version_added: '4',
+        alternative_name: 'foobar',
+        flags: [
+          {
+            type: 'preference',
+            name: '#service-worker-payment-apps',
+            value_to_set: 'Enabled',
+          },
+        ],
+      },
+    };
+
+    for (const [expected, input] of Object.entries(tests)) {
+      assert.equal(createStatementGroupKey(input), expected);
+    }
   });
 });

--- a/lint/utils.ts
+++ b/lint/utils.ts
@@ -6,7 +6,7 @@ import { platform } from 'node:os';
 import chalk from 'chalk-template';
 
 import { DataType } from '../types/index.js';
-import { BrowserName } from '../types/types.js';
+import { BrowserName, SimpleSupportStatement } from '../types/types.js';
 
 export interface LintOptions {
   only?: string[];
@@ -268,3 +268,31 @@ export class Linters {
     }
   }
 }
+
+/**
+ * Returns the key for the group that this statement belongs to.
+ * @param support The support statement.
+ * @returns The key of the support statement group.
+ */
+export const createStatementGroupKey = (
+  support: SimpleSupportStatement,
+): string => {
+  const parts: string[] = [];
+  if (support.prefix) {
+    parts.push(`prefix: ${support.prefix}`);
+  }
+
+  if (support.alternative_name) {
+    parts.push(`alt. name: ${support.alternative_name}`);
+  }
+
+  if (support.flags) {
+    parts.push(...support.flags.map((flag) => `${flag.type}: ${flag.name}`));
+  }
+
+  if (parts.length === 0) {
+    return 'normal name';
+  }
+
+  return parts.join(' / ');
+};

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -29,13 +29,12 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "4",
                 "partial_implementation": true,
                 "notes": "Only supported in XHTML documents."
               }
             ],
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -100,6 +100,7 @@
                 },
                 {
                   "version_added": "5.1",
+                  "version_removed": "9",
                   "partial_implementation": true,
                   "notes": "Only `0`, `thin`, `medium`, and `thick` are supported."
                 }

--- a/mathml/elements/mstyle.json
+++ b/mathml/elements/mstyle.json
@@ -24,6 +24,7 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "6",
                 "partial_implementation": true,
                 "notes": "Attributes `bevelled`, `notation`, `open`, `close`, `separators`, `accent`, `accentunder`, `selection`, `mathvariant` are not supported."
               }

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -222,6 +222,7 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "70",
                 "partial_implementation": true,
                 "notes": "Attribute only accepted on a few elements, as specified in MathML 3."
               }

--- a/scripts/lib/compare-statements.test.ts
+++ b/scripts/lib/compare-statements.test.ts
@@ -108,6 +108,22 @@ const tests: { input: Identifier; output: Identifier }[] = [
       },
     },
   },
+  {
+    input: {
+      __compat: {
+        support: {
+          chrome: [{ version_added: '10' }, { version_added: 'preview' }],
+        },
+      },
+    },
+    output: {
+      __compat: {
+        support: {
+          chrome: [{ version_added: 'preview' }, { version_added: '10' }],
+        },
+      },
+    },
+  },
 ] as any;
 
 /**

--- a/scripts/lib/compare-statements.ts
+++ b/scripts/lib/compare-statements.ts
@@ -75,10 +75,19 @@ const compareStatements = (
     typeof a.version_added == 'string' &&
     typeof b.version_added == 'string'
   ) {
-    return compareVersions(
-      b.version_added.replace('≤', ''),
-      a.version_added.replace('≤', ''),
-    );
+    switch ('preview') {
+      case a.version_added:
+        return -1;
+
+      case b.version_added:
+        return 1;
+
+      default:
+        return compareVersions(
+          b.version_added.replace('≤', ''),
+          a.version_added.replace('≤', ''),
+        );
+    }
   }
 
   return 0;

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -19,6 +19,7 @@
               },
               {
                 "version_added": "78",
+                "version_removed": "110",
                 "partial_implementation": true,
                 "notes": "Only supported on `SVGGraphicsElement`."
               }

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -222,6 +222,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": "`HttpOnly` cookies are not retrieved."
                 }
@@ -232,6 +233,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": "`HttpOnly` cookies are not retrieved."
                 }
@@ -305,6 +307,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": [
                     "Only the cookies in the default cookie store are retrieved.",
@@ -318,6 +321,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": [
                     "Only the cookies in the default cookie store are retrieved.",
@@ -388,6 +392,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": "Always returns the same default cookie store with ID 0."
                 }
@@ -398,6 +403,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": "Always returns the same default cookie store with ID 0."
                 }
@@ -662,6 +668,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": [
                     "Only sets cookies in the default cookie store.",
@@ -675,6 +682,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": [
                     "Only sets cookies in the default cookie store.",

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -202,6 +202,7 @@
                   },
                   {
                     "version_added": "14",
+                    "version_removed": "18",
                     "partial_implementation": true,
                     "notes": "Filtering by `windowId` doesn't work when a tab is moved from one window to another."
                   }
@@ -212,6 +213,7 @@
                   },
                   {
                     "version_added": "15",
+                    "version_removed": "18",
                     "partial_implementation": true,
                     "notes": "Filtering by `windowId` doesn't work when a tab is moved from one window to another."
                   }
@@ -251,6 +253,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": "Always returns `false`."
                 }
@@ -261,6 +264,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": "Always returns `false`."
                 }
@@ -315,6 +319,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": "Always returns `true`."
                 }
@@ -325,6 +330,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "18",
                   "partial_implementation": true,
                   "notes": "Always returns `true`."
                 }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -999,6 +999,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "Only fired in response to a message from an extension's containing app, not webpages and other extensions."
                 }
@@ -1011,6 +1012,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "Only fired in response to a message from an extension's containing app, not webpages and other extensions."
                 }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1360,6 +1360,7 @@
                   },
                   {
                     "version_added": "45",
+                    "version_removed": "110",
                     "partial_implementation": true,
                     "notes": "Returns 1, regardless of the default zoom factor setting."
                   }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1473,6 +1473,7 @@
                 },
                 {
                   "version_added": "45",
+                  "version_removed": "138",
                   "partial_implementation": true,
                   "notes": "Exposed but non-functional"
                 }
@@ -1483,6 +1484,7 @@
                 },
                 {
                   "version_added": "48",
+                  "version_removed": "138",
                   "partial_implementation": true,
                   "notes": "Exposed but non-functional"
                 }

--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -94,6 +94,7 @@
                 },
                 {
                   "version_added": "15.4",
+                  "version_removed": "16.4",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -82,6 +82,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "14.1",
                   "partial_implementation": true,
                   "notes": "Only persistent pages are supported."
                 }
@@ -94,6 +95,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "Only non-persistent pages are supported. Requires `persistent: false`."
                 }

--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -112,6 +112,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "16.4",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",
@@ -126,6 +127,7 @@
                 },
                 {
                   "version_added": "15.4",
+                  "version_removed": "16.4",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -833,6 +833,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "16",
                   "partial_implementation": true,
                   "notes": "Grants a 10 MB storage quota, instead of the standard 5 MB."
                 }
@@ -843,6 +844,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "16",
                   "partial_implementation": true,
                   "notes": "Grants a 10 MB storage quota, instead of the standard 5 MB."
                 }

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -91,6 +91,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "16.4",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",
@@ -105,6 +106,7 @@
                 },
                 {
                   "version_added": "15.4",
+                  "version_removed": "16.4",
                   "partial_implementation": true,
                   "notes": [
                     "SVG icons are not supported.",

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -955,6 +955,7 @@
                 },
                 {
                   "version_added": "14",
+                  "version_removed": "16",
                   "partial_implementation": true,
                   "notes": "Grants a 10 MB storage quota, instead of the standard 5 MB."
                 }
@@ -965,6 +966,7 @@
                 },
                 {
                   "version_added": "15",
+                  "version_removed": "16",
                   "partial_implementation": true,
                   "notes": "Grants a 10 MB storage quota, instead of the standard 5 MB."
                 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a new `overlap` linter that

- checks for overlapping version ranges, e.g. `[{ added: 1, removed: 3 }, { added: 2 }]`,
- fixes them by using the newer `version_added` as `version_removed` for the previous.

Notes:

- Each prefix and alternative name is considered as separate "statement groups" that can overlap, while statements within a group must not.
- Ignores statements with `flags` for now, as these have a separate linter, which forbids `version_removed`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26543.

Extracted manual fixes to:

- https://github.com/mdn/browser-compat-data/pull/26595
- https://github.com/mdn/browser-compat-data/pull/26596