### PR TITLE
Firefox 140 allows `setEnabled()` if policy-installed

### DIFF
--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -362,14 +362,18 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "55",
-                  "partial_implementation": true,
-                  "notes": "Only extensions whose 'type' is 'theme' can be enabled and disabled."
-                },
-                {
                   "version_added": "140",
                   "partial_implementation": true,
-                  "notes": "Extensions installed via policy can enable and disable other extensions."
+                  "notes": [
+                    "Any extension can enable and disable themes.",
+                    "Extensions installed via policies can enable and disable any extension."
+                  ]
+                },
+                {
+                  "version_added": "55",
+                  "version_removed": "140",
+                  "partial_implementation": true,
+                  "notes": "Extensions can only enable and disable themes."
                 }
               ],
               "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

In Firefox 140, we updated the behavior for setEnabled and I'm including it here.

#### Test results and supporting details

Bug is here:

https://bugzilla.mozilla.org/show_bug.cgi?id=1966113

#### Related issues
None
