### PR TITLE
Deno 2.3.2 adds `RegExp.escape`

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -356,12 +356,19 @@
           "engine": "V8",
           "engine_version": "13.4"
         },
-        "2.3": {
+        "2.3.0": {
           "release_date": "2025-05-01",
           "release_notes": "https://deno.com/blog/v2.3",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "13.5"
+        },
+        "2.3.2": {
+          "release_date": "2025-05-16",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v2.3.3",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "13.7"
         }
       }
     }

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -212,7 +212,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "2.3"
+                "version_added": "2.3.2"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add new Deno version

Update support for `RegExp.escape()` in Deno.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Deno [v2.3 released](https://deno.com/blog/v2.3).

RegExp.escape() is supported in Deno since [v2.3.2](https://github.com/denoland/deno/pull/29186).

See [v2.3.3 release notes](https://github.com/denoland/deno/releases/tag/v2.3.3).

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
