### PR TITLE
FF141 File.webkitRelativePath / HTMLInputElement.webkitdirectory

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -294,7 +294,9 @@
               "version_added": "50"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "Always an empty string ([bug 1973726](https://bugzil.la/1973726))."
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3176,7 +3176,9 @@
               "version_added": "50"
             },
             "firefox_android": {
-              "version_added": "141"
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": "`File` entries returned for a selected directory have an empty string for `webkitRelativePath` ([bug 1973726](https://bugzil.la/1973726))."
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
Firefox 141 supports `webkitdirectory` on android in https://bugzilla.mozilla.org/show_bug.cgi?id=1887878, which was added in #27108

What this does is allow you to mark that an input offers a folder selector, and when you select a folder it returns an array of `File` entries with the path in the [`File.webkitRelativePath`](https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath) property (see [`HTMLInputElement.webkitdirectory`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory#examples) for detail).

But it turns out that on Firefox for Android the returned `webkitRelativePath` is always an empty string.
What I think this means is that FF supports `webkitRelativePath` and `HTMLInputElement/webkitdirectory` in the sense that they exist as entities, but they are both partial implementations.

@danielhjacobs Can you please confirm this.

I have updated the features appropriately.


Related docs work can be tracked in https://github.com/mdn/content/issues/40024




