### PR TITLE
Chrome Android doesn't support WebAuthn large blob extension

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -531,7 +531,9 @@
                   "chrome": {
                     "version_added": "113"
                   },
-                  "chrome_android": "mirror",
+                  "chrome_android": {
+                    "version_added": false
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "139"
@@ -548,9 +550,7 @@
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
-                  "webview_android": {
-                    "version_added": false
-                  },
+                  "webview_android": "mirror",
                   "webview_ios": "mirror"
                 },
                 "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
The Chrome data was added in https://github.com/mdn/browser-compat-data/pull/19306, and the PR description points to https://chromestatus.com/feature/5657899357437952, which confirms that the feature did not ship in Android.

So we should set Chrome Android to{ version_added: false }
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes https://github.com/mdn/browser-compat-data/issues/25002
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
