### PR TITLE
Safari 12.1 added support for animated `clip-path`

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -198,7 +198,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Safari supported animating clip paths (`-webkit-clip-path` at the time) in Safari 12.1.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Documentation for this change doesn't explicitly exist in [Safari 12.1 release notes](https://developer.apple.com/documentation/safari-release-notes/safari-12_1-release-notes).

However, the change to enable this functionality has been traced to here which I can confirm our records show shipped with Safari 12.1: 
https://trac.webkit.org/changeset/236541

