### PR TITLE
Firefox Android doesn't render `<hr>` in `<select>`

### DIFF
--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -201,7 +201,10 @@
                 "partial_implementation": true,
                 "notes": "Does not expose the `<hr>` within the accessibility tree."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1867045"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",


### PR DESCRIPTION
#### Summary

Fixes `<hr>` in `<select>`  has no support in firefox android and added the bugzilla tracking issue link.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzil.la/1867045

#### Related issues

fixes #27040
