### PR TITLE
Fix several spec URLs

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -3,7 +3,7 @@
     "CSPViolationReportBody": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody",
-        "spec_url": "https://w3c.github.io/webappsec-csp/#cspviolationreportbody",
+        "spec_url": "https://w3c.github.io/webappsec-csp/#dictdef-cspviolationreportbody",
         "tags": [
           "web-features:reporting"
         ],
@@ -501,7 +501,6 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/toJSON",
-          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-tojson",
           "tags": [
             "web-features:reporting"
           ],
@@ -535,7 +534,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -154,7 +154,6 @@
       "isFallbackAdapter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter/isFallbackAdapter",
-          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapter-isfallbackadapter",
           "tags": [
             "web-features:webgpu"
           ],
@@ -191,8 +190,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -3,7 +3,7 @@
     "ImageData": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData",
-        "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#imagedata",
+        "spec_url": "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagedata",
         "tags": [
           "web-features:canvas-2d"
         ],
@@ -50,7 +50,10 @@
         "__compat": {
           "description": "`ImageData()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData/ImageData",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-dev",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagedata",
+            "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagedata-with-data"
+          ],
           "tags": [
             "web-features:canvas-2d"
           ],
@@ -117,6 +120,7 @@
           },
           "colorSpace_option": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-predefinedcolorspace-srgb",
               "support": {
                 "chrome": {
                   "version_added": "92"
@@ -189,7 +193,7 @@
       "colorSpace": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData/colorSpace",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-colorspace",
+          "spec_url": "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagedata-colorspace",
           "tags": [
             "web-features:canvas-2d"
           ],
@@ -227,7 +231,7 @@
       "data": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData/data",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-data-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagedata-data",
           "tags": [
             "web-features:canvas-2d"
           ],
@@ -274,7 +278,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData/height",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-height-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagedata-height",
           "tags": [
             "web-features:canvas-2d"
           ],
@@ -320,7 +324,7 @@
       },
       "pixelFormat": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-pixelformat",
+          "spec_url": "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagedata-pixelformat",
           "support": {
             "chrome": {
               "version_added": "137"
@@ -352,7 +356,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData/width",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-width-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagedata-width",
           "tags": [
             "web-features:canvas-2d"
           ],

--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -204,7 +204,7 @@
       "renderTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/renderTime",
-          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-rendertime",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#ref-for-dom-largestcontentfulpaint-rendertime",
           "tags": [
             "web-features:largest-contentful-paint"
           ],

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -136,7 +136,7 @@
       },
       "paintTime": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/paint-timing/#dom-painttimingmixin-painttimee",
+          "spec_url": "https://w3c.github.io/paint-timing/#dom-painttimingmixin-painttime",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -94,7 +94,6 @@
           "__compat": {
             "description": "`loaded` and `total` options accept doubles",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProgressEvent/ProgressEvent",
-            "spec_url": "https://xhr.spec.whatwg.org/#dom-progressevent-ProgressEvent",
             "tags": [
               "web-features:xhr"
             ],

--- a/api/Report.json
+++ b/api/Report.json
@@ -86,7 +86,6 @@
       },
       "toJSON": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/reporting/#dom-report-tojson",
           "tags": [
             "web-features:reporting"
           ],
@@ -121,7 +120,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/ReportBody.json
+++ b/api/ReportBody.json
@@ -44,7 +44,6 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReportBody/toJSON",
-          "spec_url": "https://w3c.github.io/reporting/#dom-reportbody-tojson",
           "tags": [
             "web-features:reporting"
           ],
@@ -79,7 +78,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -461,7 +461,7 @@
         "options_sendOrder_parameter": {
           "__compat": {
             "description": "`options.sendOrder` parameter",
-            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstreamoptions-sendorder",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendoptions-sendorder",
             "tags": [
               "web-features:webtransport"
             ],
@@ -582,7 +582,7 @@
         "options_sendOrder_parameter": {
           "__compat": {
             "description": "`options.sendOrder` parameter",
-            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstreamoptions-sendorder",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendoptions-sendorder",
             "tags": [
               "web-features:webtransport"
             ],

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -3,7 +3,7 @@
     "WebTransportDatagramDuplexStream": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream",
-        "spec_url": "https://w3c.github.io/webtransport/#duplex-stream",
+        "spec_url": "https://w3c.github.io/webtransport/#webtransportdatagramduplexstream",
         "tags": [
           "web-features:webtransport"
         ],
@@ -353,7 +353,6 @@
       "writable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/writable",
-          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-writable",
           "tags": [
             "web-features:webtransport"
           ],
@@ -390,7 +389,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/XRView.json
+++ b/api/XRView.json
@@ -158,7 +158,7 @@
       "projectionMatrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRView/projectionMatrix",
-          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrview-projectionmatrix",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrviewgeometry-projectionmatrix",
           "tags": [
             "web-features:webxr-device"
           ],
@@ -271,7 +271,7 @@
       "transform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRView/transform",
-          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrview-transform",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrviewgeometry-transform",
           "tags": [
             "web-features:webxr-device"
           ],

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -258,7 +258,7 @@
           "__compat": {
             "description": "WOFF",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_fonts/WOFF",
-            "spec_url": "https://www.w3.org/TR/WOFF/#OverallStructure",
+            "spec_url": "https://w3c.github.io/woff/woff1/spec/Overview.html#OverallStructure",
             "tags": [
               "web-features:font-face"
             ],

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -4,10 +4,7 @@
       "animation-timing-function": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timing-function",
-          "spec_url": [
-            "https://drafts.csswg.org/css-animations/#animation-timing-function",
-            "https://drafts.csswg.org/css-easing/#linear-easing-function-parsin"
-          ],
+          "spec_url": "https://drafts.csswg.org/css-animations/#animation-timing-function",
           "tags": [
             "web-features:animations-css"
           ],

--- a/css/properties/field-sizing.json
+++ b/css/properties/field-sizing.json
@@ -4,7 +4,7 @@
       "field-sizing": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/field-sizing",
-          "spec_url": "https://drafts.csswg.org/css-ui/#field-sizing",
+          "spec_url": "https://drafts.csswg.org/css-forms-1/#propdef-field-sizing",
           "tags": [
             "web-features:field-sizing"
           ],
@@ -39,7 +39,7 @@
         },
         "content": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-ui/#valdef-field-sizing-content",
+            "spec_url": "https://drafts.csswg.org/css-forms-1/#valdef-field-sizing-content",
             "tags": [
               "web-features:field-sizing"
             ],
@@ -75,7 +75,7 @@
         },
         "fixed": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-ui/#valdef-field-sizing-fixed",
+            "spec_url": "https://drafts.csswg.org/css-forms-1/#valdef-field-sizing-fixed",
             "tags": [
               "web-features:field-sizing"
             ],

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -130,7 +130,7 @@
         "nested_marker": {
           "__compat": {
             "description": "`::after::marker` nested pseudo-elements",
-            "spec_url": "https://www.w3.org/TR/css-pseudo-4/#:~:text=The%20::before::marker%20or%20::after::marker%20selectors",
+            "spec_url": "https://drafts.csswg.org/css-pseudo-4/#:~:text=The%20::before::marker%20or%20::after::marker%20selectors",
             "support": {
               "chrome": {
                 "version_added": "135"

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -147,7 +147,7 @@
         "nested_marker": {
           "__compat": {
             "description": "`::before::marker` nested pseudo-elements",
-            "spec_url": "https://www.w3.org/TR/css-pseudo-4/#:~:text=The%20::before::marker%20or%20::after::marker%20selectors",
+            "spec_url": "https://drafts.csswg.org/css-pseudo-4/#:~:text=The%20::before::marker%20or%20::after::marker%20selectors",
             "support": {
               "chrome": {
                 "version_added": "135"

--- a/css/selectors/checkmark.json
+++ b/css/selectors/checkmark.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "`::checkmark`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::checkmark",
-          "spec_url": "https://drafts.csswg.org/css-forms-1/#styling-checkmarks-the-checkmark-pseudo-element",
+          "spec_url": "https://drafts.csswg.org/css-forms-1/#checkmark",
           "tags": [
             "web-features:customizable-select"
           ],

--- a/css/selectors/picker-icon.json
+++ b/css/selectors/picker-icon.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "`::picker-icon`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::picker-icon",
-          "spec_url": "https://drafts.csswg.org/css-forms-1/#picker-opener-icon-the-picker-icon-pseudo-element",
+          "spec_url": "https://drafts.csswg.org/css-forms-1/#picker-icon",
           "tags": [
             "web-features:customizable-select"
           ],

--- a/css/selectors/picker.json
+++ b/css/selectors/picker.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "`::picker()`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::picker",
-          "spec_url": "https://drafts.csswg.org/css-forms-1/#the-picker-pseudo-element",
+          "spec_url": "https://drafts.csswg.org/css-forms-1/#picker-pseudo",
           "tags": [
             "web-features:customizable-select"
           ],

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -206,7 +206,7 @@
           "__compat": {
             "description": "`contrast-color()`",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/contrast-color",
-            "spec_url": "https://www.w3.org/TR/css-color-5/#contrast-color",
+            "spec_url": "https://drafts.csswg.org/css-color-5/#contrast-color",
             "tags": [
               "web-features:contrast-color"
             ],
@@ -1177,7 +1177,7 @@
           "relative_syntax": {
             "__compat": {
               "description": "Relative Oklch colors",
-              "spec_url": "https://drafts.csswg.org/css-color-5/#relative-Oklch",
+              "spec_url": "https://drafts.csswg.org/css-color-5/#relative-OkLCh",
               "tags": [
                 "web-features:relative-color"
               ],

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -751,7 +751,7 @@
             "__compat": {
               "description": "rel=compression-dictionary",
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Attributes/rel#compression-dictionary",
-              "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-link-relation-registration",
+              "spec_url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-compression-dictionary.html#name-link-relation-registration",
               "tags": [
                 "web-features:compression-dictionary-transport"
               ],

--- a/http/headers/Accept-Encoding.json
+++ b/http/headers/Accept-Encoding.json
@@ -4,7 +4,10 @@
       "Accept-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Accept-Encoding",
-          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept-encoding",
+          "spec_url": [
+            "https://httpwg.org/specs/rfc9110.html#field.accept-encoding",
+            "https://www.rfc-editor.org/rfc/rfc8878#name-content-encoding"
+          ],
           "tags": [
             "web-features:http11"
           ],
@@ -42,6 +45,7 @@
         },
         "br": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Accept-Encoding#br",
             "spec_url": "https://www.rfc-editor.org/rfc/rfc7932#section-13",
             "tags": [
               "web-features:brotli"
@@ -87,8 +91,7 @@
         },
         "dcb": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Accept-Encoding",
-            "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-accept-encoding",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Accept-Encoding#dcb",
             "tags": [
               "web-features:compression-dictionary-transport"
             ],
@@ -123,8 +126,7 @@
         },
         "dcz": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding",
-            "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-content-encoding",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding#dcz",
             "tags": [
               "web-features:compression-dictionary-transport"
             ],
@@ -159,8 +161,7 @@
         },
         "zstd": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Accept-Encoding",
-            "spec_url": "https://www.rfc-editor.org/rfc/rfc8878#name-content-encoding",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Accept-Encoding#zstd",
             "tags": [
               "web-features:zstd"
             ],

--- a/http/headers/Available-Dictionary.json
+++ b/http/headers/Available-Dictionary.json
@@ -4,7 +4,7 @@
       "Available-Dictionary": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Available-Dictionary",
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-available-dictionary",
+          "spec_url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-compression-dictionary.html#available-dictionary",
           "tags": [
             "web-features:compression-dictionary-transport"
           ],

--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -4,7 +4,10 @@
       "Content-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding",
-          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-encoding",
+          "spec_url": [
+            "https://httpwg.org/specs/rfc9110.html#field.content-encoding",
+            "https://www.rfc-editor.org/rfc/rfc8878#name-content-encoding"
+          ],
           "tags": [
             "web-features:http11"
           ],
@@ -87,8 +90,7 @@
         },
         "dcb": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding",
-            "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-content-encoding",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding#dcb",
             "tags": [
               "web-features:compression-dictionary-transport"
             ],
@@ -123,8 +125,7 @@
         },
         "dcz": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding",
-            "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-content-encoding",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding#dcz",
             "tags": [
               "web-features:compression-dictionary-transport"
             ],
@@ -159,8 +160,7 @@
         },
         "zstd": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding",
-            "spec_url": "https://www.rfc-editor.org/rfc/rfc8878#name-content-encoding",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding#zstd",
             "tags": [
               "web-features:zstd"
             ],

--- a/http/headers/Critical-CH.json
+++ b/http/headers/Critical-CH.json
@@ -4,7 +4,7 @@
       "Critical-CH": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Critical-CH",
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability#name-the-critical-ch-response-he",
+          "spec_url": "https://www.ietf.org/archive/id/draft-davidben-http-client-hint-reliability-03.html#critical-ch",
           "support": {
             "chrome": {
               "version_added": "91"

--- a/http/headers/Dictionary-ID.json
+++ b/http/headers/Dictionary-ID.json
@@ -4,7 +4,7 @@
       "Dictionary-ID": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Dictionary-ID",
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-dictionary-id",
+          "spec_url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-compression-dictionary.html#dictionary-id",
           "tags": [
             "web-features:compression-dictionary-transport"
           ],

--- a/http/headers/Sec-WebSocket-Accept.json
+++ b/http/headers/Sec-WebSocket-Accept.json
@@ -4,7 +4,7 @@
       "Sec-WebSocket-Accept": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.3",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc6455#section-11.3.3",
           "tags": [
             "web-features:websockets"
           ],

--- a/http/headers/Sec-WebSocket-Extensions.json
+++ b/http/headers/Sec-WebSocket-Extensions.json
@@ -4,7 +4,7 @@
       "Sec-WebSocket-Extensions": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Extensions",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.2",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc6455#section-11.3.2",
           "tags": [
             "web-features:websockets"
           ],

--- a/http/headers/Sec-WebSocket-Key.json
+++ b/http/headers/Sec-WebSocket-Key.json
@@ -4,7 +4,7 @@
       "Sec-WebSocket-Key": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Key",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.1",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc6455#section-11.3.1",
           "tags": [
             "web-features:websockets"
           ],

--- a/http/headers/Sec-WebSocket-Protocol.json
+++ b/http/headers/Sec-WebSocket-Protocol.json
@@ -4,7 +4,7 @@
       "Sec-WebSocket-Protocol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Protocol",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.4",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc6455#section-11.3.4",
           "tags": [
             "web-features:websockets"
           ],

--- a/http/headers/Sec-WebSocket-Version.json
+++ b/http/headers/Sec-WebSocket-Version.json
@@ -4,7 +4,7 @@
       "Sec-WebSocket-Version": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Version",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.5",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc6455#section-11.3.5",
           "tags": [
             "web-features:websockets"
           ],

--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -125,7 +125,7 @@
         "Partitioned": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies",
-            "spec_url": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies#section-2.1",
+            "spec_url": "https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-01.html#section-2.1",
             "tags": [
               "web-features:partitioned-cookies"
             ],

--- a/http/headers/Use-As-Dictionary.json
+++ b/http/headers/Use-As-Dictionary.json
@@ -4,7 +4,7 @@
       "Use-As-Dictionary": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Use-As-Dictionary",
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary#name-use-as-dictionary",
+          "spec_url": "https://httpwg.org/http-extensions/draft-ietf-httpbis-compression-dictionary.html#name-use-as-dictionary",
           "tags": [
             "web-features:compression-dictionary-transport"
           ],

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -877,7 +877,7 @@
         "groupBy": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-object.groupby",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.groupby",
             "tags": [
               "web-features:array-group"
             ],

--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -557,7 +557,7 @@
         "__compat": {
           "description": "Modifier: `(?ims-ims:...)`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Modifier",
-          "spec_url": "https://github.com/tc39/proposal-regexp-modifiers#syntax",
+          "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-RegularExpressionModifiers",
           "tags": [
             "web-features:regexp"
           ],

--- a/manifests/webapp/prefer_related_applications.json
+++ b/manifests/webapp/prefer_related_applications.json
@@ -4,7 +4,7 @@
       "prefer_related_applications": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Progressive_web_apps/Manifest/Reference/prefer_related_applications",
-          "spec_url": "https://w3c.github.io/manifest/#prefer_related_applications-member",
+          "spec_url": "https://wicg.github.io/manifest-incubations/#prefer_related_applications-member",
           "support": {
             "chrome": {
               "version_added": false,

--- a/manifests/webapp/related_applications.json
+++ b/manifests/webapp/related_applications.json
@@ -4,7 +4,7 @@
       "related_applications": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Progressive_web_apps/Manifest/Reference/related_applications",
-          "spec_url": "https://w3c.github.io/manifest/#related_applications-member",
+          "spec_url": "https://wicg.github.io/manifest-incubations/#related_applications-member",
           "support": {
             "chrome": {
               "version_added": false

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -47,7 +47,7 @@
         "crossorigin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/crossorigin",
-            "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterprimitivestandardattributes-height",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feimage-crossorigin",
             "tags": [
               "web-features:svg-filters"
             ],
@@ -94,9 +94,6 @@
                 "version_added": "140"
               },
               "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/webassembly/api/Tag.json
+++ b/webassembly/api/Tag.json
@@ -45,7 +45,7 @@
           "__compat": {
             "description": "`Tag()` constructor",
             "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/Tag/Tag",
-            "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-tag",
+            "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-tag-type-type",
             "tags": [
               "web-features:wasm-exception-handling"
             ],
@@ -86,7 +86,7 @@
         "type": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/Tag/type",
-            "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-type",
+            "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-tag-type-type",
             "tags": [
               "web-features:wasm-exception-handling"
             ],

--- a/webdriver/bidi/permission.json
+++ b/webdriver/bidi/permission.json
@@ -3,7 +3,7 @@
     "bidi": {
       "permission": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/webdriver-bidi/#module-permission",
+          "spec_url": "https://w3c.github.io/permissions/#webdriver-bidi-module-permissions",
           "support": {
             "chrome": {
               "version_added": "126"
@@ -34,7 +34,7 @@
         "setPermission": {
           "__compat": {
             "description": "`permission.setPermission` command",
-            "spec_url": "https://www.w3.org/TR/permissions/#webdriver-bidi-command-permissions-setPermission",
+            "spec_url": "https://w3c.github.io/permissions/#webdriver-bidi-command-permissions-setPermission",
             "support": {
               "chrome": {
                 "version_added": "126"


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes several spec URLs.

Accounts for:
- Features removed from the spec (implies setting `deprecated: true`).
- Features moved within a spec (i.e. different id).
- Features moved to another spec.
- Feature sections renamed.

Changes some spec URLs to draft, because webref/ed does not contain ids from TRs.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Extracted from: https://github.com/mdn/browser-compat-data/pull/23958
