### PR TITLE
Firefox Nightly escapes `<` and `>` in attributes when serializing HTML

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5935,7 +5935,14 @@
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -5932,7 +5932,7 @@
         },
         "escape_lt_gt_in_attributes": {
           "__compat": {
-            "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))"
+            "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
                 "version_added": false
@@ -6328,8 +6328,7 @@
         },
         "escape_lt_gt_in_attributes": {
           "__compat": {
-            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
-            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
                 "version_added": false
@@ -7540,8 +7539,7 @@
         },
         "escape_lt_gt_in_attributes": {
           "__compat": {
-            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
-            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -5966,7 +5966,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -6369,7 +6369,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -7587,7 +7587,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -5929,6 +5929,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "escape_lt_gt_in_attributes": {
+          "__compat": {
+            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
+            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "gotpointercapture_event": {
@@ -6287,6 +6322,41 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "escape_lt_gt_in_attributes": {
+          "__compat": {
+            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
+            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -7467,6 +7537,41 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "escape_lt_gt_in_attributes": {
+          "__compat": {
+            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
+            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -5932,8 +5932,7 @@
         },
         "escape_lt_gt_in_attributes": {
           "__compat": {
-            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
-            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))"
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -6338,7 +6338,14 @@
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -7549,7 +7556,14 @@
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -5930,7 +5930,7 @@
             "deprecated": false
           }
         },
-        "escape_lt_gt_in_attributes": {
+        "escapes_lt_gt_in_attributes": {
           "__compat": {
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
@@ -6333,7 +6333,7 @@
             }
           }
         },
-        "escape_lt_gt_in_attributes": {
+        "escapes_lt_gt_in_attributes": {
           "__compat": {
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
@@ -7551,7 +7551,7 @@
             "deprecated": false
           }
         },
-        "escape_lt_gt_in_attributes": {
+        "escapes_lt_gt_in_attributes": {
           "__compat": {
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -394,8 +394,7 @@
         },
         "escape_lt_gt_in_attributes": {
           "__compat": {
-            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
-            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
                 "version_added": false
@@ -583,7 +582,14 @@
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -391,6 +391,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "escape_lt_gt_in_attributes": {
+          "__compat": {
+            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
+            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getSelection": {
@@ -538,6 +573,41 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "escape_lt_gt_in_attributes": {
+          "__compat": {
+            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
+            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -421,7 +421,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -613,7 +613,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -392,7 +392,7 @@
             "deprecated": false
           }
         },
-        "escape_lt_gt_in_attributes": {
+        "escapes_lt_gt_in_attributes": {
           "__compat": {
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
@@ -577,7 +577,7 @@
             }
           }
         },
-        "escape_lt_gt_in_attributes": {
+        "escapes_lt_gt_in_attributes": {
           "__compat": {
             "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -580,8 +580,7 @@
         },
         "escape_lt_gt_in_attributes": {
           "__compat": {
-            "description": "Serializes `<` and `>` in attributes as `&lt;` and `&gt;`.",
-            "spec_url": "https://github.com/whatwg/html/issues/6235",
+            "description": "Serializes `<` and `>` in attributes as `&amp;lt;` and `&amp;gt;` (see [this spec issue](https://github.com/whatwg/html/issues/6235))",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
FF139 adds support for escaping `<` and `>` to `&lt;` and `&gt;` in attributes when serializing HTML in https://bugzilla.mozilla.org/show_bug.cgi?id=1941347. This affects all the obvious methods like innerHTML, outerHTML, getHTML.

This is enabled in nightly from FF139 (associated pref is `dom.security.html_serialization_escape_lt_gt`)

Some questions inline.

Related docs work can be tracked in https://github.com/mdn/content/issues/39309