### PR TITLE
Edge supports `summarizer` Permissions Policy only behind flag

### DIFF
--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1167,7 +1167,16 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "138",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-summarization-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
               "firefox": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

I didn't actually test this, I just assumed based on the other data for this API.

#### Test results and supporting details

@chrisdavidmills or @captainbrosset, perhaps you can confirm this? According to [the latest web-features BCD upgrade](https://github.com/web-platform-dx/web-features/pull/3091/files#diff-d6329fa3335acf35c4636cb79b6cf8d2b3a561855cf39f696ca719929f4c1e2a), this is the only part _not_ behind a flag in Edge, which looks suspicious to me.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/26875

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
