### PR TITLE
Edge 138 supports Summarizer API behind pref

### DIFF
--- a/api/CreateMonitor.json
+++ b/api/CreateMonitor.json
@@ -13,7 +13,16 @@
           "deno": {
             "version_added": false
           },
-          "edge": "mirror",
+          "edge": {
+            "version_added": "138",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#edge-llm-summarization-api-for-phi-mini",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
           "firefox": {
             "version_added": false
           },
@@ -55,7 +64,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/Summarizer.json
+++ b/api/Summarizer.json
@@ -13,7 +13,16 @@
           "deno": {
             "version_added": false
           },
-          "edge": "mirror",
+          "edge": {
+            "version_added": "138",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#edge-llm-summarization-api-for-phi-mini",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
           "firefox": {
             "version_added": false
           },
@@ -55,7 +64,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -98,7 +116,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -141,7 +168,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -184,7 +220,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -227,7 +272,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -270,7 +324,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -313,7 +376,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -356,7 +428,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -399,7 +480,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -442,7 +532,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -485,7 +584,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -528,7 +636,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -571,7 +688,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -614,7 +740,16 @@
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-summarization-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The Summarizer API BCD needed corrections — the Edge version is 138, but it is currently supported behind a developer flag. This PR corrects that. cc @captainbrosset.

<s>I am going to leave it as a draft for now; hopefully I can get in some more accurate Chrome support data too.</s>
I checked, and 138 is the correct shipping version for Chrome. I'm not sure of the available version with flags, so I'm just going to leave that for now.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
