### PR TITLE
Firefox 140 beta adds `fetchpriority` for some SVG elements

### DIFF
--- a/css/properties/field-sizing.json
+++ b/css/properties/field-sizing.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://webkit.org/b/264720"
             },
             "safari_ios": "mirror",
@@ -58,7 +58,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/264720"
               },
               "safari_ios": "mirror",
@@ -94,7 +94,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/264720"
               },
               "safari_ios": "mirror",

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -82,7 +82,7 @@
         "fetchpriority": {
           "__compat": {
             "tags": [
-              "web-features:svg"
+              "web-features:fetch-priority"
             ],
             "support": {
               "chrome": {

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -89,7 +89,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge":  "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": "140"
               },

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -89,9 +89,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge":  "mirror",
               "firefox": {
                 "version_added": "140"
               },

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -79,6 +79,45 @@
             }
           }
         },
+        "fetchpriority": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fetchpriority",
+            "tags": [
+              "web-features:svg"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "140"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -81,7 +81,6 @@
         },
         "fetchpriority": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fetchpriority",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -126,9 +126,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge":  "mirror",
               "firefox": {
                 "version_added": "140"
               },

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -126,7 +126,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge":  "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": "140"
               },

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -118,7 +118,6 @@
         },
         "fetchpriority": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fetchpriority",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -116,6 +116,45 @@
             }
           }
         },
+        "fetchpriority": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fetchpriority",
+            "tags": [
+              "web-features:svg"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "140"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "height": {
           "__compat": {
             "spec_url": "https://svgwg.org/svg2-draft/geometry.html#Sizing",

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -119,7 +119,7 @@
         "fetchpriority": {
           "__compat": {
             "tags": [
-              "web-features:svg"
+              "web-features:fetch-priority"
             ],
             "support": {
               "chrome": {

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -122,9 +122,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge":  "mirror",
               "firefox": {
                 "version_added": "140"
               },

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -112,6 +112,45 @@
             }
           }
         },
+        "fetchpriority": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fetchpriority",
+            "tags": [
+              "web-features:svg"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "140"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -122,7 +122,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge":  "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": "140"
               },

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -115,7 +115,7 @@
         "fetchpriority": {
           "__compat": {
             "tags": [
-              "web-features:svg"
+              "web-features:fetch-priority"
             ],
             "support": {
               "chrome": {

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -114,7 +114,6 @@
         },
         "fetchpriority": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fetchpriority",
             "tags": [
               "web-features:svg"
             ],


### PR DESCRIPTION
#### Summary

- Added `fetchpriority` support for the foillowing SVG elements:
  - `<feimage>`
  - `<image>`
  - `<script>`

#### Test results and supporting details

- Firefox is the first browser to support this feature, I have tested in:
  - Firefox Beta 140
  - Firefox nightly 141.0a1 (2025-06-17)
- Tested with the following code pens:
  - [svg feimage element priority](https://codepen.io/CodeRedDigital/pen/jEPpowN)
  - [svg image element priority](https://codepen.io/CodeRedDigital/pen/KwpBYYY)
  - [SVG Script priority](https://cdpn.io/pen/debug/YPXjWwb)

#### Related issues

- [Bugzill issue #1847712](https://bugzil.la/1847712)
- [Content PR]()
- [Firefox Release note PR](https://github.com/mdn/content/pull/39981)
