### PR TITLE
Chrome 123 supports `pointer_composite_access` WGSL extension

### DIFF
--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -80,8 +80,43 @@
       },
       "extension_packed_4x8_integer_dot_product": {
         "__compat": {
-          "description": "<code>packed_4x8_integer_dot_product</code> extension",
+          "description": "`packed_4x8_integer_dot_product` extension",
           "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-packed_4x8_integer_dot_product",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "123"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "extension_pointer_composite_access": {
+        "__compat": {
+          "description": "`pointer_composite_access` extension",
+          "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-pointer_composite_access",
           "tags": [
             "web-features:webgpu"
           ],
@@ -115,7 +150,7 @@
       },
       "extension_readonly_and_readwrite_storage_textures": {
         "__compat": {
-          "description": "<code>readonly_and_readwrite_storage_textures</code> extension",
+          "description": "`readonly_and_readwrite_storage_textures` extension",
           "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-readonly_and_readwrite_storage_textures",
           "tags": [
             "web-features:webgpu"
@@ -150,7 +185,7 @@
       },
       "extension_unrestricted_pointer_parameters": {
         "__compat": {
-          "description": "<code>unrestricted_pointer_parameters</code> extension",
+          "description": "`unrestricted_pointer_parameters` extension",
           "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-unrestricted_pointer_parameters",
           "tags": [
             "web-features:webgpu"

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -87,7 +87,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "123",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -122,7 +123,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "123"
+              "version_added": "123",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -157,7 +159,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "124"
+              "version_added": "124",
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 123 adds support for the `pointer_composite_access` WGSL extension. See https://developer.chrome.com/blog/new-in-webgpu-123#syntax_sugar_for_dereferencing_composites_in_wgsl.

This PR adds a data point for this support.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
