### PR TITLE
Chromium 107 removed `Expect-CT` response header

### DIFF
--- a/http/headers/Expect-CT.json
+++ b/http/headers/Expect-CT.json
@@ -8,11 +8,13 @@
           "support": {
             "chrome": {
               "version_added": "61",
+              "version_removed": "107",
               "notes": "Before later builds of Chrome 64, invalid Expect-CT reports would be sent. Newer versions do not send reports after 10 weeks from the build date. See [bug 41356303](https://crbug.com/41356303)."
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤79"
+              "version_added": "≤79",
+              "version_removed": "107"
             },
             "firefox": {
               "version_added": false,
@@ -23,9 +25,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chromium 107 disabled Expect-CT header by default. All Chromium-based browsers followed the removal too.

#### Test results and supporting details

[Chrome Platform status](https://chromestatus.com/feature/6244547273687040) lists `Expect-CT` as removed in Chrome 107.[Chromium issue 40780328](http://crbug.com/40780328) list most of the relevant CLs/PRs. Notably, [this commit](https://github.com/chromium/chromium/commit/ac7ca3a50ee55112ade8b41aa1999c32fc391014) disables this header in Chromium 107.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
N/A