### PR TITLE
Firefox Nightly adds `ShadowRoot.setHTML()` and sanitizer parameter

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5976,14 +5976,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "140",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.sanitizer.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -5964,6 +5964,48 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_sanitizer_parameter": {
+          "__compat": {
+            "description": "`options.sanitizer` parameter",
+            "spec_url": "https://wicg.github.io/sanitizer-api/#dom-shadowroot-sethtmlunsafe",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "140",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.sanitizer.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "pictureInPictureElement": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -6001,7 +6001,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/Element.json
+++ b/api/Element.json
@@ -10497,6 +10497,48 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_sanitizer_parameter": {
+          "__compat": {
+            "description": "`options.sanitizer` parameter",
+            "spec_url": "https://wicg.github.io/sanitizer-api/#dom-element-sethtmlunsafe",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "140",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.sanitizer.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "setPointerCapture": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -10509,14 +10509,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "140",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.sanitizer.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -10509,7 +10509,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "140"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -893,7 +893,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -856,6 +856,48 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_sanitizer_parameter": {
+          "__compat": {
+            "description": "`options.sanitizer` parameter",
+            "spec_url": "https://wicg.github.io/sanitizer-api/#dom-shadowroot-sethtmlunsafe",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "140",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.sanitizer.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "slotAssignment": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -789,14 +789,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "140",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.sanitizer.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -868,14 +861,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "140",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.sanitizer.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -779,6 +779,47 @@
           }
         }
       },
+      "setHTML": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-shadowroot-sethtml",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "140",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setHTMLUnsafe": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/setHTMLUnsafe",


### PR DESCRIPTION
FF140 adds remaining sanitizer method/options behind flag in https://bugzilla.mozilla.org/show_bug.cgi?id=1959727

Once FF140 becomes nightly, these would change to "preview".

Changes are:

- `ShadowRoot.setHTML()] - new method
- `options.sanitizer` added to param to `ShadowRoot.setHTMLUnsafe()` and `Document.parseHTMLUnsafe()`

This follows on from #26659

FYI @evilpie I was "somewhat wrong" in #26659. I can add them, just not as a "preview" release. I didn't think of this properly because I was so focused on FF139.

Related docs work being done in https://github.com/mdn/content/issues/38890
