### PR TITLE
Chrome 123 supports FedCM domainHint

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -978,6 +978,43 @@
               }
             }
           },
+          "providers_option_domainHint": {
+            "__compat": {
+              "description": "`identity.providers.domainHint`",
+              "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-domainhint",
+              "tags": [
+                "web-features:fedcm"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "123"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "providers_option_fields": {
             "__compat": {
               "description": "`identity.providers.fields`",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I added several missing [FedCM](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API) features in https://github.com/mdn/browser-compat-data/pull/27312, but I missed the [`identity.domainHint`](https://w3c-fedid.github.io/FedCM/#dom-identityproviderrequestoptions-domainhint) property, usable in `get()` calls, which was added in Chrome 123.

This PR adds a data point for `domainHint`.

I couldn't find a ChromeStatus entry for this feature, but I asked the Chrome engineers, and they confirmed that the version the feature was introduced in was Chrome 123.


<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
