### PR TITLE
FF141 adds HTML popover source + force option

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2415,9 +2415,9 @@
             "deprecated": false
           }
         },
-        "source": {
+        "options_source_parameter": {
           "__compat": {
-            "description": "`source` option",
+            "description": "`options.source` option",
             "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-showpopoveroptions-source",
             "tags": [
               "web-features:popover"
@@ -2862,44 +2862,10 @@
             "deprecated": false
           }
         },
-        "force": {
+        "force_parameter": {
           "__compat": {
-            "description": "`force` option",
+            "description": "`force` parameter",
             "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-togglepopoveroptions-force",
-            "tags": [
-              "web-features:popover"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "141"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "returns_boolean": {
-          "__compat": {
-            "description": "Returns `true` or `false`",
             "tags": [
               "web-features:popover"
             ],
@@ -2910,7 +2876,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "125"
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -2931,9 +2897,44 @@
             }
           }
         },
-        "source": {
+        "options_force_parameter": {
           "__compat": {
-            "description": "`source` option",
+            "description": "`options.force` parameter",
+            "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-togglepopoveroptions-force",
+            "tags": [
+              "web-features:popover"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "141"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_source_parameter": {
+          "__compat": {
+            "description": "`options.source` parameter",
             "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-showpopoveroptions-source",
             "tags": [
               "web-features:popover"
@@ -3002,6 +3003,40 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            }
+          }
+        },
+        "returns_boolean": {
+          "__compat": {
+            "description": "Returns `true` or `false`",
+            "tags": [
+              "web-features:popover"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "116"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2417,7 +2417,7 @@
         },
         "options_source_parameter": {
           "__compat": {
-            "description": "`options.source` option",
+            "description": "`options.source` parameter",
             "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-showpopoveroptions-source",
             "tags": [
               "web-features:popover"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2431,7 +2431,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -2448,7 +2448,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2467,7 +2467,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "141"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -2482,7 +2482,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -2862,6 +2862,41 @@
             "deprecated": false
           }
         },
+        "force": {
+          "__compat": {
+            "description": "`force` option",
+            "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-togglepopoveroptions-force",
+            "tags": [
+              "web-features:popover"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "141"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "returns_boolean": {
           "__compat": {
             "description": "Returns `true` or `false`",
@@ -2912,7 +2947,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -2929,7 +2964,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2948,7 +2983,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "141"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -2963,7 +2998,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
FF141 supports the `source` option to [`HTMLElement.showPopover()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover) and [`HTMLElement.togglePopover()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/togglePopover), and the `force` option to  [`HTMLElement.togglePopover()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/togglePopover) in https://bugzilla.mozilla.org/show_bug.cgi?id=1936411

This adds the features.

Related docs work can be tracked in https://github.com/mdn/content/issues/40027