### PR TITLE
Update Safari impl_url for fractional coordinates in pointer events

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -592,7 +592,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "impl_url": "https://webkit.org/b/133180"
+                "impl_url": "https://webkit.org/b/279540"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update Safari impl_url for fractional coordinates in pointer events

#### Test results and supporting details

The old bug is resolved duplicate pointing to the new bug.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
