### PR TITLE
Bug impl_url for Safari's support of overflow-anchor

### DIFF
--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -25,7 +25,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://webkit.org/b/171099"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -61,7 +62,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/171099"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -98,7 +100,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/171099"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This adds URLs to the webkit bug which tracks the implementation of the Scroll Anchoring feature (and its opt-out mechanism: `overflow-anchor`).

#### Test results and supporting details

The tracking bug: https://bugs.webkit.org/show_bug.cgi?id=171099

#### Related issues

N/A