### PR TITLE
Chrome 137 supports CSS `view-transition-name: match-element`

### DIFF
--- a/css/properties/view-transition-name.json
+++ b/css/properties/view-transition-name.json
@@ -51,7 +51,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1956141"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/view-transition-name.json
+++ b/css/properties/view-transition-name.json
@@ -38,6 +38,43 @@
             "deprecated": false
           }
         },
+        "match-element": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#auto-vt-name",
+            "tags": [
+              "web-features:view-transitions"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-view-transitions/#valdef-view-transition-name-none",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 137 supports the `view-transition-name` property's `match-element` value. See https://chromestatus.com/feature/5098745710247936.

This PR adds a data point for the new value.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
