### PR TITLE
Chrome 128 support for Webauthn hints

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -646,6 +646,43 @@
               }
             }
           },
+          "hints": {
+            "__compat": {
+              "description": "`hints` option",
+              "spec_url": "https://w3c.github.io/webauthn/#enum-hints",
+              "tags": [
+                "web-features:webauthn"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "128"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "requireResidentKey": {
             "__compat": {
               "spec_url": "https://w3c.github.io/webauthn/#dom-authenticatorselectioncriteria-requireresidentkey",
@@ -1151,6 +1188,43 @@
                   "standard_track": true,
                   "deprecated": false
                 }
+              }
+            }
+          },
+          "hints": {
+            "__compat": {
+              "description": "`hints` option",
+              "spec_url": "https://w3c.github.io/webauthn/#enum-hints",
+              "tags": [
+                "web-features:webauthn"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "128"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 128 adds support for a new `hints` option that can be specified inside the `publicKey` option of a Webauthn `create()` or `get()` call, to hint to the browser what UI to show to the user for creating or authenticating with a security key. For example, do their users tend to use a physical security key like a YubiKey, or a smartphone-based authenticator app?

This PR adds a `hints` sub-data point to both `api.CredentialsContainer.create.publicKey_option` and `api.CredentialsContainer.get.publicKey_option`

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
