### PR TITLE
Chrome 91 added ChromeOS support for Badging API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -726,7 +726,11 @@
           "support": {
             "chrome": {
               "version_added": "81",
-              "notes": "Windows and macOS only. Linux offers no universal badging API on the operating system level."
+              "notes": [
+                "Windows and macOS since Chrome 81.",
+                "ChromeOS since Chrome 91.",
+                "Linux offers no universal badging API on the operating system level."
+              ]
             },
             "chrome_android": {
               "version_added": "81"
@@ -5211,7 +5215,11 @@
           "support": {
             "chrome": {
               "version_added": "81",
-              "notes": "Windows and macOS only. Linux offers no universal badging API on the operating system level."
+              "notes": [
+                "Windows and macOS since Chrome 81.",
+                "ChromeOS since Chrome 91.",
+                "Linux offers no universal badging API on the operating system level."
+              ]
             },
             "chrome_android": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Although the Badging API is not supported on most Linux systems it is supported on ChromeOS since version 91: [Badging for Chrome OS: API usage overrides notifications · chromium/chromium@5399308](https://github.com/chromium/chromium/commit/539930833a2f4df4d163211834fe530974520e05)

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Various blog posts, personal usage on Chromebooks in the past, etc. I did not attempt to find and run ChromeOS 90 and 91 to confirm personally when the feature was made available.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

#26869