### PR TITLE
FF142 File.webkitRelativePath/HTMLInputElement.webkitdirectory full support

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -293,11 +293,16 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": {
-              "version_added": "141",
-              "partial_implementation": true,
-              "notes": "Always an empty string ([bug 1973726](https://bugzil.la/1973726))."
-            },
+            "firefox_android": [
+              {
+                "version_added": "142"
+              },
+              {
+                "version_added": "141",
+                "partial_implementation": true,
+                "notes": "Always an empty string ([bug 1973726](https://bugzil.la/1973726))."
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3177,11 +3177,16 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": {
-              "version_added": "141",
-              "partial_implementation": true,
-              "notes": "`File` entries returned for a selected directory have an empty string for `webkitRelativePath` ([bug 1973726](https://bugzil.la/1973726))."
-            },
+            "firefox_android": [
+              {
+                "version_added": "142"
+              },
+              {
+                "version_added": "141",
+                "partial_implementation": true,
+                "notes": "`File` entries returned for a selected directory have an empty string for `webkitRelativePath` ([bug 1973726](https://bugzil.la/1973726))."
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",


### PR DESCRIPTION
#### Summary

Note that FF 142 fully supports File.webkitRelativePath and HTMLInputElement.webkitdirectory

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1973726
