### PR TITLE
Firefox 138/139 adds new Sanitizer API behind flag

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5874,6 +5874,48 @@
           }
         }
       },
+      "parseHTML_static": {
+        "__compat": {
+          "description": "`parseHTML` static method",
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-document-parsehtml",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "139",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "parseHTMLUnsafe_static": {
         "__compat": {
           "description": "`parseHTMLUnsafe()` static method",

--- a/api/Element.json
+++ b/api/Element.json
@@ -10288,6 +10288,47 @@
           }
         }
       },
+      "setHTML": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-element-sethtml",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setHTMLUnsafe": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/setHTMLUnsafe",

--- a/api/Element.json
+++ b/api/Element.json
@@ -894,6 +894,7 @@
       },
       "ariaActiveDescendantElement": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaActiveDescendantElement",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaactivedescendantelement",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1311,6 +1312,7 @@
       },
       "ariaControlsElements": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaControlsElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacontrolselements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1386,6 +1388,7 @@
       },
       "ariaDescribedByElements": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaDescribedByElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariadescribedbyelements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1461,6 +1464,7 @@
       },
       "ariaDetailsElements": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaDetailsElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariadetailselements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1536,6 +1540,7 @@
       },
       "ariaErrorMessageElements": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaErrorMessageElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaerrormessageelements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1611,6 +1616,7 @@
       },
       "ariaFlowToElements": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaFlowToElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaflowtoelements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1838,6 +1844,7 @@
       },
       "ariaLabelledByElements": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaLabelledByElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-arialabelledbyelements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -2103,6 +2110,7 @@
       },
       "ariaOwnsElements": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaOwnsElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaownselements",
           "tags": [
             "web-features:aria-attribute-reflection"

--- a/api/Element.json
+++ b/api/Element.json
@@ -3886,7 +3886,7 @@
             },
             "firefox": {
               "version_added": "6",
-              "notes": "Beginning in Firefox 68, Firefox no longer incorrectly sends a `click` event for buttons other than the primary mouse button; previously, there were circumstances in which this would occur. One example: middle-clicking a link would send a `click` to the document's `&lt;html&gt;` element."
+              "notes": "Beginning in Firefox 68, Firefox no longer incorrectly sends a `click` event for buttons other than the primary mouse button; previously, there were circumstances in which this would occur. One example: middle-clicking a link would send a `click` to the document's `<html>` element."
             },
             "firefox_android": {
               "version_added": "6"
@@ -6443,7 +6443,7 @@
               "version_added": "4",
               "partial_implementation": true,
               "notes": [
-                "Before Internet Explorer 10, throws an \"Invalid target element for this operation.\" error when called on a `&lt;table&gt;`, `&lt;tbody&gt;`, `&lt;thead&gt;`, or `&lt;tr&gt;` element.",
+                "Before Internet Explorer 10, throws an \"Invalid target element for this operation.\" error when called on a `<table>`, `<tbody>`, `<thead>`, or `<tr>` element.",
                 "Only supported for [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement), not all `Element` objects, such as [`SVGElement`](https://developer.mozilla.org/docs/Web/API/SVGElement)."
               ]
             },
@@ -8652,7 +8652,7 @@
               {
                 "alternative_name": "mozRequestFullScreen",
                 "version_added": "9",
-                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a `&lt;frame&gt;` or `&lt;object&gt;` element to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an `&lt;iframe&gt;` element with the `allowfullscreen` attribute can be displayed fullscreen."
+                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a `<frame>` or `<object>` element to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an `<iframe>` element with the `allowfullscreen` attribute can be displayed fullscreen."
               }
             ],
             "firefox_android": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -10294,7 +10294,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "Version 105 to 118 (inclusive) supported this method with a significantly different specification."
+              "notes": "Chrome 105 to Chrome 118 (inclusive) supported this method with a significantly different specification."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -894,7 +894,6 @@
       },
       "ariaActiveDescendantElement": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaActiveDescendantElement",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaactivedescendantelement",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1312,7 +1311,6 @@
       },
       "ariaControlsElements": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaControlsElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacontrolselements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1388,7 +1386,6 @@
       },
       "ariaDescribedByElements": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaDescribedByElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariadescribedbyelements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1464,7 +1461,6 @@
       },
       "ariaDetailsElements": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaDetailsElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariadetailselements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1540,7 +1536,6 @@
       },
       "ariaErrorMessageElements": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaErrorMessageElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaerrormessageelements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1616,7 +1611,6 @@
       },
       "ariaFlowToElements": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaFlowToElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaflowtoelements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -1844,7 +1838,6 @@
       },
       "ariaLabelledByElements": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaLabelledByElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-arialabelledbyelements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -2110,7 +2103,6 @@
       },
       "ariaOwnsElements": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaOwnsElements",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaownselements",
           "tags": [
             "web-features:aria-attribute-reflection"
@@ -3886,7 +3878,7 @@
             },
             "firefox": {
               "version_added": "6",
-              "notes": "Beginning in Firefox 68, Firefox no longer incorrectly sends a `click` event for buttons other than the primary mouse button; previously, there were circumstances in which this would occur. One example: middle-clicking a link would send a `click` to the document's `<html>` element."
+              "notes": "Beginning in Firefox 68, Firefox no longer incorrectly sends a `click` event for buttons other than the primary mouse button; previously, there were circumstances in which this would occur. One example: middle-clicking a link would send a `click` to the document's `&lt;html&gt;` element."
             },
             "firefox_android": {
               "version_added": "6"
@@ -6443,7 +6435,7 @@
               "version_added": "4",
               "partial_implementation": true,
               "notes": [
-                "Before Internet Explorer 10, throws an \"Invalid target element for this operation.\" error when called on a `<table>`, `<tbody>`, `<thead>`, or `<tr>` element.",
+                "Before Internet Explorer 10, throws an \"Invalid target element for this operation.\" error when called on a `&lt;table&gt;`, `&lt;tbody&gt;`, `&lt;thead&gt;`, or `&lt;tr&gt;` element.",
                 "Only supported for [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement), not all `Element` objects, such as [`SVGElement`](https://developer.mozilla.org/docs/Web/API/SVGElement)."
               ]
             },
@@ -8652,7 +8644,7 @@
               {
                 "alternative_name": "mozRequestFullScreen",
                 "version_added": "9",
-                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a `<frame>` or `<object>` element to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an `<iframe>` element with the `allowfullscreen` attribute can be displayed fullscreen."
+                "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a `&lt;frame&gt;` or `&lt;object&gt;` element to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an `&lt;iframe&gt;` element with the `allowfullscreen` attribute can be displayed fullscreen."
               }
             ],
             "firefox_android": "mirror",
@@ -10293,7 +10285,8 @@
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-element-sethtml",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Version 105 to 118 (inclusive) supported this method with a significantly different specification."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -5,7 +5,8 @@
         "spec_url": "https://wicg.github.io/sanitizer-api/#sanitizer",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": false,
+            "notes": "Version 105 to 118 (inclusive) supported this interface name with a significantly different specification."
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -1,0 +1,456 @@
+{
+  "api": {
+    "Sanitizer": {
+      "__compat": {
+        "spec_url": "https://wicg.github.io/sanitizer-api/#sanitizer",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "138",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.security.sanitizer.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "Sanitizer": {
+        "__compat": {
+          "description": "`Sanitizer()` constructor",
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitizer",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "allowAttribute": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowattribute",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "allowElement": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowelement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "get": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-get",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeAttribute": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-removeattribute",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeElement": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-removeelement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeUnsafe": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-removeunsafe",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "replaceElementWithChildren": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-replaceelementwithchildren",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setComments": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-setcomments",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setDataAttributes": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-setdataattributes",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -6,7 +6,7 @@
         "support": {
           "chrome": {
             "version_added": false,
-            "notes": "Version 105 to 118 (inclusive) supported this interface name with a significantly different specification."
+            "notes": "Chrome 105 to Chrome 118 (inclusive) supported this interface name with a significantly different specification."
           },
           "chrome_android": "mirror",
           "edge": "mirror",


### PR DESCRIPTION
#### Summary

⚠️ Work in progress

- Reverts Sanitizer API deletion in https://github.com/mdn/browser-compat-data/pull/23989

EDIT.
- Undid reversion of API as per https://github.com/mdn/browser-compat-data/pull/26659#discussion_r2071110958 - not planning to redo unless you insist.
- Have not added tags

#### Test results and supporting details

- FF139 `Document.parseHTML()` : https://bugzilla.mozilla.org/show_bug.cgi?id=1959725
-  FF138 Implement an unoptimized Sanitizer prototype https://bugzilla.mozilla.org/show_bug.cgi?id=1950605
  - `Sanitizer`, `Element.setHTML()`
- FF138 Implement the `Sanitizer.removeUnsafe()` method - https://bugzilla.mozilla.org/show_bug.cgi?id=1952250

Not yet implemented "Add a sanitizer option to Element/Shadowroot `setHTMLUnsafe()` and `Document.parseHTMLUnsafe()`" - see https://bugzilla.mozilla.org/show_bug.cgi?id=1959727