### PR TITLE
`css.properties.display.contents.contents_unusual`: add spec URL

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -126,6 +126,7 @@
           "contents_unusual": {
             "__compat": {
               "description": "Specific behavior of unusual elements when `display: contents` is applied to them",
+              "spec_url": "https://drafts.csswg.org/css-display/#unbox",
               "tags": [
                 "web-features:display-contents"
               ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Add a spec URL for the "[Effects of `display: contents` on Unusual Elements](https://drafts.csswg.org/css-display/#unbox)" behavioral subfeature.

#### Test results and supporting details

This link was previously in the feature's description, but removed as links in descriptions were forbidden. I'm reinstating this here to make it easier to understand what this feature is about.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/7154
- https://github.com/web-platform-dx/web-features/pull/3161#issuecomment-3083663714

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
