### PR TITLE
Deno doesn't support Performance{Observer*,ResourceTiming}

### DIFF
--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -12,6 +12,9 @@
             "version_added": "52"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "57"
@@ -61,6 +64,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "57"
@@ -101,6 +107,9 @@
                 "version_added": "95"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -142,6 +151,9 @@
               "version_added": "62"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "57"
@@ -183,6 +195,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "57"
@@ -224,6 +239,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "57"
@@ -266,6 +284,9 @@
               "version_added": "73"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "68"
@@ -307,6 +328,9 @@
               "version_added": "65"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "60"

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -12,6 +12,9 @@
             "version_added": "52"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "57"
@@ -66,6 +69,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "57"
@@ -107,6 +113,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "57"
@@ -148,6 +157,9 @@
               "version_added": "52"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "57"

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -12,6 +12,9 @@
             "version_added": "29"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
@@ -67,6 +70,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "15"
             },
@@ -122,6 +128,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -175,6 +184,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -228,6 +240,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "129"
@@ -269,6 +284,9 @@
               "version_added": "54"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -318,6 +336,9 @@
               "version_added": "117"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -358,6 +379,9 @@
                 "version_added": "117"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -400,6 +424,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -449,6 +476,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -498,6 +528,9 @@
               "version_added": "54"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -547,6 +580,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -593,6 +629,9 @@
               "version_added": "133"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false,
@@ -632,6 +671,9 @@
               "version_added": "115"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false,
@@ -674,6 +716,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -724,6 +769,9 @@
               "version_added": "61"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -773,6 +821,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -822,6 +873,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -871,6 +925,9 @@
               "version_added": "107"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -912,6 +969,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -961,6 +1021,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -1010,6 +1073,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -1059,6 +1125,9 @@
               "version_added": "109"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "129"
@@ -1100,6 +1169,9 @@
               "version_added": "43"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "18"
             },
@@ -1149,6 +1221,9 @@
               "version_added": "65"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "61"
@@ -1190,6 +1265,9 @@
               "version_added": "45"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "16"
             },
@@ -1239,6 +1317,9 @@
               "version_added": "54"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -1288,6 +1369,9 @@
               "version_added": "46"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "16"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Deno doesn't support `PerformanceObserver`, `PerformanceObserverEntryList`, and `PerformanceResourceTiming`.

#### Test results and supporting details

Noticed as part of triaging https://github.com/mdn/browser-compat-data/issues/24584.

Verified locally with Deno v2.3.2, and confirmed with GitHub search:

- `PerformanceObserver` ([denoland/deno](https://github.com/search?q=repo%3Adenoland%2Fdeno+%2FPerformanceObserver%2F&type=code) | [v8/v8](https://github.com/search?q=repo%3Av8%2Fv8%20%2FPerformanceObserver%2F&type=code))
- `PerformanceObserverEntryList` ([denoland/deno](https://github.com/search?q=repo%3Adenoland%2Fdeno+%2FPerformanceObserverEntryList%2F&type=code) | [v8/v8](https://github.com/search?q=repo%3Av8%2Fv8%20%2FPerformanceObserveEntryListr%2F&type=code))
- `PerformanceResourceTiming` ([denoland/deno](https://github.com/search?q=repo%3Adenoland%2Fdeno+%2FPerformanceResourceTiming%2F&type=code) | [v8/v8](https://github.com/search?q=repo%3Av8%2Fv8%20%2FPerformanceResourceTiming%2F&type=code))

#### Related issues

See also: https://github.com/denoland/deno/issues/20961#issuecomment-2492828204