### PR TITLE
Correct Firefox support for `webextensions.api.storage.session.setAccessLevel`

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -963,7 +963,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "115"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
#### Summary

As per feedback provided in [webextensions.api.storage.session - setAccessLevel doesn't seem to be actually supported](https://github.com/mdn/browser-compat-data/issues/26694#top) #26694 and supported by [comment 8](https://bugzilla.mozilla.org/show_bug.cgi?id=1687778#c8) on [Bug 1687778](https://bugzilla.mozilla.org/show_bug.cgi?id=1687778) MV3 in-memory storage API (storage.session)