### PR TITLE
Chrome 116 moved `first-contentful-paint` and `first-paint` timings behind flag

### DIFF
--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -56,7 +56,7 @@
                     "value_to_set": "SoftNavigationHeuristicsExposeFPAndFCP"
                   }
                 ],
-                "notes": "See [issue 40066208](https://issues.chromium.org/issues/40066208)."
+                "notes": "See [bug 40066208](https://crbug.com/40066208)."
               },
               {
                 "version_added": "60",
@@ -109,7 +109,7 @@
                     "value_to_set": "SoftNavigationHeuristicsExposeFPAndFCP"
                   }
                 ],
-                "notes": "See [issue 40066208](https://issues.chromium.org/issues/40066208)."
+                "notes": "See [bug 40066208](https://crbug.com/40066208)."
               },
               {
                 "version_added": "60",

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -48,7 +48,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "114",
+                "version_added": "116",
                 "flags": [
                   {
                     "type": "runtime_flag",
@@ -60,7 +60,7 @@
               },
               {
                 "version_added": "60",
-                "version_removed": "114"
+                "version_removed": "116"
               }
             ],
             "chrome_android": "mirror",
@@ -101,7 +101,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "114",
+                "version_added": "116",
                 "flags": [
                   {
                     "type": "runtime_flag",
@@ -113,7 +113,7 @@
               },
               {
                 "version_added": "60",
-                "version_removed": "114"
+                "version_removed": "116"
               }
             ],
             "chrome_android": "mirror",

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -46,9 +46,23 @@
             "web-features:paint-timing"
           ],
           "support": {
-            "chrome": {
-              "version_added": "60"
-            },
+            "chrome": [
+              {
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--enable-blink-features",
+                    "value_to_set": "SoftNavigationHeuristicsExposeFPAndFCP"
+                  }
+                ],
+                "notes": "See [issue 40066208](https://issues.chromium.org/issues/40066208)."
+              },
+              {
+                "version_added": "60",
+                "version_removed": "114"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -85,9 +99,23 @@
             "web-features:paint-timing"
           ],
           "support": {
-            "chrome": {
-              "version_added": "60"
-            },
+            "chrome": [
+              {
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--enable-blink-features",
+                    "value_to_set": "SoftNavigationHeuristicsExposeFPAndFCP"
+                  }
+                ],
+                "notes": "See [issue 40066208](https://issues.chromium.org/issues/40066208)."
+              },
+              {
+                "version_added": "60",
+                "version_removed": "114"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Updates Chrome's support for `PerformancePaintTiming`, whose named entries appear to have been placed behind a launch flag since version 114.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
`All matched files use Prettier code style!`  
`All data passed linting!`  

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #26857 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
