### PR TITLE
FileList API is not supported in Node.js

### DIFF
--- a/api/FileList.json
+++ b/api/FileList.json
@@ -28,6 +28,9 @@
           "ie": {
             "version_added": "10"
           },
+          "nodejs": {
+            "version_added": false
+          },
           "oculus": "mirror",
           "opera": {
             "version_added": "11.1"
@@ -73,6 +76,9 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": {
@@ -120,6 +126,9 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Declare that FileList API is not supported in Node.js.

#### Test results and supporting details

```sh
$ node

Welcome to Node.js v22.17.0.
Type ".help" for more information.
> console.log(FileList);
Uncaught ReferenceError: FileList is not defined
```

