### PR TITLE
Updates for Firefox 141 beta

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -76,9 +76,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -133,9 +133,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -215,9 +215,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -76,9 +76,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -127,9 +127,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -178,9 +178,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -213,9 +213,13 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -228,7 +232,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -249,9 +253,13 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -264,7 +272,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -285,9 +293,13 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -300,7 +312,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -332,9 +344,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -20,9 +20,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -64,9 +64,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -112,9 +112,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -194,9 +194,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -235,9 +239,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -280,9 +284,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -20,9 +20,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -64,9 +64,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -20,9 +20,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -64,9 +64,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -109,9 +109,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -154,9 +154,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -199,9 +199,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -244,9 +244,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -289,9 +289,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -156,7 +156,9 @@
               "partial_implementation": true,
               "notes": "Currently supported on Linux and Windows only."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -145,9 +145,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -145,9 +145,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -32,9 +32,13 @@
           ],
           "edge": "mirror",
           "firefox": {
+            "version_added": "141",
+            "partial_implementation": true,
+            "notes": "Currently supported on Windows only."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -47,7 +51,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -84,9 +88,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -99,7 +107,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -20,9 +20,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "141",
+            "partial_implementation": true,
+            "notes": "Currently supported on Windows only."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -60,9 +64,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUInternalError.json
+++ b/api/GPUInternalError.json
@@ -20,9 +20,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "141",
+            "partial_implementation": true,
+            "notes": "Currently supported on Windows only."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -61,9 +65,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -89,9 +89,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -20,9 +20,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "141",
+            "partial_implementation": true,
+            "notes": "Currently supported on Windows only."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -61,9 +65,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -99,9 +107,13 @@
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "141",
+                "partial_implementation": true,
+                "notes": "Currently supported on Windows only."
+              },
+              "firefox_android": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -141,9 +153,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -145,9 +145,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -202,9 +202,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -259,9 +259,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderBundle.json
+++ b/api/GPURenderBundle.json
@@ -32,9 +32,13 @@
           ],
           "edge": "mirror",
           "firefox": {
+            "version_added": "141",
+            "partial_implementation": true,
+            "notes": "Currently supported on Windows only."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -84,9 +88,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -201,7 +201,9 @@
               "partial_implementation": true,
               "notes": "Currently supported on Linux and Windows only."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -263,7 +265,9 @@
               "partial_implementation": true,
               "notes": "Currently supported on Linux and Windows only."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -266,7 +266,9 @@
               "partial_implementation": true,
               "notes": "Currently supported on Linux and Windows only."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -328,7 +330,9 @@
               "partial_implementation": true,
               "notes": "Currently supported on Linux and Windows only."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -145,9 +145,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -76,9 +76,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -133,9 +133,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -86,9 +86,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -727,9 +731,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -778,9 +786,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -829,9 +841,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -880,9 +896,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -931,9 +951,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -983,9 +1007,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -132,9 +132,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -185,9 +189,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -242,9 +246,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -283,9 +291,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -324,9 +336,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -377,9 +393,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -430,9 +450,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -483,9 +507,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -536,9 +564,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -589,9 +621,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -642,9 +678,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -695,9 +735,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -748,9 +792,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -841,9 +889,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -894,9 +946,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -947,9 +1003,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1000,9 +1060,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1053,9 +1117,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1106,9 +1174,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1159,9 +1231,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1212,9 +1288,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1265,9 +1345,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1318,9 +1402,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1371,9 +1459,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1424,9 +1516,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1477,9 +1573,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1530,9 +1630,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1583,9 +1687,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1636,9 +1744,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1689,9 +1801,13 @@
             ],
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -88,9 +88,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -20,9 +20,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -65,9 +65,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -110,9 +110,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -32,9 +32,9 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
+            "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -89,9 +89,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -158,8 +158,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1964077"
+              "version_added": "141"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -174,7 +173,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -307,7 +307,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1849,9 +1849,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -418,7 +418,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -433,7 +433,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -17,7 +17,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "141",
+            "partial_implementation": true,
+            "notes": "Currently supported on Windows only."
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -53,7 +55,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -196,7 +200,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -233,7 +239,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -270,7 +278,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -307,7 +317,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -344,7 +356,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -382,7 +396,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -327,7 +327,9 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -15,14 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "108",
-              "flags": [
-                {
-                  "name": "layout.css.font-variant-emoji.enabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "141"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -62,7 +55,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -77,7 +70,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -96,7 +89,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -111,7 +104,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -130,7 +123,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -145,7 +138,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -164,7 +157,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -179,7 +172,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -48,8 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1964077"
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -64,7 +63,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/AsyncDisposableStack.json
+++ b/javascript/builtins/AsyncDisposableStack.json
@@ -13,7 +13,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141"
             },
             "firefox_android": "mirror",
             "nodejs": {
@@ -31,7 +31,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -48,7 +48,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -66,7 +66,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -84,7 +84,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -102,7 +102,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -120,7 +120,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -138,7 +138,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -156,7 +156,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -174,7 +174,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -192,7 +192,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -210,7 +210,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -228,7 +228,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -246,7 +246,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -264,7 +264,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -282,7 +282,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }

--- a/javascript/builtins/DisposableStack.json
+++ b/javascript/builtins/DisposableStack.json
@@ -13,7 +13,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141"
             },
             "firefox_android": "mirror",
             "nodejs": {
@@ -31,7 +31,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -48,7 +48,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -66,7 +66,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -84,7 +84,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -102,7 +102,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -120,7 +120,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -138,7 +138,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -156,7 +156,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -174,7 +174,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -192,7 +192,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -210,7 +210,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -228,7 +228,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -246,7 +246,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -264,7 +264,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -282,7 +282,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }

--- a/javascript/builtins/SuppressedError.json
+++ b/javascript/builtins/SuppressedError.json
@@ -13,7 +13,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141"
             },
             "firefox_android": "mirror",
             "nodejs": {
@@ -31,7 +31,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -48,7 +48,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -66,7 +66,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -102,7 +102,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": [
@@ -134,7 +134,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -244,7 +244,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "nodejs": [
@@ -276,7 +276,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -2143,7 +2143,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "141"
             },
             "firefox_android": "mirror",
             "nodejs": {
@@ -2161,7 +2161,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.13.3 found new features shipping in Firefox 141 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 157 features as shipping in Firefox 141:

- api.GPU
- api.GPU.getPreferredCanvasFormat
- api.GPU.requestAdapter
- api.GPU.wgslLanguageFeatures
- api.GPUAdapterInfo
- api.GPUAdapterInfo.architecture
- api.GPUAdapterInfo.description
- api.GPUAdapterInfo.device
- api.GPUAdapterInfo.isFallbackAdapter
- api.GPUAdapterInfo.subgroupMaxSize
- api.GPUAdapterInfo.subgroupMinSize
- api.GPUAdapterInfo.vendor
- api.GPUBindGroup
- api.GPUBindGroup.label
- api.GPUBindGroupLayout
- api.GPUBindGroupLayout.label
- api.GPUCanvasContext
- api.GPUCanvasContext.canvas
- api.GPUCanvasContext.configure
- api.GPUCanvasContext.getConfiguration
- api.GPUCanvasContext.getCurrentTexture
- api.GPUCanvasContext.unconfigure
- api.GPUCommandBuffer
- api.GPUCommandBuffer.label
- api.GPUCompilationInfo
- api.GPUCompilationInfo.messages
- api.GPUCompilationMessage
- api.GPUCompilationMessage.length
- api.GPUCompilationMessage.lineNum
- api.GPUCompilationMessage.linePos
- api.GPUCompilationMessage.message
- api.GPUCompilationMessage.offset
- api.GPUCompilationMessage.type
- api.GPUComputePipeline
- api.GPUComputePipeline.getBindGroupLayout
- api.GPUComputePipeline.label
- api.GPUDeviceLostInfo
- api.GPUDeviceLostInfo.message
- api.GPUDeviceLostInfo.reason
- api.GPUError
- api.GPUError.message
- api.GPUExternalTexture
- api.GPUExternalTexture.label
- api.GPUInternalError
- api.GPUInternalError.GPUInternalError
- api.GPUOutOfMemoryError
- api.GPUOutOfMemoryError.GPUOutOfMemoryError
- api.GPUPipelineError
- api.GPUPipelineError.GPUPipelineError
- api.GPUPipelineError.GPUPipelineError.message_optional
- api.GPUPipelineError.reason
- api.GPUPipelineLayout
- api.GPUPipelineLayout.label
- api.GPUQuerySet
- api.GPUQuerySet.count
- api.GPUQuerySet.destroy
- api.GPUQuerySet.label
- api.GPUQuerySet.type
- api.GPURenderBundle
- api.GPURenderBundle.label
- api.GPURenderPipeline
- api.GPURenderPipeline.getBindGroupLayout
- api.GPURenderPipeline.label
- api.GPUSampler
- api.GPUSampler.label
- api.GPUShaderModule
- api.GPUShaderModule.getCompilationInfo
- api.GPUShaderModule.label
- api.GPUSupportedFeatures
- api.GPUSupportedFeatures.entries
- api.GPUSupportedFeatures.forEach
- api.GPUSupportedFeatures.has
- api.GPUSupportedFeatures.keys
- api.GPUSupportedFeatures.size
- api.GPUSupportedFeatures.values
- api.GPUSupportedFeatures.@@iterator
- api.GPUSupportedLimits
- api.GPUSupportedLimits.maxBindGroups
- api.GPUSupportedLimits.maxBindGroupsPlusVertexBuffers
- api.GPUSupportedLimits.maxBindingsPerBindGroup
- api.GPUSupportedLimits.maxBufferSize
- api.GPUSupportedLimits.maxColorAttachmentBytesPerSample
- api.GPUSupportedLimits.maxColorAttachments
- api.GPUSupportedLimits.maxComputeInvocationsPerWorkgroup
- api.GPUSupportedLimits.maxComputeWorkgroupSizeX
- api.GPUSupportedLimits.maxComputeWorkgroupSizeY
- api.GPUSupportedLimits.maxComputeWorkgroupSizeZ
- api.GPUSupportedLimits.maxComputeWorkgroupsPerDimension
- api.GPUSupportedLimits.maxComputeWorkgroupStorageSize
- api.GPUSupportedLimits.maxDynamicStorageBuffersPerPipelineLayout
- api.GPUSupportedLimits.maxDynamicUniformBuffersPerPipelineLayout
- api.GPUSupportedLimits.maxInterStageShaderVariables
- api.GPUSupportedLimits.maxSampledTexturesPerShaderStage
- api.GPUSupportedLimits.maxSamplersPerShaderStage
- api.GPUSupportedLimits.maxStorageBufferBindingSize
- api.GPUSupportedLimits.maxStorageBuffersPerShaderStage
- api.GPUSupportedLimits.maxStorageTexturesPerShaderStage
- api.GPUSupportedLimits.maxTextureArrayLayers
- api.GPUSupportedLimits.maxTextureDimension1D
- api.GPUSupportedLimits.maxTextureDimension2D
- api.GPUSupportedLimits.maxTextureDimension3D
- api.GPUSupportedLimits.maxUniformBufferBindingSize
- api.GPUSupportedLimits.maxUniformBuffersPerShaderStage
- api.GPUSupportedLimits.maxVertexAttributes
- api.GPUSupportedLimits.maxVertexBufferArrayStride
- api.GPUSupportedLimits.maxVertexBuffers
- api.GPUSupportedLimits.minStorageBufferOffsetAlignment
- api.GPUSupportedLimits.minUniformBufferOffsetAlignment
- api.GPUTextureView
- api.GPUTextureView.label
- api.GPUUncapturedErrorEvent
- api.GPUUncapturedErrorEvent.GPUUncapturedErrorEvent
- api.GPUUncapturedErrorEvent.error
- api.GPUValidationError
- api.GPUValidationError.GPUValidationError
- api.HTMLDialogElement.closedBy
- api.IntersectionObserver.scrollMargin
- api.Navigator.gpu
- api.PointerEvent.persistentDeviceId
- api.WGSLLanguageFeatures
- api.WGSLLanguageFeatures.entries
- api.WGSLLanguageFeatures.forEach
- api.WGSLLanguageFeatures.has
- api.WGSLLanguageFeatures.keys
- api.WGSLLanguageFeatures.size
- api.WGSLLanguageFeatures.values
- api.WGSLLanguageFeatures.@@iterator
- api.WorkerNavigator.gpu
- css.properties.font-variant-emoji
- css.properties.font-variant-emoji.emoji
- css.properties.font-variant-emoji.normal
- css.properties.font-variant-emoji.text
- css.properties.font-variant-emoji.unicode
- html.elements.dialog.closedby
- javascript.builtins.AsyncDisposableStack
- javascript.builtins.AsyncDisposableStack.AsyncDisposableStack
- javascript.builtins.AsyncDisposableStack.adopt
- javascript.builtins.AsyncDisposableStack.defer
- javascript.builtins.AsyncDisposableStack.disposeAsync
- javascript.builtins.AsyncDisposableStack.disposed
- javascript.builtins.AsyncDisposableStack.move
- javascript.builtins.AsyncDisposableStack.use
- javascript.builtins.DisposableStack
- javascript.builtins.DisposableStack.DisposableStack
- javascript.builtins.DisposableStack.adopt
- javascript.builtins.DisposableStack.defer
- javascript.builtins.DisposableStack.dispose
- javascript.builtins.DisposableStack.disposed
- javascript.builtins.DisposableStack.move
- javascript.builtins.DisposableStack.use
- javascript.builtins.SuppressedError
- javascript.builtins.SuppressedError.SuppressedError
- javascript.builtins.Symbol.asyncDispose
- javascript.builtins.Symbol.dispose
- javascript.statements.using

Notes:
- WebGPU is marked as partial and Windows only, see https://groups.google.com/a/mozilla.org/g/dev-platform/c/21W7YWSvYIM
- I also https://bugzilla.mozilla.org/show_bug.cgi?id=1964343 but I did not add it because the bug says it is early beta only, for now.

See also https://github.com/mdn/mdn/issues/698 and https://www.mozilla.org/en-US/firefox/141.0beta/releasenotes/