### PR TITLE
Firefox 142 Nightly adds `:active-view-transition` pseudo-class

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8184,8 +8184,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1950759"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -8219,8 +8218,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1950759"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8255,8 +8253,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1950759"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/selectors/active-view-transition.json
+++ b/css/selectors/active-view-transition.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1956140"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Added Firefox Nightly support for:
  - `:active-view-transition` pseudo-class
  - `Document.startViewTransition` method

#### Test results and supporting details

Tested using this [codepen](https://codepen.io/CodeRedDigital/pen/empOzLe) in the following browsers:
- Firefox 140.0.4 - not supported
- Firefox Beta 141.0 - not supported
- Firefox Developer 141.0b9  - not supported
- Firefox Nightly 142.0a1 - supported

#### Related issues

- [Implement active-view-transition pseudo class](https://github.com/mdn/content/issues/40029)
- [Content PR](https://github.com/mdn/content/pull/40404)
- [Firefox Release PR](https://github.com/mdn/content/pull/40403)