### PR TITLE
Firefox Nightly supports View Transitions

### DIFF
--- a/api/ViewTransition.json
+++ b/api/ViewTransition.json
@@ -14,8 +14,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1823896"
+            "version_added": "preview",
+            "impl_url": "https://bugzil.la/1950759"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -52,7 +52,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -90,7 +91,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ViewTransition.json
+++ b/api/ViewTransition.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1950759"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -52,8 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -91,8 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/view-transition-class.json
+++ b/css/properties/view-transition-class.json
@@ -14,8 +14,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1860854"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -51,7 +51,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1950759"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/view-transition-class.json
+++ b/css/properties/view-transition-class.json
@@ -14,8 +14,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -51,8 +50,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1950759"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/view-transition-name.json
+++ b/css/properties/view-transition-name.json
@@ -15,8 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1823896"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -52,7 +52,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1950759"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/view-transition-name.json
+++ b/css/properties/view-transition-name.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -52,8 +51,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1950759"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/selectors/view-transition-group.json
+++ b/css/selectors/view-transition-group.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-group.json
+++ b/css/selectors/view-transition-group.json
@@ -16,8 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1823896"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-image-pair.json
+++ b/css/selectors/view-transition-image-pair.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-image-pair.json
+++ b/css/selectors/view-transition-image-pair.json
@@ -16,8 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1823896"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-new.json
+++ b/css/selectors/view-transition-new.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-new.json
+++ b/css/selectors/view-transition-new.json
@@ -16,8 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1823896"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-old.json
+++ b/css/selectors/view-transition-old.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition-old.json
+++ b/css/selectors/view-transition-old.json
@@ -16,8 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1823896"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition.json
+++ b/css/selectors/view-transition.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/view-transition.json
+++ b/css/selectors/view-transition.json
@@ -16,8 +16,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1823896"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1950759"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

- Added `view-transition` support for Firefox nightly
- Only works for parts and only for SPA (Single Page Applications) and not cross-document

#### Test results and supporting details

- Tested with the following:
  - https://view-transitions.chrome.dev/
  - https://codepen.io/CodeRedDigital/pen/WbbBRJr?editors=0011

#### Related issues

- [Mozilla MDN Issue #39305](https://github.com/mdn/content/issues/39305)
- [Content PR](https://github.com/mdn/content/pull/39593)
- [Firefox Release Note PR](https://github.com/mdn/content/pull/39588)
