### PR TITLE
Mention the lack of gamut mapping for OKLch and Oklab. Mark their support as partial.

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1018,12 +1018,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "111"
+                "version_added": "111",
+                "partial_implementation": true
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "113"
+                "version_added": "113",
+                "partial_implementation": true
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1033,7 +1035,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": "15.4",
+                "partial_implementation": true
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1044,6 +1047,43 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "gamut_mapping": {
+            "__compat": {
+              "description": "♿ Contrast-preserving mapping for out-of-gamut colors",
+              "tags": [
+                "web-features:oklab"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "false"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "false"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "false"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           },
           "mixed_type_parameters": {
@@ -1140,12 +1180,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "111"
+                "version_added": "111",
+                "partial_implementation": true
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "113"
+                "version_added": "113",
+                "partial_implementation": true
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1155,7 +1197,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": "15.4",
+                "partial_implementation": true
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1166,6 +1209,43 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "gamut_mapping": {
+            "__compat": {
+              "description": "♿ Contrast-preserving mapping for out-of-gamut colors",
+              "tags": [
+                "web-features:oklab"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "false"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "false"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "false"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           },
           "mixed_type_parameters": {


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Visit https://vasilis.nl/dingen/bugs/oklch.html

The squares should be white and black per spec, they aren't in any browser.

No browser currently supports the OKL* color spaces as specified, and it has accessibility implications. These spaces should be used with caution until the problem is fixed.

#### Related issues

fixes #26838

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
