### PR TITLE
Chrome 111-133 doesn't expose CSSFontFeatureValuesRule

### DIFF
--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -8,9 +8,17 @@
           "web-features:font-variant-alternates"
         ],
         "support": {
-          "chrome": {
-            "version_added": "111"
-          },
+          "chrome": [
+            {
+              "version_added": "134"
+            },
+            {
+              "version_added": "111",
+              "version_removed": "134",
+              "partial_implementation": true,
+              "notes": "The interface is defined but not exposed to window scope."
+            }
+          ],
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {

--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -16,7 +16,7 @@
               "version_added": "111",
               "version_removed": "134",
               "partial_implementation": true,
-              "notes": "Not exposed on `Window`. See [bug 385925149](https://issues.chromium.org/issues/385925149)."
+              "notes": "Not exposed on `Window`. See [bug 385925149](https://crbug.com/385925149)."
             }
           ],
           "chrome_android": "mirror",

--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -16,7 +16,7 @@
               "version_added": "111",
               "version_removed": "134",
               "partial_implementation": true,
-              "notes": "The interface is defined but not exposed to window scope."
+              "notes": "Not exposed on `Window`. See [bug 385925149](https://issues.chromium.org/issues/385925149)."
             }
           ],
           "chrome_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://drafts.csswg.org/css-fonts/#cssfontfeaturevaluesrule-dfn
https://issues.chromium.org/issues/385925149
https://chromiumdash.appspot.com/commit/9d821a1e08753f8ec3c389e3bc8014f28595c90a

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25611

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
