### PR TITLE
Move javascript.classes.static_* under static.*

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -336,6 +336,7 @@
       },
       "static": {
         "__compat": {
+          "description": "`static` keyword",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/static",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
           "tags": [
@@ -383,89 +384,89 @@
             "standard_track": true,
             "deprecated": false
           }
-        }
-      },
-      "static_class_fields": {
-        "__compat": {
-          "description": "Static class fields",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Public_class_fields",
-          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-FieldDefinition",
-          "tags": [
-            "web-features:class-syntax"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "72"
+        },
+        "class_fields": {
+          "__compat": {
+            "description": "Static class fields",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Public_class_fields",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-FieldDefinition",
+            "tags": [
+              "web-features:class-syntax"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "72"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "12.0.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "14.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
             },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "75"
-            },
-            "firefox_android": "mirror",
-            "nodejs": {
-              "version_added": "12.0.0"
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "14.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
-        }
-      },
-      "static_initialization_blocks": {
-        "__compat": {
-          "description": "Class static initialization blocks",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks",
-          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock",
-          "tags": [
-            "web-features:class-syntax"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "94"
+        },
+        "initialization_blocks": {
+          "__compat": {
+            "description": "Static initialization blocks",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock",
+            "tags": [
+              "web-features:class-syntax"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "94"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.14"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "93"
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "16.11.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
             },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.14"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "93"
-            },
-            "firefox_android": "mirror",
-            "nodejs": {
-              "version_added": "16.11.0"
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "16.4"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Moves `static_class_fields` and `static_initialization_blocks` from `javascript.classes` into `javascript.classes.static`, removing the `static_` prefix.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/19102.
