### PR TITLE
Safari TP supports `field-sizing` CSS property

### DIFF
--- a/css/properties/field-sizing.json
+++ b/css/properties/field-sizing.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://webkit.org/b/264720"
             },
             "safari_ios": "mirror",
@@ -58,7 +58,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/264720"
               },
               "safari_ios": "mirror",
@@ -94,7 +94,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/264720"
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`field-sizing`-CSS-property has been added to Safari Technology Preview 220 according to issue <https://webkit.org/b/264720>, which has been confirmed manually.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

ran `npm i && npm run test` on my localhost

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
