### PR TITLE
Add an mdn_url for OffscreenCanvasRenderingContext2D.getContextAttrib…

### DIFF
--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -955,6 +955,7 @@
       },
       "getContextAttributes": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getContextAttributes",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-canvas-getcontextattributes",
           "support": {
             "chrome": {


### PR DESCRIPTION
MDN documents all OffscreenCanvasRenderingContext2D members under CanvasRenderingContext2D. Adding the missing mdn_url here manually as the inventory cannot know this. It is also already done throughout the remaining of this file like this