### PR TITLE
Update Firefox data for RTCStatsReport API

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -2606,7 +2606,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤73"
+                "version_added": "≤60"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -5359,7 +5359,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤73"
+                "version_added": "≤60"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `RTCStatsReport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport
