### PR TITLE
Update all browsers data for html.elements.link.sizes

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1485,12 +1485,12 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72",
+                "version_added": "31",
                 "impl_url": "https://bugzil.la/441770"
               },
               "firefox_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `sizes` member of the `link` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/link/sizes
