### PR TITLE
FF90 -moz-focus-inner removal

### DIFF
--- a/css/selectors/-moz-focus-inner.json
+++ b/css/selectors/-moz-focus-inner.json
@@ -12,7 +12,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "≤72",
+              "version_removed": "90"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,9 +31,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1965660#c8 [`::-moz-focus-inner`](https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-focus-inner) was effectively removed around FF90 (this issue does final tidy up so that it is no longer in even parsed).

What I've done is marked it as removed in FF90 and indicated this is deprecated rather than experimental.
I have asked for a precise bug issue number. If we can't get that perhaps we should just change this to FF140?