### PR TITLE
Firefox 139 supports Pseudo-random function extension (prf) in `CredentialsContainer`

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -681,7 +681,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": false,
+                  "webview_android": {
+                    "version_added": false
+                  },
                   "webview_ios": "mirror"
                 },
                 "status": {
@@ -1226,7 +1228,9 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": false,
+                  "webview_android": {
+                    "version_added": false
+                  },
                   "webview_ios": "mirror"
                 },
                 "status": {


### PR DESCRIPTION
The PRF extension [in spec here](https://w3c.github.io/webauthn/#prf-extension) (and [explainer here](https://github.com/w3c/webauthn/wiki/Explainer:-PRF-extension)) is supported in desktop on FF139. The explanation of FF support is a bit more complex - see  https://bugzilla.mozilla.org/show_bug.cgi?id=1935280#c5 - and is now captured by this subfeature.

This is not implemented in chrome according to https://chromestatus.com/feature/5138422207348736

This is supposed to be implemented in Safari according to https://medium.com/@corbado_tech/automatic-passkey-upgrade-prf-extension-related-origins-18667123006f but latest info I can find from April says it isn't - see Apple forum info here https://developer.apple.com/forums/thread/774112

This is related to work in https://github.com/mdn/content/issues/39302