### PR TITLE
Fix Navigator share support on chrome to version 128

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -555,7 +555,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "129"
+                "version_added": "128"
               },
               {
                 "version_added": "89",
@@ -5268,7 +5268,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "129"
+                "version_added": "128"
               },
               {
                 "version_added": "89",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes Navigator share support version on chrome (see https://github.com/mdn/browser-compat-data/issues/25074#issuecomment-2867903077)

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

- https://chromiumdash.appspot.com/commit/60426ee006d2587433b4c9f80b95dd6a19327ff1
- https://developer.chrome.com/release-notes/128?hl=en#web_share_api_on_macos
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/25074

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->


