### PR TITLE
Fix newly overlapping version ranges

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -559,7 +559,7 @@
               },
               {
                 "version_added": "89",
-                "version_removed": "129",
+                "version_removed": "128",
                 "partial_implementation": true,
                 "notes": "Only supported on ChromeOS and Windows, see [bug 40542648](https://crbug.com/40542648) and [bug 40729163](https://crbug.com/40729163)."
               }
@@ -5274,7 +5274,7 @@
               },
               {
                 "version_added": "89",
-                "version_removed": "129",
+                "version_removed": "128",
                 "partial_implementation": true,
                 "notes": "Only supported on ChromeOS and Windows, see [bug 40542648](https://crbug.com/40542648) and [bug 40729163](https://crbug.com/40729163)."
               }

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -120,6 +120,7 @@
                 },
                 {
                   "version_added": "20.4.0",
+                  "version_removed": "21.0.0",
                   "partial_implementation": true,
                   "notes": "Only available for `fs` and `stream` resources."
                 },
@@ -270,6 +271,7 @@
                 },
                 {
                   "version_added": "20.4.0",
+                  "version_removed": "21.0.0",
                   "partial_implementation": true,
                   "notes": "Only available for `fs` and `stream` resources."
                 },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes overlapping version ranges.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Follow-up of: https://github.com/mdn/browser-compat-data/pull/26544
