### PR TITLE
Update Chromium data for print-color-adjust CSS property

### DIFF
--- a/css/properties/print-color-adjust.json
+++ b/css/properties/print-color-adjust.json
@@ -23,11 +23,7 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "prefix": "-webkit-",
-              "version_added": "79",
-              "notes": "Edge does not print backgrounds of the [`<body>`](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/body) element. If this property is set to `exact` for the `<body>` element, it will apply only to its descendants."
-            },
+            "edge": "mirror",
             "firefox": [
               {
                 "version_added": "97"
@@ -42,16 +38,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15",
-              "notes": "Opera does not print backgrounds of the [`<body>`](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/body) element. If this property is set to `exact` for the `<body>` element, it will apply only to its descendants."
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "15",
-              "notes": "Opera does not print backgrounds of the [`<body>`](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/body) element. If this property is set to `exact` for the `<body>` element, it will apply only to its descendants."
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "15.4"
@@ -63,19 +51,8 @@
               }
             ],
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "prefix": "-webkit-",
-              "version_added": "1.0",
-              "notes": [
-                "Samsung Internet does not print backgrounds of the [`<body>`](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/body) element. If this property is set to `exact` for the `<body>` element, it will apply only to its descendants.",
-                "In version 1, if background images are clipped (for example, when using `background-image` sprites) and `-webkit-print-color-adjust` is set to `exact`, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See [bug 40219905](https://crbug.com/40219905)."
-              ]
-            },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4",
-              "notes": "WebView does not print backgrounds of the [`<body>`](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/body) element. If this property is set to `exact` for the `<body>` element, it will apply only to its descendants."
-            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `print-color-adjust` CSS property. This sets the downstream browser(s) to mirror from their upstream counterpart.
