### PR TITLE
Updates for Firefox 139 beta

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -534,7 +534,7 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": "139"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1111,7 +1111,7 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": "139"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1131,7 +1131,7 @@
                   "webview_ios": "mirror"
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
                 }

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -493,7 +493,7 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": "139"
                   },
                   "firefox_android": "mirror",
                   "ie": {

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -513,7 +513,7 @@
                   "webview_ios": "mirror"
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
                 }

--- a/api/Element.json
+++ b/api/Element.json
@@ -3244,7 +3244,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "139"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3262,7 +3262,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -243,7 +243,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "139"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -427,7 +427,9 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤15"
+            },
             "firefox": {
               "version_added": "1"
             },
@@ -626,8 +628,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1761043"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -646,7 +647,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -163,15 +163,17 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": "≤15"
                 },
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.0"
                 },
-                "edge": "mirror",
+                "edge": {
+                  "version_added": "≤15"
+                },
                 "firefox": {
-                  "version_added": "54"
+                  "version_added": "≤4"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -184,7 +186,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "12"
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -3045,8 +3047,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -26,8 +26,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1912511"
+              "version_added": "139"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,8 +78,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,8 +130,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,8 +182,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,8 +234,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,8 +286,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,8 +338,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -397,8 +390,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -450,8 +442,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -503,8 +494,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -556,8 +546,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -609,8 +598,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -662,8 +650,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -715,8 +702,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -768,8 +754,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -821,8 +806,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -874,8 +858,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,8 +910,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -980,8 +962,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1033,8 +1014,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1086,12 +1066,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": [
-                    "https://bugzil.la/1912511",
-                    "https://bugzil.la/1942850"
-                  ],
-                  "notes": "Currently toLocaleString() returns a string representing this duration in the ISO 8601 format and does not respect `locales` and `options`"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1143,8 +1118,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1196,8 +1170,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1249,8 +1222,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1302,8 +1274,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1355,8 +1326,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1408,8 +1378,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,8 +78,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,8 +130,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,8 +182,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,8 +234,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,8 +286,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,8 +338,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -397,8 +390,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -450,8 +442,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -503,8 +494,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -556,8 +546,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -609,8 +598,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -662,8 +650,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -715,8 +702,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -768,8 +754,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -821,8 +806,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -874,8 +858,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,8 +910,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -980,8 +962,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -78,8 +77,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -131,8 +129,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -184,8 +181,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -237,8 +233,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -290,8 +285,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -343,8 +337,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,8 +78,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,8 +130,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,8 +182,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,8 +234,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,8 +286,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,8 +338,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -397,8 +390,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -450,8 +442,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -503,8 +494,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -556,8 +546,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -609,8 +598,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -662,8 +650,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -715,8 +702,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -768,8 +754,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -821,8 +806,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -874,8 +858,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,8 +910,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -980,8 +962,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1033,8 +1014,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1086,8 +1066,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1139,8 +1118,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1192,8 +1170,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1245,8 +1222,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1298,8 +1274,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1351,8 +1326,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1404,8 +1378,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1457,8 +1430,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1510,8 +1482,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1563,8 +1534,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1616,8 +1586,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1669,8 +1638,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1722,8 +1690,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1775,8 +1742,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1828,8 +1794,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,8 +78,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,8 +130,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,8 +182,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,8 +234,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,8 +286,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,8 +338,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -397,8 +390,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -450,8 +442,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -503,8 +494,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -556,8 +546,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -609,8 +598,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -662,8 +650,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,8 +78,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,8 +130,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,8 +182,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,8 +234,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,8 +286,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,8 +338,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -397,8 +390,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -450,8 +442,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -503,8 +494,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -556,8 +546,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -609,8 +598,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -662,8 +650,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -715,8 +702,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -768,8 +754,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -821,8 +806,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -874,8 +858,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,8 +910,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -980,8 +962,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1033,8 +1014,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1086,8 +1066,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,8 +78,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,8 +130,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,8 +182,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,8 +234,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,8 +286,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,8 +338,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -397,8 +390,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -450,8 +442,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -503,8 +494,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -556,8 +546,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -609,8 +598,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -662,8 +650,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -715,8 +702,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -768,8 +754,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -821,8 +806,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -874,8 +858,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,8 +910,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -980,8 +962,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1033,8 +1014,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1086,8 +1066,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1139,8 +1118,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1192,8 +1170,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1245,8 +1222,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1298,8 +1274,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,8 +78,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,8 +130,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,8 +182,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,8 +234,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,8 +286,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,8 +338,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -397,8 +390,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -450,8 +442,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -503,8 +494,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -556,8 +546,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -609,8 +598,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -662,8 +650,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -715,8 +702,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -768,8 +754,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -821,8 +806,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -874,8 +858,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,8 +910,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -980,8 +962,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1033,8 +1014,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1086,8 +1066,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1139,8 +1118,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1192,8 +1170,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1245,8 +1222,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1298,8 +1274,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1351,8 +1326,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1404,8 +1378,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1457,8 +1430,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1510,8 +1482,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1563,8 +1534,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1616,8 +1586,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1669,8 +1638,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1722,8 +1690,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1775,8 +1742,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1828,8 +1794,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1881,8 +1846,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1934,8 +1898,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1987,8 +1950,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2040,8 +2002,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2093,8 +2054,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2146,8 +2106,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2199,8 +2158,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2252,8 +2210,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2305,8 +2262,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2358,8 +2314,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2411,8 +2366,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2464,8 +2418,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2517,8 +2470,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2570,8 +2522,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2623,8 +2574,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2676,8 +2626,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2729,8 +2678,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.13 found new features shipping in Firefox 139 beta which was released this week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 208 features as shipping in Firefox 139:

- api.CredentialsContainer.create.publicKey_option.extensions.largeBlob
- api.CredentialsContainer.get.publicKey_option.extensions.largeBlob
- api.Element.beforematch_event
- api.HTMLDialogElement.requestClose
- html.global_attributes.hidden.until-found
- javascript.builtins.Date.toTemporalInstant
- javascript.builtins.Temporal
- javascript.builtins.Temporal.Duration
- javascript.builtins.Temporal.Duration.Duration
- javascript.builtins.Temporal.Duration.abs
- javascript.builtins.Temporal.Duration.add
- javascript.builtins.Temporal.Duration.blank
- javascript.builtins.Temporal.Duration.compare
- javascript.builtins.Temporal.Duration.days
- javascript.builtins.Temporal.Duration.from
- javascript.builtins.Temporal.Duration.hours
- javascript.builtins.Temporal.Duration.microseconds
- javascript.builtins.Temporal.Duration.milliseconds
- javascript.builtins.Temporal.Duration.minutes
- javascript.builtins.Temporal.Duration.months
- javascript.builtins.Temporal.Duration.nanoseconds
- javascript.builtins.Temporal.Duration.negated
- javascript.builtins.Temporal.Duration.round
- javascript.builtins.Temporal.Duration.seconds
- javascript.builtins.Temporal.Duration.sign
- javascript.builtins.Temporal.Duration.subtract
- javascript.builtins.Temporal.Duration.toJSON
- javascript.builtins.Temporal.Duration.toLocaleString
- javascript.builtins.Temporal.Duration.toString
- javascript.builtins.Temporal.Duration.total
- javascript.builtins.Temporal.Duration.valueOf
- javascript.builtins.Temporal.Duration.weeks
- javascript.builtins.Temporal.Duration.with
- javascript.builtins.Temporal.Duration.years
- javascript.builtins.Temporal.Instant
- javascript.builtins.Temporal.Instant.Instant
- javascript.builtins.Temporal.Instant.add
- javascript.builtins.Temporal.Instant.compare
- javascript.builtins.Temporal.Instant.epochMilliseconds
- javascript.builtins.Temporal.Instant.epochNanoseconds
- javascript.builtins.Temporal.Instant.equals
- javascript.builtins.Temporal.Instant.from
- javascript.builtins.Temporal.Instant.fromEpochMilliseconds
- javascript.builtins.Temporal.Instant.fromEpochNanoseconds
- javascript.builtins.Temporal.Instant.round
- javascript.builtins.Temporal.Instant.since
- javascript.builtins.Temporal.Instant.subtract
- javascript.builtins.Temporal.Instant.toJSON
- javascript.builtins.Temporal.Instant.toLocaleString
- javascript.builtins.Temporal.Instant.toString
- javascript.builtins.Temporal.Instant.toZonedDateTimeISO
- javascript.builtins.Temporal.Instant.until
- javascript.builtins.Temporal.Instant.valueOf
- javascript.builtins.Temporal.Now
- javascript.builtins.Temporal.Now.instant
- javascript.builtins.Temporal.Now.plainDateISO
- javascript.builtins.Temporal.Now.plainDateTimeISO
- javascript.builtins.Temporal.Now.plainTimeISO
- javascript.builtins.Temporal.Now.timeZoneId
- javascript.builtins.Temporal.Now.zonedDateTimeISO
- javascript.builtins.Temporal.PlainDate
- javascript.builtins.Temporal.PlainDate.PlainDate
- javascript.builtins.Temporal.PlainDate.add
- javascript.builtins.Temporal.PlainDate.calendarId
- javascript.builtins.Temporal.PlainDate.compare
- javascript.builtins.Temporal.PlainDate.day
- javascript.builtins.Temporal.PlainDate.dayOfWeek
- javascript.builtins.Temporal.PlainDate.dayOfYear
- javascript.builtins.Temporal.PlainDate.daysInMonth
- javascript.builtins.Temporal.PlainDate.daysInWeek
- javascript.builtins.Temporal.PlainDate.daysInYear
- javascript.builtins.Temporal.PlainDate.equals
- javascript.builtins.Temporal.PlainDate.era
- javascript.builtins.Temporal.PlainDate.eraYear
- javascript.builtins.Temporal.PlainDate.from
- javascript.builtins.Temporal.PlainDate.inLeapYear
- javascript.builtins.Temporal.PlainDate.month
- javascript.builtins.Temporal.PlainDate.monthCode
- javascript.builtins.Temporal.PlainDate.monthsInYear
- javascript.builtins.Temporal.PlainDate.since
- javascript.builtins.Temporal.PlainDate.subtract
- javascript.builtins.Temporal.PlainDate.toJSON
- javascript.builtins.Temporal.PlainDate.toLocaleString
- javascript.builtins.Temporal.PlainDate.toPlainDateTime
- javascript.builtins.Temporal.PlainDate.toPlainMonthDay
- javascript.builtins.Temporal.PlainDate.toPlainYearMonth
- javascript.builtins.Temporal.PlainDate.toString
- javascript.builtins.Temporal.PlainDate.toZonedDateTime
- javascript.builtins.Temporal.PlainDate.until
- javascript.builtins.Temporal.PlainDate.valueOf
- javascript.builtins.Temporal.PlainDate.weekOfYear
- javascript.builtins.Temporal.PlainDate.with
- javascript.builtins.Temporal.PlainDate.withCalendar
- javascript.builtins.Temporal.PlainDate.year
- javascript.builtins.Temporal.PlainDate.yearOfWeek
- javascript.builtins.Temporal.PlainMonthDay
- javascript.builtins.Temporal.PlainMonthDay.PlainMonthDay
- javascript.builtins.Temporal.PlainMonthDay.calendarId
- javascript.builtins.Temporal.PlainMonthDay.day
- javascript.builtins.Temporal.PlainMonthDay.equals
- javascript.builtins.Temporal.PlainMonthDay.from
- javascript.builtins.Temporal.PlainMonthDay.monthCode
- javascript.builtins.Temporal.PlainMonthDay.toJSON
- javascript.builtins.Temporal.PlainMonthDay.toLocaleString
- javascript.builtins.Temporal.PlainMonthDay.toPlainDate
- javascript.builtins.Temporal.PlainMonthDay.toString
- javascript.builtins.Temporal.PlainMonthDay.valueOf
- javascript.builtins.Temporal.PlainMonthDay.with
- javascript.builtins.Temporal.PlainTime
- javascript.builtins.Temporal.PlainTime.PlainTime
- javascript.builtins.Temporal.PlainTime.add
- javascript.builtins.Temporal.PlainTime.compare
- javascript.builtins.Temporal.PlainTime.equals
- javascript.builtins.Temporal.PlainTime.from
- javascript.builtins.Temporal.PlainTime.hour
- javascript.builtins.Temporal.PlainTime.microsecond
- javascript.builtins.Temporal.PlainTime.millisecond
- javascript.builtins.Temporal.PlainTime.minute
- javascript.builtins.Temporal.PlainTime.nanosecond
- javascript.builtins.Temporal.PlainTime.round
- javascript.builtins.Temporal.PlainTime.second
- javascript.builtins.Temporal.PlainTime.since
- javascript.builtins.Temporal.PlainTime.subtract
- javascript.builtins.Temporal.PlainTime.toJSON
- javascript.builtins.Temporal.PlainTime.toLocaleString
- javascript.builtins.Temporal.PlainTime.toString
- javascript.builtins.Temporal.PlainTime.until
- javascript.builtins.Temporal.PlainTime.valueOf
- javascript.builtins.Temporal.PlainTime.with
- javascript.builtins.Temporal.PlainYearMonth
- javascript.builtins.Temporal.PlainYearMonth.PlainYearMonth
- javascript.builtins.Temporal.PlainYearMonth.add
- javascript.builtins.Temporal.PlainYearMonth.calendarId
- javascript.builtins.Temporal.PlainYearMonth.compare
- javascript.builtins.Temporal.PlainYearMonth.daysInMonth
- javascript.builtins.Temporal.PlainYearMonth.daysInYear
- javascript.builtins.Temporal.PlainYearMonth.equals
- javascript.builtins.Temporal.PlainYearMonth.era
- javascript.builtins.Temporal.PlainYearMonth.eraYear
- javascript.builtins.Temporal.PlainYearMonth.from
- javascript.builtins.Temporal.PlainYearMonth.inLeapYear
- javascript.builtins.Temporal.PlainYearMonth.month
- javascript.builtins.Temporal.PlainYearMonth.monthCode
- javascript.builtins.Temporal.PlainYearMonth.monthsInYear
- javascript.builtins.Temporal.PlainYearMonth.since
- javascript.builtins.Temporal.PlainYearMonth.subtract
- javascript.builtins.Temporal.PlainYearMonth.toJSON
- javascript.builtins.Temporal.PlainYearMonth.toLocaleString
- javascript.builtins.Temporal.PlainYearMonth.toPlainDate
- javascript.builtins.Temporal.PlainYearMonth.toString
- javascript.builtins.Temporal.PlainYearMonth.until
- javascript.builtins.Temporal.PlainYearMonth.valueOf
- javascript.builtins.Temporal.PlainYearMonth.with
- javascript.builtins.Temporal.PlainYearMonth.year
- javascript.builtins.Temporal.ZonedDateTime
- javascript.builtins.Temporal.ZonedDateTime.ZonedDateTime
- javascript.builtins.Temporal.ZonedDateTime.add
- javascript.builtins.Temporal.ZonedDateTime.calendarId
- javascript.builtins.Temporal.ZonedDateTime.compare
- javascript.builtins.Temporal.ZonedDateTime.day
- javascript.builtins.Temporal.ZonedDateTime.dayOfWeek
- javascript.builtins.Temporal.ZonedDateTime.dayOfYear
- javascript.builtins.Temporal.ZonedDateTime.daysInMonth
- javascript.builtins.Temporal.ZonedDateTime.daysInWeek
- javascript.builtins.Temporal.ZonedDateTime.daysInYear
- javascript.builtins.Temporal.ZonedDateTime.epochMilliseconds
- javascript.builtins.Temporal.ZonedDateTime.epochNanoseconds
- javascript.builtins.Temporal.ZonedDateTime.equals
- javascript.builtins.Temporal.ZonedDateTime.era
- javascript.builtins.Temporal.ZonedDateTime.eraYear
- javascript.builtins.Temporal.ZonedDateTime.from
- javascript.builtins.Temporal.ZonedDateTime.getTimeZoneTransition
- javascript.builtins.Temporal.ZonedDateTime.hour
- javascript.builtins.Temporal.ZonedDateTime.hoursInDay
- javascript.builtins.Temporal.ZonedDateTime.inLeapYear
- javascript.builtins.Temporal.ZonedDateTime.microsecond
- javascript.builtins.Temporal.ZonedDateTime.millisecond
- javascript.builtins.Temporal.ZonedDateTime.minute
- javascript.builtins.Temporal.ZonedDateTime.month
- javascript.builtins.Temporal.ZonedDateTime.monthCode
- javascript.builtins.Temporal.ZonedDateTime.monthsInYear
- javascript.builtins.Temporal.ZonedDateTime.nanosecond
- javascript.builtins.Temporal.ZonedDateTime.offset
- javascript.builtins.Temporal.ZonedDateTime.offsetNanoseconds
- javascript.builtins.Temporal.ZonedDateTime.round
- javascript.builtins.Temporal.ZonedDateTime.second
- javascript.builtins.Temporal.ZonedDateTime.since
- javascript.builtins.Temporal.ZonedDateTime.startOfDay
- javascript.builtins.Temporal.ZonedDateTime.subtract
- javascript.builtins.Temporal.ZonedDateTime.timeZoneId
- javascript.builtins.Temporal.ZonedDateTime.toInstant
- javascript.builtins.Temporal.ZonedDateTime.toJSON
- javascript.builtins.Temporal.ZonedDateTime.toLocaleString
- javascript.builtins.Temporal.ZonedDateTime.toPlainDate
- javascript.builtins.Temporal.ZonedDateTime.toPlainDateTime
- javascript.builtins.Temporal.ZonedDateTime.toPlainTime
- javascript.builtins.Temporal.ZonedDateTime.toString
- javascript.builtins.Temporal.ZonedDateTime.until
- javascript.builtins.Temporal.ZonedDateTime.valueOf
- javascript.builtins.Temporal.ZonedDateTime.weekOfYear
- javascript.builtins.Temporal.ZonedDateTime.with
- javascript.builtins.Temporal.ZonedDateTime.withCalendar
- javascript.builtins.Temporal.ZonedDateTime.withPlainTime
- javascript.builtins.Temporal.ZonedDateTime.withTimeZone
- javascript.builtins.Temporal.ZonedDateTime.year
- javascript.builtins.Temporal.ZonedDateTime.yearOfWeek
- webdriver.bidi.emulation
- webdriver.bidi.emulation.setGeolocationOverride

Note: I also observe WebGPU enabled by default, but it seems to be a beta channel thing for now only, see  https://groups.google.com/a/mozilla.org/g/dev-platform/c/hi1kFQF13Pk

See also https://github.com/mdn/mdn/issues/668 and https://www.mozilla.org/en-US/firefox/139.0beta/releasenotes/