### PR TITLE
Edge 137 also supports `jspi` WebAssembly feature

### DIFF
--- a/webassembly/jspi.json
+++ b/webassembly/jspi.json
@@ -11,9 +11,7 @@
           "chrome_android": {
             "version_added": false
           },
-          "edge": {
-            "version_added": false
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `jspi` WebAssembly feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/jspi
