### PR TITLE
webextension.api add missing `__compat` objects

### DIFF
--- a/webextensions/api/bookmarks.json
+++ b/webextensions/api/bookmarks.json
@@ -2,6 +2,28 @@
   "webextensions": {
     "api": {
       "bookmarks": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror"
+          }
+        },
         "BookmarkTreeNode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode",

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -21,9 +21,34 @@
           }
         },
         "DataTypeSet": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/DataTypeSet",
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "85"
+                },
+                {
+                  "version_added": "56",
+                  "version_removed": "79"
+                }
+              ],
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
           "cache": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/DataTypeSet",
               "support": {
                 "chrome": {
                   "version_added": "26"
@@ -302,9 +327,34 @@
           }
         },
         "RemovalOptions": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/RemovalOptions",
+            "support": {
+              "chrome": {
+                "version_added": "19"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": [
+                {
+                  "version_added": "84"
+                },
+                {
+                  "version_added": "56",
+                  "version_removed": "79"
+                }
+              ],
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
           "cookieStoreId": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/RemovalOptions",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -659,6 +709,25 @@
             }
           },
           "removalOptions": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "58"
+                },
+                "firefox_android": {
+                  "version_added": "85"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "hostnames": {
               "__compat": {
                 "support": {

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -2,6 +2,28 @@
   "webextensions": {
     "api": {
       "cookies": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies",
+          "support": {
+            "chrome": {
+              "version_added": "6"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "opera": "mirror",
+            "safari": {
+              "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
+            }
+          }
+        },
         "Cookie": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie",

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -770,6 +770,26 @@
             }
           },
           "ExtensionSidebarPane": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane",
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "onHidden": {
               "__compat": {
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onHidden",

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -100,6 +100,27 @@
           }
         },
         "DownloadItem": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/DownloadItem",
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": "48",
+                "version_removed": "79"
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
           "byExtensionId": {
             "__compat": {
               "support": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -854,6 +854,25 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "22"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
             "id": {
               "__compat": {
                 "support": {
@@ -1321,6 +1340,25 @@
             }
           },
           "options": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "32"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "includeTlsChannelId": {
               "__compat": {
                 "support": {
@@ -1334,25 +1372,6 @@
                   "firefox_android": {
                     "version_added": "48"
                   },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
-              }
-            },
-            "toProxyScript": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "55"
-                  },
-                  "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
                     "version_added": false

--- a/webextensions/api/sidebarAction.json
+++ b/webextensions/api/sidebarAction.json
@@ -136,6 +136,25 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "61"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "windowId": {
               "__compat": {
                 "support": {
@@ -183,6 +202,25 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "61"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "windowId": {
               "__compat": {
                 "support": {
@@ -358,6 +396,25 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "61"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "windowId": {
               "__compat": {
                 "support": {
@@ -427,6 +484,25 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "61"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "windowId": {
               "__compat": {
                 "support": {
@@ -496,6 +572,25 @@
             }
           },
           "details": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "61"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "windowId": {
               "__compat": {
                 "support": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -595,7 +595,6 @@
               "firefox_android": {
                 "version_added": "54"
               },
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab",
               "opera": "mirror",
               "safari": {
                 "version_added": "14"

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -580,6 +580,31 @@
           }
         },
         "Tab": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab",
+            "support": {
+              "chrome": {
+                "version_added": "5"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
+              }
+            }
+          },
           "active": {
             "__compat": {
               "support": {
@@ -1547,6 +1572,31 @@
             }
           },
           "connectInfo": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "41"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "`name` is supported, but `frameId` is not."
+                },
+                "safari_ios": {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": "`name` is supported, but `frameId` is not."
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {
@@ -2851,6 +2901,29 @@
             }
           },
           "changeInfo": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "4"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
             "audible": {
               "__compat": {
                 "support": {
@@ -3142,6 +3215,25 @@
               }
             },
             "properties": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "61"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              },
               "groupId": {
                 "__compat": {
                   "support": {
@@ -3924,6 +4016,27 @@
             }
           },
           "options": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "41"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -686,6 +686,27 @@
             }
           },
           "createData": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "4"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": "mirror"
+              }
+            },
             "allowScriptsToClose": {
               "__compat": {
                 "support": {

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -704,7 +704,9 @@
                 "safari": {
                   "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             },
             "allowScriptsToClose": {


### PR DESCRIPTION
#### Summary

This change adds missing `__compat` objects to the path of several web extension API features. 

This was done for two reasons:

- The definition of the scheme of states that "identifiers without __compat aren't necessarily features". The items affected in this PR are features.
- It resolves some presentation issues. For example, take the example of `browsingData.DataTypeSet`:

  - In the BCD data presented about [`browsingData`,](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browsingData#browser_compatibility) `DataTypeSet` is not listed.
  - In the BCD about [`DataTypeSet`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/DataTypeSet#browser_compatibility) the properties are listed, however, the first property has a link back to the page, rather than the link being on `DataTypeSet`.


**Note**. Removed `runtime.sendMessage.options.toProxyScript` as it's not mentioned in the [runtime schema](https://searchfox.org/mozilla-central/source/toolkit/components/extensions/schemas/runtime.json), documented on MDM, or mentioned in any item.
