### PR TITLE
fix(update-browser-releases): find Opera engine version in content

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -877,14 +877,26 @@
           "engine_version": "131"
         },
         "117": {
-          "status": "beta",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "132"
         },
         "118": {
-          "status": "nightly",
+          "release_date": "2025-04-15",
+          "release_notes": "https://blogs.opera.com/desktop/2025/04/opera-118/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "133"
+        },
+        "119": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "134"
+        },
+        "120": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "135"
         }
       }
     }

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -872,7 +872,7 @@
         "116": {
           "release_date": "2025-01-08",
           "release_notes": "https://blogs.opera.com/desktop/2025/01/opera-116/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "131"
         },

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -877,6 +877,8 @@
           "engine_version": "131"
         },
         "117": {
+          "release_date": "2025-02-13",
+          "release_notes": "https://blogs.opera.com/desktop/2025/02/opera-117/",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "132"

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -178,7 +178,7 @@ const options = {
     skippedReleases: [],
     releaseFeedURL: 'https://blogs.opera.com/desktop/category/stable-2/feed/',
     titleVersionPattern: /^Opera (\d+)$/,
-    descriptionEngineVersionPattern: /Chromium (\d+)/,
+    descriptionEngineVersionPattern: /Chromium(?: to version)? (\d+)/,
   },
   opera_android: {
     browserName: 'Opera for Android',

--- a/scripts/update-browser-releases/opera.ts
+++ b/scripts/update-browser-releases/opera.ts
@@ -26,15 +26,14 @@ interface Release {
  * @param descriptionEngineVersionPattern the pattern to match the description and extract the engine version.
  * @returns the latest release, if found, otherwise null.
  */
-const findRelease = (
+const findRelease = async (
   items: RSSItem[],
   titleVersionPattern: RegExp,
   descriptionEngineVersionPattern: RegExp,
-): Release | null => {
+): Promise<Release | null> => {
   const item = items.find(
-    (item) =>
-      titleVersionPattern.test(item.title) &&
-      descriptionEngineVersionPattern.test(item.description),
+    (item) => titleVersionPattern.test(item.title) /* &&
+      descriptionEngineVersionPattern.test(item.description)*/,
   );
 
   if (!item) {
@@ -46,9 +45,10 @@ const findRelease = (
   )[1];
   const date = new Date(item.pubDate).toISOString().split('T')[0];
   const releaseNote = item.link;
-  const engineVersion = (
-    item.description.match(descriptionEngineVersionPattern) as RegExpMatchArray
-  )[1];
+  const engineVersion = await findEngineVersion(
+    item,
+    descriptionEngineVersionPattern,
+  );
 
   return {
     version,
@@ -58,6 +58,41 @@ const findRelease = (
     engine: 'Blink',
     engineVersion,
   };
+};
+
+/**
+ * Extracts the engine version from the item.
+ * @param item the RSS item.
+ * @param engineVersionPattern the pattern to match the description or content.
+ * @returns the engine version, found
+ * @throws {Error} if engine version cannot be found
+ */
+const findEngineVersion = async (
+  item: RSSItem,
+  engineVersionPattern: RegExp,
+): Promise<string> => {
+  const descriptionMatch = item.description.match(engineVersionPattern);
+
+  if (descriptionMatch) {
+    return descriptionMatch[1];
+  }
+
+  const res = await fetch(item.link);
+
+  if (!res.ok) {
+    throw Error(`Failed to fetch: ${item.link}`);
+  }
+
+  const html = await res.text();
+  const text = html.replaceAll(/<[^>]*>/g, '');
+
+  const contentMatch = text.match(engineVersionPattern);
+
+  if (contentMatch) {
+    return contentMatch[1];
+  }
+
+  throw Error(`Failed to find engine version here: ${item.link}`);
 };
 
 /**
@@ -74,9 +109,10 @@ export const updateOperaReleases = async (options) => {
 
   const items = await getRSSItems(options.releaseFeedURL);
 
-  const release = findRelease(
-    items.filter((item) =>
-      options.releaseFilterCreator?.includes(item['dc:creator'] ?? true),
+  const release = await findRelease(
+    items.filter(
+      (item) =>
+        options.releaseFilterCreator?.includes(item['dc:creator']) ?? true,
     ),
     options.titleVersionPattern,
     options.descriptionEngineVersionPattern,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the update-browser-releases script for Opera to look for the Chromium version in the actual blog post content, if the description doesn't contain it.

Also updates the Opera release data, by running the script (`npm run update-browser-releases -- --opera`), and applying manual fixes.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26584.