### PR TITLE
Chrome 126 added Topics API (`browsingTopics`)

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -881,7 +881,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/browsingTopics",
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -261,7 +261,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/browsingTopics",
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Request.json
+++ b/api/Request.json
@@ -196,7 +196,7 @@
             "description": "`init.browsingTopics` parameter",
             "support": {
               "chrome": {
-                "version_added": "115"
+                "version_added": "126"
               },
               "chrome_android": "mirror",
               "deno": {

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -220,7 +220,7 @@
           "description": "`init.browsingTopics` parameter",
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "deno": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1647,7 +1647,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "115"
+                "version_added": "126"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `browsingTopics` member of the `Document` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/browsingTopics
