### PR TITLE
Chrome 136 captured-surface-control Permissions

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -223,6 +223,39 @@
           }
         }
       },
+      "permission_captured-surface-control": {
+        "__compat": {
+          "description": "`captured-surface-control` permission",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "permission_clipboard-read": {
         "__compat": {
           "description": "`clipboard-read` permission",

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -278,6 +278,39 @@
             }
           }
         },
+        "captured-surface-control": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/mediacapture-surface-control/#feature-policy-integration",
+            "support": {
+              "chrome": {
+                "version_added": "136"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "compute-pressure": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/compute-pressure",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 136 adds support for the [Captured Surface Control API](https://w3c.github.io/mediacapture-surface-control/), another extension to the [Screen Capture API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API). See https://chromestatus.com/feature/5092615678066688 for details of the addition.

I'm currently documenting the API over in https://github.com/mdn/content/pull/39982. At the point I started, most of the relevant BCD was already added, but I just noticed that the BCD for the permissions aspects of the API was missing.

This PR adds data points for the permissions aspects, namely:

- The `captured-surface-control` `Permissions-Policy` HTTP header directive.
- The `captured-surface-control` Permissions API permission.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
