### PR TITLE
Chrome 138 supports SnapEvent constructor behind pref

### DIFF
--- a/api/SnapEvent.json
+++ b/api/SnapEvent.json
@@ -45,7 +45,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "129"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SnapEvent` member of the `SnapEvent` API. Data comes from https://github.com/mdn/browser-compat-data/pull/26687#discussion_r2142486603.
