### PR TITLE
Safari 26 adds beforetoggle / toggle events on dialog elements

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -475,7 +475,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2777,7 +2777,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This was the commit that added support for them: https://github.com/WebKit/WebKit/commit/bd7649ea03d308c55de707c6cf8488dc552d43f9

Manually tested here: https://jsfiddle.net/ktmfjn97/1/