### PR TITLE
Chrome 136 supports MediaTrackSettings.screenPixelRatio

### DIFF
--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -1,0 +1,71 @@
+{
+  "api": {
+    "MediaTrackSettings": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings",
+        "spec_url": "https://w3c.github.io/mediacapture-main/#media-track-settings",
+        "support": {
+          "chrome": {
+            "version_added": "59"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "50"
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "11"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "screenPixelRatio": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediatracksettings-screenpixelratio",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 136+ supports the `MediaTrackSettings.screenPixelRatio` property, on desktop only. See https://chromestatus.com/feature/6738236535472128 for details.

This PR attempts to add a data point for this new property. However, I'm not convinced I've done this right. This is a tricky situation, and I'm not sure what else to do.

The thing with [Media Capture and Streams](https://developer.mozilla.org/en-US/docs/Web/API/Media_Capture_and_Streams_API) is that you have these properties that can act as [capabilities, constraints, and settings](https://developer.mozilla.org/en-US/docs/Web/API/Media_Capture_and_Streams_API/Constraints).

The way these have been represented historically in BCD is as [sub-data items under the `MediaStreamTrack.applyConstraints()` method](https://github.com/mdn/browser-compat-data/blob/main/api/MediaStreamTrack.json#L39). These same data points have been used for the browser compat tables on the [`MediaStreamTrack.applyConstraints()` page](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/applyConstraints#browser_compatibility), AND on the pages under [`MediaTrackConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) and [`MediaTrackSettings`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings). 

Possibly other places too.

This has mostly worked so far, as the properties are generally usable as constraints, capabilities, and settings. However, it doesn't work for `screenPixelRatio`, because it is a setting only; the [spec specifically states that it is not usable as a constraint or capability](https://w3c.github.io/mediacapture-screen-share/#dfn-screenpixelratio). So, to represent it as `api.MediaStreamTrack.applyConstraints.screenPixelRatio_constraint` would make no sense whatsoever.

Ideally, IMO we should have separate BCD objects for `MediaTrackSettings` and `MediaTrackConstraints`, especially given that we have separate MDN pages for them. The latter could also be used for the associated `MediaStreamTrack.applyConstraints()` method, rather than the other way round. Even without this problem I've uncovered, it is still confusing as-is.

I don't have time to figure this whole thing out now; it probably needs a deeper discussion at some point. But adding it as `api.MediaTrackSettings.screenPixelRatio` at least makes a move in the right direction?

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
