### PR TITLE
Safari 18.4 supports CaretPosition API only behind flag

### DIFF
--- a/api/CaretPosition.json
+++ b/api/CaretPosition.json
@@ -24,7 +24,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "18.4"
+            "version_added": "18.4",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "document.caretPositionFromPoint() API",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -60,7 +67,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.4"
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "document.caretPositionFromPoint() API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -97,7 +111,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.4"
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "document.caretPositionFromPoint() API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -134,7 +155,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.4"
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "document.caretPositionFromPoint() API",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `CaretPosition` API. A previous update with collector data said this was supported, but this was from the beta version of Safari 18.4, which appears to have had the flag enabled.
