### PR TITLE
Add CSS `text-underline-position: auto` and other values' specs

### DIFF
--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -46,8 +46,46 @@
             "deprecated": false
           }
         },
+        "auto": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor/#underline-auto",
+            "tags": [
+              "web-features:text-underline-position"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "74"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "from-font": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor-4/#valdef-text-underline-position-from-font",
             "tags": [
               "web-features:text-underline-position"
             ],
@@ -84,6 +122,7 @@
         },
         "left": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor/#underline-left",
             "tags": [
               "web-features:text-underline-position"
             ],
@@ -120,6 +159,7 @@
         },
         "right": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor/#underline-left",
             "tags": [
               "web-features:text-underline-position"
             ],
@@ -156,6 +196,7 @@
         },
         "under": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor/#underline-under",
             "tags": [
               "web-features:text-underline-position"
             ],

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -63,7 +63,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "6"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

The auto value was missing from text-underline-position. Also, add spec_urls.

#### Test results and supporting details

The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.0).

#### Related issues

None.
