### PR TITLE
ci: pass data between steps via GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -54,9 +54,10 @@ jobs:
           FORCE_COLOR: 3
 
       - name: Determine job url
+        id: job
         run: |
           job_id=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '.jobs[0].id')
-          echo "JOB_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${job_id}?pr=$PR_NUMBER" >> $GITHUB_ENV
+          echo "JOB_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${job_id}?pr=$PR_NUMBER" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -86,6 +87,6 @@ jobs:
           COMMENT: |
             _Tip_: Review these changes [grouped by change][1] (recommended for most PRs), or [grouped by feature][2] (for large PRs).
 
-            [1]: ${{ env.JOB_URL }}#step:5:1
-            [2]: ${{ env.JOB_URL }}#step:7:1
+            [1]: ${{ steps.job.outputs.JOB_URL }}#step:5:1
+            [2]: ${{ steps.job.outputs.JOB_URL }}#step:7:1
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -21,18 +21,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # get the full repository checkout, not just the inciting commit
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: npm
+
       - run: npm install -D typescript
+
       - run: npm install -D tsx
+
       - name: Run update-browser-releases script
-        id: ubr
+        id: update
         run: |
-          echo "RESULT<<EOF" >> $GITHUB_ENV
-          npm run update-browser-releases -- --all >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          echo "RESULT<<EOF" >> "$GITHUB_OUTPUT"
+          npm run update-browser-releases -- --all >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
@@ -46,5 +51,5 @@ jobs:
           title: "Update browser releases"
           body: |
             The output of the `update-browser-releases` script is:
-            ${{ env.RESULT }}
+            ${{ steps.update.outputs.RESULT }}
           draft: false

--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -41,10 +41,11 @@ jobs:
         run: npm ci
 
       - name: Update tags
+        id: update
         run: |
-          echo "RESULT<<EOF" >> $GITHUB_ENV
-          npm run tag-web-features .. >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          echo "RESULT<<EOF" >> "$GITHUB_OUTPUT"
+          npm run tag-web-features .. >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
@@ -59,5 +60,5 @@ jobs:
           title: "Update web-features tags"
           body: |
             The output of the `tag-web-features` script is:
-            ${{ env.RESULT }}
+            ${{ steps.update.outputs.RESULT }}
           draft: false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Ensures workflows pass data between steps via `GITHUB_OUTPUT`.

#### Test results and supporting details

Avoids unintended side-effects of using `GITHUB_ENV`.

#### Related issues

See also:

- https://github.com/mdn/content/pull/38702
- https://github.com/mdn/translated-content/pull/26462
