### PR TITLE
Chrome 138 support for scope_extensions manifest member

### DIFF
--- a/manifests/webapp/scope_extensions.json
+++ b/manifests/webapp/scope_extensions.json
@@ -1,0 +1,42 @@
+{
+  "manifests": {
+    "webapp": {
+      "scope_extensions": {
+        "__compat": {
+          "tags": [
+            "web-features:manifest"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "138"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 138 supports the `scope_extensions` webapp manifest member; see https://chromestatus.com/feature/5746537956114432 for details.

This PR adds a data point for that feature. Note that the PR to add it to the spec isn't merged yet, so I've marked it as non-standard for now.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
