### PR TITLE
Safari 26 adds `GPUOutOfMemoryError`, not Safari 18.5

### DIFF
--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -43,7 +43,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "18.5"
+            "version_added": "26"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -100,7 +100,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.5"
+              "version_added": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
The collector updates for Safari 26 were a bit tricky because the beta version doesn't yet present itself as version 26. I missed this file to correct the version to 26. Follow up to https://github.com/mdn/browser-compat-data/pull/27087