### PR TITLE
Update Firefox data for flex CSS property

### DIFF
--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -30,7 +30,7 @@
             ],
             "firefox": [
               {
-                "version_added": "20",
+                "version_added": "22",
                 "notes": [
                   "Since Firefox 28, multi-line flexbox is supported.",
                   "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at `0`.",
@@ -102,7 +102,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "22"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `flex` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/flex
