### PR TITLE
Safari 18.4 adds `Math.sumPrecise()`

### DIFF
--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -2107,7 +2107,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "18.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -2115,7 +2115,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Safari has supported `Math.sumPrecise()` since Safari 18.4.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#JavaScript
- https://commits.webkit.org/283774@main