### PR TITLE
Firefox 139 supports Temporal.PlainDateTime

### DIFF
--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -26,8 +26,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1912511"
+                "version_added": "139"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -79,8 +78,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -132,8 +130,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -185,8 +182,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -238,8 +234,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -291,8 +286,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,8 +338,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -397,8 +390,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -450,8 +442,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -503,8 +494,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -556,8 +546,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -609,8 +598,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -662,8 +650,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -715,8 +702,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -768,8 +754,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -821,8 +806,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -874,8 +858,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -927,8 +910,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -980,8 +962,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1033,8 +1014,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1086,8 +1066,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1139,8 +1118,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1192,8 +1170,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1245,8 +1222,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1298,8 +1274,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1351,8 +1326,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1404,8 +1378,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1457,8 +1430,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1510,8 +1482,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1563,8 +1534,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1616,8 +1586,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1669,8 +1638,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1722,8 +1690,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1775,8 +1742,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1828,8 +1794,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1881,8 +1846,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1934,8 +1898,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1987,8 +1950,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2040,8 +2002,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2093,8 +2054,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2146,8 +2106,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -2199,8 +2158,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1912511"
+                  "version_added": "139"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
Follow-up to https://github.com/mdn/browser-compat-data/pull/26693. I seem to have simply forgotten to add this file to my previous PR. Sorry!