### PR TITLE
Chrome 138 data for Web Codecs flip and rotate options

### DIFF
--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -150,7 +150,7 @@
         "flip_option": {
           "__compat": {
             "description": "`flip` configuration option",
-            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videodecoderconfig-flip",
+            "spec_url": "https://w3c.github.io/webcodecs/#dom-videodecoderconfig-flip",
             "tags": [
               "web-features:webcodecs"
             ],
@@ -185,7 +185,7 @@
         "rotation_option": {
           "__compat": {
             "description": "`rotation` configuration option",
-            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videodecoderconfig-rotation",
+            "spec_url": "https://w3c.github.io/webcodecs/#dom-videodecoderconfig-rotation",
             "tags": [
               "web-features:webcodecs"
             ],
@@ -407,7 +407,7 @@
         "flip_option": {
           "__compat": {
             "description": "`flip` configuration option",
-            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videodecoderconfig-flip",
+            "spec_url": "https://w3c.github.io/webcodecs/#dom-videodecoderconfig-flip",
             "tags": [
               "web-features:webcodecs"
             ],
@@ -442,7 +442,7 @@
         "rotation_option": {
           "__compat": {
             "description": "`rotation` configuration option",
-            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videodecoderconfig-rotation",
+            "spec_url": "https://w3c.github.io/webcodecs/#dom-videodecoderconfig-rotation",
             "tags": [
               "web-features:webcodecs"
             ],

--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -146,6 +146,76 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "flip_option": {
+          "__compat": {
+            "description": "`flip` configuration option",
+            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videodecoderconfig-flip",
+            "tags": [
+              "web-features:webcodecs"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "rotation_option": {
+          "__compat": {
+            "description": "`rotation` configuration option",
+            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videodecoderconfig-rotation",
+            "tags": [
+              "web-features:webcodecs"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "decode": {
@@ -332,6 +402,76 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "flip_option": {
+          "__compat": {
+            "description": "`flip` configuration option",
+            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videodecoderconfig-flip",
+            "tags": [
+              "web-features:webcodecs"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "rotation_option": {
+          "__compat": {
+            "description": "`rotation` configuration option",
+            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videodecoderconfig-rotation",
+            "tags": [
+              "web-features:webcodecs"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -68,6 +68,76 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "flip_option": {
+          "__compat": {
+            "description": "`flip` option",
+            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videoframeinit-flip",
+            "tags": [
+              "web-features:webcodecs"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "rotation_option": {
+          "__compat": {
+            "description": "`rotation` option",
+            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videoframeinit-rotation",
+            "tags": [
+              "web-features:webcodecs"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "allocationSize": {

--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -72,7 +72,7 @@
         "flip_option": {
           "__compat": {
             "description": "`flip` option",
-            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videoframeinit-flip",
+            "spec_url": "https://w3c.github.io/webcodecs/#dom-videoframeinit-rotation",
             "tags": [
               "web-features:webcodecs"
             ],
@@ -107,7 +107,7 @@
         "rotation_option": {
           "__compat": {
             "description": "`rotation` option",
-            "spec_url": "https://www.w3.org/TR/webcodecs/#dom-videoframeinit-rotation",
+            "spec_url": "https://w3c.github.io/webcodecs/#dom-videoframeinit-rotation",
             "tags": [
               "web-features:webcodecs"
             ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 138 adds support for the WebCodecs API `flip` and `rotate` options. See https://chromestatus.com/feature/5128855343595520

 @Elchi3 already added docs for these features, and the BCD for `VideoFrame.flip` and `VideoFrame.rotation` was added in https://github.com/mdn/browser-compat-data/pull/26937.

However, I thought it might be helpful to add data points for those options being available in the `VideoFrame()` constructor, `VideoDecoder.configure()`, and `VideoDecoder.isConfigSupported()`. This PR adds those things.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
