### PR TITLE
Updates for Chrome 138 beta

### DIFF
--- a/api/PushSubscriptionChangeEvent.json
+++ b/api/PushSubscriptionChangeEvent.json
@@ -8,8 +8,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": false,
-            "impl_url": "https://crbug.com/41275327"
+            "version_added": "138"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -57,7 +56,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "138"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -103,7 +102,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "138"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -150,7 +149,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "138"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -944,8 +944,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/41275327"
+              "version_added": "138"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -494,6 +494,40 @@
           }
         }
       },
+      "flip": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webcodecs/#dom-videoframe-flip",
+          "support": {
+            "chrome": {
+              "version_added": "138"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "format": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoFrame/format",
@@ -527,6 +561,40 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rotation": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webcodecs/#dom-videoframe-rotation",
+          "support": {
+            "chrome": {
+              "version_added": "138"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Viewport.json
+++ b/api/Viewport.json
@@ -1,0 +1,72 @@
+{
+  "api": {
+    "Viewport": {
+      "__compat": {
+        "spec_url": "https://drafts.csswg.org/css-viewport/#the-viewport-interface",
+        "support": {
+          "chrome": {
+            "version_added": "138"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "segments": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-viewport/#dom-viewport-segments",
+          "support": {
+            "chrome": {
+              "version_added": "138"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Window.json
+++ b/api/Window.json
@@ -7634,6 +7634,40 @@
           }
         }
       },
+      "viewport": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-viewport/#dom-window-viewport",
+          "support": {
+            "chrome": {
+              "version_added": "138"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "visualViewport": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/visualViewport",

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -319,10 +319,15 @@
               "web-features:stretch"
             ],
             "support": {
-              "chrome": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "28"
-              },
+              "chrome": [
+                {
+                  "version_added": "138"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "28"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -349,10 +349,15 @@
               "web-features:stretch"
             ],
             "support": {
-              "chrome": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "28"
-              },
+              "chrome": [
+                {
+                  "version_added": "138"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "28"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -367,10 +367,15 @@
               "web-features:stretch"
             ],
             "support": {
-              "chrome": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "22"
-              },
+              "chrome": [
+                {
+                  "version_added": "138"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "22"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -351,10 +351,15 @@
               "web-features:stretch"
             ],
             "support": {
-              "chrome": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "28"
-              },
+              "chrome": [
+                {
+                  "version_added": "138"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "28"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -382,10 +382,15 @@
               "web-features:stretch"
             ],
             "support": {
-              "chrome": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "22"
-              },
+              "chrome": [
+                {
+                  "version_added": "138"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "22"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -398,10 +398,15 @@
               "web-features:stretch"
             ],
             "support": {
-              "chrome": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "22"
-              },
+              "chrome": [
+                {
+                  "version_added": "138"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "22"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -11,8 +11,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40253181"
+              "version_added": "138"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.13.1 found new features shipping in Chrome 138 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 57 features as shipping in Chrome 138:

- api.CreateMonitor
- api.CreateMonitor.downloadprogress_event
- api.LanguageDetector
- api.LanguageDetector.availability_static
- api.LanguageDetector.create_static
- api.LanguageDetector.destroy
- api.LanguageDetector.detect
- api.LanguageDetector.expectedInputLanguages
- api.LanguageDetector.inputQuota
- api.LanguageDetector.measureInputUsage
- api.PushSubscriptionChangeEvent
- api.PushSubscriptionChangeEvent.PushSubscriptionChangeEvent
- api.PushSubscriptionChangeEvent.newSubscription
- api.PushSubscriptionChangeEvent.oldSubscription
- api.ServiceWorkerGlobalScope.pushsubscriptionchange_event
- api.Summarizer
- api.Summarizer.availability_static
- api.Summarizer.create_static
- api.Summarizer.destroy
- api.Summarizer.expectedContextLanguages
- api.Summarizer.expectedInputLanguages
- api.Summarizer.format
- api.Summarizer.inputQuota
- api.Summarizer.length
- api.Summarizer.measureInputUsage
- api.Summarizer.outputLanguage
- api.Summarizer.sharedContext
- api.Summarizer.summarize
- api.Summarizer.summarizeStreaming
- api.Summarizer.type
- api.Translator
- api.Translator.availability_static
- api.Translator.create_static
- api.Translator.destroy
- api.Translator.inputQuota
- api.Translator.measureInputUsage
- api.Translator.sourceLanguage
- api.Translator.targetLanguage
- api.Translator.translate
- api.Translator.translateStreaming
- api.VideoFrame.flip
- api.VideoFrame.rotation
- api.Viewport
- api.Viewport.segments
- api.Window.viewport
- css.properties.height.stretch
- css.properties.max-height.stretch
- css.properties.max-width.stretch
- css.properties.min-height.stretch
- css.properties.min-width.stretch
- css.properties.width.stretch
- css.types.abs
- html.elements.script.type.speculationrules.target_hint
- http.headers.Clear-Site-Data.prefetchCache
- http.headers.Clear-Site-Data.prerenderCache
- http.headers.Permissions-Policy.summarizer
- manifests.webapp.scope_extensions

(several keys were updated in separate PRs, in particular those for the LLM features)

See also the 138 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-138-beta