### PR TITLE
ci(system-file-changes): ignore mdn-bot

### DIFF
--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -25,7 +25,7 @@ jobs:
   block:
     # This makes sure it only runs on our origin repo
     # and makes an exception for Dependabot.
-    if: github.repository_owner == 'mdn' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.repository_owner == 'mdn' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'mdn-bot'
     runs-on: ubuntu-latest
     steps:
       - name: Block if author/actor is not admin or BCD owner


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Skips the `system-file-changes` workflow on PRs created by @mdn-bot.

#### Test results and supporting details

Avoids the checks to fail on the release PR.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
