### PR TITLE
Revert "Chrome 87 + Safari 14.1 supported single `<number>` as `<ratio>`"

### DIFF
--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -51,7 +51,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "87"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -66,7 +66,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "14.1"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -74,7 +74,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Reverts mdn/browser-compat-data#26849

See https://github.com/mdn/browser-compat-data/pull/26849#issuecomment-2908611555 