### PR TITLE
Firefox 22 added `flex-direction` CSS property

### DIFF
--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -30,7 +30,7 @@
             ],
             "firefox": [
               {
-                "version_added": "20",
+                "version_added": "22",
                 "notes": "Since Firefox 28, multi-line flexbox is supported."
               },
               {
@@ -102,7 +102,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "22"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -145,7 +145,7 @@
                   "version_added": "81"
                 },
                 {
-                  "version_added": "≤72",
+                  "version_added": "22",
                   "version_removed": "81",
                   "partial_implementation": true,
                   "notes": "Before Firefox 81, overflow with `column-reverse` was unsupported. See [bug 1042151](https://bugzil.la/1042151)."
@@ -188,7 +188,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "22"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -231,7 +231,7 @@
                   "version_added": "81"
                 },
                 {
-                  "version_added": "≤72",
+                  "version_added": "22",
                   "version_removed": "81",
                   "partial_implementation": true,
                   "notes": "Before Firefox 81, overflow with `column-reverse` was unsupported. See [bug 1042151](https://bugzil.la/1042151)."


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `flex-direction` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/flex-direction
