### PR TITLE
Firefox 129 + Safari 18.2 implemented `api.Element.{click,auxclick,contextmenu}_event` as `PointerEvent`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3131,8 +3131,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/218665"
+                "version_added": "18.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3933,8 +3932,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/218665"
+                "version_added": "18.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -4468,10 +4466,12 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/218665"
+                "version_added": "18.2"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/213953"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"

--- a/api/Element.json
+++ b/api/Element.json
@@ -3139,7 +3139,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -3940,7 +3940,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -4477,7 +4477,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/Element.json
+++ b/api/Element.json
@@ -3121,8 +3121,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1675847"
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -3924,8 +3923,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1675847"
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -4460,8 +4458,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1675847"
+                "version_added": "129"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Previously `click`, `auxclick`, `contextmenu` events were not a `PointerEvent` in Firefox and Safari. But it seems like that's changed. This patch updates the "Is a `PointerEvent`" subfeatures to reflect their correct implementation status.

#### Test results and supporting details

These events were made PointerEvents in this bug in Firefox: https://bugzil.la/1675847
These events were made PointerEvents in this bug in Safari: https://webkit.org/b/218665

Rel notes for Safari: https://developer.apple.com/documentation/safari-release-notes/safari-18_2-release-notes#New-Features

#### Related issues

Fixes #25566.