### PR TITLE
Update Chromium data for Symbol JavaScript builtin

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -100,7 +100,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "134"
+                "version_added": "127"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -242,7 +242,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "134"
+                "version_added": "125"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Symbol` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.11).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Symbol
