### PR TITLE
Update Edge data for svg SVG element

### DIFF
--- a/svg/elements/svg.json
+++ b/svg/elements/svg.json
@@ -57,7 +57,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1.5"
@@ -232,7 +232,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1.5"
@@ -453,7 +453,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1.5"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `svg` SVG element. https://github.com/mdn/browser-compat-data/pull/27177/files/61f57ef4e859ed2652834f6a49d194a4611e1204#r2178277143
