### PR TITLE
Updates for Chrome 137 beta

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -333,6 +333,40 @@
           }
         }
       },
+      "pixelFormat": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-pixelformat",
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData/width",

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -557,7 +557,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "137"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -842,7 +842,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "137"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -865,7 +865,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/reading-flow.json
+++ b/css/properties/reading-flow.json
@@ -9,15 +9,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "128",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.reading-flow.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://crbug.com/40932006"
+              "version_added": "137"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -43,6 +35,244 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "flex-flow": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display-4/#valdef-reading-flow-flex-flow",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "flex-visual": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display-4/#valdef-reading-flow-flex-visual",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "grid-columns": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display-4/#valdef-reading-flow-grid-columns",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "grid-order": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display-4/#valdef-reading-flow-grid-order",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "grid-rows": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display-4/#valdef-reading-flow-grid-rows",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "normal": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display-4/#valdef-reading-flow-normal",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "source-order": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-display-4/#valdef-reading-flow-source-order",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/reading-order.json
+++ b/css/properties/reading-order.json
@@ -1,0 +1,40 @@
+{
+  "css": {
+    "properties": {
+      "reading-order": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-display-4/#propdef-reading-order",
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/lint/linter/test-spec-urls.ts
+++ b/lint/linter/test-spec-urls.ts
@@ -46,6 +46,7 @@ const specsExceptions = [
   'https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md',
   'https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md',
   'https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md',
+  'https://github.com/WebAssembly/js-promise-integration',
 ];
 
 const allowedSpecURLs = [

--- a/webassembly/jspi.json
+++ b/webassembly/jspi.json
@@ -1,0 +1,43 @@
+{
+  "webassembly": {
+    "jspi": {
+      "__compat": {
+        "description": "JavaScript-Promise Integration",
+        "spec_url": "https://github.com/WebAssembly/js-promise-integration",
+        "support": {
+          "chrome": {
+            "version_added": "137"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.12.13 found new features shipping in Chrome 137 beta which was released last week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 13 features as shipping in Chrome 137:

- api.ImageData.pixelFormat
- api.Selection.direction
- api.Selection.getComposedRanges
- css.properties.reading-flow
- css.properties.reading-flow.flex-flow
- css.properties.reading-flow.flex-visual
- css.properties.reading-flow.grid-columns
- css.properties.reading-flow.grid-order
- css.properties.reading-flow.grid-rows
- css.properties.reading-flow.normal
- css.properties.reading-flow.source-order
- css.properties.reading-order
- webassembly.jspi

See also the 137 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-137-beta

cc @rachelandrew 