### PR TITLE
Firefox 135 added fractional coordinates for pointer events

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -578,8 +578,7 @@
                 }
               ],
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1680669"
+                "version_added": "135"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 135 added fractional coordinates for pointer events

#### Test results and supporting details

The linked `impl_url` was marked as resolved / fixed.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
