### PR TITLE
Chrome Android doesn't support Summarizer API

### DIFF
--- a/api/CreateMonitor.json
+++ b/api/CreateMonitor.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "138"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "deno": {
             "version_added": false
           },
@@ -47,7 +49,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },

--- a/api/Summarizer.json
+++ b/api/Summarizer.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "138"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "deno": {
             "version_added": false
           },
@@ -47,7 +49,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -88,7 +92,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -129,7 +135,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -170,7 +178,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -211,7 +221,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -252,7 +264,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -293,7 +307,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -334,7 +350,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -375,7 +393,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -416,7 +436,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -457,7 +479,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -498,7 +522,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -539,7 +565,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },
@@ -580,7 +608,9 @@
             "chrome": {
               "version_added": "138"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1317,7 +1317,9 @@
               "chrome": {
                 "version_added": "138"
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In discussions with Google devrel, I learned that the Summarizer API is only supported on Windows/macOS/Linux, not Android (or ChromeOS). This PR updates our data to suit.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
