### PR TITLE
Chrome 127 + Safari 18 add `selectionchange` event on `HTMLInputElement` + `HTMLTextAreaElement`

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2002,7 +2002,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1978,7 +1978,7 @@
           "support": {
             "chrome": {
               "version_added": "127",
-              "notes": "Before Chrome 127, a `selectionchange` event was fired on `Document`, see [`Document`'s `selectionchange` event](https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event). See [bug 40840956](https://crbug.com/40840956) for firing the event on `<input>` elements before Chrome 127."
+              "notes": "Before Chrome 127, a `selectionchange` event was fired on `Document`, see [`Document`'s `selectionchange` event](https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event). See [bug 40840956](https://crbug.com/40840956) for firing the event on `<input>` elements."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1977,8 +1977,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "A `selectionchange` event is fired on `Document`, see [`Document`'s `selectionchange` event](https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event). See [bug 40840956](https://crbug.com/40840956) for firing the event on `<input>` elements."
+              "version_added": "127",
+              "notes": "Before Chrome 127, a `selectionchange` event was fired on `Document`, see [`Document`'s `selectionchange` event](https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event). See [bug 40840956](https://crbug.com/40840956) for firing the event on `<input>` elements before Chrome 127."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -1993,7 +1993,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "18",
               "impl_url": "https://webkit.org/b/234348"
             },
             "safari_ios": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1994,7 +1994,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "18",
-              "impl_url": "https://webkit.org/b/234348"
+              "notes": "Before Safari 18, a `selectionchange` event was fired on `Document`, see [`Document`'s `selectionchange` event](https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event). See [bug 271033](https://webkit.org/b/271033) for firing the event on `<input>` elements."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -850,8 +850,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "A `selectionchange` event is fired on `Document`, see [`Document`'s `selectionchange` event](https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event). See [bug 40840956](https://crbug.com/40840956) for firing the event on `<textarea>` elements."
+              "version_added": "127",
+              "notes": "Before Chrome 127, a `selectionchange` event was fired on `Document`, see [`Document`'s `selectionchange` event](https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event). See [bug 40840956](https://crbug.com/40840956) for firing the event on `<textarea>` elements."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -866,8 +866,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/234348"
+              "version_added": "18",
+              "notes": "Before Safari 18, a `selectionchange` event was fired on `Document`, see [`Document`'s `selectionchange` event](https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event). See [bug 271033](https://webkit.org/b/271033) for firing the event on `<textarea>` elements."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -875,7 +875,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary
+ `selectionchange` event is available in Chrome since version 127 and in Safari since version 18 (specifically Webkit [619.1.6](https://github.com/WebKit/WebKit/blob/0a064d401bd0a68d148be77d03cb3c157188c04b/Configurations/Version.xcconfig#L24-L26)).
+ Also, the feature is now no longer in experimental status, as it's supported by the three major browser engines.

#### Test results and supporting details
See:
Description | Link
-------------|-----
Webkit bug tracker | https://bugs.webkit.org/show_bug.cgi?id=271033
Chrome bug tracker | https://issues.chromium.org/issues/40840956
Automated test cases | https://wpt.fyi/results/selection/textcontrols/selectionchange.html?label=experimental&label=master&aligned
JSFiddle by @caugner | https://jsfiddle.net/jx6gakhb/


<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
+ Fixes #25672
