### PR TITLE
Firefox/Safari parse `break-before/after: avoid` without effect

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -139,7 +139,8 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "impl_url": "https://bugzil.la/775617"
+                "impl_url": "https://bugzil.la/775617",
+                "notes": "The value is recognized, but has no effect. See [bug 1972340](https://bugzil.la/1972340)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -147,7 +148,8 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "impl_url": "https://webkit.org/b/34155"
+                "impl_url": "https://webkit.org/b/34155",
+                "notes": "The value is recognized, but has no effect. See [bug 294559](https://webkit.org/b/294559)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -139,7 +139,8 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "impl_url": "https://bugzil.la/775617"
+                "impl_url": "https://bugzil.la/775617",
+                "notes": "The value is recognized, but has no effect. See [bug 1972340](https://bugzil.la/1972340)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -147,7 +148,8 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "impl_url": "https://webkit.org/b/34155"
+                "impl_url": "https://webkit.org/b/34155",
+                "notes": "The value is recognized, but has no effect. See [bug 294559](https://webkit.org/b/294559)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mentions that Firefox/Safari recognize the `avoid` value for the `break-before/after` CSS properties, but it has no effect.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Follow up to:

- https://github.com/mdn/browser-compat-data/pull/27073