### PR TITLE
Safari 18 supports `webextensions.api.webRequest` in MV3

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -22,7 +22,9 @@
               "version_added": "14",
               "notes": "Support for use in Manifest V3 extensions, that is with non-persistent background pages/scripts, provided in Safari 18."
             },
-            "safari_ios": "mirror"
+            "safari_ios": {
+              "version_added": "18"
+            }
           }
         },
         "BlockingResponse": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14",
-              "notes": "Before Safari 18, only worked with Manifest V2 extensions using persistent background content. From Safari 18, works with Manifest V2 and V3 extensions ."
+              "notes": "Before Safari 18, only worked with Manifest V2 extensions using persistent background content. From Safari 18, works with Manifest V2 and V3 extensions."
             },
             "safari_ios": {
               "version_added": "18"

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -19,7 +19,8 @@
             },
             "opera": "mirror",
             "safari": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Support for use in Manifest V3 extensions, that is with non-persistent background pages/scripts, provided in Safari 18."
             },
             "safari_ios": "mirror"
           }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -20,7 +20,7 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14",
-              "notes": "Support for use in Manifest V3 extensions, that is with non-persistent background pages/scripts, provided in Safari 18."
+              "notes": "Before Safari 18, only worked with Manifest V2 extensions using persistent background content. From Safari 18, works with Manifest V2 and V3 extensions ."
             },
             "safari_ios": {
               "version_added": "18"


### PR DESCRIPTION
#### Summary

Add a note that Safari provided for support for `webRequest` use in MV3 in Safari 18.

Fixes https://github.com/mdn/browser-compat-data/issues/24571
