### PR TITLE
Deno 1.25 supports `NumberFormat.format` decimal string

### DIFF
--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -1361,7 +1361,7 @@
                   },
                   "chrome_android": "mirror",
                   "deno": {
-                    "version_added": false
+                    "version_added": "1.25"
                   },
                   "edge": "mirror",
                   "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Deno 1.25 supports decimal string number format

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Tested: https://github.com/mdn/browser-compat-data/issues/25128#issuecomment-2871722504

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://github.com/mdn/browser-compat-data/issues/25128

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
