### PR TITLE
Add Safari impl_url for CSS `::marker` selector

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -29,7 +29,7 @@
               "version_added": "11.1",
               "impl_url": "https://webkit.org/b/204163",
               "partial_implementation": true,
-              "notes": "Safari support is limited to `color` and `font-size`. See [bug 204163](https://webkit.org/b/204163)."
+              "notes": "Safari support is limited to `color` and `font-size`."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -27,6 +27,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "11.1",
+              "impl_url": "https://webkit.org/b/204163",
               "partial_implementation": true,
               "notes": "Safari support is limited to `color` and `font-size`. See [bug 204163](https://webkit.org/b/204163)."
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The Safari bug which tracks full support of the `:marker` pseudo is already mentioned in the notes, but having it in the `impl_url` field makes it better for scripts which use the data.

#### Test results and supporting details

See https://bugs.webkit.org/show_bug.cgi?id=204163
