### PR TITLE
Chrome 21 added `webextensions.api.events`

### DIFF
--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events",
           "support": {
             "chrome": {
-              "version_added": "≤58"
+              "version_added": "21"
             },
             "edge": {
               "version_added": "14"
@@ -29,7 +29,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "21"
               },
               "edge": {
                 "version_added": "14"
@@ -52,7 +52,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/addListener",
               "support": {
                 "chrome": {
-                  "version_added": "≤65"
+                  "version_added": "21"
                 },
                 "edge": {
                   "version_added": "14"
@@ -76,7 +76,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/addRules",
               "support": {
                 "chrome": {
-                  "version_added": "≤65"
+                  "version_added": "21"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -96,7 +96,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/getRules",
               "support": {
                 "chrome": {
-                  "version_added": "≤65"
+                  "version_added": "21"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -116,7 +116,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/hasListener",
               "support": {
                 "chrome": {
-                  "version_added": "≤65"
+                  "version_added": "21"
                 },
                 "edge": {
                   "version_added": "14"
@@ -140,7 +140,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/hasListeners",
               "support": {
                 "chrome": {
-                  "version_added": "≤65"
+                  "version_added": "21"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -160,7 +160,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/removeListener",
               "support": {
                 "chrome": {
-                  "version_added": "≤65"
+                  "version_added": "21"
                 },
                 "edge": {
                   "version_added": "14"
@@ -184,7 +184,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/removeRules",
               "support": {
                 "chrome": {
-                  "version_added": "≤65"
+                  "version_added": "21"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -205,7 +205,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Rule",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "21"
               },
               "edge": "mirror",
               "firefox": {
@@ -225,7 +225,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/UrlFilter",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "21"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

Replaces several Chrome version ranges in `webextensions.api.events`.

#### Test results and supporting details

See: https://github.com/caugner/chromium-releases/blame/v21/chrome/common/extensions/api/events.json

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
