### PR TITLE
Safari 18.5 disabled Partitioned Cookies (CHIPS)

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -146,7 +146,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.4"
+                "version_added": "18.4",
+                "version_removed": "18.5"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary
Added  version_removed: "18.5" in browser-compat-data/http/headers/Set-Cookie.json for Safari based on issue #27023

