### PR TITLE
Chrome 119-121 had partial relative `oklab()`/`oklch()` support

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1018,7 +1018,7 @@
                 {
                   "version_added": "111",
                   "partial_implementation": true,
-                  "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2)."
+                  "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2). See [bug 40940488](https://crbug.com/40940488)."
                 }
               ],
               "chrome_android": "mirror",
@@ -1213,7 +1213,7 @@
                   {
                     "version_added": "119",
                     "partial_implementation": true,
-                    "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2)."
+                    "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2). See [bug 40940488](https://crbug.com/40940488)."
                   }
                 ],
                 "chrome_android": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1011,16 +1011,9 @@
               "web-features:oklab"
             ],
             "support": {
-              "chrome": [
-                {
-                  "version_added": "122"
-                },
-                {
-                  "version_added": "111",
-                  "partial_implementation": true,
-                  "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2). See [bug 40940488](https://crbug.com/40940488)."
-                }
-              ],
+              "chrome": {
+                "version_added": "111"
+              },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1092,9 +1085,16 @@
                 "web-features:relative-color"
               ],
               "support": {
-                "chrome": {
-                  "version_added": "119"
-                },
+                "chrome": [
+                  {
+                    "version_added": "122"
+                  },
+                  {
+                    "version_added": "119",
+                    "partial_implementation": true,
+                    "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2). See [bug 40940488](https://crbug.com/40940488)."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1011,9 +1011,16 @@
               "web-features:oklab"
             ],
             "support": {
-              "chrome": {
-                "version_added": "111"
-              },
+              "chrome": [
+                {
+                  "version_added": "122"
+                },
+                {
+                  "version_added": "111",
+                  "partial_implementation": true,
+                  "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2)."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1199,9 +1206,16 @@
                 "web-features:relative-color"
               ],
               "support": {
-                "chrome": {
-                  "version_added": "119"
-                },
+                "chrome": [
+                  {
+                    "version_added": "122"
+                  },
+                  {
+                    "version_added": "119",
+                    "partial_implementation": true,
+                    "notes": "`l` channel values incorrectly resolve to numbers between 0-100 rather than 0-1. As a result, channel value calculations require `l` values to be specified as percentage numbers without units (e.g. 20 for 0.2)."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

As noted in the linked issue, this mostly copies the partial support notes for relative `rgb()`, `hsl()`, and `hwb()` in certain Chrome versions to document a very similar incorrect channel serialization range in relative `oklab()`/`oklch()`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Code used and per-browser-version results are commented in the linked issue: https://github.com/mdn/browser-compat-data/issues/26041#issuecomment-2684039848. I observed the erroneous behavior in Chromium 121, but not 122.

~~I'm not familiar enough with the Chromium bug tracker to find if there's a bug that should be linked here. (I wouldn't be surprised if it was fixed with the relative `rgb()` bug, which links to https://crbug.com/41490327.)~~ Found using bisect-builds.py; will update link.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Resolves #26041.
