### PR TITLE
XMLSerializer moved into HTML spec

### DIFF
--- a/api/XMLSerializer.json
+++ b/api/XMLSerializer.json
@@ -3,7 +3,7 @@
     "XMLSerializer": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLSerializer",
-        "spec_url": "https://w3c.github.io/DOM-Parsing/#the-xmlserializer-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#xmlserializer",
         "tags": [
           "web-features:xml-serializer"
         ],
@@ -49,7 +49,7 @@
         "__compat": {
           "description": "`XMLSerializer()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLSerializer/XMLSerializer",
-          "spec_url": "https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-constructor",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-xmlserializer-constructor",
           "tags": [
             "web-features:xml-serializer"
           ],
@@ -95,7 +95,7 @@
       "serializeToString": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLSerializer/serializeToString",
-          "spec_url": "https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-xmlserializer-serializetostring",
           "tags": [
             "web-features:xml-serializer"
           ],


### PR DESCRIPTION
The interface has been removed from the DOMParsing spec in https://github.com/w3c/DOM-Parsing/commit/91273610d3bb07dd555dcc84a49e2e4d0ef12851 and moved to the html standard (https://github.com/whatwg/html/pull/11077).