### PR TITLE
Add the lack of proper gamut mapping in OKLch and Oklab. The browser support is thus only parial.

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1018,12 +1018,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "111"
+                "version_added": "111",
+                "partial_implementation": true
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "113"
+                "version_added": "113",
+                "partial_implementation": true
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1033,7 +1035,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": "15.4",
+                "partial_implementation": true
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1044,6 +1047,43 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "gamut_mapping": {
+            "__compat": {
+              "description": "♿ Contrast-preserving mapping for out-of-gamut colors",
+              "tags": [
+                "web-features:oklab"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           },
           "mixed_type_parameters": {
@@ -1140,12 +1180,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "111"
+                "version_added": "111",
+                "partial_implementation": true
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "113"
+                "version_added": "113",
+                "partial_implementation": true
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1155,7 +1197,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": "15.4",
+                "partial_implementation": true
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1166,6 +1209,43 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "gamut_mapping": {
+            "__compat": {
+              "description": "♿ Contrast-preserving mapping for out-of-gamut colors",
+              "tags": [
+                "web-features:oklab"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           },
           "mixed_type_parameters": {

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1039,7 +1039,7 @@
               "safari": {
                 "version_added": "15.4",
                 "partial_implementation": true,
-                "notes": "Faulty gamut mapping. Colors beyond the gamut of the user agent should be mapped to colors of equal luminance, ensuring proper contrast. The current implementation changes the luminosity. See https://github.com/w3c/csswg-drafts/issues/9449"
+                "notes": "Faulty gamut mapping. Colors beyond the gamut of the user agent should be mapped to colors of equal luminance, ensuring proper contrast. The current implementation changes the luminosity. See https://github.com/w3c/csswg-drafts/issues/9449."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1184,13 +1184,15 @@
             "support": {
               "chrome": {
                 "version_added": "111",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Faulty gamut mapping. Colors beyond the gamut of the user agent should be mapped to colors of equal luminance, ensuring proper contrast. The current implementation changes the luminosity. See https://github.com/w3c/csswg-drafts/issues/9449."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "113",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Faulty gamut mapping. Colors beyond the gamut of the user agent should be mapped to colors of equal luminance, ensuring proper contrast. The current implementation changes the luminosity. See https://github.com/w3c/csswg-drafts/issues/9449."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1201,7 +1203,8 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Faulty gamut mapping. Colors beyond the gamut of the user agent should be mapped to colors of equal luminance, ensuring proper contrast. The current implementation changes the luminosity. See https://github.com/w3c/csswg-drafts/issues/9449."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1019,13 +1019,15 @@
             "support": {
               "chrome": {
                 "version_added": "111",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Faulty gamut mapping. Colors beyond the gamut of the user agent should be mapped to colors of equal luminance, ensuring proper contrast. The current implementation changes the luminosity. See https://github.com/w3c/csswg-drafts/issues/9449"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "113",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Faulty gamut mapping. Colors beyond the gamut of the user agent should be mapped to colors of equal luminance, ensuring proper contrast. The current implementation changes the luminosity. See https://github.com/w3c/csswg-drafts/issues/9449"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1036,7 +1038,8 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Faulty gamut mapping. Colors beyond the gamut of the user agent should be mapped to colors of equal luminance, ensuring proper contrast. The current implementation changes the luminosity. See https://github.com/w3c/csswg-drafts/issues/9449"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

The current browser implementation of gamut mapping is buggy and not spec compliant. This has accessibility ramifications (the spec ensures that color contrast is preserved, even if a color is beyond what a user can display, but browser don't respect that invariant in their implementation).

#### Test results and supporting details

Visit https://vasilis.nl/dingen/bugs/oklch.html

The squares should be white and black per spec, they aren't in any browser.

- https://github.com/w3c/csswg-drafts/issues/9449
- https://bugs.webkit.org/show_bug.cgi?id=255939
- https://bugzilla.mozilla.org/show_bug.cgi?id=1847421
- https://issues.chromium.org/issues/40909194
- https://github.com/w3c/csswg-drafts/issues/7610
- https://github.com/w3c/csswg-drafts/issues/7653

#### Related issues

This fixes #26838 
