### PR TITLE
fix(update-browser-releases): generalize Opera engine version pattern

### DIFF
--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -178,7 +178,7 @@ const options = {
     skippedReleases: [],
     releaseFeedURL: 'https://blogs.opera.com/desktop/category/stable-2/feed/',
     titleVersionPattern: /^Opera (\d+)$/,
-    descriptionEngineVersionPattern: /Chromium(?: to version)? (\d+)/,
+    descriptionEngineVersionPattern: /Chromium(?:\s[^.\d]+)?\s(\d+)(?=[.])/,
   },
   opera_android: {
     browserName: 'Opera for Android',


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Generalize the pattern to extract the Chromium version from the Opera release notes blog post.

#### Test results and supporting details

Originally, the blog post was not mentioning the Chromium version, but after reaching out, this was added:

> Chromium version bumped to 134.0.6998.205.

However, our pattern was expecting either `Chromium 134` or `Chromium to version 134`.

Now, we're basically accepting any text between "Chromium" and the version number, except dots, digits, and if the version number is followed by a dot.

#### Related issues

Follow-up of https://github.com/mdn/browser-compat-data/pull/26801.

Part of resolving https://github.com/mdn/browser-compat-data/issues/26797.