### PR TITLE
Safari 17.5 added `supports()` as import condition

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -109,7 +109,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Changing `preview` to `17.5` was missed for `css.at-rules.import.supports` in #22765.

#### Related issues

Fixes #24842
