### PR TITLE
Safari 14.1 adds support for animatable `::marker`

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -65,7 +65,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Safari has supported animatable `::marker` since Safari 14.1.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes#CSS-and-Web-Animations
- https://trac.webkit.org/changeset/269813/webkit
