### PR TITLE
Update Safari data for css.properties.overflow-x.auto

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -100,7 +100,7 @@
                 },
                 {
                   "alternative_name": "overlay",
-                  "version_added": "≤13.1"
+                  "version_added": "6"
                 }
               ],
               "safari_ios": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `auto` member of the `overflow-x` CSS property. This sets the downstream browser(s) to mirror from their upstream counterpart.
