### PR TITLE
Firefox 124 partially supports `white-space` shorthand values like Chrome

### DIFF
--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -344,7 +344,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -324,7 +324,9 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124",
+                "partial_implementation": true,
+                "notes": "Only accepts values for `white-space-collapse` and `text-wrap-mode`, not `white-space-trim`."
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

see https://bugzilla.mozilla.org/show_bug.cgi?id=1852478, also notice like chrome, `white-space-trim` value is not supported

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25215

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
