### PR TITLE
Update Safari data for html.global_attributes.contenteditable.plaintext-only

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -353,7 +353,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `contenteditable.plaintext-only` member of the `global_attributes` HTML feature. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code:

```

```
