### PR TITLE
Firefox Android 141 supports `webkitdirectory` on `<input>`

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3176,7 +3176,7 @@
               "version_added": "50"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "141"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -1553,7 +1553,7 @@
                 "version_added": "50"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "141"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Firefox 141 supports webkitdirectory

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1887878