### PR TITLE
Add data points for Chrome 137 WebGPU additions

### DIFF
--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -472,6 +472,49 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "offset_size_optional": {
+          "__compat": {
+            "description": "Offets and `size` optional when copying entire buffer.",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "137",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "137"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "copyBufferToTexture": {

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -156,7 +156,7 @@
             "deprecated": false
           }
         },
-        "bind_GPUTextureView": {
+        "descriptor_entries_option_accepts_GPUTextureView_resource": {
           "__compat": {
             "description": "Bind `GPUTextureView` in place of a `GPUExternalTexture`.",
             "tags": [

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -155,6 +155,49 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "bind_GPUTextureView": {
+          "__compat": {
+            "description": "Bind `GPUTextureView` in place of a `GPUExternalTexture`.",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "137",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": "137"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createBindGroupLayout": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 137 supports the following WebGPU updates:

- When using [copyBufferToBuffer()](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer), you can omit the offsets and the `size` parameter when copying the entire buffer. See https://developer.chrome.com/blog/new-in-webgpu-137?hl=en#buffers_copy_without_specifying_offsets_and_size.
- When creating a `GPUBindGroup` using [`createBindGroup()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createBindGroup), you can specify a `GPUTextureView` in place of a `GPUExternalTexture`. See https://developer.chrome.com/blog/new-in-webgpu-137?hl=en#use_texture_view_for_externaltexture_binding

This PR adds data point for both those features.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

- Spec PR: https://github.com/gpuweb/gpuweb/pull/5098

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
