### PR TITLE
enhance(lint): fix common errors

### DIFF
--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -14,6 +14,7 @@ import chalk from 'chalk-template';
 import dataFolders from '../scripts/lib/data-folders.js';
 
 import fixBrowserOrder from './fixer/browser-order.js';
+import fixCommonErrors from './fixer/common-errors.js';
 import fixFeatureOrder from './fixer/feature-order.js';
 import fixPropertyOrder from './fixer/property-order.js';
 import fixStatementOrder from './fixer/statement-order.js';
@@ -30,6 +31,7 @@ const dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const FIXES = Object.freeze({
   descriptions: fixDescriptions,
+  common_errors: fixCommonErrors,
   flags: fixFlags,
   links: fixLinks,
   mdn_urls: fixMDNURLs,

--- a/lint/fixer/common-errors.test.ts
+++ b/lint/fixer/common-errors.test.ts
@@ -1,0 +1,47 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import assert from 'node:assert/strict';
+
+import { fixCommonErrorsInCompatStatement } from './common-errors.js';
+
+const tests: { input: any; output?: any }[] = [
+  // Replace unwrapped "false".
+  {
+    input: false,
+    output: {
+      version_added: false,
+    },
+  },
+  // Replace wrapped "mirror".
+  {
+    input: {
+      version_added: 'mirror',
+    },
+    output: 'mirror',
+  },
+];
+
+describe('fix -> common errors', () => {
+  let i = 1;
+  for (const test of tests) {
+    it(`Test #${i}`, () => {
+      const input = {
+        support: {
+          firefox_android: test.input,
+        },
+      };
+      const output = {
+        support: {
+          firefox_android: test.output ?? test.input,
+        },
+      };
+
+      fixCommonErrorsInCompatStatement(input);
+
+      assert.deepStrictEqual(input, output);
+    });
+
+    i += 1;
+  }
+});

--- a/lint/fixer/common-errors.ts
+++ b/lint/fixer/common-errors.ts
@@ -1,0 +1,55 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import fs from 'node:fs';
+
+import { CompatStatement, SimpleSupportStatement } from '../../types/types.js';
+import { walk } from '../../utils/index.js';
+
+/**
+ * Fixes common errors in CompatStatements.
+ *
+ * - Replaces `browser: { version_added: "mirror" }` with `browser: "mirror"`
+ * - Wraps `browser: false` with `browser: `{ version_added: false }`
+ *
+ * @param compat The compat statement to fix
+ */
+export const fixCommonErrorsInCompatStatement = (
+  compat: CompatStatement,
+): void => {
+  for (const browser of Object.keys(compat.support)) {
+    if (compat.support[browser] === false) {
+      compat.support[browser] = {
+        version_added: false,
+      } satisfies SimpleSupportStatement;
+    } else if (
+      typeof compat.support[browser] === 'object' &&
+      JSON.stringify(compat.support[browser]) === '{"version_added":"mirror"}'
+    ) {
+      compat.support[browser] = 'mirror';
+    }
+  }
+};
+
+/**
+ * Update compat data to 'mirror' if the statement matches mirroring
+ * @param filename The name of the file to fix
+ */
+const fixCommonErrors = (filename: string): void => {
+  if (filename.includes('/browsers/')) {
+    return;
+  }
+
+  const actual = fs.readFileSync(filename, 'utf-8').trim();
+  const bcd = JSON.parse(actual);
+  for (const { compat } of walk(undefined, bcd)) {
+    fixCommonErrorsInCompatStatement(compat);
+  }
+  const expected = JSON.stringify(bcd, null, 2);
+
+  if (actual !== expected) {
+    fs.writeFileSync(filename, expected + '\n', 'utf-8');
+  }
+};
+
+export default fixCommonErrors;


### PR DESCRIPTION
#### Summary

Enhances the linter to fix two common errors:

1. Replaces `firefox: false` with `firefox: { version_added: false }`.
2. Replaces `edge: { version_added: "mirror" }` with `edge: "mirror"`.

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/pull/26946#pullrequestreview-2881492892, where this issue appeared.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
