### PR TITLE
Update Edge data for set SVG element

### DIFF
--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -14,7 +14,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"
@@ -167,7 +167,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `set` SVG element. Considering the support data for all other browsers, it seems unlikely that Edge support came any later.
