### PR TITLE
Update Firefox data for api.SVGElement.load_event

### DIFF
--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -409,9 +409,9 @@
               "version_added": "12"
             },
             "firefox": {
-              "alternative_name": "SVGLoad",
               "version_added": "4",
-              "notes": "See [bug 620002](https://bugzil.la/620002) for implementation status of the standard `load` event."
+              "partial_implementation": true,
+              "notes": "Firefox uses a non-standard `SVGLoad` event. See [bug 620002](https://bugzil.la/620002) for implementation status of the standard `load` event."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `load_event` member of the `SVGElement` API. The `alternative_name` property was incorrectly used in this context.
