### PR TITLE
Update all browsers data for text-orientation CSS property

### DIFF
--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -67,7 +67,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
                 },
                 {
                   "alternative_name": "sideways-right",
-                  "version_added": "≤83"
+                  "version_added": "25"
                 }
               ],
               "chrome_android": "mirror",
@@ -105,7 +105,7 @@
                 },
                 {
                   "alternative_name": "sideways-right",
-                  "version_added": "≤72"
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",
@@ -147,7 +147,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `text-orientation` CSS property. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code:

```

(Using bcd.testCSSProperty() from the collector)

```
