### PR TITLE
Update Chromium data for api.EventTarget.addEventListener.options_parameter.options_capture_parameter

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -222,7 +222,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "52"
+                  "version_added": "49"
                 },
                 "chrome_android": "mirror",
                 "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `addEventListener.options_parameter.options_capture_parameter` member of the `EventTarget` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.13).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/EventTarget/addEventListener/options_parameter/options_capture_parameter
