### PR TITLE
feat(lint): check + fix hash of MDN urls

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -473,7 +473,7 @@
       "remove_duplicates": {
         "__compat": {
           "description": "Removes duplicates",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList#Trimming_of_whitespace_and_removal_of_duplicates",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList#trimming_of_whitespace_and_removal_of_duplicates",
           "tags": [
             "web-features:dom"
           ],
@@ -761,7 +761,7 @@
       "trim_whitespace": {
         "__compat": {
           "description": "Trims whitespace",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList#Trimming_of_whitespace_and_removal_of_duplicates",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList#trimming_of_whitespace_and_removal_of_duplicates",
           "tags": [
             "web-features:dom"
           ],

--- a/api/Element.json
+++ b/api/Element.json
@@ -274,7 +274,7 @@
         "implicit_tofrom": {
           "__compat": {
             "description": "Implicit to/from keyframes are supported",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/animate#Implicit_tofrom_keyframes",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/animate#implicit_tofrom_keyframes",
             "tags": [
               "web-features:web-animations"
             ],

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -207,7 +207,7 @@
         "audio_capture_support": {
           "__compat": {
             "description": "Audio capture support",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen_Capture_API/Using_Screen_Capture#Capturing_shared_audio",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen_Capture_API/Using_Screen_Capture#capturing_shared_audio",
             "tags": [
               "web-features:screen-capture"
             ],

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -268,7 +268,6 @@
       "type_candidate-pair": {
         "__compat": {
           "description": "`candidate-pair` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#canditate_pair",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-candidate-pair",
           "tags": [
             "web-features:webrtc-stats"
@@ -1305,7 +1304,6 @@
       "type_certificate": {
         "__compat": {
           "description": "`certificate` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#certificate",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-certificate",
           "tags": [
             "web-features:webrtc-stats"
@@ -1578,7 +1576,6 @@
       "type_codec": {
         "__compat": {
           "description": "`codec` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#codec",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-codec",
           "tags": [
             "web-features:webrtc-stats"
@@ -1968,7 +1965,6 @@
       "type_data-channel": {
         "__compat": {
           "description": "`data-channel` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#data_channel",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-data-channel",
           "tags": [
             "web-features:webrtc-stats"
@@ -2460,7 +2456,6 @@
       "type_inbound-rtp": {
         "__compat": {
           "description": "`inbound-rtp` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#inbound_rtp",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-inbound-rtp",
           "tags": [
             "web-features:webrtc-stats"
@@ -4236,7 +4231,6 @@
       "type_local-candidate": {
         "__compat": {
           "description": "`local-candidate` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#local_candidate",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-local-candidate",
           "tags": [
             "web-features:webrtc-stats"
@@ -4721,7 +4715,6 @@
       "type_media-playout": {
         "__compat": {
           "description": "`media-playout` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#media_playout",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-media-playout",
           "tags": [
             "web-features:webrtc-stats"
@@ -5102,7 +5095,6 @@
       "type_media-source": {
         "__compat": {
           "description": "`media-source` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#media_source",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-media-source",
           "tags": [
             "web-features:webrtc-stats"
@@ -5604,7 +5596,6 @@
       "type_outbound-rtp": {
         "__compat": {
           "description": "`outbound-rtp` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#outbound_rtp",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-outbound-rtp",
           "tags": [
             "web-features:webrtc-stats"
@@ -7132,7 +7123,6 @@
       "type_remote-candidate": {
         "__compat": {
           "description": "`remote-candidate` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_candidate",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-remote-candidate",
           "tags": [
             "web-features:webrtc-stats"
@@ -7608,7 +7598,6 @@
       "type_remote-inbound-rtp": {
         "__compat": {
           "description": "`remote-inbound-rtp` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_inbound_rtp",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-remote-inbound-rtp",
           "tags": [
             "web-features:webrtc-stats"
@@ -8232,7 +8221,6 @@
       "type_remote-outbound-rtp": {
         "__compat": {
           "description": "`remote-outbound-rtp` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_outbound_rtp",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-remote-outbound-rtp",
           "tags": [
             "web-features:webrtc-stats"
@@ -8814,7 +8802,6 @@
       "type_transport": {
         "__compat": {
           "description": "`transport` stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#transport",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-transport",
           "tags": [
             "web-features:webrtc-stats"

--- a/api/Window.json
+++ b/api/Window.json
@@ -5255,7 +5255,6 @@
       },
       "resolveLocalFileSystemURL": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/File_and_Directory_Entries_API#resolvelocalfilesystemurl()",
           "support": {
             "chrome": {
               "prefix": "webkit",

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1346,7 +1346,6 @@
         "body_ArrayBuffer_type": {
           "__compat": {
             "description": "ArrayBuffer as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#arraybuffer",
             "tags": [
               "web-features:xhr"
             ],
@@ -1390,7 +1389,6 @@
         "body_ArrayBufferView_type": {
           "__compat": {
             "description": "ArrayBufferView as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#arraybufferview",
             "tags": [
               "web-features:xhr"
             ],
@@ -1434,7 +1432,6 @@
         "body_Blob_type": {
           "__compat": {
             "description": "Blob as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#blob",
             "tags": [
               "web-features:xhr"
             ],
@@ -1478,7 +1475,6 @@
         "body_FormData_type": {
           "__compat": {
             "description": "FormData as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#formdata",
             "tags": [
               "web-features:xhr"
             ],
@@ -1522,7 +1518,6 @@
         "body_URLSearchParams_type": {
           "__compat": {
             "description": "URLSearchParams as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#urlsearchparams",
             "tags": [
               "web-features:xhr"
             ],

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1346,7 +1346,7 @@
         "body_ArrayBuffer_type": {
           "__compat": {
             "description": "ArrayBuffer as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#ArrayBuffer",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#arraybuffer",
             "tags": [
               "web-features:xhr"
             ],
@@ -1390,7 +1390,7 @@
         "body_ArrayBufferView_type": {
           "__compat": {
             "description": "ArrayBufferView as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#ArrayBufferView",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#arraybufferview",
             "tags": [
               "web-features:xhr"
             ],
@@ -1434,7 +1434,7 @@
         "body_Blob_type": {
           "__compat": {
             "description": "Blob as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#Blob",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#blob",
             "tags": [
               "web-features:xhr"
             ],
@@ -1478,7 +1478,7 @@
         "body_FormData_type": {
           "__compat": {
             "description": "FormData as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#FormData",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#formdata",
             "tags": [
               "web-features:xhr"
             ],
@@ -1522,7 +1522,7 @@
         "body_URLSearchParams_type": {
           "__compat": {
             "description": "URLSearchParams as parameter to send()",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#URLSearchParams",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#urlsearchparams",
             "tags": [
               "web-features:xhr"
             ],

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1580,7 +1580,6 @@
         "range_syntax": {
           "__compat": {
             "description": "Range syntax from Media Queries Level 4",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax_improvements_in_level_4",
             "tags": [
               "web-features:media-query-range-syntax"
             ],

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -123,7 +123,7 @@
         "auto": {
           "__compat": {
             "description": "`auto` value",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-duration#Values",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-duration#values",
             "spec_url": "https://drafts.csswg.org/css-animations-2/#valdef-animation-duration-auto",
             "tags": [
               "web-features:animations-css"

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -41,7 +41,7 @@
         "annotation": {
           "__compat": {
             "description": "`annotation()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#annotation()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#annotation",
             "spec_url": "https://drafts.csswg.org/css-fonts/#annotation",
             "tags": [
               "web-features:font-variant-alternates"
@@ -80,7 +80,7 @@
         "character_variant": {
           "__compat": {
             "description": "`character-variant()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#character-variant()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#character-variant",
             "spec_url": "https://drafts.csswg.org/css-fonts/#character-variant",
             "tags": [
               "web-features:font-variant-alternates"
@@ -193,7 +193,7 @@
         "ornaments": {
           "__compat": {
             "description": "`ornaments()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#ornaments()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#ornaments",
             "spec_url": "https://drafts.csswg.org/css-fonts/#ornaments",
             "tags": [
               "web-features:font-variant-alternates"
@@ -232,7 +232,7 @@
         "styleset": {
           "__compat": {
             "description": "`styleset()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#styleset()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#styleset",
             "spec_url": "https://drafts.csswg.org/css-fonts/#styleset",
             "tags": [
               "web-features:font-variant-alternates"
@@ -271,7 +271,7 @@
         "stylistic": {
           "__compat": {
             "description": "`stylistic()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#stylistic()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#stylistic",
             "spec_url": "https://drafts.csswg.org/css-fonts/#stylistic",
             "tags": [
               "web-features:font-variant-alternates"
@@ -310,7 +310,7 @@
         "swash": {
           "__compat": {
             "description": "`swash()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#swash()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#swash",
             "spec_url": "https://drafts.csswg.org/css-fonts/#swash",
             "tags": [
               "web-features:font-variant-alternates"

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -41,7 +41,7 @@
         "circle": {
           "__compat": {
             "description": "`circle()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#circle()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#syntax_for_circles",
             "tags": [
               "web-features:shape-outside"
             ],
@@ -157,7 +157,7 @@
         "inset": {
           "__compat": {
             "description": "`inset()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#inset()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#syntax_for_rectangles_by_container_insets",
             "tags": [
               "web-features:shape-outside"
             ],
@@ -271,7 +271,7 @@
         "polygon": {
           "__compat": {
             "description": "`polygon()`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#polygon()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#syntax_for_polygons",
             "tags": [
               "web-features:shape-outside"
             ],

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -45,7 +45,7 @@
         "reset": {
           "__compat": {
             "description": "The `reset` value",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/zoom#Values",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/zoom#values",
             "support": {
               "chrome": {
                 "version_added": "1",

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -96,7 +96,7 @@
         "forgiving_selector_list": {
           "__compat": {
             "description": "Support for forgiving selector list",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:is#Forgiving_Selector_Parsing",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:is#forgiving_selector_parsing",
             "tags": [
               "web-features:is"
             ],

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -42,7 +42,7 @@
         "forgiving_selector_list": {
           "__compat": {
             "description": "Support for forgiving selector list",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where#Forgiving_Selector_Parsing",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where#forgiving_selector_parsing",
             "tags": [
               "web-features:where"
             ],

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -42,7 +42,7 @@
         "animation": {
           "__compat": {
             "description": "Animation",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#Interpolation_of_basic_shapes",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#interpolation_of_basic_shapes",
             "tags": [
               "web-features:shapes"
             ],

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -216,7 +216,7 @@
         "currentcolor": {
           "__compat": {
             "description": "`currentcolor` keyword",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#currentcolor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#currentcolor_keyword",
             "spec_url": "https://drafts.csswg.org/css-color/#currentcolor-color",
             "tags": [
               "web-features:currentcolor"

--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -133,7 +133,6 @@
         },
         "alpha": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/input#alpha",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-alpha",
             "tags": [
               "web-features:input"
@@ -346,7 +345,6 @@
         },
         "colorspace": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/input#colorspace",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-colorspace",
             "tags": [
               "web-features:input"

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -100,7 +100,7 @@
         "json_superset": {
           "__compat": {
             "description": "JavaScript is a superset of JSON",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON#JavaScript_and_JSON_differences",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON#javascript_and_json_differences",
             "tags": [
               "web-features:snapshot:ecmascript-2019",
               "web-features:json"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -336,7 +336,7 @@
         "incumbent_settings_object_tracking": {
           "__compat": {
             "description": "Incumbent settings object tracking",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise#Incumbent_settings_object_tracking",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise#incumbent_settings_object_tracking",
             "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object-tracking-in-promises",
             "tags": [
               "web-features:promise"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -933,7 +933,7 @@
           "dom_objects": {
             "__compat": {
               "description": "`toStringTag` available on all DOM prototype objects",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag#toStringTag_available_on_all_DOM_prototype_objects",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag#tostringtag_available_on_all_dom_prototype_objects",
               "tags": [
                 "web-features:snapshot:ecmascript-2015",
                 "web-features:symbol"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -4,7 +4,7 @@
       "array_literals": {
         "__compat": {
           "description": "Array literals (`[1, 2, 3]`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Array_literals",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#array_literals",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-array-initializer",
           "tags": [
             "web-features:array",
@@ -56,7 +56,7 @@
       "binary_numeric_literals": {
         "__compat": {
           "description": "Binary numeric literals (`0b`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Binary",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#binary",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-BinaryIntegerLiteral",
           "tags": [
             "web-features:snapshot:ecmascript-2015",
@@ -104,7 +104,7 @@
       "boolean_literals": {
         "__compat": {
           "description": "Boolean literals (`true`/`false`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Boolean_literal",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#boolean_literal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-boolean-literals",
           "tags": [
             "web-features:snapshot:ecmascript-1",
@@ -156,7 +156,7 @@
       "decimal_numeric_literals": {
         "__compat": {
           "description": "Decimal numeric literals (`1234567890`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Decimal",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#decimal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-DecimalLiteral",
           "tags": [
             "web-features:snapshot:ecmascript-1",
@@ -208,7 +208,7 @@
       "hashbang_comments": {
         "__compat": {
           "description": "Hashbang (`#!`) comment syntax",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#hashbang_comments",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-hashbang",
           "tags": [
             "web-features:snapshot:ecmascript-2023",
@@ -254,7 +254,7 @@
       "hexadecimal_escape_sequences": {
         "__compat": {
           "description": "Hexadecimal escape sequences (`'\\xA9'`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hexadecimal_escape_sequences",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#hexadecimal_escape_sequences",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-HexEscapeSequence",
           "tags": [
             "web-features:javascript"
@@ -305,7 +305,7 @@
       "hexadecimal_numeric_literals": {
         "__compat": {
           "description": "Hexadecimal numeric literals (`0xAF`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hexadecimal",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#hexadecimal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-HexIntegerLiteral",
           "tags": [
             "web-features:snapshot:ecmascript-1",
@@ -357,7 +357,7 @@
       "null_literal": {
         "__compat": {
           "description": "Null literal (`null`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Null_literal",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#null_literal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-null-literals",
           "tags": [
             "web-features:snapshot:ecmascript-1",
@@ -409,7 +409,7 @@
       "numeric_separators": {
         "__compat": {
           "description": "Numeric separators (`1_000_000_000_000`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_separators",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#numeric_separators",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-NumericLiteralSeparator",
           "tags": [
             "web-features:numeric-seperators"
@@ -454,7 +454,7 @@
       "octal_numeric_literals": {
         "__compat": {
           "description": "Octal numeric literals (`0o`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Octal",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#octal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-OctalIntegerLiteral",
           "tags": [
             "web-features:snapshot:ecmascript-2015",
@@ -502,7 +502,7 @@
       "regular_expression_literals": {
         "__compat": {
           "description": "Regular expression literals (`/ab+c/g`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Regular_expression_literals",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#regular_expression_literals",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-literals-regular-expression-literals",
           "tags": [
             "web-features:snapshot:ecmascript-3",
@@ -554,7 +554,7 @@
       "string_literals": {
         "__compat": {
           "description": "String literals (`'Hello world'`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#String_literals",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#string_literals",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-literals-string-literals",
           "tags": [
             "web-features:snapshot:ecmascript-1",
@@ -606,7 +606,7 @@
       "unicode_escape_sequences": {
         "__compat": {
           "description": "Unicode escape sequences (`'\\u00A9'`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Unicode_escape_sequences",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#unicode_escape_sequences",
           "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-unicodeescape",
           "tags": [
             "web-features:snapshot:ecmascript-1",
@@ -658,7 +658,7 @@
       "unicode_point_escapes": {
         "__compat": {
           "description": "Unicode point escapes (`\\u{}`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Unicode_code_point_escapes",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#unicode_code_point_escapes",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-UnicodeEscapeSequence",
           "tags": [
             "web-features:snapshot:ecmascript-2015",

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -4,7 +4,7 @@
       "array_literals": {
         "__compat": {
           "description": "Array literals (`[1, 2, 3]`)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#array_literals",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Array#array_literal_notation",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-array-initializer",
           "tags": [
             "web-features:array",

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -59,7 +59,7 @@
         "spread_in_arrays": {
           "__compat": {
             "description": "Spread in array literals",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_array_literals",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_array_literals",
             "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-SpreadElement",
             "tags": [
               "web-features:snapshot:ecmascript-2015",
@@ -111,7 +111,7 @@
         "spread_in_function_calls": {
           "__compat": {
             "description": "Spread in function calls",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_function_calls",
             "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ArgumentList",
             "tags": [
               "web-features:snapshot:ecmascript-2015",
@@ -163,7 +163,7 @@
         "spread_in_object_literals": {
           "__compat": {
             "description": "Spread in object literals",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals",
             "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-PropertyDefinition",
             "tags": [
               "web-features:spread"

--- a/scripts/check-mdn-url-anchors.ts
+++ b/scripts/check-mdn-url-anchors.ts
@@ -1,0 +1,63 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import esMain from 'es-main';
+import chalk from 'chalk-template';
+
+import { lowLevelWalk } from '../utils/walk.js';
+
+/**
+ * Checks the anchors of all `mdn_url` values.
+ */
+const checkAnchors = async () => {
+  const bySlug = new Map<string, { path: string; hash: string }[]>();
+
+  for (const support of lowLevelWalk()) {
+    const { compat, path } = support;
+    if (!compat) {
+      continue;
+    }
+
+    const { mdn_url } = compat;
+    if (!mdn_url) {
+      continue;
+    }
+
+    const { pathname, hash } = new URL(mdn_url);
+    if (!hash) {
+      continue;
+    }
+
+    const item = {
+      path,
+      hash,
+    };
+
+    const items = bySlug.get(pathname) ?? [];
+    items.push(item);
+    bySlug.set(pathname, items);
+  }
+
+  await Promise.all(
+    [...bySlug.entries()].map(async ([slug, items]) => {
+      const url = `https://developer.mozilla.org${slug}`;
+      const res = await fetch(url);
+      const text = await res.text();
+      if (!res.ok) {
+        console.error(`Failed to fetch ${url}`, text);
+        return;
+      }
+      for (const { path, hash } of items) {
+        if (!text.includes(`id="${hash.slice(1)}"`)) {
+          console.warn(
+            chalk`{yellow Invalid mdn_url anchor https://developer.mozilla.org${slug}{bold ${hash}}} in {italic ${path}}`,
+          );
+        }
+      }
+    }),
+  );
+};
+
+if (esMain(import.meta)) {
+  await checkAnchors();
+}

--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -31,7 +31,6 @@
         },
         "extension_pages": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#extension_pages",
             "support": {
               "chrome": {
                 "version_added": "88",
@@ -60,7 +59,6 @@
         },
         "sandbox": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#sandbox",
             "support": {
               "chrome": {
                 "version_added": "88"

--- a/webextensions/manifest/theme_experiment.json
+++ b/webextensions/manifest/theme_experiment.json
@@ -24,7 +24,7 @@
         },
         "colors": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#syntax",
             "support": {
               "chrome": {
                 "version_added": false
@@ -46,7 +46,7 @@
         },
         "images": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#syntax",
             "support": {
               "chrome": {
                 "version_added": false
@@ -68,7 +68,7 @@
         },
         "properties": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#syntax",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/manifest/web_accessible_resources.json
+++ b/webextensions/manifest/web_accessible_resources.json
@@ -26,7 +26,6 @@
         },
         "extension_ids": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#extension_ids",
             "support": {
               "chrome": {
                 "version_added": "88"
@@ -46,7 +45,6 @@
         },
         "matches": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#matches",
             "support": {
               "chrome": {
                 "version_added": "88"
@@ -68,7 +66,6 @@
         },
         "resources": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#resources",
             "support": {
               "chrome": {
                 "version_added": "88"
@@ -90,7 +87,6 @@
         },
         "use_dynamic_url": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#use_dynamic_url",
             "support": {
               "chrome": {
                 "version_added": "88"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a lint that checks the hash of `mdn_url`s to ensure they're lowercase.

Fixes all errors, and removes some no-longer existing anchors.

Also adds a `check-mdn-url-anchors` script that fetches all MDN urls with a fragment, and checks whether the page contains the anchor.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26597.
