### PR TITLE
Update web extension data for Safari 26 and correct versioning for some older releases.

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -315,7 +315,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294444"
               },
               "safari_ios": "mirror"
             }
@@ -454,7 +455,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294444"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -369,7 +369,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294444"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -225,7 +225,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }
@@ -248,7 +248,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/289990"
               },
               "safari_ios": "mirror"
             }
@@ -270,7 +271,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294448"
               },
               "safari_ios": "mirror"
             }
@@ -292,7 +294,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294448"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -1083,7 +1083,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "26"
                 },
                 "safari_ios": "mirror"
               }
@@ -1121,7 +1121,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "26"
                 },
                 "safari_ios": "mirror"
               }
@@ -1140,7 +1140,8 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/275158"
                 },
                 "safari_ios": "mirror"
               }
@@ -1219,7 +1220,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "26"
                 },
                 "safari_ios": "mirror"
               }
@@ -1278,7 +1279,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "26"
                 },
                 "safari_ios": "mirror"
               }
@@ -1297,7 +1298,8 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/275158"
                 },
                 "safari_ios": "mirror"
               }
@@ -1514,7 +1516,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/261039"
               },
               "safari_ios": "mirror"
             }
@@ -1552,7 +1555,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18.5"
                 },
                 "safari_ios": "mirror"
               }
@@ -1631,7 +1634,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18.5"
                 },
                 "safari_ios": "mirror"
               }
@@ -2116,7 +2119,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/261039"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/dom.json
+++ b/webextensions/api/dom.json
@@ -15,7 +15,7 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari_ios": "mirror"
           }
@@ -35,7 +35,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -138,6 +138,44 @@
             }
           }
         },
+        "getPreferredSystemLanguages": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "getSystemUILanguage": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "getUILanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage",

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -62,7 +62,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -146,9 +146,11 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -572,7 +574,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294455"
               },
               "safari_ios": "mirror"
             }
@@ -592,7 +595,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294456"
               },
               "safari_ios": "mirror"
             }
@@ -926,7 +930,8 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": false,
+                    "impl_url": "https://webkit.org/b/294457"
                   },
                   "safari_ios": "mirror"
                 }
@@ -1117,7 +1122,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294458"
               },
               "safari_ios": "mirror"
             }
@@ -1138,7 +1144,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/294458"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -16,7 +16,8 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": "15.4"
+              "version_added": "15.4",
+              "notes": "Available for use in Manifest V2 or later."
             },
             "safari_ios": "mirror"
           }
@@ -93,8 +94,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "15.4",
-                "notes": "Available for use in Manifest V2 or later."
+                "version_added": "15.4"
               },
               "safari_ios": "mirror"
             }
@@ -114,8 +114,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "16.4",
-                "notes": "Available for use in Manifest V2 or later."
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }
@@ -133,8 +132,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/264829"
+                  "version_added": "18.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -293,7 +291,9 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4",
+                  "partial_implementation": true,
+                  "notes": "Scripts are always injected immediately."
                 },
                 "safari_ios": "mirror"
               }
@@ -371,8 +371,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "16.4",
-                "notes": "Available for use in Manifest V2 or later."
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }
@@ -431,8 +430,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "16.4",
-                "notes": "Available for use in Manifest V2 or later."
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }
@@ -491,8 +489,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "16.4",
-                "notes": "Available for use in Manifest V2 or later."
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }
@@ -512,8 +509,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "16.4",
-                "notes": "Available for use in Manifest V2 or later."
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -133,7 +133,7 @@
                     "version_added": "33"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }
@@ -242,7 +242,7 @@
                     "version_added": "33"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }
@@ -294,7 +294,8 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "17.1",
+                  "notes": "Only supported for the session storage area."
                 },
                 "safari_ios": "mirror"
               }
@@ -422,7 +423,7 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }
@@ -521,7 +522,7 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }
@@ -847,7 +848,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }
@@ -927,7 +928,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }
@@ -1086,7 +1087,7 @@
                     "version_added": false
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }
@@ -1186,7 +1187,7 @@
                     "version_added": false
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -665,7 +665,8 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/265970"
                 },
                 "safari_ios": "mirror"
               }
@@ -708,7 +709,8 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/265970"
                 },
                 "safari_ios": "mirror"
               }
@@ -1659,7 +1661,8 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/265970"
                 },
                 "safari_ios": "mirror"
               }
@@ -1919,7 +1922,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/265970"
               },
               "safari_ios": "mirror"
             }
@@ -2074,7 +2078,7 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -2473,7 +2477,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -2887,7 +2891,8 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": false,
+                    "impl_url": "https://webkit.org/b/265970"
                   },
                   "safari_ios": "mirror"
                 }
@@ -3001,9 +3006,11 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "14"
                   },
-                  "safari_ios": "mirror"
+                  "safari_ios": {
+                    "version_added": "15"
+                  }
                 }
               }
             },
@@ -3387,7 +3394,8 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": false,
+                    "impl_url": "https://webkit.org/b/265970"
                   },
                   "safari_ios": "mirror"
                 }
@@ -3463,7 +3471,8 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": false,
+                    "impl_url": "https://webkit.org/b/265970"
                   },
                   "safari_ios": "mirror"
                 }
@@ -4139,7 +4148,8 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/265970"
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -18,10 +18,17 @@
               "version_added": "48"
             },
             "opera": "mirror",
-            "safari": {
-              "version_added": "14",
-              "notes": "Before Safari 18, only worked with Manifest V2 extensions using persistent background content. From Safari 18, works with Manifest V2 and V3 extensions."
-            },
+            "safari": [
+              {
+                "version_added": "18"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "18",
+                "partial_implementation": true,
+                "notes": "Only worked with Manifest V2 extensions using persistent background content."
+              }
+            ],
             "safari_ios": {
               "version_added": "18"
             }
@@ -117,7 +124,7 @@
                 "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "18"
               }
             }
           }
@@ -174,7 +181,7 @@
                 "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "18"
               }
             }
           },
@@ -196,7 +203,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             }
@@ -223,7 +230,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             }
@@ -269,7 +276,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             }
@@ -1518,7 +1525,8 @@
                 "notes": "`extraInfoSpec` options are not supported."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "18",
+                "notes": "`extraInfoSpec` options are not supported."
               }
             }
           },
@@ -1561,7 +1569,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -1584,7 +1592,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1647,7 +1655,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1691,7 +1699,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1714,7 +1722,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1756,7 +1764,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1798,7 +1806,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1821,7 +1829,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1844,7 +1852,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1867,7 +1875,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1890,7 +1898,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1913,7 +1921,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1936,7 +1944,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -1980,7 +1988,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2003,7 +2011,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2026,7 +2034,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2072,12 +2080,19 @@
                 "version_added": "48"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "`extraInfoSpec` options are not supported."
-              },
+              "safari": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ],
               "safari_ios": {
-                "version_added": false
+                "version_added": "18"
               }
             }
           },
@@ -2101,7 +2116,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -2165,7 +2180,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2190,7 +2205,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2236,7 +2251,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2261,7 +2276,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2305,7 +2320,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2349,7 +2364,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2374,7 +2389,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2399,7 +2414,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2424,7 +2439,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2449,7 +2464,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2474,7 +2489,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2520,7 +2535,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2545,7 +2560,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2570,7 +2585,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2620,13 +2635,28 @@
                 "notes": "Asynchronous event listeners are supported from version 52."
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "`extraInfoSpec` options are not supported."
-              },
-              "safari_ios": {
-                "version_added": false
-              }
+              "safari": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ]
             }
           },
           "details": {
@@ -2649,7 +2679,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -2732,7 +2762,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2778,7 +2808,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2822,7 +2852,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2862,7 +2892,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2887,7 +2917,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2912,7 +2942,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2958,7 +2988,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -2983,7 +3013,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3008,7 +3038,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3058,13 +3088,28 @@
                 "notes": "Asynchronous event listeners are supported from version 52."
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "`extraInfoSpec` options are not supported."
-              },
-              "safari_ios": {
-                "version_added": false
-              }
+              "safari": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ]
             }
           },
           "details": {
@@ -3087,7 +3132,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -3170,7 +3215,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3216,7 +3261,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3260,7 +3305,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3302,7 +3347,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3327,7 +3372,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3352,7 +3397,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3398,7 +3443,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3423,7 +3468,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3448,7 +3493,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3494,13 +3539,28 @@
                 "version_added": "48"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "`extraInfoSpec` options are not supported."
-              },
-              "safari_ios": {
-                "version_added": false
-              }
+              "safari": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ]
             }
           },
           "details": {
@@ -3523,7 +3583,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -3587,7 +3647,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3612,7 +3672,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3658,7 +3718,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3683,7 +3743,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3727,7 +3787,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3771,7 +3831,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3796,7 +3856,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3821,7 +3881,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3846,7 +3906,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3871,7 +3931,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3917,7 +3977,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3942,7 +4002,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -3967,7 +4027,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4014,11 +4074,10 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "14",
-                "notes": "`extraInfoSpec` options are not supported."
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "18"
               }
             }
           },
@@ -4042,7 +4101,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -4106,7 +4165,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4131,7 +4190,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4156,7 +4215,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4202,7 +4261,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4227,7 +4286,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4271,7 +4330,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4315,7 +4374,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4340,7 +4399,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4386,7 +4445,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4411,7 +4470,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4436,7 +4495,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4492,13 +4551,28 @@
                 ]
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "`extraInfoSpec` options are not supported."
-              },
-              "safari_ios": {
-                "version_added": false
-              }
+              "safari": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ]
             }
           },
           "details": {
@@ -4521,7 +4595,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -4606,7 +4680,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4694,7 +4768,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4738,7 +4812,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4782,7 +4856,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4807,7 +4881,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4832,7 +4906,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4857,7 +4931,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4882,7 +4956,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4928,7 +5002,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4953,7 +5027,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -4978,7 +5052,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5024,13 +5098,28 @@
                 "version_added": "48"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "`extraInfoSpec` options are not supported."
-              },
-              "safari_ios": {
-                "version_added": false
-              }
+              "safari": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ]
             }
           },
           "details": {
@@ -5053,7 +5142,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -5117,7 +5206,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5142,7 +5231,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5211,7 +5300,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5255,7 +5344,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5299,7 +5388,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5324,7 +5413,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5349,7 +5438,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5374,7 +5463,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5399,7 +5488,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5445,7 +5534,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5493,7 +5582,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5539,13 +5628,28 @@
                 "version_added": "48"
               },
               "opera": "mirror",
-              "safari": {
-                "version_added": "14",
-                "notes": "`extraInfoSpec` options are not supported."
-              },
-              "safari_ios": {
-                "version_added": false
-              }
+              "safari": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "18.4"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "18.4",
+                  "partial_implementation": true,
+                  "notes": "`extraInfoSpec` options are not supported."
+                }
+              ]
             }
           },
           "details": {
@@ -5568,7 +5672,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "18"
                 }
               }
             },
@@ -5632,7 +5736,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5678,7 +5782,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5722,7 +5826,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5766,7 +5870,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5791,7 +5895,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5816,7 +5920,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5862,7 +5966,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5887,7 +5991,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }
@@ -5912,7 +6016,7 @@
                     "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "18"
                   }
                 }
               }

--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -16,10 +16,17 @@
               "version_added": false
             },
             "opera": "mirror",
-            "safari": {
-              "version_added": "14",
-              "notes": "Changing the keyboard shortcut for a command is not supported."
-            },
+            "safari": [
+              {
+                "version_added": "26"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "26",
+                "partial_implementation": true,
+                "notes": "Changing the keyboard shortcut for a command is not supported."
+              }
+            ],
             "safari_ios": {
               "version_added": "15",
               "notes": "Changing the keyboard shortcut for a command is not supported."

--- a/webextensions/manifest/content_scripts.json
+++ b/webextensions/manifest/content_scripts.json
@@ -198,8 +198,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/275622"
+                "version_added": "18.4"
               },
               "safari_ios": "mirror"
             }
@@ -218,8 +217,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/264829"
+                "version_added": "18.4"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -21,7 +21,7 @@
               "version_added": "15.4",
               "impl_url": "https://webkit.org/b/269299",
               "partial_implementation": true,
-              "notes": "Safari only supports the `matches` property."
+              "notes": "Only supports the `matches` property."
             },
             "safari_ios": "mirror"
           }

--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -16,10 +16,32 @@
             },
             "firefox_android": "mirror",
             "opera": "mirror",
-            "safari": {
-              "version_added": "14"
-            },
-            "safari_ios": "mirror"
+            "safari": [
+              {
+                "version_added": "17",
+                "partial_implementation": true,
+                "notes": "Controlled by a user setting. When allowed, operates in spanning mode."
+              },
+              {
+                "version_added": "14",
+                "version_removed": "17",
+                "partial_implementation": true,
+                "notes": "No user setting. Always operated in spanning mode."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "17",
+                "partial_implementation": true,
+                "notes": "Controlled by a user setting. When allowed, operates in spanning mode."
+              },
+              {
+                "version_added": "15",
+                "version_removed": "17",
+                "partial_implementation": true,
+                "notes": "No user setting. Always operated in spanning mode."
+              }
+            ]
           }
         },
         "not_allowed": {
@@ -37,7 +59,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "14"
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -58,7 +80,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "14"
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -77,14 +99,12 @@
                 "version_added": "127",
                 "impl_url": "https://bugzil.la/1380812",
                 "partial_implementation": true,
-                "notes": "Split mode is not supported in Firefox. Extensions using this value are treated as requesting \"incognito\":\"not_allowed\"."
+                "notes": "Split mode is not supported in Firefox. Extensions using this value are treated as requesting \"incognito\": \"not_allowed\"."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "14",
-                "partial_implementation": true,
-                "notes": "Split mode is not supported in Safari. Extensions using this value are treated as requesting \"incognito\":\"spanning\"."
+                "version_added": false
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -56,9 +56,11 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15"
+              }
             }
           }
         },
@@ -911,7 +913,7 @@
                 "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "18"
               }
             }
           }

--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -60,14 +60,20 @@
                 "version_added": "57"
               },
               "opera": {
-                "version_added": false,
+                "version_added": "27",
+                "partial_implementation": true,
                 "notes": "Options pages are always opened in a separate browser tab."
               },
               "safari": {
-                "version_added": false,
+                "version_added": "14",
+                "partial_implementation": true,
                 "notes": "Options pages are always opened in a separate browser tab."
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "Options pages are always opened in a separate browser tab."
+              }
             }
           }
         },

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -401,7 +401,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "16"
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -1039,7 +1039,7 @@
                 "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "18"
               }
             }
           }

--- a/webextensions/manifest/web_accessible_resources.json
+++ b/webextensions/manifest/web_accessible_resources.json
@@ -98,10 +98,15 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "14",
+                "partial_implementation": true,
                 "notes": "The extension's base URL is always dynamic in Safari."
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "The extension's base URL is always dynamic in Safari."
+              }
             }
           }
         }


### PR DESCRIPTION
#### Summary

Went through and updated all web extension BCD data for Safari, adding new Safari 26 release support and correcting items for older releases that were wrong or missing.

#### Test results and supporting details

Cross-referenced Safari release notes and bugs.

#### Related issues

None