### PR TITLE
Firefox Nightly supports `Animation.overallProgress`

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -404,7 +404,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "142"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 142 supports overallProgress API.
This PR reflects it and switch OFF the experimental status of the API, because now two rendering engines support it :)

#### Test results and supporting details

mozilla bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1834878

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
