### PR TITLE
Firefox Android 128 enabled residentKey support

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -701,8 +701,7 @@
                   "version_added": "114"
                 },
                 "firefox_android": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1831137"
+                  "version_added": "128"
                 },
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox Android 128 enabled residentKey support

#### Test results and supporting details

The linked `impl_url` was marked as resolved / fixed.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
