### PR TITLE
Chrome 126 added SharedStorage API

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -1132,7 +1132,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "124"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1067,7 +1067,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "124"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SharedStorage.json
+++ b/api/SharedStorage.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "117"
+            "version_added": "126"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -46,7 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -123,7 +123,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -200,7 +200,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -355,7 +355,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SharedStorageWorklet.json
+++ b/api/SharedStorageWorklet.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "117"
+            "version_added": "126"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -45,7 +45,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "125"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -82,7 +82,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "125"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SharedStorageWorkletGlobalScope.json
+++ b/api/SharedStorageWorkletGlobalScope.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "117"
+            "version_added": "126"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -80,7 +80,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -118,7 +118,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SharedStorage` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SharedStorage
