### PR TITLE
Revert "Bump codelytv/pr-size-labeler from 1.10.2 to 1.10.3"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,7 +21,7 @@ jobs:
     needs: label-py-path
     runs-on: ubuntu-latest
     steps:
-      - uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
+      - uses: codelytv/pr-size-labeler@1c3422395d899286d5ee2c809fd5aed264d5eb9b # v1.10.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           github_api_url: "https://api.github.com"


### PR DESCRIPTION
Reverts mdn/browser-compat-data#26896

See: https://github.com/CodelyTV/pr-size-labeler/issues/96