### PR TITLE
Firefox 137 supports `font-synthesis-style: oblique-only`

### DIFF
--- a/css/properties/font-synthesis-style.json
+++ b/css/properties/font-synthesis-style.json
@@ -111,6 +111,40 @@
               "deprecated": false
             }
           }
+        },
+        "oblique-only": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-synthesis-style-oblique-only",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "137"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Found by the collector (might be forgotten earlier or the spec was just updated recently for this new value to be picked up)

Evidence: https://bugzilla.mozilla.org/show_bug.cgi?id=1945641