### PR TITLE
Update Edge data for foreignObject SVG element

### DIFF
--- a/svg/elements/foreignObject.json
+++ b/svg/elements/foreignObject.json
@@ -14,7 +14,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "2"
@@ -57,7 +57,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"
@@ -146,7 +146,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"
@@ -190,7 +190,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"
@@ -234,7 +234,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `foreignObject` SVG element. Considering the support data for all other browsers, it seems unlikely that Edge support came any later.
