### PR TITLE
Deno 1.37+ supports `using` statements

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -2223,7 +2223,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.37"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
#### Summary

Deno 1.37+ supports `using` statements in TypeScript.

Support at the JS (V8) engine level was only [added in 2.3](https://deno.com/blog/v2.3#explicit-resource-management-and-the-using-keyword), so not sure if the version number should list 1.37 or 2.3. Most Deno code is written in TypeScript.

#### Test results and supporting details

```ts
deno upgrade --version 1.36.0
deno
> {
    using _ = { [Symbol.dispose]: () => console.log('dispose') }
    console.log('end of scope')
}
Uncaught SyntaxError: Unexpected identifier '_'

deno upgrade --version 1.37.0
deno
> {
    using _ = { [Symbol.dispose]: () => console.log('dispose') }
    console.log('end of scope')
}
end of scope
dispose
```

#### Related issues

N/A