### PR TITLE
Revert "Firefox 136 adds CookieStore API"

### DIFF
--- a/api/CookieChangeEvent.json
+++ b/api/CookieChangeEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "136"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -52,7 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -90,7 +90,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -128,7 +128,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "136"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -56,7 +56,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -94,7 +94,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -131,7 +131,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "136"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -170,7 +170,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -283,7 +283,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "136"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -473,7 +473,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "136"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -512,7 +512,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -550,7 +550,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -587,7 +587,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "136"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -477,7 +477,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -1040,7 +1040,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "136"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Reverts mdn/browser-compat-data#26556

Fixes https://github.com/mdn/browser-compat-data/issues/26600.