### PR TITLE
Chrome 47 / Safari 8 added `<rtc>` HTML element

### DIFF
--- a/html/elements/rtc.json
+++ b/html/elements/rtc.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#rtc",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "47"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -19,7 +19,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `rtc` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/rtc
