### PR TITLE
Roll up `css.properties.accent-color.maintains_contrast` into parent

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -12,7 +12,11 @@
             "chrome": {
               "version_added": "93"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "93",
+              "partial_implementation": true,
+              "notes": "Chrome for Android does not maintain minimum contrast for legibility of the control. See [bug 343503163](https://crbug.com/343503163)."
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "92"
@@ -25,7 +29,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.4"
+              "version_added": "15.4",
+              "partial_implementation": true,
+              "notes": "Safari does not maintain minimum contrast for legibility of the control. See [bug 244233](https://webkit.org/b/244233)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -61,48 +67,6 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "maintains_contrast": {
-          "__compat": {
-            "description": "Maintains contrast",
-            "spec_url": "https://drafts.csswg.org/css-ui/#:~:text=must%20maintain%20contrast%20for%20legibility%20of%20the%20control",
-            "tags": [
-              "web-features:accent-color"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "93"
-              },
-              "chrome_android": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/343503163"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "92"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/244233"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

This undoes the structural changes represented by https://github.com/mdn/browser-compat-data/pull/26493 and the follow-up https://github.com/mdn/browser-compat-data/pull/26518, but keeps the data as `partial_implementation`.

I suspect we'll wish to discuss this at the next BCD meeting—before merging—since it touches on (so far minimal) guidelines for `partial_implementation` and when to use it.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Roughly, the support details _are_ the previous two PRs.

I think there was perhaps a case to be made for Safari being alone as a weird, but mostly functional outlier. But the sum of the two PRs are such that we have this story:

1. `accent-color` has 3 distinct behaviors for certain color values (Firefox and deskop Chrome; Chrome for Android; Safari).
2. Two of those behaviors (Chrome for Android and Safari's) are inaccessible for some color values.
3. The inaccessible color values differ across browsers.

That is to say, `accent-color`, taken as a whole, fails the contrast test **incompatibly**. I think it's easier to tell this story in the support for the property overall than it is to represent this as a behavioral subfeature.

That's the main story. There's a side story here that we typically use behavioral subfeatures to represent later additions to existing features or behaviors that are, by specification, discretionary between implementations (that is, "should" not "must"). Here we have behavior required by specification text ("must maintain contrast") that has existed since well before the first implementation (https://github.com/w3c/csswg-drafts/commit/37aeebb1b9b0bdea54f3ba228e4f69e97dce7878). I think the use of a behavioral subfeature here breaks with convention, if not formal practice.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/issues/16367
- https://github.com/mdn/browser-compat-data/issues/26073
- https://github.com/mdn/browser-compat-data/pull/26493
- https://github.com/mdn/browser-compat-data/pull/26518

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
