### PR TITLE
Safari iOS 18.4 also supports `text-autospace`

### DIFF
--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -62,9 +62,7 @@
               "safari": {
                 "version_added": "18.4"
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
@@ -101,9 +99,7 @@
               "safari": {
                 "version_added": "18.4"
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
@@ -140,9 +136,7 @@
               "safari": {
                 "version_added": "18.4"
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
@@ -179,9 +173,7 @@
               "safari": {
                 "version_added": "18.4"
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"
@@ -218,9 +210,7 @@
               "safari": {
                 "version_added": "18.4"
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"

--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -26,9 +26,7 @@
             "safari": {
               "version_added": "18.4"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari iOS 18.4 supported CSS property `text-autospace`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Tested in [https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-autospace](https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-autospace):

![image](https://github.com/user-attachments/assets/98e0a322-a841-4f54-989d-e6e290cbad0d)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Description from webkit blog: [https://webkit.org/blog/16574/webkit-features-in-safari-18-4/](https://webkit.org/blog/16574/webkit-features-in-safari-18-4/)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fix #26696 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
