### PR TITLE
FF139 Prioritize Scheduler API enabled Nightly

### DIFF
--- a/api/Scheduler.json
+++ b/api/Scheduler.json
@@ -14,15 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "101",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.enable_web_task_scheduling",
-                "value_to_set": "true"
-              }
-            ],
-            "impl_url": "https://bugzil.la/1795625"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -59,14 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -104,7 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/TaskController.json
+++ b/api/TaskController.json
@@ -14,14 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "101",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.enable_web_task_scheduling",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -59,14 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -104,14 +90,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/TaskPriorityChangeEvent.json
+++ b/api/TaskPriorityChangeEvent.json
@@ -14,14 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "101",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.enable_web_task_scheduling",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -59,14 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -104,14 +90,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -14,14 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "101",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.enable_web_task_scheduling",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -97,14 +90,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -146,14 +132,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/_globals/scheduler.json
+++ b/api/_globals/scheduler.json
@@ -14,14 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "101",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.enable_web_task_scheduling",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
FF139 enables the Prioritized Scheduling API in Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1958943 (sets `dom.enable_web_task_scheduling` to `true`, and also adds support for the `scheduler.yield()` method in https://bugzilla.mozilla.org/show_bug.cgi?id=1920115

This changes all the features to indicate their support in preview.

Related docs work can be tracked in https://github.com/mdn/content/issues/39310