### PR TITLE
Firefox 140 removes UA styles for `<h1>` in article/aside/nav/section

### DIFF
--- a/html/elements/h1.json
+++ b/html/elements/h1.json
@@ -40,9 +40,9 @@
             "deprecated": false
           }
         },
-        "no_ua_styles_for_h1_in_article_aside_nav_section": {
+        "no_ua_styles_in_article_aside_nav_section": {
           "__compat": {
-            "description": "No user agent styles for `<h1>` in `<article>`, `<aside>`, `<nav>`, and `<section>`.",
+            "description": "No user agent styles in `<article>`, `<aside>`, `<nav>`, and `<section>`.",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/Heading_Elements#specifying_a_uniform_font_size_for_h1",
             "spec_url": "https://html.spec.whatwg.org/multipage/rendering.html#sections-and-headings",
             "tags": [


### PR DESCRIPTION
Fixes #26881.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
