### PR TITLE
Named timeline range keyframe selectors supported in Safari 26

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -168,7 +168,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "26",
-                "impl_url": "https://bugzil.la/286920"
+                "impl_url": "https://webkit.org/b/286920"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -167,8 +167,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/222295"
+                "version_added": "26",
+                "impl_url": "https://bugzil.la/286920"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

See https://webkit.org/b/286920 for implementation details.

Scroll-driven animations shipped in Safari 26 beta: https://webkit.org/blog/16993/news-from-wwdc25-web-technology-coming-this-fall-in-safari-26-beta/

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
