### PR TITLE
Chrome 137 added `exceptionsFinal` WebAssembly feature

### DIFF
--- a/webassembly/exceptionsFinal.json
+++ b/webassembly/exceptionsFinal.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "137"
           },
           "chrome_android": "mirror",
           "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `exceptionsFinal` WebAssembly feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/exceptionsFinal
