### PR TITLE
Ff139 remove svg discard element

### DIFF
--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -12,7 +12,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "136"
+            "version_added": "136",
+            "version_removed": "139"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "136",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "svg.discard.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF139 removes experimental support for the SVG [`<discard>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/discard) element added behind pref in FF136, and the [`SVGDiscardElement`](https://developer.mozilla.org/en-US/docs/Web/API/SVGDiscardElement) interface added to release in FF136 in https://bugzilla.mozilla.org/show_bug.cgi?id=1958839

I've removed the experimental feature entirely as it never released.

For `SVGDiscardElement` I've added the remove version, which is technically correct. Note though, this was pretty unsusable, and I suspect unused. It should have been behind pref IMO. So you might want to delete that too.

Associated docs work can be tracked in https://github.com/mdn/content/issues/39618

