### PR TITLE
Firefox 140 Nightly enables `CloseWatcher` on Desktop

### DIFF
--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -14,16 +14,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "132",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.closewatcher.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "preview"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -59,16 +54,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "132",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.closewatcher.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -105,16 +95,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "132",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.closewatcher.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -150,16 +135,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "132",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.closewatcher.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -196,16 +176,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "132",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.closewatcher.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -241,16 +216,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "132",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.closewatcher.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -286,16 +256,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "132",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.closewatcher.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
FF140 enables `dom.closewatcher.enabled` in Nightly for desktop only (not android) in https://bugzilla.mozilla.org/show_bug.cgi?id=1966459

Note that Android is behind  `dom.closewatcher.enabled` which is set false.

This updates the associated features.

Docs work done in https://github.com/mdn/content/pull/39862

