### PR TITLE
Update Safari data for `{min,max}-{height,width}: stretch`

### DIFF
--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -366,7 +366,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -374,7 +375,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -384,7 +384,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -392,7 +393,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -377,7 +377,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -399,7 +399,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -407,7 +408,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Safari data for `{min,max}-{height,width}: stretch`.

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/issues/24190#issuecomment-2858357934 (and previous comments)

Safari 7 added support for `{min,max}-height: -webkit-fill-available`.
Safari 9 added support for `{min,max}-width: -webkit-fill-available`.

#### Related issues

- Fixes https://github.com/mdn/browser-compat-data/issues/24190.