### PR TITLE
Bug-1550032 addition of unspecified to webextension.api.cookie.SameSiteStatus

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -619,7 +619,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "140"
                 },
                 "firefox_android": "mirror",
                 "opera": {
@@ -730,7 +730,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "63"
+                  "version_added": "63",
+                  "notes": "Until Firefox 139, defaults to `no_restriction`. From Firefox 140, defaults to `unspecified`. "
                 },
                 "firefox_android": "mirror",
                 "opera": {


### PR DESCRIPTION
#### Summary

Provide the updates necessary for [Bug 1550032](https://bugzilla.mozilla.org/show_bug.cgi?id=1550032) Change cookie API to explicitly support sameSite=none. Specifically:

- To note the introduction of `unspecified` to `cookie.SameSiteStatus`
- That `unspecified` is now the default value for `sameSite` in `cookies.set()`.

#### Related issues

MDN documentation changes made in https://github.com/mdn/content/pull/39512.
Release note update made in https://github.com/mdn/content/pull/39513.
