### PR TITLE
Chrome 137 adds CSS `if()` function

### DIFF
--- a/css/types/if.json
+++ b/css/types/if.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "types": {
+      "if": {
+        "__compat": {
+          "description": "`if()`",
+          "spec_url": "https://drafts.csswg.org/css-values-5/#if-notation",
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The CSS [`if()`](https://drafts.csswg.org/css-values-5/#if-notation) function is supported in Chrome from version 137. See https://chromestatus.com/feature/6313805904347136.

This PR adds a data point for it.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
