### PR TITLE
Chrome/Firefox support labeled values on range input

### DIFF
--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -65,7 +65,7 @@
           "labeled_values": {
             "__compat": {
               "description": "Labeled values support",
-              "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range#adding_labels",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/input/range#adding_labels",
               "spec_url": "https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range):~:text=labeled%20values",
               "tags": [
                 "web-features:input-range"


### PR DESCRIPTION
#### Summary

Add "labeled values support" entry of input[type="range"] 

#### Supporting details

Safari can't render the options content of input[type="range"]  so far.

So add a new sub-feature to describe it.

#### Related issues

Fixes #24782
