### PR TITLE
Firefox/Safari don't support `break-before/after: avoid`

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -138,14 +138,16 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "65"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/775617"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10"
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/34155"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -138,14 +138,16 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "65"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/775617"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10"
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/34155"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mark `break-before/after: avoid` as not supported by Firefox and Safari, like `page-break-before/after: avoid`.

#### Test results and supporting details

The MDN BCD Collector tests are passing, but these are false positives.

See:

- https://bugzilla.mozilla.org/show_bug.cgi?id=1972340
- https://bugs.webkit.org/show_bug.cgi?id=294559

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22723.

Collector PR:

- https://github.com/openwebdocs/mdn-bcd-collector/pull/2476