### PR TITLE
Update CSS resize support for Firefox/Android

### DIFF
--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -17,7 +17,11 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "79",
+              "notes": "The value is recognized, but has no effect. See [bug 1776834](https://bugzil.la/1776834)."
+            },
             "oculus": "mirror",
             "opera": {
               "version_added": "12.1"
@@ -56,7 +60,10 @@
               "firefox": {
                 "version_added": "63"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "63",
+                "version_removed": "79"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -93,7 +100,10 @@
                 "version_added": "5",
                 "notes": "`resize` doesn't have any effect on [`<iframe>`](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/iframe). See [bug 680823](https://bugzil.la/680823))"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "5",
+                "version_removed": "79"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -130,7 +140,10 @@
               "firefox": {
                 "version_added": "63"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "63",
+                "version_removed": "79"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",


### PR DESCRIPTION
Currently, Firefox/Android shows resizable control with the `resize` property, but it doesn't work well due to bug 1618678 and bug 1776834.

So this PR updates the `resize` property support in Firefox/Android.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
