### PR TITLE
Firefox 23 started supporting vertical HTML range inputs

### DIFF
--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -126,7 +126,7 @@
                     "notes": "Vertical orientation available via the `writing-mode` property (see [Creating vertical controls](https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls))."
                   },
                   {
-                    "version_added": "23",
+                    "version_added": "22",
                     "version_removed": "120",
                     "impl_url": [
                       "https://bugzil.la/840820",

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -126,7 +126,7 @@
                     "notes": "Vertical orientation available via the `writing-mode` property (see [Creating vertical controls](https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls))."
                   },
                   {
-                    "version_added": "≤72",
+                    "version_added": "23",
                     "version_removed": "120",
                     "impl_url": [
                       "https://bugzil.la/840820",
@@ -136,7 +136,22 @@
                     "notes": "Supported using the non-standard `orient=\"vertical\"` attribute."
                   }
                 ],
-                "firefox_android": "mirror",
+                "firefox_android": [
+                  {
+                    "version_added": "120",
+                    "notes": "Vertical orientation available via the `writing-mode` property (see [Creating vertical controls](https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls))."
+                  },
+                  {
+                    "version_added": "52",
+                    "version_removed": "120",
+                    "impl_url": [
+                      "https://bugzil.la/840820",
+                      "https://bugzil.la/981916"
+                    ],
+                    "partial_implementation": true,
+                    "notes": "Supported using the non-standard `orient=\"vertical\"` attribute."
+                  }
+                ],
                 "ie": {
                   "version_added": "10",
                   "notes": "Vertical orientation available by setting the `writing-mode: bt-lr` style on the `input` element."

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -141,10 +141,7 @@
                   {
                     "version_added": "52",
                     "version_removed": "120",
-                    "impl_url": [
-                      "https://bugzil.la/840820",
-                      "https://bugzil.la/981916"
-                    ],
+                    "impl_url": "https://bugzil.la/840820",
                     "partial_implementation": true,
                     "notes": "Supported using the non-standard `orient=\"vertical\"` attribute."
                   }

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -128,10 +128,7 @@
                   {
                     "version_added": "22",
                     "version_removed": "120",
-                    "impl_url": [
-                      "https://bugzil.la/840820",
-                      "https://bugzil.la/981916"
-                    ],
+                    "impl_url": "https://bugzil.la/840820",
                     "partial_implementation": true,
                     "notes": "Supported using the non-standard `orient=\"vertical\"` attribute."
                   }

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -126,7 +126,7 @@
                     "notes": "Vertical orientation available via the `writing-mode` property (see [Creating vertical controls](https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls))."
                   },
                   {
-                    "version_added": "22",
+                    "version_added": "23",
                     "version_removed": "120",
                     "impl_url": "https://bugzil.la/840820",
                     "partial_implementation": true,


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `type_range.vertical_orientation` member of the `input` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code:

```

<input id="foo" type="range" orient="vertical" />

```
