### PR TITLE
Firefox 140 removes `MutationEvent`

### DIFF
--- a/api/MutationEvent.json
+++ b/api/MutationEvent.json
@@ -17,7 +17,8 @@
             "version_removed": "127"
           },
           "firefox": {
-            "version_added": "1"
+            "version_added": "1",
+            "version_removed": "140"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -106,7 +107,8 @@
               "version_removed": "127"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -151,7 +153,8 @@
               "version_removed": "127"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -196,7 +199,8 @@
               "version_removed": "127"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -241,7 +245,8 @@
               "version_removed": "127"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "140"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -286,7 +291,8 @@
               "version_removed": "127"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "140"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/MutationEvent.json
+++ b/api/MutationEvent.json
@@ -62,7 +62,8 @@
               "version_removed": "127"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "140"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF140 removes the [`MutationEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent) and associated events such as `DOMAttrModified`, `DOMCharacterDataModified` ... in https://bugzilla.mozilla.org/show_bug.cgi?id=1963043
(These are behind a pref that is now false).

This marks the API as removed. The events do not appear to have any BCD entries so no changes there.

Related docs work can be tracked in https://github.com/mdn/content/issues/39825