### PR TITLE
FF140 Notification.actions .maxactions_static behind pref

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -843,9 +843,15 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": "138"
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "138",
+                "version_removed": "140"
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF140 puts [Notification.maxActions`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/maxActions_static) behind the pref `dom.webnotifications.actions.enabled` which is enabled in nightly, along with [`Notification.actions`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/actions)) in https://bugzilla.mozilla.org/show_bug.cgi?id=1963263

The effect on desktop is simple -  `maxActions` was published, but is now enabled in preview. `actions` stays the same - in preview.

The bug also changes the pref to false in android.
I tried to indicate this but the tools stripped it out. 
It looks to me like the current docs indicate that if I have a nightly version of FF on my phone it should work (?) - but that is not the case. I guess this is right?

Related docs work can be tracked in #39620


