### PR TITLE
Firefox doesn't support `tspan` attrs`lengthAdjust/textLength`

### DIFF
--- a/svg/elements/tspan.json
+++ b/svg/elements/tspan.json
@@ -209,7 +209,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1.5"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/890692"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -330,7 +331,8 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1.5"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/890692"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26945.