### PR TITLE
Chrome 121 supports the speculationrules Request.destination value

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -946,6 +946,47 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "speculationrules": {
+          "__compat": {
+            "description": "`speculationrules` value",
+            "spec_url": "https://wicg.github.io/nav-speculation/speculation-rules.html#fetch",
+            "tags": [
+              "web-features:fetch"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "duplex": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 121 added support for the [`Speculation-Rules`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Speculation-Rules#specifications) HTTP header, which also includes the [`Request.destination`](https://developer.mozilla.org/en-US/docs/Web/API/Request/destination) value of `speculationrules`.

See https://github.com/mdn/content/issues/40289#issuecomment-3071572654

Also see https://wicg.github.io/nav-speculation/speculation-rules.html#fetch for the spec.

This PR adds a separate data point for the `Request.destination` value.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
