### PR TITLE
Add Chrome bug for partial relative `hsl()`/`hwb()` support

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -391,7 +391,7 @@
                   {
                     "version_added": "119",
                     "partial_implementation": true,
-                    "notes": "`s` and `l` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `s` and `l` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%)."
+                    "notes": "`s` and `l` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `s` and `l` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%). See [bug 330096624](https://crbug.com/330096624)."
                   }
                 ],
                 "chrome_android": "mirror",
@@ -556,7 +556,7 @@
                   {
                     "version_added": "119",
                     "partial_implementation": true,
-                    "notes": "`w` and `b` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `w` and `b` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%)."
+                    "notes": "`w` and `b` channel values incorrectly resolve to numbers between 0-1 rather than 0-100. As a result, channel value calculations require `w` and `b` values to be specified as decimal percentage equivalents (e.g. 0.2 for 20%). See [bug 330096624](https://crbug.com/330096624)."
                   }
                 ],
                 "chrome_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

For consistency with the other similar partial support bugs in relative color syntax in Chrome, this adds crbug links to the notes on the relative `hsl()`/`hwb()` features.

Found using chromium bisect after documenting #26551.

#### Test results and supporting details

Chromium bisect points to https://chromium.googlesource.com/chromium/src/+/37587902e6a31e47b8a9493e430ed06393a93e8a, which mentions bug 330096624.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

n/a
