### PR TITLE
Bump range cutoff date to five years ago

### DIFF
--- a/lint/linter/test-versions.ts
+++ b/lint/linter/test-versions.ts
@@ -21,7 +21,7 @@ const now = new Date();
 
 /* The latest date a range's release can correspond to */
 const rangeCutoffDate = new Date(
-  now.getFullYear() - 4,
+  now.getFullYear() - 5,
   now.getMonth(),
   now.getDate(),
 );


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Extends the cut off date range from 4 to 5 years ago.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/23991.

Similar to:

- https://github.com/mdn/browser-compat-data/pull/25963
