### PR TITLE
Chromium 128 enabled api.Navigator.deprecatedReplaceInURN

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1095,7 +1095,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "128"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `deprecatedReplaceInURN` member of the `Navigator` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Navigator/deprecatedReplaceInURN
