### PR TITLE
FF140 serializes `<` and `>` in attributes

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5952,7 +5952,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -6355,7 +6355,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -7573,7 +7573,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -402,7 +402,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -594,7 +594,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF140 ships support for escaping `<` and `>` to `&lt;` and `&gt;` in attributes when serializing HTML in https://bugzilla.mozilla.org/show_bug.cgi?id=1962084. This affects all the obvious methods like innerHTML, outerHTML, getHTML.

This was implemented in FF139 last month and added to BCD in https://github.com/mdn/content/issues/39309.
All this does is change the items updated in that PR from preview to 140

Related docs work can be tracked in https://github.com/mdn/content/issues/39628