### PR TITLE
Mark `Document.writeln()` as deprecated

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8940,7 +8940,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/api/Document.json
+++ b/api/Document.json
@@ -8898,7 +8898,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "accepts_TrustedHTML": {


### PR DESCRIPTION
`Document.writeln()` is `Document.write()` with a line break added to the end of the input string. Since `Document.write()` is deprecated for a whole bunch of reasons in the spec, the same status should apply to `writeln()`.

Fell out of docs work in https://github.com/mdn/content/pull/37952