### PR TITLE
Chrome 105 removed http.headers.Link.blocking

### DIFF
--- a/http/headers/Link.json
+++ b/http/headers/Link.json
@@ -40,7 +40,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "105"
+                "version_added": "103",
+                "version_removed": "105"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 105 removed http.headers.Link.blocking

#### Test results and supporting details

Once this lands, the BCD feature will be removed in https://github.com/mdn/browser-compat-data/pull/27145.

#### Related issues

See: https://github.com/mdn/browser-compat-data/pull/27145#discussion_r2167768759
