### PR TITLE
Safari 18.4 supports WebTransport behind a flag

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -30,7 +30,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18.4",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebTransport",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -74,7 +81,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -111,7 +125,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebTransport",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -149,7 +170,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebTransport",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -187,7 +215,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebTransport",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -225,7 +260,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebTransport",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -313,7 +355,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -357,7 +406,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -401,7 +457,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -445,7 +508,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -482,7 +552,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebTransport",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -529,7 +606,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -603,7 +687,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebTransport",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -648,7 +739,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -695,7 +793,16 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "Method is defined but throws a NotSupportedRrror."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -739,7 +846,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -783,7 +897,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -827,7 +948,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -871,7 +999,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/WebTransportBidirectionalStream.json
+++ b/api/WebTransportBidirectionalStream.json
@@ -30,7 +30,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18.4",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebTransport",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -73,7 +80,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -116,7 +130,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebTransport",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -161,7 +182,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -204,7 +232,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebTransport",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -30,7 +30,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18.4",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebTransport",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -116,7 +123,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -160,7 +174,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -204,7 +225,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -248,7 +276,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -292,7 +327,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -336,7 +378,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -379,7 +428,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/WebTransportError.json
+++ b/api/WebTransportError.json
@@ -30,7 +30,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18.4",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebTransport",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -74,7 +81,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -118,7 +132,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -162,7 +183,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/WebTransportReceiveStream.json
+++ b/api/WebTransportReceiveStream.json
@@ -30,7 +30,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18.4",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebTransport",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/WebTransportSendStream.json
+++ b/api/WebTransportSendStream.json
@@ -30,7 +30,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "18.4",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "WebTransport",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -116,7 +123,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -160,7 +174,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "18.4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "WebTransport",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Notes Safari 18.3.1ish's support for WebTransport behind its "WebTransport" Feature Flag.

#### Test results and supporting details

- Unfortunately, https://wpt.fyi/results/webtransport?label=experimental&label=master&aligned doesn't appear to be running Safari with the WebTransport Feature Flag set yet, so I had to get creative to test support
- Tested Safari 18.5 (not TP) functionality with https://wt-ord.akaleapi.net/echo/ and https://wt-ord.akaleapi.net/webcodecs-echo/ (minus visual frames for unrelated reasons), as well as a [custom fiddle](https://jsfiddle.net/jib1/2p6jceq4/) for a few details

- Relied on 18.3.1 BCD collector data in https://github.com/mdn/browser-compat-data/issues/26151#issuecomment-2801690212
#### Related issues

Fixes #26151. cc @ekinnear