### PR TITLE
Safari 17.4 added CSS `rx` and `ry` properties

### DIFF
--- a/css/properties/rx.json
+++ b/css/properties/rx.json
@@ -25,8 +25,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
+              "version_added": 17.4,
+              "notes": "The value is recognized but has no effect prior to 17.4. This property is only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/rx.json
+++ b/css/properties/rx.json
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": 17.4,
+              "version_added": "17.4",
               "notes": "The value is recognized but has no effect prior to 17.4. This property is only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
             },
             "safari_ios": "mirror",

--- a/css/properties/rx.json
+++ b/css/properties/rx.json
@@ -26,7 +26,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "17.4",
-              "notes": "The value is recognized but has no effect prior to 17.4. This property is only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
+              "notes": "Before Safari 17.4, the value was recognized, but had no effect, and was only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -25,8 +25,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
+              "version_added": 17.4,
+              "notes": "The value is recognized but has no effect prior to 17.4. This property is only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": 17.4,
+              "version_added": "17.4",
               "notes": "The value is recognized but has no effect prior to 17.4. This property is only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
             },
             "safari_ios": "mirror",

--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -26,7 +26,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "17.4",
-              "notes": "The value is recognized but has no effect prior to 17.4. This property is only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
+              "notes": "Before Safari 17.4, the value was recognized, but had no effect, and was only recognized as an attribute applied to the SVG element. See [bug 266090](https://webkit.org/b/266090)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Update version for rx and ry css properties 
#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
fixes https://github.com/mdn/browser-compat-data/issues/25021
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
