### PR TITLE
Firefox Nightly supports import attributes with `with` syntax for json modules

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1627,8 +1627,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1736059"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1721,8 +1720,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1736059"
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
#### Summary

[Bug 1950836](https://bugzilla.mozilla.org/show_bug.cgi?id=1950836) adds support for `import...with { type: "json" }`.
This PR updates the BCD entries for the `with` attribute to reflect support in Nightly.

#### Test results and supporting details

Tested in Firefox Nightly 130.0a1:
- `with { type: "json" }` is working as expected: The imported json module loads and logs correctly.
- `with { type: "css" }` is not supported: Importing a css module throws an "invalid module type" error. (tbd in [Bug 1720570](https://bugzilla.mozilla.org/show_bug.cgi?id=1720570))

#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/38878

#### Additional context

[Firefox Nightly Release Notes 138.0a1](https://www.mozilla.org/en-US/firefox/138.0a1/releasenotes/) > Web Platform section
