### PR TITLE
Firefox 138 supports dynamic import features

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -919,8 +919,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1736059"
+                "version_added": "138"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -116,8 +116,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1736059"
+                "version_added": "138"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marks `javascript.grammar.trailing_commas.trailing_commas_in_dynamic_import` and `javascript.operators.import.options_parameter` as supported in Firefox 138

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
https://brassy-sly-storm.glitch.me/
https://developer.mozilla.org/en-US/play?id=7R3devH9%2FzJfqyok61KERDbVW4tQY7KqsunVc7zUesJUcA5PpokTG8DLzPbseMOzzqnIoP2cdzijhTMt

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1950836

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #26811

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
