### PR TITLE
Firefox 136 exposes SVGDiscardElement API

### DIFF
--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -12,14 +12,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "136",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "svg.discard.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "136"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `SVGDiscardElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.13).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SVGDiscardElement

Additional Notes: It looks like in the stable release, the flag was enabled by default.
