### PR TITLE
Firefox 140 adds `Atomics.awaitAsync()` behind pref

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -680,7 +680,8 @@
                     "name": "javascript.options.atomics_wait_async",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1467846"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF140 adds support for [`Atomics.waitAsync()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync) behind a pref in https://bugzilla.mozilla.org/show_bug.cgi?id=1467846

This adds the release info.

Related docs work can be tracked in https://github.com/mdn/content/issues/39615