### PR TITLE
Remove HTTP `Permissions-Policy` directive `document-domain`

### DIFF
--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -499,49 +499,6 @@
             }
           }
         },
-        "document-domain": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/document-domain",
-            "spec_url": "https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features",
-            "support": {
-              "chrome": {
-                "version_added": "64",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--enable-blink-features=ExperimentalProductivityFeatures"
-                  }
-                ]
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "encrypted-media": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/encrypted-media",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Remove data about the obsolete HTTP header `Permissions-Policy` directive `document-domain`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Permissions-Policy directive `document-domain` was removed from spec[1]. It was only ever implemented in Chromium behind a flag, never enabled by default and was removed entirely in Chromium 110[2].

[1] https://github.com/whatwg/html/pull/8549
[2] https://github.com/chromium/chromium/commit/09ae39cb337e46a2f97a763e57986154b8af91eb

#### Related issues

- https://github.com/mdn/content/issues/22732
- https://github.com/mdn/content/pull/39575
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
