### PR TITLE
Chromium doesn't support `mask-clip: {border,content,padding,text}` without prefix

### DIFF
--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -65,7 +65,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "Only works when using `-webkit-mask-clip`."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -105,7 +107,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "Only works when using `-webkit-mask-clip`."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -145,7 +149,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "Only works when using `-webkit-mask-clip`."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -185,7 +191,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "Only works when using `-webkit-mask-clip`."
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `mask-clip` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.12).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/mask-clip
