### PR TITLE
HTTP Cache-Control stale-while-revalidate is standard

### DIFF
--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -84,6 +84,7 @@
         },
         "stale-while-revalidate": {
           "__compat": {
+            "spec_url": "https://httpwg.org/specs/rfc5861.html#n-the-stale-while-revalidate-cache-control-extension",
             "support": {
               "chrome": {
                 "version_added": "75"
@@ -114,7 +115,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
The [stale-while-revalidate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#stale-while-revalidate) indicates non standard, but it is in the linked standard.

Note that this standard also has `stale-if-error`. As far as I can tell that isn't supported in any browsers, but the CDNs etc widely support it.

Fell out of looking at https://github.com/mdn/content/issues/39674#issuecomment-2907943249
