### PR TITLE
Add Samsung Internet version 28

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -297,9 +297,15 @@
         },
         "27.0": {
           "release_date": "2024-11-06",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "125"
+        },
+        "28.0": {
+          "release_date": "2025-04-02",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "130"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Add Samsung Internet version 28.

#### Test results and supporting details

Chromium version seems accurate from testing on my phone. Can't find a release note, but the date seems about right. https://www.sammyfans.com/2025/04/03/samsung-internet-browser-28-0-0-55-update-enhances-your-browsing-experience/ is an article about it written about it on April 3rd, and I found the APK was uploaded to apkmirror on April 2nd.
