### PR TITLE
Safari 18.4 added `<input type=color>` with alpha/colorspace

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -431,12 +431,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/368059226"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1919718"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -153,7 +153,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "18.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -345,19 +345,21 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/368059226"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1919718"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "18.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -66,7 +66,9 @@
                   "version_added": false,
                   "impl_url": "https://bugzil.la/1919718"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -47,6 +47,43 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "accepts_css_colors": {
+            "__compat": {
+              "description": "Accepts any CSS `<color>` value",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#color-state-(type=color)",
+              "tags": [
+                "web-features:input-color"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/368059226"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1919718"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "18.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
- Shipped in Safari 18.4 https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes
- Add missing bug links