### PR TITLE
Deno 1.46 supports URLPattern.hasRegExpGroups and ignoreCase option

### DIFF
--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -202,6 +202,9 @@
               "version_added": "122"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.46"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -89,7 +89,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.46"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
https://github.com/denoland/deno/releases/tag/v1.46.0