### PR TITLE
fix(update-browser-releases): handle Opera release note without Engine version

### DIFF
--- a/scripts/update-browser-releases/opera.ts
+++ b/scripts/update-browser-releases/opera.ts
@@ -92,7 +92,7 @@ const findEngineVersion = async (
     return contentMatch[1];
   }
 
-  throw Error(`Failed to find engine version here: ${item.link}`);
+  return '';
 };
 
 /**
@@ -131,6 +131,22 @@ export const updateOperaReleases = async (options) => {
   const current = structuredClone(
     data.browsers[browser].releases[release.version],
   );
+
+  if (!release.engineVersion) {
+    const currentEngineVersion = current.engine_version;
+    if (!currentEngineVersion) {
+      return gfmNoteblock(
+        'CAUTION',
+        `**${options.browserName}**: No engine version found in [this blog post](<${release.releaseNote}>).`,
+      );
+    }
+
+    result += gfmNoteblock(
+      'WARN',
+      `**${options.browserName}**: No engine version found in [this blog post](<${release.releaseNote}>). Using (previous engine version + 1) instead.`,
+    );
+    release.engineVersion = currentEngineVersion;
+  }
 
   if (isDesktop && !current) {
     return gfmNoteblock(

--- a/scripts/update-browser-releases/opera.ts
+++ b/scripts/update-browser-releases/opera.ts
@@ -80,7 +80,7 @@ const findEngineVersion = async (
   const res = await fetch(item.link);
 
   if (!res.ok) {
-    throw Error(`Failed to fetch: ${item.link}`);
+    throw Error(`Failed to fetch [this blog post](${item.link})`);
   }
 
   const html = await res.text();
@@ -92,7 +92,9 @@ const findEngineVersion = async (
     return contentMatch[1];
   }
 
-  throw Error(`Failed to find engine version here: ${item.link}`);
+  throw Error(
+    `Failed to find engine version [in this blog post](${item.link})!`,
+  );
 };
 
 /**
@@ -109,87 +111,94 @@ export const updateOperaReleases = async (options) => {
 
   const items = await getRSSItems(options.releaseFeedURL);
 
-  const release = await findRelease(
-    items.filter(
-      (item) =>
-        options.releaseFilterCreator?.includes(item['dc:creator']) ?? true,
-    ),
-    options.titleVersionPattern,
-    options.descriptionEngineVersionPattern,
-  );
-
-  if (!release) {
-    return gfmNoteblock(
-      'NOTE',
-      `**${options.browserName}**: No release announcement found among ${items.length} items in [this RSS feed](<${options.releaseFeedURL}>).`,
+  try {
+    const release = await findRelease(
+      items.filter(
+        (item) =>
+          options.releaseFilterCreator?.includes(item['dc:creator']) ?? true,
+      ),
+      options.titleVersionPattern,
+      options.descriptionEngineVersionPattern,
     );
-  }
 
-  const file = await fs.readFile(`${options.bcdFile}`, 'utf-8');
-  const data = JSON.parse(file.toString());
+    if (!release) {
+      return gfmNoteblock(
+        'NOTE',
+        `**${options.browserName}**: No release announcement found among ${items.length} items in [this RSS feed](<${options.releaseFeedURL}>).`,
+      );
+    }
 
-  const current = structuredClone(
-    data.browsers[browser].releases[release.version],
-  );
+    const file = await fs.readFile(`${options.bcdFile}`, 'utf-8');
+    const data = JSON.parse(file.toString());
 
-  if (isDesktop && !current) {
-    return gfmNoteblock(
-      'WARN',
-      `Latest stable **${options.browserName}** release **${release.version}** not yet tracked.`,
+    const current = structuredClone(
+      data.browsers[browser].releases[release.version],
     );
-  }
 
-  result += createOrUpdateBrowserEntry(
-    data,
-    browser,
-    release.version,
-    release.channel,
-    release.engine,
-    release.engineVersion,
-    release.date,
-    release.releaseNote,
-  );
+    if (isDesktop && !current) {
+      return gfmNoteblock(
+        'WARNING',
+        `Latest stable **${options.browserName}** release **${release.version}** not yet tracked.`,
+      );
+    }
 
-  // Set previous release to "retired".
-  const previousVersion = String(Number(release.version) - 1);
-  result += updateBrowserEntry(
-    data,
-    browser,
-    previousVersion,
-    undefined,
-    'retired',
-    undefined,
-    undefined,
-  );
-
-  if (isDesktop) {
-    // 1. Set next release to "beta".
     result += createOrUpdateBrowserEntry(
       data,
       browser,
-      String(Number(release.version) + 1),
-      'beta',
+      release.version,
+      release.channel,
       release.engine,
-      String(Number(release.engineVersion) + 1),
+      release.engineVersion,
+      release.date,
+      release.releaseNote,
     );
 
-    // 2. Add another release as "nightly".
-    result += createOrUpdateBrowserEntry(
+    // Set previous release to "retired".
+    const previousVersion = String(Number(release.version) - 1);
+    result += updateBrowserEntry(
       data,
       browser,
-      String(Number(release.version) + 2),
-      'nightly',
-      release.engine,
-      String(Number(release.engineVersion) + 2),
+      previousVersion,
+      undefined,
+      'retired',
+      undefined,
+      undefined,
+    );
+
+    if (isDesktop) {
+      // 1. Set next release to "beta".
+      result += createOrUpdateBrowserEntry(
+        data,
+        browser,
+        String(Number(release.version) + 1),
+        'beta',
+        release.engine,
+        String(Number(release.engineVersion) + 1),
+      );
+
+      // 2. Add another release as "nightly".
+      result += createOrUpdateBrowserEntry(
+        data,
+        browser,
+        String(Number(release.version) + 2),
+        'nightly',
+        release.engine,
+        String(Number(release.engineVersion) + 2),
+      );
+    }
+
+    await fs.writeFile(`./${options.bcdFile}`, stringify(data) + '\n');
+
+    // Returns the log
+    if (result) {
+      result = `### Updates for ${options.browserName}${result}`;
+    }
+
+    return result;
+  } catch (e) {
+    return gfmNoteblock(
+      'CAUTION',
+      `**${options.browserName}**: Could not update releases.\n\n${e}`,
     );
   }
-
-  await fs.writeFile(`./${options.bcdFile}`, stringify(data) + '\n');
-
-  // Returns the log
-  if (result) {
-    result = `### Updates for ${options.browserName}${result}`;
-  }
-
-  return result;
 };

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -190,10 +190,7 @@ export const getRSSItems = async (url): Promise<RSSItem[]> => {
  * @param message the message of the noteblock.
  * @returns the message as a GFM noteblock.
  */
-export const gfmNoteblock = (
-  type: 'NOTE' | 'TIP' | 'IMPORTANT' | 'WARNING' | 'CAUTION',
-  message: string,
-) =>
+export const gfmNoteblock = (type: 'NOTE' | 'WARN', message: string) =>
   `> [!${type}]\n${message
     .split('\n')
     .map((line) => `> ${line}`)

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -190,7 +190,10 @@ export const getRSSItems = async (url): Promise<RSSItem[]> => {
  * @param message the message of the noteblock.
  * @returns the message as a GFM noteblock.
  */
-export const gfmNoteblock = (type: 'NOTE' | 'WARN', message: string) =>
+export const gfmNoteblock = (
+  type: 'NOTE' | 'WARN' | 'CAUTION',
+  message: string,
+) =>
   `> [!${type}]\n${message
     .split('\n')
     .map((line) => `> ${line}`)

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -190,7 +190,10 @@ export const getRSSItems = async (url): Promise<RSSItem[]> => {
  * @param message the message of the noteblock.
  * @returns the message as a GFM noteblock.
  */
-export const gfmNoteblock = (type: 'NOTE' | 'WARN', message: string) =>
+export const gfmNoteblock = (
+  type: 'NOTE' | 'TIP' | 'IMPORTANT' | 'WARNING' | 'CAUTION',
+  message: string,
+) =>
   `> [!${type}]\n${message
     .split('\n')
     .map((line) => `> ${line}`)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Improves the `update-browser-releases` script by falling back to the incremented engine version if the Opera release notes don't mention the Chrome version.

#### Test results and supporting details

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26797.
