### PR TITLE
ci(pr-rebase-needed): update job name

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write # To add labels and comment on PRs
 
 jobs:
-  mergeable:
+  label-rebase-needed:
     uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main
     with:
       target-repo: "mdn/browser-compat-data"

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write # To add labels and comment on PRs
 
 jobs:
-  idle:
+  mergeable:
     uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main
     with:
       target-repo: "mdn/browser-compat-data"


### PR DESCRIPTION
#### Summary

Tweaks the "PR Needs Rebase" job id for consistency.

#### Test results and supporting details

When externalizing the workflow to org reusables, the "idle" job key got in most likely via copypasta from unrelated action boilerplate.

> ![Screenshot 2025-04-19 at 18 04 00](https://github.com/user-attachments/assets/7d3c681c-7086-4cc5-a1ab-95b43de4742c)

~Not calling it `pr-rebase-needed` or `label-rebase-needed` from the source files as that seems too long and already repetitive (esp. for the check summary previews around the UI), and also skipping `dirty` nomenclature from the marketplace action used as that may mean more than just a conflict — instead went with GH's own API terminology and picked "mergeable", which sounds reasonably concise.~