### PR TITLE
Chrome 138 adds CSS `sibling-count()` and `sibling-index()`

### DIFF
--- a/css/types/sibling-count.json
+++ b/css/types/sibling-count.json
@@ -14,7 +14,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/types/sibling-count.json
+++ b/css/types/sibling-count.json
@@ -1,0 +1,43 @@
+{
+  "css": {
+    "types": {
+      "sibling-count": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-values-5/#funcdef-sibling-count",
+          "tags": [
+            "web-features:sibling-count"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "138"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/sibling-count.json
+++ b/css/types/sibling-count.json
@@ -3,6 +3,7 @@
     "types": {
       "sibling-count": {
         "__compat": {
+          "description": "`sibling-count()`",
           "spec_url": "https://drafts.csswg.org/css-values-5/#funcdef-sibling-count",
           "support": {
             "chrome": {
@@ -11,7 +12,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1953973"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/sibling-count.json
+++ b/css/types/sibling-count.json
@@ -4,9 +4,6 @@
       "sibling-count": {
         "__compat": {
           "spec_url": "https://drafts.csswg.org/css-values-5/#funcdef-sibling-count",
-          "tags": [
-            "web-features:sibling-count"
-          ],
           "support": {
             "chrome": {
               "version_added": "138"

--- a/css/types/sibling-index.json
+++ b/css/types/sibling-index.json
@@ -1,0 +1,43 @@
+{
+  "css": {
+    "types": {
+      "sibling-index": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-values-5/#funcdef-sibling-index",
+          "tags": [
+            "web-features:sibling-count"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "138"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/sibling-index.json
+++ b/css/types/sibling-index.json
@@ -14,7 +14,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/types/sibling-index.json
+++ b/css/types/sibling-index.json
@@ -3,6 +3,7 @@
     "types": {
       "sibling-index": {
         "__compat": {
+          "description": "`sibling-index()`",
           "spec_url": "https://drafts.csswg.org/css-values-5/#funcdef-sibling-index",
           "support": {
             "chrome": {
@@ -11,7 +12,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1953973"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/sibling-index.json
+++ b/css/types/sibling-index.json
@@ -4,9 +4,6 @@
       "sibling-index": {
         "__compat": {
           "spec_url": "https://drafts.csswg.org/css-values-5/#funcdef-sibling-index",
-          "tags": [
-            "web-features:sibling-count"
-          ],
           "support": {
             "chrome": {
               "version_added": "138"


### PR DESCRIPTION
The data was collected from Chrome 137 (stable) and 138 (beta) using new
tests in the collector:
https://github.com/openwebdocs/mdn-bcd-collector/pull/2453
