### PR TITLE
Updates for Node.js 24.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -737,7 +737,7 @@
         "23.0.0": {
           "release_date": "2024-10-16",
           "release_notes": "https://nodejs.org/en/blog/release/v23.0.0",
-          "status": "esr",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "12.9"
         },

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -737,9 +737,16 @@
         "23.0.0": {
           "release_date": "2024-10-16",
           "release_notes": "https://nodejs.org/en/blog/release/v23.0.0",
-          "status": "current",
+          "status": "esr",
           "engine": "V8",
           "engine_version": "12.9"
+        },
+        "24.0.0": {
+          "release_date": "2025-05-06",
+          "release_notes": "https://nodejs.org/en/blog/release/v24.0.0",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "13.6"
         }
       }
     }

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -420,7 +420,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -422,7 +422,7 @@
               "nodejs": {
                 "version_added": "24.0.0",
                 "partial_implementation": true,
-                "notes": "Returns `false` for `DOMException` instances."
+                "notes": "Returns `false` for `DOMException` instances. See [issue 56497](https://github.com/nodejs/node/issues/56497)."
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -420,7 +420,9 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "24.0.0"
+                "version_added": "24.0.0",
+                "partial_implementation": true,
+                "notes": "Returns `false` for `DOMException` instances."
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/Float16Array.json
+++ b/javascript/builtins/Float16Array.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "24.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -69,7 +69,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -223,7 +223,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": 24.0.0
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -223,7 +223,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": 24.0.0
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -121,7 +121,7 @@
                 {
                   "version_added": "20.4.0",
                   "partial_implementation": true,
-                  "note": "Initial implementation only for fs and stream"
+                  "notes": "Initial implementation only for fs and stream"
                 },
                 {
                   "version_added": "18.18.0",
@@ -268,7 +268,7 @@
                 {
                   "version_added": "20.4.0",
                   "partial_implementation": true,
-                  "note": "Initial implementation only for fs and stream"
+                  "notes": "Initial implementation only for fs and stream"
                 },
                 {
                   "version_added": "18.18.0",

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -125,7 +125,9 @@
                 },
                 {
                   "version_added": "18.18.0",
-                  "version_removed": "19.0.0"
+                  "version_removed": "19.0.0",
+                  "partial_implementation": true,
+                  "notes": "Only available for `fs` and `stream` resources."
                 }
               ],
               "oculus": "mirror",
@@ -272,7 +274,9 @@
                 },
                 {
                   "version_added": "18.18.0",
-                  "version_removed": "19.0.0"
+                  "version_removed": "19.0.0",
+                  "partial_implementation": true,
+                  "notes": "Only available for `fs` and `stream` resources."
                 }
               ],
               "oculus": "mirror",

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -266,7 +266,7 @@
                   "version_added": "24.0.0"
                 },
                 {
-                  "version_added": "20.4.0"
+                  "version_added": "20.4.0",
                   "partial_implementation": true,
                   "note": "Initial implementation only for fs and stream"
                 },

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -121,7 +121,7 @@
                 {
                   "version_added": "20.4.0",
                   "partial_implementation": true,
-                  "notes": "Initial implementation only for fs and stream"
+                  "notes": "Only available for `fs` and `stream` resources."
                 },
                 {
                   "version_added": "18.18.0",
@@ -268,7 +268,7 @@
                 {
                   "version_added": "20.4.0",
                   "partial_implementation": true,
-                  "notes": "Initial implementation only for fs and stream"
+                  "notes": "Only available for `fs` and `stream` resources."
                 },
                 {
                   "version_added": "18.18.0",

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -116,7 +116,12 @@
               },
               "nodejs": [
                 {
-                  "version_added": "20.4.0"
+                  "version_added": "24.0.0"
+                },
+                {
+                  "version_added": "20.4.0",
+                  "partial_implementation": true,
+                  "note": "Initial implementation only for fs and stream"
                 },
                 {
                   "version_added": "18.18.0",
@@ -258,7 +263,12 @@
               },
               "nodejs": [
                 {
+                  "version_added": "24.0.0"
+                },
+                {
                   "version_added": "20.4.0"
+                  "partial_implementation": true,
+                  "note": "Initial implementation only for fs and stream"
                 },
                 {
                   "version_added": "18.18.0",

--- a/webassembly/memory64.json
+++ b/webassembly/memory64.json
@@ -19,6 +19,9 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "24.0.0"
+          },
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",


### PR DESCRIPTION
#### Summary

RegExp.escape added to nodejs v24

#### Test results and supporting details

https://nodejs.org/en/blog/release/v24.0.0



