### PR TITLE
Safari doesn't support Math.sumPrecise

### DIFF
--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -2056,7 +2056,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.4"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
I don't see it working in Safari 26 beta or in Safari TP. I think it is not enabled by default yet.