### PR TITLE
docs: add alphabetical index

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Read how this project is [governed](./GOVERNANCE.md).
 
 Chat with us on Matrix at [chat.mozilla.org#mdn](https://chat.mozilla.org/#/room/#mdn:mozilla.org)!
 
+Are you interested in contributing to this project? Check out the [Contributing to browser-compat-data](./docs/contributing.md) documentation.
+
+> [!TIP]
+> Looking for something? Consult the [alphabetical index](./docs/index.md) of the project documentation.
+
 ## Installation and Import
 
 ### NodeJS

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,107 @@
+# Index
+
+An alphabetical index of keywords linking to relevant sections in the docs.
+
+---
+
+- **API features** – [Data guidelines for API features](./data-guidelines/api.md)
+
+---
+
+- **Browser addition/removal** – [Data guidelines for browser data](./data-guidelines/browsers.md#addition-of-browsers)
+- **Browser data** – [Data guidelines for browser data](./data-guidelines/browsers.md)
+- **Browser versions** – [Matching web features to browser release version numbers](./matching-browser-releases/index.md#matching-web-features-to-browser-release-version-numbers)
+
+---
+
+- **Chromium** – [Contributing: Helpful resources](./contributing.md#chromium)
+- **Constants** – [Data guidelines for API features](./data-guidelines/api.md#constants)
+- **Constructors** – [Data guidelines for API features](./data-guidelines/api.md#constructors)
+- **Consumers** – [README: Projects using the data](../README.md#projects-using-the-data)
+- **Contributing** – [Contributing to browser-compat-data](./contributing.md)
+
+---
+
+- **Data guidelines** – [Overview of data guidelines](./data-guidelines/index.md)
+- **Deprecated** – [Data guidelines: Setting `deprecated`](./data-guidelines/index.md#setting-deprecated)
+- **Dictionaries** – [Data guidelines for API features: Dictionaries and enumerations (enums)](./data-guidelines/api.md#dictionaries-and-enumerations-enums)
+
+---
+
+- **Edge** – [Contributing: Helpful resources](./contributing.md#edge)
+- **Enumerations (enums)** – [Data guidelines for API features: Dictionaries and enumerations (enums)](./data-guidelines/api.md#dictionaries-and-enumerations-enums)
+- **Events (DOM)** – [Data guidelines for API features](./data-guidelines/api.md#dom-events-eventname_event)
+- **Experimental** – [Data guidelines: Setting `experimental`](./data-guidelines/index.md#setting-experimental)
+
+---
+
+- **Firefox** – [Contributing: Helpful resources](./contributing.md#firefox)
+- **FAQ** – [BCD FAQ](./faq.md)
+
+---
+
+- **Global APIs** – [Data guidelines for API features: Global APIs](./data-guidelines/api.md#global-apis)
+
+---
+
+- **Idle PRs** – [FAQ: If another PR is idle, may I take over it?](./faq.md#if-another-pr-is-idle-may-i-take-over-it)
+- **Installation** – [README: Installation and Import](../README.md#installation-and-import)
+- **Irrelevant features** – [Data guidelines: Removal of irrelevant features](./data-guidelines/index.md#removal-of-irrelevant-features)
+- **Irrelevant flags** –[Data guidelines: Removal of irrelevant flag data](./data-guidelines/index.md#removal-of-irrelevant-flag-data)
+- **Issue triage** – [Issue triage checklist](./issue-triage-checklist.md)
+
+---
+
+- **Labels** – [Label usage](./labels.md)
+- **Linting** – [Testing, validating, and linting](./testing.md)
+
+---
+
+- **Migrations** – [Migrations](./migrations.md)
+- **Mirroring** – [Contributing: Generating data by mirroring](./contributing.md#optional-generating-data-by-mirroring)
+- **Mixins** – [Data guidelines for API features](./data-guidelines/api.md#mixins)
+
+---
+
+- **Namespaces** – [Data guidelines for API features](./data-guidelines/api.md#namespaces)
+- **Node.js** – [Data guidelines for browser data](./data-guidelines/browsers.md#nodejs)
+
+---
+
+- **Partial implementation** – [Data guidelines: "partial_implementation" requires a note](./data-guidelines/index.md#partial_implementation-requires-a-note)
+- **Permissions API** – [Data guidelines for API features](./data-guidelines/api.md#permissions-api-permissions-permissionname_permission)
+- **Preview support** – [Data guidelines: Choosing "preview" values](./data-guidelines/index.md#choosing-preview-values)
+- **Promises** – [Data guidelines for API features](./data-guidelines/api.md#methods-returning-promises-returns_promise)
+- **Prototype chain** – [Data guidelines for API features](./data-guidelines/api.md#apis-moved-on-the-prototype-chain)
+- **Publishing** – [Publishing a new version of `@mdn/browser-compat-data`](./publishing.md)
+- **Pull requests** – [Contributing: Opening pull requests](./contributing.md#opening-pull-requests)
+
+---
+
+- **Safari** – [Contributing: Helpful resources](./contributing.md#safari)
+- **Schema** – [The browser JSON schema](../schemas/browsers-schema.md) | [The compat data JSON schema](../schemas/compat-data-schema.md)
+- **Scope** – [README: What isn't tracked?](../README.md#what-isnt-tracked)
+- **Secure Context** – [Data guidelines for API features](./data-guidelines/api.md#secure-context-required-secure_context_required)
+- **Standard track** – [Data guidelines: Choosing status properties](./data-guidelines/index.md#choosing-status-properties)
+- **Static API members** – [Data guidelines for API features](./data-guidelines/api.md#static-api-members)
+- **Status** – [Data guidelines: Choosing status properties](./data-guidelines/index.md#choosing-status-properties)
+- **Stringifier (toString)** – [Data guidelines for API features](./data-guidelines/api.md#stringifier-attributes-tostring)
+
+---
+
+- **Tags** – [Data guidelines for tagging BCD features](./data-guidelines/tags.md)
+- **Testing** – [Testing, validating, and linting](./testing.md)
+- **Tools** – [Contributing: Helpful resources](./contributing.md#general)
+
+---
+
+- **Usage** – [README: Installation and Import](../README.md#usage)
+
+---
+
+- **Versioning** – [README: Semantic versioning policy](../README.md#semantic-versioning-policy)
+
+---
+
+- **Web features** – [Data guidelines for tagging BCD features](./data-guidelines/tags.md#the-web-features-namespace)
+- **Workers** – [Data guidelines for API features](./data-guidelines/api.md#web-workers-worker_support)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds an alphabetical index of keywords covered by the BCD project docs.

#### Test results and supporting details

Goals:

- Make it easier to quickly find frequently consulted sections.
- Provide an overview of what's currently covered by the docs.
- Making it easier to spot what's currently _not_ covered by the docs.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
