### PR TITLE
Safari 18.4 supports `context` parameter in `JSON.parse()` reviver

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -225,7 +225,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update Safari data for context parameter on reviver function of `JSON.parse` feature

#### Test results and supporting details

* How
  Running on below script on `Console` tab on `Developer Tool` of `Safari 18.4` directly.

  ```
  var json = '{"test":"abc","test2":"def","test3":{"test4":"ghi"}}'
  JSON.parse(json, (key, value, context) => {
    console.log({ key, value, context })
    return value
  })
  ```

* Result

  ![Result on Safari 18.4](https://github.com/user-attachments/assets/0489f860-3906-473f-b78c-7009646ef7e8)

#### Related issues

* Fixes #26720
