### PR TITLE
Safari 15 supports `FontFace` and `FontFaceSet` in workers

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -103,7 +103,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -97,7 +97,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Adds `worker_support` for WebKit on both FontFace and FontFaceSet interfaces.

Quoting https://github.com/mdn/browser-compat-data/issues/26816#issuecomment-2886551788

> Based on [that commit](https://github.com/WebKit/WebKit/commit/792fde69d188dc5b10a7a09372bee06931dd9bac), which landed in [WebKit 612.1.12](https://github.com/WebKit/WebKit/blob/792fde69d188dc5b10a7a09372bee06931dd9bac/Source/WebCore/Configurations/Version.xcconfig#L24-L26), and the [corresponding bug 224178](https://bugs.webkit.org/show_bug.cgi?id=224178), worker support for FontFace, and FontFaceSet landed in [Safari 15 (WebKit 612.1.27)](https://github.com/mdn/browser-compat-data/blob/b57256ae8ac7f29be2eb59a8e6be5be2d24d2b9f/browsers/safari.json#L176-L182).
>
> The MDN BCD Collector currently doesn't test this, as they are [marked as untestable features](https://github.com/openwebdocs/mdn-bcd-collector/blob/79dffa1d4990c5d84f74c074b90c52010635bade/untestable-features.jsonc#L243-L244), because "[update-bcd doesn't know how to update these](https://github.com/openwebdocs/mdn-bcd-collector/blob/79dffa1d4990c5d84f74c074b90c52010635bade/untestable-features.jsonc#L229)".
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
https://jsfiddle.net/hf46tr8k/
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://github.com/WebKit/WebKit/commit/792fde69d188dc5b10a7a09372bee06931dd9bac
#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #26816
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
