### PR TITLE
Firefox 1 added `::-moz-list-number` CSS pseudo-element

### DIFF
--- a/css/selectors/-moz-list-number.json
+++ b/css/selectors/-moz-list-number.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤69"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/selectors/-moz-list-number.json
+++ b/css/selectors/-moz-list-number.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "≤69"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `-moz-list-number` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/-moz-list-number
