### PR TITLE
Chrome 87 + Safari 14.1 supported single `<number>` as `<ratio>`

### DIFF
--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -51,7 +51,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -66,7 +66,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -74,7 +74,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary
Updates support for ratios with single values, which preceded the `aspect-ratio` property, and was used by the aspect ratio media query features.

#### Test results and supporting details

See #25034 

#### Related issues

Fixes #25034 
