### PR TITLE
add css.types.color.contrast-color function compat data

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -214,6 +214,44 @@
             }
           }
         },
+        "contrast-color": {
+          "__compat": {
+            "description": "`contrast-color()`",
+            "spec_url": "https://www.w3.org/TR/css-color-5/#contrast-color",
+            "tags": [
+              "web-features:contrast-color"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "currentcolor": {
           "__compat": {
             "description": "`currentcolor` keyword",


### PR DESCRIPTION
#### Summary

Add the compat data for `css.types.color.contrast-color` function.

#### Test results and supporting details

- https://webkit.org/blog/16929/contrast-color/
- https://github.com/WebKit/WebKit/pull/40424
- 

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26987