### PR TITLE
fix(lint/fix): read/write files only once

### DIFF
--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs/promises';
+import fs, { readFile, writeFile } from 'node:fs/promises';
 import { Stats } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -25,11 +25,14 @@ import fixMDNURLs from './fixer/mdn-urls.js';
 import fixStatus from './fixer/status.js';
 import fixMirror from './fixer/mirror.js';
 import fixOverlap from './fixer/overlap.js';
-import { LintOptions } from './utils.js';
+import { IS_WINDOWS, LintOptions } from './utils.js';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
 
-const FIXES = Object.freeze({
+const FIXES: Record<
+  string,
+  (filename: string, actual: string) => Promise<string> | string
+> = Object.freeze({
   descriptions: fixDescriptions,
   common_errors: fixCommonErrors,
   flags: fixFlags,
@@ -73,8 +76,21 @@ const load = async (
 
     if (fsStats.isFile()) {
       if (path.extname(file) === '.json' && !file.endsWith('.schema.json')) {
+        let initial = (await readFile(file, 'utf-8')).trim();
+        let expected = initial;
+
         for (const fix of fixes) {
-          await fix(file);
+          expected = await fix(file, expected);
+        }
+
+        if (IS_WINDOWS) {
+          // prevent false positives from git.core.autocrlf on Windows
+          initial = initial.replace(/\r/g, '');
+          expected = expected.replace(/\r/g, '');
+        }
+
+        if (initial !== expected) {
+          await writeFile(file, expected + '\n', 'utf-8');
         }
       }
     } else {

--- a/lint/fix.ts
+++ b/lint/fix.ts
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs, { readFile, writeFile } from 'node:fs/promises';
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { Stats } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -68,7 +68,7 @@ const load = async (
     let fsStats: Stats;
 
     try {
-      fsStats = await fs.stat(file);
+      fsStats = await stat(file);
     } catch (e) {
       console.warn(chalk`{yellow File {bold ${file}} doesn't exist!}`);
       continue;
@@ -94,7 +94,7 @@ const load = async (
         }
       }
     } else {
-      const subFiles = (await fs.readdir(file)).map((subfile) =>
+      const subFiles = (await readdir(file)).map((subfile) =>
         path.join(file, subfile),
       );
 

--- a/lint/fixer/browser-order.ts
+++ b/lint/fixer/browser-order.ts
@@ -1,14 +1,11 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import {
   BrowserName,
   CompatStatement,
   SupportBlock,
 } from '../../types/types.js';
-import { IS_WINDOWS } from '../utils.js';
 
 /**
  * Return a new "support_block" object whose first-level properties
@@ -42,24 +39,15 @@ export const orderSupportBlock = (
  * all the data in a specified file.  The function will then automatically
  * write any needed changes back into the file.
  * @param filename The path to the file to fix in-place
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixBrowserOrder = (filename: string): void => {
+const fixBrowserOrder = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
 
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = JSON.stringify(JSON.parse(actual, orderSupportBlock), null, 2);
-
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(JSON.parse(actual, orderSupportBlock), null, 2);
 };
 
 export default fixBrowserOrder;

--- a/lint/fixer/common-errors.ts
+++ b/lint/fixer/common-errors.ts
@@ -1,8 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import { CompatStatement, SimpleSupportStatement } from '../../types/types.js';
 import { walk } from '../../utils/index.js';
 
@@ -11,7 +9,6 @@ import { walk } from '../../utils/index.js';
  *
  * - Replaces `browser: { version_added: "mirror" }` with `browser: "mirror"`
  * - Wraps `browser: false` with `browser: `{ version_added: false }`
- *
  * @param compat The compat statement to fix
  */
 export const fixCommonErrorsInCompatStatement = (
@@ -34,22 +31,21 @@ export const fixCommonErrorsInCompatStatement = (
 /**
  * Update compat data to 'mirror' if the statement matches mirroring
  * @param filename The name of the file to fix
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixCommonErrors = (filename: string): void => {
+const fixCommonErrors = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
 
-  const actual = fs.readFileSync(filename, 'utf-8').trim();
   const bcd = JSON.parse(actual);
+
   for (const { compat } of walk(undefined, bcd)) {
     fixCommonErrorsInCompatStatement(compat);
   }
-  const expected = JSON.stringify(bcd, null, 2);
 
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(bcd, null, 2);
 };
 
 export default fixCommonErrors;

--- a/lint/fixer/descriptions.ts
+++ b/lint/fixer/descriptions.ts
@@ -1,22 +1,19 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
-import { IS_WINDOWS } from '../utils.js';
 import testDescriptions, { processData } from '../linter/test-descriptions.js';
 import walk from '../../utils/walk.js';
 
 /**
  * Fixes issues with descriptions
  * @param filename The filename containing compatibility info
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixDescriptions = (filename: string): void => {
+const fixDescriptions = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
-
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
 
   const data = JSON.parse(actual);
   const walker = walk(undefined, data);
@@ -46,17 +43,7 @@ const fixDescriptions = (filename: string): void => {
     }
   }
 
-  let expected = JSON.stringify(data, null, 2);
-
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(data, null, 2);
 };
 
 export default fixDescriptions;

--- a/lint/fixer/feature-order.ts
+++ b/lint/fixer/feature-order.ts
@@ -1,11 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import { Identifier } from '../../types/types.js';
 import compareFeatures from '../../scripts/lib/compare-features.js';
-import { IS_WINDOWS } from '../utils.js';
 
 /**
  * Return a new feature object whose first-level properties have been
@@ -33,24 +30,15 @@ export const orderFeatures = (_: string, value: Identifier): Identifier => {
  * Perform a fix of feature order within all the data in a specified file.
  * The function will then automatically write any needed changes back into the file.
  * @param filename The filename to perform fix upon
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixFeatureOrder = (filename: string): void => {
+const fixFeatureOrder = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
 
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = JSON.stringify(JSON.parse(actual, orderFeatures), null, 2);
-
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(JSON.parse(actual, orderFeatures), null, 2);
 };
 
 export default fixFeatureOrder;

--- a/lint/fixer/flags.ts
+++ b/lint/fixer/flags.ts
@@ -1,14 +1,11 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import {
   BrowserName,
   SupportStatement,
   SimpleSupportStatement,
 } from '../../types/types.js';
-import { IS_WINDOWS } from '../utils.js';
 import testFlags, {
   isIrrelevantFlagData,
   getBasicSupportStatement,
@@ -60,13 +57,13 @@ export const removeIrrelevantFlags = (
 /**
  * Removes irrelevant flags from the compatibility data of a specified file
  * @param filename The filename containing compatibility info
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixFlags = (filename: string): void => {
+const fixFlags = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
-
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
 
   const data = JSON.parse(actual);
   const walker = walk(undefined, data);
@@ -84,17 +81,7 @@ const fixFlags = (filename: string): void => {
     }
   }
 
-  let expected = JSON.stringify(data, null, 2);
-
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(data, null, 2);
 };
 
 export default fixFlags;

--- a/lint/fixer/links.ts
+++ b/lint/fixer/links.ts
@@ -1,38 +1,35 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import { IS_WINDOWS } from '../utils.js';
 import { processData } from '../linter/test-links.js';
 
 /**
  * Fix issues with links throughout the BCD files
  * @param filename The name of the file to fix
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixLinks = async (filename: string): Promise<void> => {
+const fixLinks = async (filename: string, actual: string): Promise<string> => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
 
-  const original = fs.readFileSync(filename, 'utf-8').trim();
-  const errors = await processData(original);
-  let data = original;
+  const errors = await processData(actual);
+  let expected = actual;
 
   if (IS_WINDOWS) {
     // prevent false positives from git.core.autocrlf on Windows
-    data = data.replace(/\r/g, '');
+    expected = expected.replace(/\r/g, '');
   }
 
   for (const error of errors) {
     if (error.expected) {
-      data = data.replace(error.actual, error.expected);
+      expected = expected.replace(error.actual, error.expected);
     }
   }
 
-  if (original !== data) {
-    fs.writeFileSync(filename, data + '\n', 'utf-8');
-  }
+  return expected;
 };
 
 export default fixLinks;

--- a/lint/fixer/mdn-urls.ts
+++ b/lint/fixer/mdn-urls.ts
@@ -1,22 +1,22 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
-import { IS_WINDOWS } from '../utils.js';
 import testMDNURLs, { processData } from '../linter/test-mdn-urls.js';
 import walk from '../../utils/walk.js';
 
 /**
  * Fixes issues with MDN URLs
  * @param filename The filename containing compatibility info
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixMDNURLs = (filename: string): void => {
+const fixMDNURLs = async (
+  filename: string,
+  actual: string,
+): Promise<string> => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
-
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
 
   const data = JSON.parse(actual);
   const walker = walk(undefined, data);
@@ -37,17 +37,7 @@ const fixMDNURLs = (filename: string): void => {
     }
   }
 
-  let expected = JSON.stringify(data, null, 2);
-
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(data, null, 2);
 };
 
 export default fixMDNURLs;

--- a/lint/fixer/mirror.ts
+++ b/lint/fixer/mirror.ts
@@ -1,8 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import stringify from 'fast-json-stable-stringify';
 
 import { CompatData, BrowserName } from '../../types/types.js';
@@ -96,20 +94,18 @@ export const mirrorIfEquivalent = (bcd: CompatData): void => {
 /**
  * Update compat data to 'mirror' if the statement matches mirroring
  * @param filename The name of the file to fix
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixMirror = (filename: string): void => {
+const fixMirror = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
 
-  const actual = fs.readFileSync(filename, 'utf-8').trim();
   const bcd = JSON.parse(actual);
   mirrorIfEquivalent(bcd);
-  const expected = JSON.stringify(bcd, null, 2);
 
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(bcd, null, 2);
 };
 
 export default fixMirror;

--- a/lint/fixer/overlap.ts
+++ b/lint/fixer/overlap.ts
@@ -1,10 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import { BrowserName, CompatStatement } from '../../types/types.js';
-import { IS_WINDOWS } from '../utils.js';
 import { checkOverlap as checkOverlap } from '../common/overlap.js';
 
 /**
@@ -34,24 +31,15 @@ export const processStatement = (
 /**
  * Fix issues with statement order throughout the BCD files
  * @param filename The name of the file to fix
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixOverlap = (filename: string): void => {
+const fixOverlap = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
 
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = JSON.stringify(JSON.parse(actual, processStatement), null, 2);
-
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(JSON.parse(actual, processStatement), null, 2);
 };
 
 export default fixOverlap;

--- a/lint/fixer/property-order.ts
+++ b/lint/fixer/property-order.ts
@@ -1,28 +1,18 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
-import { IS_WINDOWS } from '../utils.js';
 import stringifyAndOrderProperties from '../../scripts/lib/stringify-and-order-properties.js';
 
 /**
  * Fix issues with the property order throughout the BCD files
  * @param filename The name of the file to fix
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixPropertyOrder = (filename: string): void => {
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = stringifyAndOrderProperties(actual);
+const fixPropertyOrder = (filename: string, actual: string): string => {
+  const expected = stringifyAndOrderProperties(actual);
 
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return expected;
 };
 
 export default fixPropertyOrder;

--- a/lint/fixer/statement-order.ts
+++ b/lint/fixer/statement-order.ts
@@ -1,10 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import { BrowserName, CompatStatement } from '../../types/types.js';
-import { IS_WINDOWS } from '../utils.js';
 import compareStatements from '../../scripts/lib/compare-statements.js';
 
 /**
@@ -33,24 +30,15 @@ export const orderStatements = (
 /**
  * Fix issues with statement order throughout the BCD files
  * @param filename The name of the file to fix
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixStatementOrder = (filename: string): void => {
+const fixStatementOrder = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
 
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = JSON.stringify(JSON.parse(actual, orderStatements), null, 2);
-
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
+  return JSON.stringify(JSON.parse(actual, orderStatements), null, 2);
 };
 
 export default fixStatementOrder;

--- a/lint/fixer/status.ts
+++ b/lint/fixer/status.ts
@@ -1,11 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import { Identifier } from '../../types/types.js';
 import { checkExperimental } from '../linter/test-status.js';
-import { IS_WINDOWS } from '../utils.js';
 import walk from '../../utils/walk.js';
 
 /**
@@ -62,30 +59,21 @@ export const fixStatusValue = (value: Identifier): Identifier => {
 /**
  * Fix feature statuses throughout the BCD files
  * @param filename The name of the file to fix
+ * @param actual The current content of the file
+ * @returns expected content of the file
  */
-const fixStatusFromFile = (filename: string): void => {
+const fixStatusFromFile = (filename: string, actual: string): string => {
   if (filename.includes('/browsers/')) {
-    return;
+    return actual;
   }
 
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = JSON.stringify(
+  return JSON.stringify(
     JSON.parse(actual, (_key: string, value: Identifier) =>
       fixStatusValue(value),
     ),
     null,
     2,
   );
-
-  if (IS_WINDOWS) {
-    // prevent false positives from git.core.autocrlf on Windows
-    actual = actual.replace(/\r/g, '');
-    expected = expected.replace(/\r/g, '');
-  }
-
-  if (actual !== expected) {
-    fs.writeFileSync(filename, expected + '\n', 'utf-8');
-  }
 };
 
 export default fixStatusFromFile;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Reads and writes files at most once when running `lint:fix`.

#### Test results and supporting details

```console
$ git checkout main

$ time npm run lint:fix --silent
npm run lint:fix --silent  7.02s user 0.56s system 108% cpu 6.967 total

$ git checkout read-write-files-once-in-lint-fix

$ time npm run lint:fix --silent
npm run lint:fix --silent  6.39s user 0.36s system 112% cpu 6.018 total
```

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
