### PR TITLE
Firefox 138 supports `import` attribute for JSON modules

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1627,7 +1627,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "138"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1720,7 +1720,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": "138"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This is a follow-up to https://github.com/mdn/browser-compat-data/pull/26583.

The feature is confirmed to be available in all trains: https://groups.google.com/a/mozilla.org/g/dev-platform/c/segjV77p6k0/m/A3ikPo1cAwAJ

#### Test results and supporting details

- Tested in 138.01a Nightly and 138.0b9 Beta
- Confirmed with the Firefox engineer

#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/38878

#### Additional context

- [Firefox Nightly Release Notes 138.0a1](https://www.mozilla.org/en-US/firefox/138.0a1/releasenotes/) > Web Platform section
- [Firefox Beta and Developer Edition Release Notes](https://www.mozilla.org/en-US/firefox/138.0beta/releasenotes/) > Web Platform section
