### PR TITLE
Remove http.headers.Link.blocking

### DIFF
--- a/http/headers/Link.json
+++ b/http/headers/Link.json
@@ -32,42 +32,6 @@
             "deprecated": false
           }
         },
-        "blocking": {
-          "__compat": {
-            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-blocking",
-            "tags": [
-              "web-features:blocking-render"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "105"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1751383"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/267232"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "fetchpriority": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-fetchpriority",


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This removes `http.headers.Link.blocking`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Unfortunately the tests for this were removed from WPT in https://github.com/web-platform-tests/wpt/pull/34083. I've filed a draft PR with these reverted in https://github.com/web-platform-tests/wpt/pull/53403 to demonstrate lack of support, but results are yet to appear on wpt.fyi as of writing.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Support for `render=blocking` on a `link` element was removed in https://github.com/whatwg/html/commit/448f240bb8a9af2cab512e6bdee8662f185b97ae, and https://github.com/whatwg/html/commit/0ea88cf472012c7f59dc9a836da1382567a5b13e clarified which `link` things were also valid in the `Link` header.

These were both removed from Chromium in https://github.com/chromium/chromium/commit/1372f2379a46b86177b5537b5be77a00c83c6bda, and the earliest tag containing this is 104.0.5074.0. Chrome 104 shipped Tue, Aug 2, 2022 per https://chromiumdash.appspot.com/schedule.

Thus, per [the guidelines](https://github.com/mdn/browser-compat-data/blob/835d933fc7e27b64493f58baf580bb0246feff86/docs/data-guidelines/index.md#removal-of-irrelevant-features) the "a feature was implemented and has since been removed from all browsers dating back two or more years ago" criteria is met and this feature can be removed.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes https://github.com/mdn/browser-compat-data/issues/26880.

See also https://github.com/web-platform-dx/web-features/issues/3077.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
