### PR TITLE
Add support for Partitioned cookie attribute in upcoming Firefox 

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -136,7 +136,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
#### Summary

Noting the Partitioned Set-Cookie attribute is enabled in the next version of Firefox.

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1931488

#### Related issues

