### PR TITLE
Add speculation-rules target_hint and clear-site-data support

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -1249,6 +1249,49 @@
                 }
               }
             },
+            "target_hint": {
+              "__compat": {
+                "description": "`target_hint` key",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/script/type/speculationrules#target_hint",
+                "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+                "tags": [
+                  "web-features:speculation-rules"
+                ],
+                "support": {
+                  "chrome": {
+                    "version_added": "138",
+                    "partial_implementation": true,
+                    "notes": "Only `&quot;_blank&quot;` and `&quot;_self&quot;` are supported."
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": {
+                    "version_added": false
+                  },
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "urls": {
               "__compat": {
                 "description": "`urls` key",

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -82,7 +82,7 @@
         "cache": {
           "__compat": {
             "description": "`&quot;cache&quot;`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#cache",
             "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-cache",
             "tags": [
               "web-features:clear-site-data"
@@ -138,7 +138,7 @@
         "clientHints": {
           "__compat": {
             "description": "`&quot;clientHints&quot;`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#clientHints",
             "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-clienthints",
             "tags": [
               "web-features:clear-site-data"
@@ -177,7 +177,7 @@
         "cookies": {
           "__compat": {
             "description": "`&quot;cookies&quot;`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#cookies",
             "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-cookies",
             "tags": [
               "web-features:clear-site-data"
@@ -218,7 +218,7 @@
         "executionContexts": {
           "__compat": {
             "description": "`&quot;executionContexts&quot;`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#executionContexts",
             "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-executioncontexts",
             "tags": [
               "web-features:clear-site-data"
@@ -245,6 +245,84 @@
               "safari": {
                 "version_added": "17",
                 "version_removed": "18.3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "prefetchCache": {
+          "__compat": {
+            "description": "`&quot;prefetchCache&quot;`",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#prefetchcache",
+            "spec_url": "https://wicg.github.io/nav-speculation/prefetch.html#clear-site-data-patches",
+            "tags": [
+              "web-features:clear-site-data"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "prerenderCache": {
+          "__compat": {
+            "description": "`&quot;prerenderCache&quot;`",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#prerendercache",
+            "spec_url": "https://wicg.github.io/nav-speculation/prefetch.html#clear-site-data-patches",
+            "tags": [
+              "web-features:clear-site-data"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -302,7 +380,7 @@
         "wildcard": {
           "__compat": {
             "description": "`&quot;*&quot;` (wildcard)",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#sect",
             "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-",
             "tags": [
               "web-features:clear-site-data"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 138 will add two new features for Speculation Rules:
- [`target_hint`](https://chromestatus.com/feature/5162540351094784)
- [`clear-site-data`](https://chromestatus.com/feature/4755745652080640)

This will probably be picked up by BCD collector soon, but there's a note I want to add to `target_hint`, and I have the docs in https://github.com/mdn/content/pull/39652 so thought I'd go ahead and raise this.

Clear-site-data

Chrome Status link: https://chromestatus.com/feature/4755745652080640
Explainer link: https://github.com/WICG/nav-speculation/blob/main/clear-site-data-integration.md

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

**`target_hint`**

Chrome Status link: https://chromestatus.com/feature/5162540351094784
Explainer link: https://github.com/WICG/nav-speculation/blob/main/triggers.md#window-name-targeting-hints

**`Clear-site-data`**

Chrome Status link: https://chromestatus.com/feature/4755745652080640
Explainer link: https://github.com/WICG/nav-speculation/blob/main/clear-site-data-integration.md

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

See content PR here: https://github.com/mdn/content/pull/39652

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
