### PR TITLE
Safari 13.1 added `mutable-globals` WebAssembly feature

### DIFF
--- a/webassembly/mutable-globals.json
+++ b/webassembly/mutable-globals.json
@@ -20,7 +20,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "≤13.1"
+            "version_added": "13.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `mutable-globals` WebAssembly feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/mutable-globals
