### PR TITLE
Bump range cutoff date to 2020-05-19

### DIFF
--- a/lint/linter/test-versions.ts
+++ b/lint/linter/test-versions.ts
@@ -17,14 +17,8 @@ import {
 import bcd from '../../index.js';
 const { browsers } = bcd;
 
-const now = new Date();
-
 /* The latest date a range's release can correspond to */
-const rangeCutoffDate = new Date(
-  now.getFullYear() - 5,
-  now.getMonth(),
-  now.getDate(),
-);
+const rangeCutoffDate = '2020-05-19';
 
 const browserTips: Record<string, string> = {
   nodejs:
@@ -154,10 +148,10 @@ const checkVersions = (
           if (
             !releaseData ||
             !releaseData.release_date ||
-            new Date(releaseData.release_date) > rangeCutoffDate
+            releaseData.release_date > rangeCutoffDate
           ) {
             logger.error(
-              chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Ranged values are only allowed for browser versions released on or before ${rangeCutoffDate.toDateString()}. (Ranged values are also not allowed for browser versions without a known release date.)`,
+              chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Ranged values are only allowed for browser versions released on or before ${rangeCutoffDate}. (Ranged values are also not allowed for browser versions without a known release date.)`,
             );
           }
         }


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Bump range cutoff date to 2025-05-19, which is the earliest date possible, due to [these Chrome 83 ranges](https://github.com/search?q=repo%3Amdn%2Fbrowser-compat-data+%2F%22chrome%22%3A+%5C%7B%5Cn%5Cs*%22version_added%22%3A+%22%E2%89%A483%22%2F&type=code) (released 2025-05-19).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
