### PR TITLE
Use enforces_trusted_types keys for scripts

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1755,9 +1755,9 @@
             "deprecated": false
           }
         },
-        "scripts_accept_TrustedScript": {
+        "enforces_trusted_types": {
           "__compat": {
-            "description": "Can be set with `TrustedScript` instances in `HTMLScriptElement`.",
+            "description": "Requires `TrustedScript` instance in `HTMLScriptElement` when trusted types are enforced.",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
             "tags": [
               "web-features:trusted-types"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -666,9 +666,9 @@
             "deprecated": false
           }
         },
-        "accepts_TrustedScriptURL": {
+        "enforces_trusted_types": {
           "__compat": {
-            "description": "Can be set with a `TrustedScriptURL` instance",
+            "description": "Requires `TrustedScriptURL` instance when trusted types are enforced",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-src",
             "tags": [
               "web-features:trusted-types"
@@ -790,9 +790,9 @@
             "deprecated": false
           }
         },
-        "accepts_TrustedScript": {
+        "enforces_trusted_types": {
           "__compat": {
-            "description": "Can be set with a `TrustedScript` instance",
+            "description": "Requires `TrustedScript` instance when trusted types are enforced.",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-text",
             "tags": [
               "web-features:trusted-types"

--- a/api/Node.json
+++ b/api/Node.json
@@ -1384,9 +1384,9 @@
             "deprecated": false
           }
         },
-        "scripts_accept_TrustedScript": {
+        "enforces_trusted_types": {
           "__compat": {
-            "description": "Can be set with `TrustedScript` instances in `HTMLScriptElement`.",
+            "description": "Requires `TrustedScript` instance in `HTMLScriptElement` when trusted types are enforced.",
             "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
             "tags": [
               "web-features:trusted-types"

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -105,9 +105,9 @@
           }
         }
       },
-      "code_param_accepts_trustedScript": {
+      "code_param_enforces_trusted_types": {
         "__compat": {
-          "description": "`code` parameter can be set with a `TrustedScript` instance",
+          "description": "`code` parameter requires `TrustedScript` instance when trusted types are enforced.",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
           "tags": [
             "web-features:trusted-types"

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -105,9 +105,9 @@
           }
         }
       },
-      "code_param_accepts_trustedScript": {
+      "code_param_enforces_trusted_types": {
         "__compat": {
-          "description": "`code` parameter can be set with a `TrustedScript` instance",
+          "description": "`code` parameter requires `TrustedScript` instance when trusted types are enforced.",
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-xss-injection-sinks",
           "tags": [
             "web-features:trusted-types"


### PR DESCRIPTION
We recently updated keys for features that accepted trusted HTML to use `enforces_trusted_types` with a clear statement of the requirement. This mirrors the behaviour for the other existing BCD entries that take TrustedScript and TrustedScriptURL. 

FYI @lukewarlow