### PR TITLE
Add support data for CSP script-src trusted-types-eval keyword

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1036,6 +1036,44 @@
               }
             }
           },
+          "trusted-types-eval": {
+            "__compat": {
+              "description": "`trusted-types-eval` source expression",
+              "spec_url": "https://w3c.github.io/webappsec-csp/#grammardef-trusted-types-eval",
+              "tags": [
+                "web-features:csp",
+                "web-features:trusted-types"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/388437274"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1940493"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "26"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "wasm-unsafe-eval": {
             "__compat": {
               "description": "Source expression allowing WebAssembly execution",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add support data for CSP script-src trusted-types-eval keyword

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Manually tested in iOS 26 beta using a WPT https://wpt.live/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval.html

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
