### PR TITLE
Re-add IDBDatabase abort event

### DIFF
--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -98,6 +98,58 @@
           }
         }
       },
+      "abort_event": {
+        "__compat": {
+          "description": "`abort` event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/abort_event",
+          "spec_url": [
+            "https://w3c.github.io/IndexedDB/#transaction-abort",
+            "https://w3c.github.io/IndexedDB/#dom-idbdatabase-onabort"
+          ],
+          "tags": [
+            "web-features:indexeddb"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": "Unknown limitations"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": "≤37"
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/close",


### PR DESCRIPTION
Based on https://github.com/mdn/browser-compat-data/pull/15006.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds the `abort` event on `IDBDatabase`.

#### Test results and supporting details

The data was originally removed in https://github.com/mdn/browser-compat-data/pull/15006.

#### Related issues

Fixes: https://github.com/mdn/browser-compat-data/issues/15345
