### PR TITLE
Update Chromium data for webassembly.api

### DIFF
--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -146,7 +146,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -166,9 +166,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "47"
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "15"
@@ -330,7 +328,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -350,9 +348,7 @@
               "version_added": "18.1.0"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "47"
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "15"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `api` member of the `webassembly` WebAssembly interface. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.13).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/api
