### PR TITLE
Firefox Nightly adds `HTMLDialogElement.closeBy`

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -167,7 +167,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1964077"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -48,7 +48,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1964077"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF140 enables the [`HTMLDialogElement.closedBy`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy) property and `<dialog>` [`closedby`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby) attribute in Nightly (pref `dom.dialog.light-dismiss.enabled` ) in https://bugzilla.mozilla.org/show_bug.cgi?id=1964077

This updates both of those with the attribute and the impl url in which the related pref was enabled.

Related docs work can be tracked in https://github.com/mdn/content/issues/39621