### PR TITLE
Chrome 138 adds CSS `progress()` function

### DIFF
--- a/css/types/progress.json
+++ b/css/types/progress.json
@@ -1,0 +1,38 @@
+{
+  "css": {
+    "types": {
+      "progress": {
+        "__compat": {
+          "description": "`progress()`",
+          "spec_url": "https://drafts.csswg.org/css-values-5/#progress",
+          "support": {
+            "chrome": {
+              "version_added": "138"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 138 adds the CSS [`progress()`](https://drafts.csswg.org/css-values-5/#progress) function — see https://chromestatus.com/feature/5112558941634560.

This PR adds a data point for the `progress()` function.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
