### PR TITLE
Update Chromium data for checkmark CSS selector

### DIFF
--- a/css/selectors/checkmark.json
+++ b/css/selectors/checkmark.json
@@ -11,7 +11,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "134"
+              "version_added": "133"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `checkmark` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.12).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/checkmark
