### PR TITLE
Fix formatting in update-browser-releases script

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -237,7 +237,7 @@ export const updateChromiumReleases = async (options) => {
 
   // Returns the log
   if (result) {
-    result = `### Updates for ${options.browserName}${result}`;
+    result = `### Updates for ${options.browserName}\n${result}`;
   }
   return result;
 };

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -287,7 +287,7 @@ export const updateEdgeReleases = async (options) => {
 
   // Returns the log
   if (result) {
-    result = `### Updates for ${options.browserName}${result}`;
+    result = `### Updates for ${options.browserName}\n${result}`;
   }
   return result;
 };

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -225,7 +225,7 @@ export const updateFirefoxReleases = async (options) => {
 
   // Returns the log
   if (result) {
-    result = `### Updates for ${options.browserName}${result}`;
+    result = `### Updates for ${options.browserName}\n${result}`;
   }
   return result;
 };

--- a/scripts/update-browser-releases/opera.ts
+++ b/scripts/update-browser-releases/opera.ts
@@ -142,7 +142,7 @@ export const updateOperaReleases = async (options) => {
     }
 
     result += gfmNoteblock(
-      'WARN',
+      'WARNING',
       `**${options.browserName}**: No engine version found in [this blog post](<${release.releaseNote}>). Using (previous engine version + 1) instead.`,
     );
     release.engineVersion = currentEngineVersion;
@@ -150,7 +150,7 @@ export const updateOperaReleases = async (options) => {
 
   if (isDesktop && !current) {
     return gfmNoteblock(
-      'WARN',
+      'WARNING',
       `Latest stable **${options.browserName}** release **${release.version}** not yet tracked.`,
     );
   }
@@ -204,7 +204,7 @@ export const updateOperaReleases = async (options) => {
 
   // Returns the log
   if (result) {
-    result = `### Updates for ${options.browserName}${result}`;
+    result = `### Updates for ${options.browserName}\n${result}`;
   }
 
   return result;

--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -163,7 +163,7 @@ export const updateSafariReleases = async (options) => {
 
   // Returns the log
   if (result) {
-    result = `### Updates for ${options.browserName}${result}`;
+    result = `### Updates for ${options.browserName}\n${result}`;
   }
   return result;
 };

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -191,7 +191,7 @@ export const getRSSItems = async (url): Promise<RSSItem[]> => {
  * @returns the message as a GFM noteblock.
  */
 export const gfmNoteblock = (
-  type: 'NOTE' | 'WARN' | 'CAUTION',
+  type: 'NOTE' | 'WARNING' | 'CAUTION',
   message: string,
 ) =>
   `> [!${type}]\n${message


### PR DESCRIPTION
This PR is a quick follow-up to #26801 to fix the formatting in two ways:

- The GFM noteblock is 'WARNING', not 'WARN'
- The first line was rendered onto the same line as the title, so a newline is always added to prevent that from occurring
