### PR TITLE
Chrome 63 allowed all HTML character refs in VTTCue text

### DIFF
--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -486,7 +486,7 @@
         },
         "all_html_character_references": {
           "__compat": {
-            "description": "All HTML character references allowed.",
+            "description": "Allows all HTML character references",
             "tags": [
               "web-features:webvtt"
             ],


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `text.all_html_character_references` member of the `VTTCue` API. This data comes from tests on WPT (which is where the original data for this feature came from): https://wpt.fyi/results/webvtt/parsing/cue-text-parsing/tests/entities.html?label=stable&product=chrome-60.0
