### PR TITLE
Notification maxActions in preview

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -844,7 +844,7 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "138"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -865,7 +865,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1225110#c33 `Notification.maxActions` static property is nightly only, not release as indicated by https://github.com/mdn/browser-compat-data/pull/26371

Note that I fixed up the `Notification.actions` in https://github.com/mdn/browser-compat-data/pull/26450 but it wasn't obvious to me that this particular item was behind a pref (i.e. I thought the developers had made a mistake).

Related docs work can be tracked in https://github.com/mdn/content/issues/38886

**EDIT** Actually, this was omitted and current value correct.. This may need to change, but is waiting on https://bugzilla.mozilla.org/show_bug.cgi?id=1963263