### PR TITLE
Update Edge data for EventTarget API

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -184,7 +184,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "≤18"
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": "49"
@@ -229,7 +229,7 @@
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "≤18"
+                  "version_added": "16"
                 },
                 "firefox": {
                   "version_added": "49"
@@ -275,7 +275,7 @@
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "≤18"
+                  "version_added": "16"
                 },
                 "firefox": {
                   "version_added": "50"
@@ -321,7 +321,7 @@
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "≤18"
+                  "version_added": "16"
                 },
                 "firefox": {
                   "version_added": "49"
@@ -660,7 +660,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "≤18"
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": "49"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `EventTarget` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.12.13).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/EventTarget
