### PR TITLE
Use more stable headings/dfns for ECMAScript spec_urls

### DIFF
--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -4,7 +4,7 @@
       "Float32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:typed-arrays",
             "web-features:snapshot:ecmascript-2015"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -4,7 +4,7 @@
       "Float64Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:typed-arrays",
             "web-features:snapshot:ecmascript-2015"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -4,7 +4,7 @@
       "Int16Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:typed-arrays",
             "web-features:snapshot:ecmascript-2015"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -4,7 +4,7 @@
       "Int32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:typed-arrays",
             "web-features:snapshot:ecmascript-2015"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -4,7 +4,7 @@
       "Int8Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:typed-arrays",
             "web-features:snapshot:ecmascript-2015"

--- a/javascript/builtins/Intl/Collator.json
+++ b/javascript/builtins/Intl/Collator.json
@@ -54,7 +54,7 @@
             "__compat": {
               "description": "`Collator()` constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator",
-              "spec_url": "https://tc39.es/ecma402/#sec-the-intl-collator-constructor",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl-collator-constructor",
               "tags": [
                 "web-features:intl"
               ],

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Temporal API",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal",
-          "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-intro",
+          "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-objects",
           "tags": [
             "web-features:temporal"
           ],

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -4,7 +4,7 @@
       "Uint16Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:typed-arrays",
             "web-features:snapshot:ecmascript-2015"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -4,7 +4,7 @@
       "Uint32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:snapshot:ecmascript-2015",
             "web-features:typed-arrays"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -4,7 +4,7 @@
       "Uint8Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:typed-arrays",
             "web-features:snapshot:ecmascript-2015"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -4,7 +4,7 @@
       "Uint8ClampedArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray",
-          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
             "web-features:typed-arrays",
             "web-features:snapshot:ecmascript-2015"


### PR DESCRIPTION
ECMAScript breakout of https://github.com/mdn/browser-compat-data/pull/23958.

This PR fixes **some** ECMAScript `spec_urls` to use more stable headings and dfns that are (will be) exported by webref. See the discussion in https://github.com/mdn/browser-compat-data/pull/23958#pullrequestreview-2991570241. The goal is that BCD does a deeper validation of spec_urls including anchors.

@tidoust says
> 72 links to ECMAScript that target tables or production rules. In some cases, I wonder about these links. That is, they don't strike me as developer-friendly. Wouldn't targeting the enclosing section be better?

I fixed this for the tables. For the prod spec urls, I wasn't sure if linking to the section would be good. Or if webref should consider making '#prod-' ids official dfns? Maybe @Josh-Cena has thoughts. 

<details><summary>List #prod-* spec urls that would fail validation and that would need links to the corresponding heading or dfn</summary>
<p>

 ✖ javascript.classes.private_class_fields - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-PrivateIdentifier.
 ✖ javascript.classes.private_class_fields_in - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-00OK517S.
 ✖ javascript.classes.private_class_methods - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-PrivateIdentifier.
 ✖ javascript.classes.public_class_fields - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-FieldDefinition.
 ✖ javascript.classes.static.class_fields - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-FieldDefinition.
 ✖ javascript.classes.static.initialization_blocks - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock.
 ✖ javascript.grammar.binary_numeric_literals - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-BinaryIntegerLiteral.
 ✖ javascript.grammar.decimal_numeric_literals - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-DecimalLiteral.
 ✖ javascript.grammar.hexadecimal_escape_sequences - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-HexEscapeSequence.
 ✖ javascript.grammar.hexadecimal_numeric_literals - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-HexIntegerLiteral.
 ✖ javascript.grammar.numeric_separators - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-NumericLiteralSeparator.
 ✖ javascript.grammar.octal_numeric_literals - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-OctalIntegerLiteral.
 ✖ javascript.grammar.unicode_point_escapes - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-UnicodeEscapeSequence.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-Elision.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ObjectLiteral.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ArrayLiteral.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-Arguments.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-FormalParameters.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-CoverParenthesizedExpressionAndArrowParameterList.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-NamedImports.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-NamedExports.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-QuantifierPrefix.
 ✖ javascript.grammar.trailing_commas - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#prod-annexB-InvalidBracedQuantifier.
 ✖ javascript.operators.bitwise_and - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseANDExpression.
 ✖ javascript.operators.bitwise_or - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseORExpression.
 ✖ javascript.operators.bitwise_xor - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseXORExpression.
 ✖ javascript.operators.import_meta - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ImportMeta.
 ✖ javascript.operators.logical_and - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-LogicalANDExpression.
 ✖ javascript.operators.logical_or - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-LogicalORExpression.
 ✖ javascript.operators.nullish_coalescing - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-CoalesceExpression.
 ✖ javascript.operators.optional_chaining - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-OptionalExpression.
 ✖ javascript.operators.spread - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-SpreadElement.
 ✖ javascript.operators.spread - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ArgumentList.
 ✖ javascript.operators.spread - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-PropertyDefinition.
 ✖ javascript.operators.spread.spread_in_arrays - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-SpreadElement.
 ✖ javascript.operators.spread.spread_in_function_calls - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ArgumentList.
 ✖ javascript.operators.spread.spread_in_object_literals - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-PropertyDefinition.
 ✖ javascript.operators.yield - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-YieldExpression.
 ✖ javascript.regular_expressions.backreference - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-DecimalEscape.
 ✖ javascript.regular_expressions.capturing_group - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Atom.
 ✖ javascript.regular_expressions.character_class - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-CharacterClass.
 ✖ javascript.regular_expressions.character_class_escape - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-CharacterClassEscape.
 ✖ javascript.regular_expressions.character_escape - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-CharacterEscape.
 ✖ javascript.regular_expressions.disjunction - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Disjunction.
 ✖ javascript.regular_expressions.input_boundary_assertion - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion.
 ✖ javascript.regular_expressions.literal_character - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-PatternCharacter.
 ✖ javascript.regular_expressions.lookahead_assertion - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion.
 ✖ javascript.regular_expressions.lookbehind_assertion - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion.
 ✖ javascript.regular_expressions.modifier - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-RegularExpressionModifiers.
 ✖ javascript.regular_expressions.named_backreference - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-AtomEscape.
 ✖ javascript.regular_expressions.named_capturing_group - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Atom.
 ✖ javascript.regular_expressions.non_capturing_group - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Atom.
 ✖ javascript.regular_expressions.quantifier - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Quantifier.
 ✖ javascript.regular_expressions.unicode_character_class_escape - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-CharacterClassEscape.
 ✖ javascript.regular_expressions.wildcard - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Atom.
 ✖ javascript.regular_expressions.word_boundary_assertion - Error → Invalid specification fragment found: https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion.
 ✖ javascript.statements.import.import_attributes - Error → Invalid specification fragment found: https://tc39.es/proposal-import-attributes/#prod-WithClause.

</p>
</details> 
