### PR TITLE
Update Firefox impl_url for CSS `prefers-reduced-transparency`

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1553,7 +1553,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "impl_url": "https://bugzil.la/1736914"
+                "impl_url": "https://bugzil.la/1822176"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Updates Firefox bug for the CSS `prefers-reduced-transparency` media feature.

#### Test results and supporting details

The old bug covering the implementation was fixed, the new bug is about enabling the feature by default.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
