### PR TITLE
Chrome 126 added Fence API

### DIFF
--- a/api/Fence.json
+++ b/api/Fence.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "115"
+            "version_added": "126"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -46,7 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -84,7 +84,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -122,7 +122,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -158,7 +158,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "120",
+                "version_added": "126",
                 "notes": "Previously only a single `eventType` was available, `reserved.top_navigation`, but this has been replaced by the new values."
               },
               "chrome_android": "mirror",

--- a/api/FencedFrameConfig.json
+++ b/api/FencedFrameConfig.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "115"
+            "version_added": "126"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -46,7 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLFencedFrameElement.json
+++ b/api/HTMLFencedFrameElement.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "115"
+            "version_added": "126"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -46,7 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -84,7 +84,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -122,7 +122,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -159,7 +159,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -197,7 +197,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1643,7 +1643,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "deno": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -946,7 +946,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "115"
+                  "version_added": "126"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/html/elements/fencedframe.json
+++ b/html/elements/fencedframe.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -46,7 +46,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "115"
+                "version_added": "126"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -83,7 +83,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "115"
+                "version_added": "126"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -120,7 +120,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "115"
+                "version_added": "126"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -321,7 +321,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "115"
+                "version_added": "126"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/http/headers/Sec-Fetch-Dest.json
+++ b/http/headers/Sec-Fetch-Dest.json
@@ -46,7 +46,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "115"
+                "version_added": "126"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Fence` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Fence
