### PR TITLE
Chrome 122-136 FedCM features

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -905,7 +905,44 @@
               }
             }
           },
-          "loginHint": {
+          "providers_fields": {
+            "__compat": {
+              "description": "`identity.providers.fields`",
+              "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-fields",
+              "tags": [
+                "web-features:fedcm"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "132"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "providers_loginHint": {
             "__compat": {
               "description": "`identity.providers.loginHint`",
               "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-loginhint",
@@ -915,6 +952,80 @@
               "support": {
                 "chrome": {
                   "version_added": "116"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "providers_mode": {
+            "__compat": {
+              "description": "`identity.providers.mode`",
+              "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-params",
+              "tags": [
+                "web-features:fedcm"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "132"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "providers_params": {
+            "__compat": {
+              "description": "`identity.providers.params`",
+              "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-params",
+              "tags": [
+                "web-features:fedcm"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "132"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -905,7 +905,80 @@
               }
             }
           },
-          "providers_fields": {
+          "mode_option": {
+            "__compat": {
+              "description": "`identity.mode`",
+              "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identitycredentialrequestoptions-mode",
+              "tags": [
+                "web-features:fedcm"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "132"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "providers_multiple": {
+            "__compat": {
+              "description": "Support for multiple `providers`",
+              "tags": [
+                "web-features:fedcm"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "136"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "providers_option_fields": {
             "__compat": {
               "description": "`identity.providers.fields`",
               "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-fields",
@@ -942,7 +1015,7 @@
               }
             }
           },
-          "providers_loginHint": {
+          "providers_option_loginHint": {
             "__compat": {
               "description": "`identity.providers.loginHint`",
               "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-loginhint",
@@ -979,44 +1052,7 @@
               }
             }
           },
-          "providers_mode": {
-            "__compat": {
-              "description": "`identity.providers.mode`",
-              "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-params",
-              "tags": [
-                "web-features:fedcm"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": "132"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": false
-                },
-                "webview_ios": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "providers_params": {
+          "providers_option_params": {
             "__compat": {
               "description": "`identity.providers.params`",
               "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-params",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome has added several [FedCM](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API) features that we are missing from BCD and/or MDN. This PR adds BCD for the features we were missing compat data for.

The features are:

- Support for multiple IdPs in a single `get()` call, as specified inside the `providers` array, added in Chrome 136: https://chromestatus.com/feature/5067784766095360. I've added a data point for this.
- The above ChromeStatus entry also includes the `IdentityCredential.configURL` (if you look at the [associated spec changes](https://github.com/w3c-fedid/FedCM/pull/686/files#diff-40cc3a1ba233cc3ca7b6d5873260da9676f6ae20bb897b62f7871c80d0bda4e9R445)), but this is already in BCD.
- `IdentityCredential.disconnect()`, added in Chrome 122: https://chromestatus.com/feature/5202286040580096. This was already in BCD as well.
- `identity.mode` in `get()` calls, added in Chrome 132: https://chromestatus.com/feature/4689551782313984. I've added a data point for this
- `identity.fields` and `identity.params` in `get()` calls, added in Chrome 132. I'm not sure what ChromeStatus entry covers these, but [developer.chrome.com](https://privacysandbox.google.com/cookies/fedcm/implement/relying-party#providers_property) says they were added in Chrome 132.  I've added data points for these.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
