### PR TITLE
Add spec_url for scope_extensions manifest member

### DIFF
--- a/manifests/webapp/scope_extensions.json
+++ b/manifests/webapp/scope_extensions.json
@@ -3,6 +3,7 @@
     "webapp": {
       "scope_extensions": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/manifest-incubations/#scope_extensions-member",
           "tags": [
             "web-features:manifest"
           ],
@@ -32,7 +33,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I previously added a data point for the web app manifest `scope_extensions` member, but didn't include the `spec_url`.

I've now found the `spec_url` for it, and this PR adds it.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
