### PR TITLE
Chrome 126 added api.Window.sharedStorage

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6926,7 +6926,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "117"
+              "version_added": "126"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `sharedStorage` member of the `Window` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/sharedStorage
