### PR TITLE
Firefox 140 adds `pointerrawupdate` event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8121,7 +8121,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8139,7 +8139,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF140 supports `pointerrawupdate_event` in https://bugzilla.mozilla.org/show_bug.cgi?id=1550462 (see https://hg-edge.mozilla.org/mozilla-central/rev/ccd6d2c97e41#l2.10)

This updates the subfeature (missed from #26916 )

Related docs work can be tracked in https://github.com/mdn/content/issues/39614