### PR TITLE
Node.js 16.6 shipped `shared` flag on WebAssembly `Memory()` constructor

### DIFF
--- a/webassembly/api/Memory.json
+++ b/webassembly/api/Memory.json
@@ -118,13 +118,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--experimental-wasm-threads"
-                    }
-                  ]
+                  "version_added": "16.6.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update Node.js data for `webassembly.api.Memory.Memory.shared`.

Note: This makes the previous statement obsolete, because it has `flags`.

#### Test results and supporting details

The flag was enabled in V8 9.2.45, see: https://github.com/v8/v8/commit/be9ff65a06963f9326756c056a338e1b9e07499c
Node.js 16.5 used V8 9.1, and Node.js used V8 9.2.230, see: https://nodejs.org/dist/index.json

See also: https://github.com/nodejs/node/pull/45074

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
