### PR TITLE
Replace Chrome ranges in `webextensions.api.webRequest`

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -3791,7 +3791,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "43"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3887,7 +3887,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "44"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -202,7 +202,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "18"
                 },
                 "edge": {
                   "version_added": "14"
@@ -252,7 +252,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤61"
+                  "version_added": "18"
                 },
                 "edge": {
                   "version_added": "14"
@@ -1530,7 +1530,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1594,7 +1594,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1638,7 +1638,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1661,7 +1661,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1703,7 +1703,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1745,7 +1745,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1768,7 +1768,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1791,7 +1791,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1814,7 +1814,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1837,7 +1837,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "43"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1860,7 +1860,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1883,7 +1883,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1927,7 +1927,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1950,7 +1950,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2110,7 +2110,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2135,7 +2135,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2181,7 +2181,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2206,7 +2206,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2250,7 +2250,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2294,7 +2294,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2319,7 +2319,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2344,7 +2344,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2369,7 +2369,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2394,7 +2394,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2419,7 +2419,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2465,7 +2465,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2490,7 +2490,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2515,7 +2515,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2677,7 +2677,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2723,7 +2723,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2767,7 +2767,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2811,7 +2811,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "23"
                   },
                   "edge": "mirror",
                   "firefox": {
@@ -2832,7 +2832,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2857,7 +2857,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2903,7 +2903,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2928,7 +2928,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -2953,7 +2953,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3115,7 +3115,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3161,7 +3161,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3205,7 +3205,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3249,7 +3249,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3272,7 +3272,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3297,7 +3297,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3343,7 +3343,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3368,7 +3368,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3393,7 +3393,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3532,7 +3532,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3557,7 +3557,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3603,7 +3603,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3628,7 +3628,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3672,7 +3672,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3716,7 +3716,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3741,7 +3741,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3766,7 +3766,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "43"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3791,7 +3791,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "43"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3816,7 +3816,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3862,7 +3862,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3887,7 +3887,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "44"
                   },
                   "edge": {
                     "version_added": "14"
@@ -3912,7 +3912,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4051,7 +4051,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4076,7 +4076,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4101,7 +4101,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4147,7 +4147,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4172,7 +4172,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4216,7 +4216,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4260,7 +4260,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4285,7 +4285,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4331,7 +4331,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4356,7 +4356,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4381,7 +4381,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4551,7 +4551,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4639,7 +4639,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4683,7 +4683,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4727,7 +4727,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4752,7 +4752,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4777,7 +4777,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "43"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4802,7 +4802,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4827,7 +4827,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4873,7 +4873,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4898,7 +4898,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -4923,7 +4923,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5062,7 +5062,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5087,7 +5087,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5133,7 +5133,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5156,7 +5156,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5200,7 +5200,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5244,7 +5244,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5269,7 +5269,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5294,7 +5294,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5319,7 +5319,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5344,7 +5344,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5390,7 +5390,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5415,7 +5415,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5438,7 +5438,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5577,7 +5577,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5623,7 +5623,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5667,7 +5667,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5711,7 +5711,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5736,7 +5736,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5761,7 +5761,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5807,7 +5807,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5832,7 +5832,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"
@@ -5857,7 +5857,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": "≤61"
+                    "version_added": "18"
                   },
                   "edge": {
                     "version_added": "14"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Replaces 105 Chrome ranges in `webextensions.api.webRequest`.

#### Test results and supporting details

Sources:

- Chrome 18: https://github.com/caugner/chromium-releases/blame/v18/chrome/common/extensions/api/webRequest.json
- Chrome 23: https://github.com/caugner/chromium-releases/blame/v23/chrome/common/extensions/api/web_request.json
- Chrome 43: https://github.com/caugner/chromium-releases/blame/v43/extensions/common/api/web_request.json

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25797.