### PR TITLE
Safari on iOS 26 adds `dns-prefetch` support

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -818,7 +818,9 @@
                 "safari": {
                   "version_added": "5"
                 },
-                "safari_ios": "mirror",
+                "safari_ios": {
+                  "version_added": "26"
+                },
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
                 "webview_ios": "mirror"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari on iOS 26 adds `dns-prefetch` support. Before, it was only supported on macOS.

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/issues/16299#issuecomment-2655788790

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/16299.
