### PR TITLE
Chrome 136 returns MediaTrackSettings.screenPixelRatio

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -1134,6 +1134,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false
+                "impl_url": "https://bugzil.la/1965499"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -1120,9 +1120,9 @@
             "deprecated": false
           }
         },
-        "screenPixelRatio": {
+        "return_object_property_screenPixelRatio": {
           "__compat": {
-            "description": "Return object contains `screenPixelRatio`",
+            "description": "`screenPixelRatio` property in returned object",
             "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediatracksettings-screenpixelratio",
             "support": {
               "chrome": {

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -1122,7 +1122,7 @@
         },
         "return_object_property_screenPixelRatio": {
           "__compat": {
-            "description": "`screenPixelRatio` property in returned object",
+            "description": "[`screenPixelRatio`](https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/screenPixelRatio) property in returned object",
             "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediatracksettings-screenpixelratio",
             "support": {
               "chrome": {
@@ -1133,7 +1133,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
                 "impl_url": "https://bugzil.la/1965499"
               },
               "firefox_android": "mirror",

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -1122,7 +1122,8 @@
         },
         "return_object_property_screenPixelRatio": {
           "__compat": {
-            "description": "[`screenPixelRatio`](https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/screenPixelRatio) property in returned object",
+            "description": "`screenPixelRatio` property in returned object",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/screenPixelRatio",
             "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediatracksettings-screenpixelratio",
             "support": {
               "chrome": {

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -1119,6 +1119,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "screenPixelRatio": {
+          "__compat": {
+            "description": "Return object contains `screenPixelRatio`",
+            "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediatracksettings-screenpixelratio",
+            "support": {
+              "chrome": {
+                "version_added": "136"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "id": {


### PR DESCRIPTION
…ettings subfeature

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Previously, I tried to add data for `MediaTrackSettings.screenPixelRatio` in its own `MediaTrackSettings` file, but then learned that we don't do BCD for dictionaries only. You can see the following for the backstory:

- https://github.com/mdn/browser-compat-data/pull/27092
- https://github.com/mdn/browser-compat-data/issues/27119

This PR takes a different approach, suggested by @wbamberg, which instead adds a sub-data point to `MediaStreamTrack.getSettings()` to represent `screenPixelRatio`. This makes sense, as `getSettings()` returns a `MediaTrackSettings` object.

What do we think of this approach?

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
