### PR TITLE
webextension.api.webNavigation.onCommitted Chrome only properties

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -414,6 +414,101 @@
               }
             }
           },
+          "documentId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "106"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "documentLifecycle": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "106"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "frameType": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "106"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "parentDocumentId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "106"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "parentFrameId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "106"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "transitionQualifiers": {
             "__compat": {
               "support": {


### PR DESCRIPTION
#### Summary

Add details of properties added to `webNavigation.onCommitted` in Chrome in version 74 and 106.

#### Related issues

Addresses the issue raised in [webNavigation.onCommitted details does not mention discrepancy with Chromium](https://github.com/mdn/content/issues/39630#top) #39630 by providing clarification that these properties are only supported in Chrome.
