### PR TITLE
Update Firefox data for api.Window.cookieStore

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1040,7 +1040,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "136"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1643,7 +1643,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -2005,9 +2005,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "35",
-              "partial_implementation": true,
-              "notes": "The `ongamepadconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "37",
@@ -2017,11 +2015,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "≤18",
-              "partial_implementation": true,
-              "notes": "The `ongamepadconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
-            },
+            "edge": "mirror",
             "firefox": [
               {
                 "version_added": "89"
@@ -2083,9 +2077,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "35",
-              "partial_implementation": true,
-              "notes": "The `ongamepaddisconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "37",
@@ -2095,11 +2087,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "≤18",
-              "partial_implementation": true,
-              "notes": "The `ongamepaddisconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
-            },
+            "edge": "mirror",
             "firefox": [
               {
                 "version_added": "89"
@@ -2337,7 +2325,9 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "134"
+            },
             "firefox": {
               "version_added": false
             },
@@ -6926,7 +6916,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `cookieStore` member of the `Window` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/cookieStore
