### PR TITLE
Add CSS `empty-cells: {hide,show}`

### DIFF
--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -43,6 +43,92 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "hide": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css2/#valdef-empty-cells-hide",
+            "tags": [
+              "web-features:table"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "8"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "1.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "show": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css2/#valdef-empty-cells-show",
+            "tags": [
+              "web-features:table"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "8"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "1.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
#### Summary

Add the missing values `hide` and `show` to` empty-cells`.

#### Test results and supporting details

The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.0).
And these values are essential for the property and likely supported from the start.

#### Related issues

None.