### PR TITLE
Update api/ spec_urls

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -42,7 +42,7 @@
         "__compat": {
           "description": "`AudioBufferSourceNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/AudioBufferSourceNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-constructor-audiobuffersourcenode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-audiobuffersourcenode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/BatteryManager.json
+++ b/api/BatteryManager.json
@@ -112,7 +112,7 @@
           "description": "`chargingchange` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingchange_event",
           "spec_url": [
-            "https://w3c.github.io/battery/#ref-for-dfn-chargingchange-1",
+            "https://w3c.github.io/battery/#dfn-chargingchange",
             "https://w3c.github.io/battery/#dom-batterymanager-onchargingchange"
           ],
           "tags": [
@@ -198,7 +198,7 @@
           "description": "`chargingtimechange` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingtimechange_event",
           "spec_url": [
-            "https://w3c.github.io/battery/#ref-for-dfn-chargingtimechange-1",
+            "https://w3c.github.io/battery/#dfn-chargingtimechange",
             "https://w3c.github.io/battery/#dom-batterymanager-onchargingtimechange"
           ],
           "tags": [
@@ -284,7 +284,7 @@
           "description": "`dischargingtimechange` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingtimechange_event",
           "spec_url": [
-            "https://w3c.github.io/battery/#ref-for-dfn-dischargingtimechange-1",
+            "https://w3c.github.io/battery/#dfn-dischargingtimechange",
             "https://w3c.github.io/battery/#dom-batterymanager-ondischargingtimechange"
           ],
           "tags": [
@@ -360,7 +360,7 @@
           "description": "`levelchange` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/levelchange_event",
           "spec_url": [
-            "https://w3c.github.io/battery/#ref-for-dfn-levelchange-1",
+            "https://w3c.github.io/battery/#dfn-levelchange",
             "https://w3c.github.io/battery/#dom-batterymanager-onlevelchange"
           ],
           "tags": [

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1515,7 +1515,7 @@
         "__compat": {
           "description": "`paintWorklet` static property",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/paintWorklet_static",
-          "spec_url": "https://drafts.css-houdini.org/css-paint-api/#ref-for-dom-css-paintworklet",
+          "spec_url": "https://drafts.css-houdini.org/css-paint-api/#dom-css-paintworklet",
           "tags": [
             "web-features:paint"
           ],
@@ -2028,7 +2028,7 @@
         "__compat": {
           "description": "`supports()` static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/supports_static",
-          "spec_url": "https://drafts.csswg.org/css-conditional-3/#ref-for-dom-css-supports",
+          "spec_url": "https://drafts.csswg.org/css-conditional-3/#dom-css-supports",
           "tags": [
             "web-features:css-supports"
           ],

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -42,7 +42,7 @@
         "__compat": {
           "description": "`ChannelMergerNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChannelMergerNode/ChannelMergerNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-channelmergernode-constructor-channelmergernode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-channelmergernode-channelmergernode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -44,7 +44,7 @@
         "__compat": {
           "description": "`ChannelSplitterNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChannelSplitterNode/ChannelSplitterNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-channelsplitternode-constructor-channelsplitternode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-channelsplitternode-channelsplitternode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/ConstantSourceNode.json
+++ b/api/ConstantSourceNode.json
@@ -38,7 +38,7 @@
         "__compat": {
           "description": "`ConstantSourceNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstantSourceNode/ConstantSourceNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-constantsourcenode-constructor-constantsourcenode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-constantsourcenode-constantsourcenode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -42,7 +42,7 @@
         "__compat": {
           "description": "`ConvolverNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConvolverNode/ConvolverNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-convolvernode-constructor-convolvernode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-convolvernode-convolvernode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/DOMStringMap.json
+++ b/api/DOMStringMap.json
@@ -3,7 +3,7 @@
     "DOMStringMap": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMStringMap",
-        "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes:domstringmap-3",
+        "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#domstringmap",
         "tags": [
           "web-features:dataset"
         ],

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -40,7 +40,7 @@
         "__compat": {
           "description": "`DelayNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DelayNode/DelayNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-delaynode-constructor-delaynode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-delaynode-delaynode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -82,7 +82,7 @@
       "acceleration": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent/acceleration",
-          "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-acceleration③",
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotionevent-acceleration",
           "tags": [
             "web-features:device-orientation-events"
           ],
@@ -124,7 +124,7 @@
       "accelerationIncludingGravity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent/accelerationIncludingGravity",
-          "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-accelerationincludinggravity④",
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotionevent-accelerationincludinggravity",
           "tags": [
             "web-features:device-orientation-events"
           ],
@@ -166,7 +166,7 @@
       "interval": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent/interval",
-          "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-interval①",
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotionevent-interval",
           "tags": [
             "web-features:device-orientation-events"
           ],
@@ -245,7 +245,7 @@
       "rotationRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent/rotationRate",
-          "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-rotationrate②",
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotionevent-rotationrate",
           "tags": [
             "web-features:device-orientation-events"
           ],

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -94,7 +94,7 @@
       "absolute": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceOrientationEvent/absolute",
-          "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-deviceorientationevent-absolute",
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-deviceorientationevent-absolute",
           "tags": [
             "web-features:device-orientation-events"
           ],
@@ -136,7 +136,7 @@
       "alpha": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceOrientationEvent/alpha",
-          "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-deviceorientationevent-alpha③",
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-deviceorientationevent-alpha",
           "tags": [
             "web-features:device-orientation-events"
           ],
@@ -180,7 +180,7 @@
       "beta": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceOrientationEvent/beta",
-          "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-deviceorientationevent-beta②",
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-deviceorientationevent-beta",
           "tags": [
             "web-features:device-orientation-events"
           ],
@@ -224,7 +224,7 @@
       "gamma": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceOrientationEvent/gamma",
-          "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-deviceorientationevent-gamma②",
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-deviceorientationevent-gamma",
           "tags": [
             "web-features:device-orientation-events"
           ],

--- a/api/Document.json
+++ b/api/Document.json
@@ -3572,7 +3572,7 @@
       "exitPictureInPicture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/exitPictureInPicture",
-          "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-document-exitpictureinpicture",
+          "spec_url": "https://w3c.github.io/picture-in-picture/#dom-document-exitpictureinpicture",
           "tags": [
             "web-features:picture-in-picture"
           ],
@@ -5941,7 +5941,7 @@
       "pictureInPictureElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pictureInPictureElement",
-          "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-documentorshadowroot-pictureinpictureelement①⑤",
+          "spec_url": "https://w3c.github.io/picture-in-picture/#dom-documentorshadowroot-pictureinpictureelement",
           "tags": [
             "web-features:picture-in-picture"
           ],
@@ -5981,7 +5981,7 @@
       "pictureInPictureEnabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pictureInPictureEnabled",
-          "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-document-pictureinpictureenabled",
+          "spec_url": "https://w3c.github.io/picture-in-picture/#dom-document-pictureinpictureenabled",
           "tags": [
             "web-features:picture-in-picture"
           ],

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -40,7 +40,7 @@
         "__compat": {
           "description": "`DynamicsCompressorNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DynamicsCompressorNode/DynamicsCompressorNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-constructor-dynamicscompressornode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-dynamicscompressornode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/Element.json
+++ b/api/Element.json
@@ -2666,7 +2666,7 @@
       "attachShadow": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attachShadow",
-          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-element-attachshadow①",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-element-attachshadow",
           "tags": [
             "web-features:shadow-dom"
           ],

--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -3,7 +3,7 @@
     "ErrorEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ErrorEvent",
-        "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#errorevent",
         "support": {
           "chrome": {
             "version_added": "10"

--- a/api/Event.json
+++ b/api/Event.json
@@ -211,7 +211,7 @@
       "cancelBubble": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/cancelBubble",
-          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-event-cancelbubble①",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-event-cancelbubble",
           "support": {
             "chrome": {
               "version_added": "1",
@@ -564,7 +564,7 @@
       "initEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/initEvent",
-          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-event-initevent①",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-event-initevent",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/FontData.json
+++ b/api/FontData.json
@@ -151,7 +151,7 @@
       "postscriptName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontData/postscriptName",
-          "spec_url": "https://wicg.github.io/local-font-access/#ref-for-dom-fontdata-postscriptname",
+          "spec_url": "https://wicg.github.io/local-font-access/#dom-fontdata-postscriptname",
           "tags": [
             "web-features:local-fonts"
           ],

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -3,7 +3,7 @@
     "GPUAdapter": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter",
-        "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-adapter",
+        "spec_url": "https://gpuweb.github.io/gpuweb/#gpuadapter",
         "tags": [
           "web-features:webgpu"
         ],

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -3,7 +3,7 @@
     "GPUAdapterInfo": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapterInfo",
-        "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-adapterinfo",
+        "spec_url": "https://gpuweb.github.io/gpuweb/#gpuadapterinfo",
         "tags": [
           "web-features:webgpu"
         ],

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -3,7 +3,7 @@
     "GPUQueue": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQueue",
-        "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-queue",
+        "spec_url": "https://gpuweb.github.io/gpuweb/#gpuqueue",
         "tags": [
           "web-features:webgpu"
         ],

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -3,7 +3,7 @@
     "GPUSupportedFeatures": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedFeatures",
-        "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-supportedfeatures",
+        "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
         "tags": [
           "web-features:webgpu"
         ],

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -3,7 +3,7 @@
     "GPUTexture": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture",
-        "spec_url": "https://gpuweb.github.io/gpuweb/#texture-interface",
+        "spec_url": "https://gpuweb.github.io/gpuweb/#gputexture",
         "tags": [
           "web-features:webgpu"
         ],

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -40,7 +40,7 @@
         "__compat": {
           "description": "`GainNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GainNode/GainNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-gainnode-constructor-gainnode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-gainnode-gainnode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -405,7 +405,7 @@
       "csp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/csp",
-          "spec_url": "https://w3c.github.io/webappsec-cspee/#ref-for-dom-htmliframeelement-csp",
+          "spec_url": "https://w3c.github.io/webappsec-cspee/#dom-htmliframeelement-csp",
           "tags": [
             "web-features:csp"
           ],
@@ -1084,7 +1084,7 @@
       },
       "sharedStorageWritable": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#ref-for-dom-htmlsharedstoragewritableelementutils-sharedstoragewritable",
+          "spec_url": "https://wicg.github.io/shared-storage/#html-attr",
           "tags": [
             "web-features:shared-storage"
           ],

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1031,7 +1031,7 @@
       },
       "sharedStorageWritable": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#ref-for-dom-htmlsharedstoragewritableelementutils-sharedstoragewritable",
+          "spec_url": "https://wicg.github.io/shared-storage/#html-attr",
           "tags": [
             "web-features:shared-storage"
           ],

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -3,7 +3,7 @@
     "IDBCursorWithValue": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursorWithValue",
-        "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-idbcursorwithvalue②",
+        "spec_url": "https://w3c.github.io/IndexedDB/#idbcursorwithvalue",
         "tags": [
           "web-features:indexeddb"
         ],

--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -40,7 +40,7 @@
         "__compat": {
           "description": "`IIRFilterNode()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IIRFilterNode/IIRFilterNode",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-iirfilternode-constructor-iirfilternode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-iirfilternode-iirfilternode",
           "tags": [
             "web-features:web-audio"
           ],

--- a/api/LaunchParams.json
+++ b/api/LaunchParams.json
@@ -39,7 +39,7 @@
       "files": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LaunchParams/files",
-          "spec_url": "https://wicg.github.io/web-app-launch/#ref-for-dom-launchparams-files-1",
+          "spec_url": "https://wicg.github.io/web-app-launch/#dom-launchparams-files",
           "tags": [
             "web-features:app-file-handlers"
           ],
@@ -76,7 +76,7 @@
       "targetURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LaunchParams/targetURL",
-          "spec_url": "https://wicg.github.io/web-app-launch/#ref-for-dom-launchparams-targeturl-7",
+          "spec_url": "https://wicg.github.io/web-app-launch/#dom-launchparams-targeturl",
           "tags": [
             "web-features:app-launch-handler"
           ],

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -39,7 +39,7 @@
       "decodingInfo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo",
-          "spec_url": "https://w3c.github.io/media-capabilities/#ref-for-dom-mediacapabilities-decodinginfo",
+          "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediacapabilities-decodinginfo",
           "tags": [
             "web-features:media-capabilities"
           ],
@@ -124,7 +124,7 @@
       "encodingInfo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo",
-          "spec_url": "https://w3c.github.io/media-capabilities/#ref-for-dom-mediacapabilities-encodinginfo",
+          "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediacapabilities-encodinginfo",
           "tags": [
             "web-features:media-capabilities"
           ],

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -147,7 +147,7 @@
       "notification": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NotificationEvent/notification",
-          "spec_url": "https://notifications.spec.whatwg.org/#ref-for-dom-notificationevent-notification",
+          "spec_url": "https://notifications.spec.whatwg.org/#dom-notificationevent-notification",
           "tags": [
             "web-features:notifications"
           ],

--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -39,7 +39,7 @@
       "devicePixelRatio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintWorkletGlobalScope/devicePixelRatio",
-          "spec_url": "https://drafts.css-houdini.org/css-paint-api/#ref-for-dom-paintworkletglobalscope-devicepixelratio",
+          "spec_url": "https://drafts.css-houdini.org/css-paint-api/#dom-paintworkletglobalscope-devicepixelratio",
           "tags": [
             "web-features:paint"
           ],

--- a/api/PerformanceElementTiming.json
+++ b/api/PerformanceElementTiming.json
@@ -37,7 +37,7 @@
       "element": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/element",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-element",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-element",
           "tags": [
             "web-features:element-timing"
           ],
@@ -72,7 +72,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/id",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-id",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-id",
           "tags": [
             "web-features:element-timing"
           ],
@@ -107,7 +107,7 @@
       "identifier": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/identifier",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-identifier",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-identifier",
           "tags": [
             "web-features:element-timing"
           ],
@@ -142,7 +142,7 @@
       "intersectionRect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/intersectionRect",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-intersectionrect",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-intersectionrect",
           "tags": [
             "web-features:element-timing"
           ],
@@ -177,7 +177,7 @@
       "loadTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/loadTime",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-loadtime①",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-loadtime",
           "tags": [
             "web-features:element-timing"
           ],
@@ -212,7 +212,7 @@
       "naturalHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/naturalHeight",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-naturalheight",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-naturalheight",
           "tags": [
             "web-features:element-timing"
           ],
@@ -247,7 +247,7 @@
       "naturalWidth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/naturalWidth",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-naturalwidth",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-naturalwidth",
           "tags": [
             "web-features:element-timing"
           ],
@@ -282,7 +282,7 @@
       "renderTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/renderTime",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-rendertime①",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-rendertime",
           "tags": [
             "web-features:element-timing"
           ],
@@ -387,7 +387,7 @@
       "url": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/url",
-          "spec_url": "https://w3c.github.io/element-timing/#ref-for-dom-performanceelementtiming-url",
+          "spec_url": "https://w3c.github.io/element-timing/#dom-performanceelementtiming-url",
           "tags": [
             "web-features:element-timing"
           ],

--- a/api/PictureInPictureWindow.json
+++ b/api/PictureInPictureWindow.json
@@ -42,7 +42,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PictureInPictureWindow/height",
-          "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-pictureinpicturewindow-height",
+          "spec_url": "https://w3c.github.io/picture-in-picture/#dom-pictureinpicturewindow-height",
           "tags": [
             "web-features:picture-in-picture"
           ],
@@ -126,7 +126,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PictureInPictureWindow/width",
-          "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-pictureinpicturewindow-width",
+          "spec_url": "https://w3c.github.io/picture-in-picture/#dom-pictureinpicturewindow-width",
           "tags": [
             "web-features:picture-in-picture"
           ],

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -3,7 +3,7 @@
     "PromiseRejectionEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent",
-        "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#the-promiserejectionevent-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#promiserejectionevent",
         "support": {
           "chrome": {
             "version_added": "49"

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -130,7 +130,7 @@
         "__compat": {
           "description": "`getClientExtensionResults()` method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/getClientExtensionResults",
-          "spec_url": "https://w3c.github.io/webauthn/#ref-for-dom-publickeycredential-getclientextensionresults",
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-getclientextensionresults",
           "tags": [
             "web-features:webauthn"
           ],
@@ -349,7 +349,7 @@
       "rawId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/rawId",
-          "spec_url": "https://w3c.github.io/webauthn/#ref-for-dom-publickeycredential-rawid",
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-rawid",
           "tags": [
             "web-features:webauthn"
           ],

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -139,7 +139,7 @@
         "__compat": {
           "description": "`from()` static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStream/from_static",
-          "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-from",
+          "spec_url": "https://streams.spec.whatwg.org/#rs-from",
           "tags": [
             "web-features:readablestream-from"
           ],

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -175,7 +175,7 @@
       "read": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/read",
-          "spec_url": "https://streams.spec.whatwg.org/#ref-for-byob-reader-read③",
+          "spec_url": "https://streams.spec.whatwg.org/#byob-reader-read",
           "tags": [
             "web-features:readable-byte-streams"
           ],

--- a/api/Response.json
+++ b/api/Response.json
@@ -966,7 +966,7 @@
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/type",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-type①",
+          "spec_url": "https://fetch.spec.whatwg.org/#dom-response-type",
           "tags": [
             "web-features:fetch"
           ],

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -643,7 +643,7 @@
       "pictureInPictureElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/pictureInPictureElement",
-          "spec_url": "https://w3c.github.io/picture-in-picture/#ref-for-dom-documentorshadowroot-pictureinpictureelement①⑤",
+          "spec_url": "https://w3c.github.io/picture-in-picture/#dom-pictureinpictureevent-pictureinpicturewindow",
           "tags": [
             "web-features:picture-in-picture"
           ],

--- a/api/StorageAccessHandle.json
+++ b/api/StorageAccessHandle.json
@@ -41,7 +41,7 @@
       "BroadcastChannel": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/BroadcastChannel",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-broadcastchannel",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-broadcastchannel",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -80,7 +80,7 @@
       "SharedWorker": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/SharedWorker",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-sharedworker",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-sharedworker",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -119,7 +119,7 @@
       "caches": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/caches",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-caches",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-caches",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -158,7 +158,7 @@
       "createObjectURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/createObjectURL",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-createobjecturl",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-createobjecturl",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -197,7 +197,7 @@
       "estimate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/estimate",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-estimate",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-estimate",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -236,7 +236,7 @@
       "getDirectory": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/getDirectory",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-getdirectory",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-getdirectory",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -275,7 +275,7 @@
       "indexedDB": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/indexedDB",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-indexeddb",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-indexeddb",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -314,7 +314,7 @@
       "localStorage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/localStorage",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-localstorage",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-localstorage",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -353,7 +353,7 @@
       "locks": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/locks",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-locks",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-locks",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -392,7 +392,7 @@
       "revokeObjectURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/revokeObjectURL",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-revokeobjecturl",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-revokeobjecturl",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],
@@ -431,7 +431,7 @@
       "sessionStorage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageAccessHandle/sessionStorage",
-          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#ref-for-dom-storageaccesshandle-sessionstorage",
+          "spec_url": "https://privacycg.github.io/saa-non-cookie-storage/#dom-storageaccesshandle-sessionstorage",
           "tags": [
             "web-features:non-cookie-storage-access"
           ],

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -37,7 +37,7 @@
       "estimate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/estimate",
-          "spec_url": "https://storage.spec.whatwg.org/#ref-for-dom-storagemanager-estimate",
+          "spec_url": "https://storage.spec.whatwg.org/#dom-storagemanager-estimate",
           "tags": [
             "web-features:storage-manager"
           ],
@@ -139,7 +139,7 @@
       "persist": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/persist",
-          "spec_url": "https://storage.spec.whatwg.org/#ref-for-dom-storagemanager-persist",
+          "spec_url": "https://storage.spec.whatwg.org/#dom-storagemanager-persist",
           "tags": [
             "web-features:storage-manager"
           ],

--- a/api/SyncEvent.json
+++ b/api/SyncEvent.json
@@ -80,7 +80,7 @@
       "lastChance": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SyncEvent/lastChance",
-          "spec_url": "https://wicg.github.io/background-sync/spec/#ref-for-dom-syncevent-lastchance③",
+          "spec_url": "https://wicg.github.io/background-sync/spec/#dom-syncevent-lastchance",
           "tags": [
             "web-features:background-sync"
           ],
@@ -118,7 +118,7 @@
       "tag": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SyncEvent/tag",
-          "spec_url": "https://wicg.github.io/background-sync/spec/#ref-for-dom-syncevent-tag",
+          "spec_url": "https://wicg.github.io/background-sync/spec/#dom-syncevent-tag",
           "tags": [
             "web-features:background-sync"
           ],

--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -110,7 +110,7 @@
           "description": "`prioritychange` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskSignal/prioritychange_event",
           "spec_url": [
-            "https://wicg.github.io/scheduling-apis/#ref-for-eventdef-tasksignal-prioritychange",
+            "https://wicg.github.io/scheduling-apis/#eventdef-tasksignal-prioritychange",
             "https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange"
           ],
           "tags": [

--- a/api/TreeWalker.json
+++ b/api/TreeWalker.json
@@ -50,7 +50,7 @@
       "currentNode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TreeWalker/currentNode",
-          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-treewalker-currentnode①",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-treewalker-currentnode",
           "tags": [
             "web-features:dom"
           ],

--- a/api/USB.json
+++ b/api/USB.json
@@ -91,7 +91,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/connect_event",
           "spec_url": [
             "https://wicg.github.io/webusb/#connect",
-            "https://wicg.github.io/webusb/#ref-for-dom-usb-onconnect"
+            "https://wicg.github.io/webusb/#dom-usb-onconnect"
           ],
           "tags": [
             "web-features:webusb"
@@ -132,7 +132,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/disconnect_event",
           "spec_url": [
             "https://wicg.github.io/webusb/#disconnect",
-            "https://wicg.github.io/webusb/#ref-for-dom-usb-ondisconnect"
+            "https://wicg.github.io/webusb/#dom-usb-ondisconnect"
           ],
           "tags": [
             "web-features:webusb"
@@ -170,7 +170,7 @@
       "getDevices": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/getDevices",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usb-getdevices②",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usb-getdevices",
           "tags": [
             "web-features:webusb"
           ],
@@ -207,7 +207,7 @@
       "requestDevice": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/requestDevice",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usb-requestdevice④",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usb-requestdevice",
           "tags": [
             "web-features:webusb"
           ],

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -126,7 +126,7 @@
       "configurationName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBConfiguration/configurationName",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbconfiguration-configurationname",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbconfiguration-configurationname",
           "tags": [
             "web-features:webusb"
           ],
@@ -163,7 +163,7 @@
       "configurationValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBConfiguration/configurationValue",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbconfiguration-configurationvalue",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbconfiguration-configurationvalue",
           "tags": [
             "web-features:webusb"
           ],
@@ -200,7 +200,7 @@
       "interfaces": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBConfiguration/interfaces",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbconfiguration-interfaces",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbconfiguration-interfaces",
           "tags": [
             "web-features:webusb"
           ],

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -88,7 +88,7 @@
       "claimInterface": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/claimInterface",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-claiminterface②",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-claiminterface",
           "tags": [
             "web-features:webusb"
           ],
@@ -125,7 +125,7 @@
       "clearHalt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/clearHalt",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-clearhalt①",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-clearhalt",
           "tags": [
             "web-features:webusb"
           ],
@@ -162,7 +162,7 @@
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/close",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-close",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-close",
           "tags": [
             "web-features:webusb"
           ],
@@ -199,7 +199,7 @@
       "configuration": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/configuration",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-configuration①",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-configuration",
           "tags": [
             "web-features:webusb"
           ],
@@ -236,7 +236,7 @@
       "configurations": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/configurations",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-configurations①",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-configurations",
           "tags": [
             "web-features:webusb"
           ],
@@ -273,7 +273,7 @@
       "controlTransferIn": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/controlTransferIn",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-controltransferin",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-controltransferin",
           "tags": [
             "web-features:webusb"
           ],
@@ -310,7 +310,7 @@
       "controlTransferOut": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/controlTransferOut",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-controltransferout①",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-controltransferout",
           "tags": [
             "web-features:webusb"
           ],
@@ -347,7 +347,7 @@
       "deviceClass": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/deviceClass",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-deviceclass",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-deviceclass",
           "tags": [
             "web-features:webusb"
           ],
@@ -384,7 +384,7 @@
       "deviceProtocol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/deviceProtocol",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-deviceprotocol",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-deviceprotocol",
           "tags": [
             "web-features:webusb"
           ],
@@ -421,7 +421,7 @@
       "deviceSubclass": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/deviceSubclass",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-devicesubclass",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-devicesubclass",
           "tags": [
             "web-features:webusb"
           ],
@@ -458,7 +458,7 @@
       "deviceVersionMajor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/deviceVersionMajor",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-deviceversionmajor",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-deviceversionmajor",
           "tags": [
             "web-features:webusb"
           ],
@@ -495,7 +495,7 @@
       "deviceVersionMinor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/deviceVersionMinor",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-deviceversionminor",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-deviceversionminor",
           "tags": [
             "web-features:webusb"
           ],
@@ -532,7 +532,7 @@
       "deviceVersionSubminor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/deviceVersionSubminor",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-deviceversionsubminor",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-deviceversionsubminor",
           "tags": [
             "web-features:webusb"
           ],
@@ -606,7 +606,7 @@
       "isochronousTransferIn": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/isochronousTransferIn",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-isochronoustransferin",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferin",
           "tags": [
             "web-features:webusb"
           ],
@@ -643,7 +643,7 @@
       "isochronousTransferOut": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/isochronousTransferOut",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-isochronoustransferout",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferout",
           "tags": [
             "web-features:webusb"
           ],
@@ -680,7 +680,7 @@
       "manufacturerName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/manufacturerName",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-manufacturername",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-manufacturername",
           "tags": [
             "web-features:webusb"
           ],
@@ -717,7 +717,7 @@
       "open": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/open",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-open①",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-open",
           "tags": [
             "web-features:webusb"
           ],
@@ -754,7 +754,7 @@
       "opened": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/opened",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-opened",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-opened",
           "tags": [
             "web-features:webusb"
           ],
@@ -791,7 +791,7 @@
       "productId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/productId",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-productid",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-productid",
           "tags": [
             "web-features:webusb"
           ],
@@ -828,7 +828,7 @@
       "productName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/productName",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-productname",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-productname",
           "tags": [
             "web-features:webusb"
           ],
@@ -865,7 +865,7 @@
       "releaseInterface": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/releaseInterface",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-releaseinterface①",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-releaseinterface",
           "tags": [
             "web-features:webusb"
           ],
@@ -902,7 +902,7 @@
       "reset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/reset",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-reset",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-reset",
           "tags": [
             "web-features:webusb"
           ],
@@ -939,7 +939,7 @@
       "selectAlternateInterface": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/selectAlternateInterface",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-selectalternateinterface",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-selectalternateinterface",
           "tags": [
             "web-features:webusb"
           ],
@@ -1013,7 +1013,7 @@
       "serialNumber": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/serialNumber",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-serialnumber",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-serialnumber",
           "tags": [
             "web-features:webusb"
           ],
@@ -1050,7 +1050,7 @@
       "transferIn": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/transferIn",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-transferin①",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-transferin",
           "tags": [
             "web-features:webusb"
           ],
@@ -1087,7 +1087,7 @@
       "transferOut": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/transferOut",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-transferout",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-transferout",
           "tags": [
             "web-features:webusb"
           ],
@@ -1124,7 +1124,7 @@
       "usbVersionMajor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/usbVersionMajor",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-usbversionmajor",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-usbversionmajor",
           "tags": [
             "web-features:webusb"
           ],
@@ -1198,7 +1198,7 @@
       "usbVersionSubminor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/usbVersionSubminor",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-usbversionsubminor",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-usbversionsubminor",
           "tags": [
             "web-features:webusb"
           ],
@@ -1235,7 +1235,7 @@
       "vendorId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/vendorId",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-vendorid",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-vendorid",
           "tags": [
             "web-features:webusb"
           ],

--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -3,7 +3,7 @@
     "ValidityState": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ValidityState",
-        "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api:validitystate-3",
+        "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#validitystate",
         "tags": [
           "web-features:constraint-validation"
         ],

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -309,7 +309,7 @@
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/close",
-          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-close①",
+          "spec_url": "https://websockets.spec.whatwg.org/#dom-websocket-close",
           "tags": [
             "web-features:websockets"
           ],

--- a/api/Window.json
+++ b/api/Window.json
@@ -1134,7 +1134,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/devicemotion_event",
           "spec_url": [
             "https://w3c.github.io/deviceorientation/#devicemotion",
-            "https://w3c.github.io/deviceorientation/#ref-for-dom-window-ondevicemotion"
+            "https://w3c.github.io/deviceorientation/#dom-window-ondevicemotion"
           ],
           "tags": [
             "web-features:device-orientation-events"
@@ -1183,7 +1183,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/deviceorientation_event",
           "spec_url": [
             "https://w3c.github.io/deviceorientation/#deviceorientation",
-            "https://w3c.github.io/deviceorientation/#ref-for-dom-window-ondeviceorientation"
+            "https://w3c.github.io/deviceorientation/#dom-window-ondeviceorientation"
           ],
           "tags": [
             "web-features:device-orientation-events"


### PR DESCRIPTION
Adresses https://github.com/mdn/browser-compat-data/pull/23958#issuecomment-3062666104

We usually use anchors in the form of `#dom-interface-member` and not `#ref-for-interface-member(number)`. This PR fixes instances where this is currently not used. 