### PR TITLE
Update Chromium data for api.CanvasRenderingContext2D.drawImage.ImageBitmap_source_image

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -841,7 +841,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "30"
+                "version_added": "50"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `drawImage.ImageBitmap_source_image` member of the `CanvasRenderingContext2D` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.13).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CanvasRenderingContext2D/drawImage/ImageBitmap_source_image

Additional Notes: ImageBitmap wasn't available in Chrome before Chrome 50.
