### PR TITLE
Firefox 138 supports AudioWorkletGlobalScope.port

### DIFF
--- a/api/AudioWorkletGlobalScope.json
+++ b/api/AudioWorkletGlobalScope.json
@@ -113,6 +113,43 @@
           }
         }
       },
+      "port": {
+        "__compat": {
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioworkletglobalscope-port",
+          "tags": [
+            "web-features:audio-worklet"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "registerProcessor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletGlobalScope/registerProcessor",


### PR DESCRIPTION
#### Summary

Assuming we need an entry for this, not picked up in https://github.com/mdn/browser-compat-data/pull/26371

#### Test results and supporting details

- __Spec:__ https://webaudio.github.io/web-audio-api/#dom-audioworklet-port
- __WPT:__ https://wpt.fyi/results/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https.html?label=experimental&label=master&aligned
- __Bugzilla:__ [1861363](https://bugzilla.mozilla.org/show_bug.cgi?id=1951240)

#### Related issues

- [x] https://github.com/mdn/content/pull/39264
