### PR TITLE
ci(system-file-changes): use PAT to read team membership

### DIFF
--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Block if author/actor is not admin or BCD owner
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ORG_PAT }}
         run: |
           is_admin_or_owner() {
             local USER="$1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes the `system-file-changes` workflow to use a fine-grained access token (PAT) to read the team membership.

#### Test results and supporting details

Noticed in https://github.com/mdn/browser-compat-data/actions/runs/15910632781/job/44876768775?pr=23958 that it fails, although the PR creator is BCD owner.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
