### PR TITLE
Safari 18.4 supports multiple import maps

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -704,7 +704,7 @@
                   "webview_ios": "mirror"
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
                 }

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -696,7 +696,7 @@
                   "opera": "mirror",
                   "opera_android": "mirror",
                   "safari": {
-                    "version_added": "preview"
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Given https://wpt.fyi/results/import-maps/multiple-import-maps?label=stable&label=master&aligned, this changes the support matrix for multiple import maps to include Safari 18.4

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

[https://wpt.fyi/results/import-maps/multiple-import-maps?label=stable&label=master&aligned](WPT tests) show that's the case.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
