### PR TITLE
ci(pr-rebase-needed): use branch for push concurrency group

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write # To add labels and comment on PRs
 
 concurrency:
-  group: pr-rebase-needed-${{ github.event.pull_request.number }}
+  group: pr-rebase-needed-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Improves the `pr-rebase-needed` workflow by separating workflow runs triggered by push events into different concurrency groups per branch.

#### Test results and supporting details

Previously, any push to any origin branch was cancelling the current workflow run for the main branch.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
