### PR TITLE
Update Chromium data for api.HTMLCanvasElement.contextlost_event

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -95,7 +95,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "98"
+              "version_added": "99"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `contextlost_event` member of the `HTMLCanvasElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.13).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLCanvasElement/contextlost_event
