### PR TITLE
Chrome 137 support for SVG transform on `<svg>` root

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -2942,9 +2942,9 @@
             "deprecated": false
           }
         },
-        "svg_root_support": {
+        "svg_root": {
           "__compat": {
-            "description": "Supported on `<svg>` root",
+            "description": "On `<svg>` root",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -2941,6 +2941,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "svg_root_support": {
+          "__compat": {
+            "description": "Supported on `<svg>` root",
+            "tags": [
+              "web-features:svg"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "transform-origin": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 137+ supports setting an SVG `transform` attribute on the root `<svg>` element. See https://chromestatus.com/feature/6129368025530368 for details.

This PR adds a data point for the new support.

BTW, from tests it looks like Firefox supports this as well, but I don't know the version number, so I've left it as `false` for now.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
