### PR TITLE
Derive Edge beta/nightly/planned release from stable version

### DIFF
--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -243,9 +243,49 @@ export const updateEdgeReleases = async (options) => {
   }
 
   //
+  // Ensure that the release following stable is 'beta'
+  //
+
+  const betaVersion = (data[options.releaseBranch].version + 1).toString();
+  const betaRelease =
+    edgeBCD.browsers[options.bcdBrowserName].releases[betaVersion];
+
+  if (betaRelease.status != 'beta') {
+    result += updateBrowserEntry(
+      edgeBCD,
+      options.bcdBrowserName,
+      betaVersion.toString(),
+      betaRelease.release_date,
+      'beta',
+      '',
+      '',
+    );
+  }
+
+  //
+  // Ensure that the release following beta is 'nightly'
+  //
+
+  const nightlyVersion = (data[options.releaseBranch].version + 2).toString();
+  const nightlyRelease =
+    edgeBCD.browsers[options.bcdBrowserName].releases[nightlyVersion];
+
+  if (nightlyRelease.status != 'nightly') {
+    result += updateBrowserEntry(
+      edgeBCD,
+      options.bcdBrowserName,
+      nightlyVersion.toString(),
+      nightlyRelease.release_date,
+      'nightly',
+      '',
+      '',
+    );
+  }
+
+  //
   // Add a planned version entry
   //
-  const planned = (data[options.nightlyBranch].version + 1).toString();
+  const planned = (data[options.releaseBranch].version + 3).toString();
   let releaseDate;
   try {
     releaseDate = await getFutureReleaseDate(

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -7,7 +7,11 @@ import chalk from 'chalk-template';
 
 import stringify from '../lib/stringify-and-order-properties.js';
 
-import { newBrowserEntry, updateBrowserEntry } from './utils.js';
+import {
+  newBrowserEntry,
+  setBrowserReleaseStatus,
+  updateBrowserEntry,
+} from './utils.js';
 
 /**
  * getFutureReleaseDate - Read the future release date
@@ -245,42 +249,24 @@ export const updateEdgeReleases = async (options) => {
   //
   // Ensure that the release following stable is 'beta'
   //
-
-  const betaVersion = (data[options.releaseBranch].version + 1).toString();
-  const betaRelease =
-    edgeBCD.browsers[options.bcdBrowserName].releases[betaVersion];
-
-  if (betaRelease.status != 'beta') {
-    result += updateBrowserEntry(
-      edgeBCD,
-      options.bcdBrowserName,
-      betaVersion.toString(),
-      betaRelease.release_date,
-      'beta',
-      '',
-      '',
-    );
-  }
+  const betaVersion = data[options.releaseBranch].version + 1;
+  result += setBrowserReleaseStatus(
+    edgeBCD,
+    options.bcdBrowserName,
+    betaVersion.toString(),
+    'beta',
+  );
 
   //
   // Ensure that the release following beta is 'nightly'
   //
-
-  const nightlyVersion = (data[options.releaseBranch].version + 2).toString();
-  const nightlyRelease =
-    edgeBCD.browsers[options.bcdBrowserName].releases[nightlyVersion];
-
-  if (nightlyRelease.status != 'nightly') {
-    result += updateBrowserEntry(
-      edgeBCD,
-      options.bcdBrowserName,
-      nightlyVersion.toString(),
-      nightlyRelease.release_date,
-      'nightly',
-      '',
-      '',
-    );
-  }
+  const nightlyVersion = data[options.releaseBranch].version + 2;
+  result += setBrowserReleaseStatus(
+    edgeBCD,
+    options.bcdBrowserName,
+    nightlyVersion.toString(),
+    'nightly',
+  );
 
   //
   // Add a planned version entry

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -4,6 +4,8 @@
 import chalk from 'chalk-template';
 import xml2js from 'xml2js';
 
+import { BrowserName, BrowserStatus, CompatData } from '../../types/types.js';
+
 const USER_AGENT =
   'MDN-Browser-Release-Update-Bot/1.0 (+https://developer.mozilla.org/)';
 
@@ -137,6 +139,37 @@ export const createOrUpdateBrowserEntry = (
     releaseDate,
     releaseNotesURL,
     engineVersion,
+  );
+};
+
+/**
+ * Updates the status of a browser release.
+ * @param json json file to update
+ * @param browser the entry name where to add it in the bcd file
+ * @param version the version to add
+ * @param status the status
+ * @returns Text describing what has been updated
+ */
+export const setBrowserReleaseStatus = (
+  json: CompatData,
+  browser: BrowserName,
+  version: string,
+  status: BrowserStatus,
+): string => {
+  const release = json.browsers[browser].releases[version];
+
+  if (release.status === status) {
+    return '';
+  }
+
+  return updateBrowserEntry(
+    json,
+    browser,
+    version,
+    release.release_date,
+    status,
+    '',
+    '',
   );
 };
 


### PR DESCRIPTION
#### Summary

Derive Edge beta/nightly/planned release from stable version, to avoid a stable release without a beta release:

- Beta version = Stable version + 1
- Nightly version = Stable version + 2
- Planned version = Stable version + 3

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/pull/27158#discussion_r2171109673

When the Edge Beta release is promoted to Stable, the Edge Dev release is not necessarily promoted to Beta yet.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
