### PR TITLE
Fix overlapping VR support statements for Firefox

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -247,12 +247,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -83,12 +83,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -1826,12 +1826,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -29,12 +29,12 @@
             {
               "version_added": "64",
               "version_removed": "98",
-              "notes": "macOS support was enabled in Firefox 64."
+              "notes": "Only on macOS and Windows."
             },
             {
               "version_added": "55",
-              "version_removed": "98",
-              "notes": "Windows support was enabled in Firefox 55."
+              "version_removed": "64",
+              "notes": "Only on Windows."
             }
           ],
           "firefox_android": {
@@ -93,12 +93,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -158,12 +158,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -223,12 +223,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -288,12 +288,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -353,12 +353,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -418,12 +418,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -483,12 +483,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -548,12 +548,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -613,12 +613,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -675,12 +675,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -737,12 +737,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -802,12 +802,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -867,12 +867,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -932,12 +932,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -997,12 +997,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -1062,12 +1062,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -1127,12 +1127,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -1192,12 +1192,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -1257,12 +1257,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -29,12 +29,12 @@
             {
               "version_added": "64",
               "version_removed": "98",
-              "notes": "macOS support was enabled in Firefox 64."
+              "notes": "Only on macOS and Windows."
             },
             {
               "version_added": "55",
-              "version_removed": "98",
-              "notes": "Windows support was enabled in Firefox 55."
+              "version_removed": "64",
+              "notes": "Only on Windows."
             }
           ],
           "firefox_android": {
@@ -93,12 +93,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -158,12 +158,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -223,12 +223,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -288,12 +288,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -353,12 +353,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -29,12 +29,12 @@
             {
               "version_added": "64",
               "version_removed": "98",
-              "notes": "macOS support was enabled in Firefox 64."
+              "notes": "Only on macOS and Windows."
             },
             {
               "version_added": "55",
-              "version_removed": "98",
-              "notes": "Windows support was enabled in Firefox 55."
+              "version_removed": "64",
+              "notes": "Only on Windows."
             }
           ],
           "firefox_android": {
@@ -94,12 +94,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -159,12 +159,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -224,12 +224,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -29,12 +29,12 @@
             {
               "version_added": "64",
               "version_removed": "98",
-              "notes": "macOS support was enabled in Firefox 64."
+              "notes": "Only on macOS and Windows."
             },
             {
               "version_added": "55",
-              "version_removed": "98",
-              "notes": "Windows support was enabled in Firefox 55."
+              "version_removed": "64",
+              "notes": "Only on Windows."
             }
           ],
           "firefox_android": {
@@ -93,12 +93,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -155,12 +155,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -214,12 +214,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -276,12 +276,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -341,12 +341,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -406,12 +406,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -29,12 +29,12 @@
             {
               "version_added": "64",
               "version_removed": "98",
-              "notes": "macOS support was enabled in Firefox 64."
+              "notes": "Only on macOS and Windows."
             },
             {
               "version_added": "55",
-              "version_removed": "98",
-              "notes": "Windows support was enabled in Firefox 55."
+              "version_removed": "64",
+              "notes": "Only on Windows."
             }
           ],
           "firefox_android": {
@@ -93,12 +93,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -158,12 +158,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -223,12 +223,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -288,12 +288,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -29,12 +29,12 @@
             {
               "version_added": "64",
               "version_removed": "98",
-              "notes": "macOS support was enabled in Firefox 64."
+              "notes": "Only on macOS and Windows."
             },
             {
               "version_added": "55",
-              "version_removed": "98",
-              "notes": "Windows support was enabled in Firefox 55."
+              "version_removed": "64",
+              "notes": "Only on Windows."
             }
           ],
           "firefox_android": {
@@ -94,12 +94,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -159,12 +159,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -224,12 +224,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -289,12 +289,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -354,12 +354,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -419,12 +419,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -484,12 +484,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -29,12 +29,12 @@
             {
               "version_added": "64",
               "version_removed": "98",
-              "notes": "macOS support was enabled in Firefox 64."
+              "notes": "Only on macOS and Windows."
             },
             {
               "version_added": "55",
-              "version_removed": "98",
-              "notes": "Windows support was enabled in Firefox 55."
+              "version_removed": "64",
+              "notes": "Only on Windows."
             }
           ],
           "firefox_android": {
@@ -93,12 +93,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -158,12 +158,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -223,12 +223,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -288,12 +288,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -353,12 +353,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -418,12 +418,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -29,12 +29,12 @@
             {
               "version_added": "64",
               "version_removed": "98",
-              "notes": "macOS support was enabled in Firefox 64."
+              "notes": "Only on macOS and Windows."
             },
             {
               "version_added": "55",
-              "version_removed": "98",
-              "notes": "Windows support was enabled in Firefox 55."
+              "version_removed": "64",
+              "notes": "Only on Windows."
             }
           ],
           "firefox_android": {
@@ -93,12 +93,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -158,12 +158,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -223,12 +223,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -7711,12 +7711,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -7777,12 +7777,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -7847,12 +7847,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -7920,12 +7920,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {
@@ -8001,12 +8001,12 @@
               {
                 "version_added": "64",
                 "version_removed": "98",
-                "notes": "macOS support was enabled in Firefox 64."
+                "notes": "Only on macOS and Windows."
               },
               {
                 "version_added": "55",
-                "version_removed": "98",
-                "notes": "Windows support was enabled in Firefox 55."
+                "version_removed": "64",
+                "notes": "Only on Windows."
               }
             ],
             "firefox_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes several overlapping support statements for Firefox related to VR features.

#### Test results and supporting details

Before, there were _distinct_ statements for

1. Windows support (added 55, removed 98), and
2. macOS support (added 64, removed 98).

After, there are _cumulative_ statements for

1. Windows support (added 55, removed 64), and
2. macOS **and** Windows support (added 64, removed 98).

#### Related issues

Extracted from https://github.com/mdn/browser-compat-data/pull/26544.

Part of https://github.com/mdn/browser-compat-data/issues/26543.
