### PR TITLE
Bug-1965007 added removeInfo to tabGroups.onRemoved

### DIFF
--- a/webextensions/api/tabGroups.json
+++ b/webextensions/api/tabGroups.json
@@ -375,6 +375,27 @@
               },
               "safari_ios": "mirror"
             }
+          },
+          "removeInfo": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "139"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "onUpdated": {


### PR DESCRIPTION
#### Summary

Add the `removeInfo` listener argument to `tabGroups.onRemoved`. This change was made [Bug 1965007](https://bugzilla.mozilla.org/show_bug.cgi?id=1965007) tabGroups.onRemoved not firing when window is closed and documented on MDN in [Addition of the webextensions.api.tabGroups documentation #39370](https://github.com/mdn/content/pull/39370)
