### PR TITLE
Updates for Firefox 140 beta

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1092,8 +1092,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/CookieChangeEvent.json
+++ b/api/CookieChangeEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "140"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -52,7 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -90,7 +90,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -128,7 +128,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "140"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -56,7 +56,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -94,7 +94,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -131,7 +131,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -170,7 +170,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -283,7 +283,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -473,7 +473,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -512,7 +512,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -550,7 +550,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -587,7 +587,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "140"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/CookieStoreManager.json
+++ b/api/CookieStoreManager.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "140"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -89,7 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -127,7 +127,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ExtendableCookieChangeEvent.json
+++ b/api/ExtendableCookieChangeEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "140"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -52,7 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -90,7 +90,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -166,7 +166,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Highlight.json
+++ b/api/Highlight.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1703961"
+            "version_added": "140"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -53,8 +52,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -91,8 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -129,8 +126,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -167,8 +163,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -205,8 +200,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -243,8 +237,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -281,8 +274,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -319,8 +311,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -358,8 +349,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -396,8 +386,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -435,8 +424,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -473,8 +461,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -511,8 +498,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1703961"
+            "version_added": "140"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,8 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -89,8 +87,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -127,8 +124,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -165,8 +161,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -203,8 +198,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -241,8 +235,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -279,8 +272,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -317,8 +309,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -355,8 +346,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -393,8 +383,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -431,8 +420,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -151,6 +151,74 @@
           }
         }
       },
+      "paintTime": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/paint-timing/#dom-painttimingmixin-painttime",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "140"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "presentationTime": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/paint-timing/#dom-painttimingmixin-presentationtime",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "140"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "renderTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/renderTime",

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -142,6 +142,108 @@
             "deprecated": false
           }
         }
+      },
+      "paintTime": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/paint-timing/#dom-painttimingmixin-painttimee",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "140"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "presentationTime": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/paint-timing/#dom-painttimingmixin-presentationtime",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "140"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/paint-timing/#dom-performancepainttiming-tojson",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "140"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -439,7 +439,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -457,7 +457,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -477,7 +477,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -140,7 +140,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -158,7 +158,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Window.json
+++ b/api/Window.json
@@ -1040,7 +1040,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -19,8 +19,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1703961",
+              "version_added": "140",
               "partial_implementation": true,
               "notes": "Cannot yet be used with `text-decoration` and `text-shadow`."
             },


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.13.1 found new features shipping in Firefox 140 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 66 features as shipping in Firefox 140:

- api.CSS.highlights_static
- api.CookieChangeEvent
- api.CookieChangeEvent.CookieChangeEvent
- api.CookieChangeEvent.changed
- api.CookieChangeEvent.deleted
- api.CookieStore
- api.CookieStore.change_event
- api.CookieStore.delete
- api.CookieStore.delete.partitioned_option
- api.CookieStore.get
- api.CookieStore.get.name_return_property
- api.CookieStore.get.value_return_property
- api.CookieStore.getAll
- api.CookieStore.set
- api.CookieStore.set.partitioned_option
- api.CookieStoreManager
- api.CookieStoreManager.getSubscriptions
- api.CookieStoreManager.subscribe
- api.CookieStoreManager.unsubscribe
- api.Element.getHTML.escapes_lt_gt_in_attributes
- api.Element.innerHTML.escapes_lt_gt_in_attributes
- api.Element.outerHTML.escapes_lt_gt_in_attributes
- api.ExtendableCookieChangeEvent
- api.ExtendableCookieChangeEvent.ExtendableCookieChangeEvent
- api.ExtendableCookieChangeEvent.changed
- api.ExtendableCookieChangeEvent.deleted
- api.Highlight
- api.Highlight.Highlight
- api.Highlight.add
- api.Highlight.clear
- api.Highlight.delete
- api.Highlight.entries
- api.Highlight.forEach
- api.Highlight.has
- api.Highlight.keys
- api.Highlight.priority
- api.Highlight.size
- api.Highlight.type
- api.Highlight.values
- api.Highlight.@@iterator
- api.HighlightRegistry
- api.HighlightRegistry.clear
- api.HighlightRegistry.delete
- api.HighlightRegistry.entries
- api.HighlightRegistry.forEach
- api.HighlightRegistry.get
- api.HighlightRegistry.has
- api.HighlightRegistry.keys
- api.HighlightRegistry.set
- api.HighlightRegistry.size
- api.HighlightRegistry.values
- api.HighlightRegistry.@@iterator
- api.LargestContentfulPaint.paintTime
- api.LargestContentfulPaint.presentationTime
- api.Notification.maxActions_static
- api.PerformancePaintTiming.paintTime
- api.PerformancePaintTiming.presentationTime
- api.PerformancePaintTiming.toJSON
- api.ServiceWorkerGlobalScope.cookiechange_event
- api.ServiceWorkerGlobalScope.cookieStore
- api.ServiceWorkerRegistration.cookies
- api.ShadowRoot.getHTML.escapes_lt_gt_in_attributes
- api.ShadowRoot.innerHTML.escapes_lt_gt_in_attributes
- api.Window.cookieStore
- css.selectors.highlight

Note: I also observe WebGPU enabled by default, but it seems to be a beta channel thing for now only, see  https://groups.google.com/a/mozilla.org/g/dev-platform/c/hi1kFQF13Pk

See also https://github.com/mdn/mdn/issues/680 and https://www.mozilla.org/en-US/firefox/140.0beta/releasenotes/