### PR TITLE
text-wrap-style: pretty is supported in Safari Technology Preview 

### DIFF
--- a/css/properties/text-wrap-style.json
+++ b/css/properties/text-wrap-style.json
@@ -135,7 +135,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
`text-wrap-style: pretty` is supported in Safari Technology Preview. 
See: https://webkit.org/blog/16547/better-typography-with-text-wrap-pretty/

(`text-wrap: pretty` was [updated previously](https://github.com/mdn/browser-compat-data/pull/26473), but this was missed.)
