### PR TITLE
Chrome 140 support for HighlightRegisty.highlightsFromPoint()

### DIFF
--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -238,6 +238,40 @@
           }
         }
       },
+      "highlightsFromPoint": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-highlight-api-1/#dom-highlightregistry-highlightsfrompoint",
+          "tags": [
+            "web-features:highlight"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "140"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HighlightRegistry/keys",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 140 adds support for the [`HighlightRegisty.highlightsFromPoint()`](https://drafts.csswg.org/css-highlight-api-1/#dom-highlightregistry-highlightsfrompoint) method; see https://chromestatus.com/feature/4552801607483392.

I've tested it in Chrome 140, and it works fine; Chrome 139 throws `Uncaught TypeError: CSS.highlights.highlightsFromPoint is not a function`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
