### PR TITLE
Update Firefox data for api.Permissions.permission_screen-wake-lock

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -781,7 +781,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "126"
+              "version_added": "122"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `permission_screen-wake-lock` member of the `Permissions` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Permissions/permission_screen-wake-lock
