### PR TITLE
Mark svg.elements.view.zoomAndPan as standard track

### DIFF
--- a/svg/elements/view.json
+++ b/svg/elements/view.json
@@ -134,7 +134,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }


### PR DESCRIPTION
I identified an inconsistency in our BCD status for `svg.elements.svg.zoomAndPan` and that of the `view` element. In fact, both are standardized [SVG 1.1](https://www.w3.org/TR/SVG11/linking.html#ViewElement) and removed in [SVG 2](https://svgwg.org/svg2-draft/linking.html#ViewElement), so they should either be both standard or non-standard. 