### PR TITLE
Adds MDN urls and spec urls for `<script type="speculationrules">` subfeatures

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -819,6 +819,7 @@
               "__compat": {
                 "description": "`eagerness` key",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#eagerness",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule-eagerness",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -859,6 +860,7 @@
               "__compat": {
                 "description": "`expects_no_vary_search` key",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#expects_no_vary_search",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule-no-vary-search-hint",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -906,6 +908,7 @@
               "__compat": {
                 "description": "`prefetch` key",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#prefetch",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule-set-prefetch-rules",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -948,6 +951,7 @@
               "__compat": {
                 "description": "`prerender` key",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#prerender",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule-set-prerender-rules",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -990,6 +994,7 @@
               "__compat": {
                 "description": "`referrer_policy` key",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#referrer_policy",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule-referrer-policy",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -1070,6 +1075,7 @@
               "__compat": {
                 "description": "`requires` key",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#requires",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule-requirements",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -1202,6 +1208,7 @@
               "__compat": {
                 "description": "`tag` key",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#tag",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rules-tag",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -1241,6 +1248,7 @@
             "urls": {
               "__compat": {
                 "description": "`urls` key",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rule-urls",
                 "tags": [
                   "web-features:speculation-rules"
                 ],

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -818,6 +818,7 @@
             "eagerness": {
               "__compat": {
                 "description": "`eagerness` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#eagerness",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -857,6 +858,7 @@
             "expects_no_vary_search": {
               "__compat": {
                 "description": "`expects_no_vary_search` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#expects_no_vary_search",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -903,6 +905,7 @@
             "prefetch": {
               "__compat": {
                 "description": "`prefetch` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#prefetch",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -944,6 +947,7 @@
             "prerender": {
               "__compat": {
                 "description": "`prerender` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#prerender",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -985,6 +989,7 @@
             "referrer_policy": {
               "__compat": {
                 "description": "`referrer_policy` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#referrer_policy",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -1024,6 +1029,7 @@
             "relative_to": {
               "__compat": {
                 "description": "`relative_to` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#relative_to_2",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -1063,6 +1069,7 @@
             "requires": {
               "__compat": {
                 "description": "`requires` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#requires",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -1103,6 +1110,7 @@
               "anonymous-client-ip-when-cross-origin": {
                 "__compat": {
                   "description": "`anonymous-client-ip-when-cross-origin` value",
+                  "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#anonymous-client-ip-when-cross-origin",
                   "tags": [
                     "web-features:speculation-rules"
                   ],
@@ -1153,6 +1161,7 @@
             "source_optional": {
               "__compat": {
                 "description": "`source` key is optional",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#source",
                 "tags": [
                   "web-features:speculation-rules"
                 ],
@@ -1192,6 +1201,7 @@
             "tag": {
               "__compat": {
                 "description": "`tag` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#tag",
                 "tags": [
                   "web-features:speculation-rules"
                 ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds several `mdn_url` and `spec_url` values for  `<script type="speculationrules">` subfeatures.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Related to: https://github.com/mdn/browser-compat-data/pull/26485
