### PR TITLE
Safari 6 supported CSS `overflow-y: auto` with alt name

### DIFF
--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -100,7 +100,8 @@
                 },
                 {
                   "alternative_name": "overlay",
-                  "version_added": "6"
+                  "version_added": "6",
+                  "notes": "Before Safari 12.1, `overlay` only had an effect on legacy scrollbars on macOS. Since Safari 12.1, it is parsed as `auto`."
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -100,7 +100,7 @@
                 },
                 {
                   "alternative_name": "overlay",
-                  "version_added": "≤13.1"
+                  "version_added": "6"
                 }
               ],
               "safari_ios": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `auto` member of the `overflow-y` CSS property. This sets the downstream browser(s) to mirror from their upstream counterpart.
