### PR TITLE
webextensions.api.downloads.DownloadItem byExtensionId and byExtensionName fixed in FF 69

### DIFF
--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -175,7 +175,6 @@
                   "version_added": "48",
                   "version_removed": "79",
                   "partial_implementation": true,
-                  "partial_implementation": true,
                   "notes": "Always returns `undefined`."
                 },
                 "opera": "mirror",

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -135,12 +135,14 @@
                   {
                     "version_added": "47",
                     "version_removed": "69",
+                    "partial_implementation": true,
                     "notes": "Always returns `undefined`."
                   }
                 ],
                 "firefox_android": {
                   "version_added": "48",
                   "version_removed": "79",
+                  "partial_implementation": true,
                   "notes": "Always returns `undefined`."
                 },
                 "opera": "mirror",
@@ -165,12 +167,14 @@
                   {
                     "version_added": "47",
                     "version_removed": "69",
+                    "partial_implementation": true,
                     "notes": "Always returns `undefined`."
                   }
                 ],
                 "firefox_android": {
                   "version_added": "48",
                   "version_removed": "79",
+                  "partial_implementation": true,
                   "notes": "Always returns `undefined`."
                 },
                 "opera": "mirror",

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -128,13 +128,27 @@
                   "version_added": "30"
                 },
                 "edge": "mirror",
-                "firefox": {
-                  "version_added": "47"
-                },
-                "firefox_android": {
-                  "version_added": "48",
-                  "version_removed": "79"
-                },
+                "firefox": [
+                  {
+                    "version_added": "69"
+                  },
+                  {
+                    "version_added": "47",
+                    "version_removed": "69",
+                    "notes": "Always returns `undefined`."
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "69",
+                    "version_removed": "79"
+                  },
+                  {
+                    "version_added": "48",
+                    "version_removed": "69",
+                    "notes": "Always returns `undefined`."
+                  }
+                ],
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -150,13 +164,27 @@
                   "version_added": "30"
                 },
                 "edge": "mirror",
-                "firefox": {
-                  "version_added": "47"
-                },
-                "firefox_android": {
-                  "version_added": "48",
-                  "version_removed": "79"
-                },
+                "firefox": [
+                  {
+                    "version_added": "69"
+                  },
+                  {
+                    "version_added": "47",
+                    "version_removed": "69",
+                    "notes": "Always returns `undefined`."
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "69",
+                    "version_removed": "79"
+                  },
+                  {
+                    "version_added": "48",
+                    "version_removed": "69",
+                    "notes": "Always returns `undefined`."
+                  }
+                ],
                 "opera": "mirror",
                 "safari": {
                   "version_added": false

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -175,6 +175,7 @@
                   "version_added": "48",
                   "version_removed": "79",
                   "partial_implementation": true,
+                  "partial_implementation": true,
                   "notes": "Always returns `undefined`."
                 },
                 "opera": "mirror",

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -138,17 +138,11 @@
                     "notes": "Always returns `undefined`."
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "69",
-                    "version_removed": "79"
-                  },
-                  {
-                    "version_added": "48",
-                    "version_removed": "69",
-                    "notes": "Always returns `undefined`."
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79",
+                  "notes": "Always returns `undefined`."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -174,17 +168,11 @@
                     "notes": "Always returns `undefined`."
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "69",
-                    "version_removed": "79"
-                  },
-                  {
-                    "version_added": "48",
-                    "version_removed": "69",
-                    "notes": "Always returns `undefined`."
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79",
+                  "notes": "Always returns `undefined`."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false


### PR DESCRIPTION
#### Summary

The initial implementation contained an error, resulting in the two properties being returned as undefined. This issue was fixed in [Bug 1305663](https://bugzilla.mozilla.org/show_bug.cgi?id=1305663) Support downloadItem.byExtensionId

#### Related issues

Fixes #27210