### PR TITLE
Updating `font-style: oblique` details for Chrome and Safari

### DIFF
--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -134,7 +134,7 @@
               "chrome": {
                 "version_added": "62",
                 "partial_implementation": true,
-                "notes": "The provided angle has little effect. Angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle. Angles from -90 to 13 are generally shown without slant, like `font-style: normal`. In some situations, like with a vertical `writing-mode` being used, a negative angle does produce a slant."
+                "notes": "The provided angle has little effect. Generally, angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle, and angles from -90 to 13 are generally shown without slant, like `font-style: normal`. In some situations, like with a vertical `writing-mode` being used, a negative angle does produce a slant. See [bug 425388876](https://issues.chromium.org/issues/425388876)"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -148,7 +148,7 @@
               "safari": {
                 "version_added": "11.1",
                 "partial_implementation": true,
-                "notes": "The provided angle has little effect. Angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle. Angles from -90 to 13 are generally shown without slant, like `font-style: normal`. See [bug 261283](https://bugs.webkit.org/show_bug.cgi?id=261283) and [bug 174865](https://bugs.webkit.org/show_bug.cgi?id=174865)."
+                "notes": "The provided angle has little effect. Generally, angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle, and angles from -90 to 13 are generally shown without slant, like `font-style: normal`. See [bug 261283](https://bugs.webkit.org/show_bug.cgi?id=261283) and [bug 174865](https://bugs.webkit.org/show_bug.cgi?id=174865)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -134,7 +134,7 @@
               "chrome": {
                 "version_added": "62",
                 "partial_implementation": true,
-                "notes": "Angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle. Angles from -90 to 13 are shown without slant, like `font-style: normal`.",
+                "notes": "The provided angle has little effect. Angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle. Angles from -90 to 13 are generally shown without slant, like `font-style: normal`. In some situations, like with a vertical `writing-mode` being used, a negative angle does produce a slant."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -148,7 +148,7 @@
               "safari": {
                 "version_added": "11.1",
                 "partial_implementation": true,
-                "notes": "Angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle. Angles from -90 to 13 are shown without slant, like `font-style: normal`. See [bug 261283](https://bugs.webkit.org/show_bug.cgi?id=261283) and [bug 174865](https://bugs.webkit.org/show_bug.cgi?id=174865).",
+                "notes": "The provided angle has little effect. Angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle. Angles from -90 to 13 are generally shown without slant, like `font-style: normal`. See [bug 261283](https://bugs.webkit.org/show_bug.cgi?id=261283) and [bug 174865](https://bugs.webkit.org/show_bug.cgi?id=174865)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -132,7 +132,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "62"
+                "version_added": "62",
+                "partial_implementation": true,
+                "notes": "Angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle. Angles from -90 to 13 are shown without slant, like `font-style: normal`.",
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -144,7 +146,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11.1"
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "Angles from 14 to 90 are shown with a slant of 14 degrees, like `font-style: oblique` without a provided angle. Angles from -90 to 13 are shown without slant, like `font-style: normal`. See [bug 261283](https://bugs.webkit.org/show_bug.cgi?id=261283) and [bug 174865](https://bugs.webkit.org/show_bug.cgi?id=174865).",
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR comes from this issue: https://github.com/mdn/browser-compat-data/issues/27050

I tried to add understandable explanation of the issue to the notes to.

#### Test results and supporting details

These are provided in the issue, but in short, it seems that Chrome (and Safari apparently) accept the angles supplied for `font-style: oblique`, but don't really properly use them. Certain degrees seem to fall back to `font-style: italic` while others seem to fall back to `font-style: normal`. Meanwhile, in stark contrast, Firefox supports the full degree range from -90 to 90.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27050, more or less.
