### PR TITLE
Firefox Nightly adds `TaskSignal.any()`

### DIFF
--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -52,7 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF140 supports [`TaskSignal.any()`](https://developer.mozilla.org/en-US/docs/Web/API/TaskSignal/any_static) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1964407

This adds the preview version.

Related work can be tracked in https://github.com/mdn/content/issues/39627