### PR TITLE
Firefox 128 added api.Element.attachShadow.options_serializable_parameter

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2994,7 +2994,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "128"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -3012,7 +3012,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `attachShadow.options_serializable_parameter` member of the `Element` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Element/attachShadow/options_serializable_parameter
