### PR TITLE
Remove deprecation for navigator.vendor and navigator.platform

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2959,7 +2959,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -5585,7 +5585,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
#### Summary

The WhatWG spec for [the navigator object](https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object) does not list these properties as deprecated, but _does_ call them out as being _useful_ rather than to be avoided.

While for security reasons the _amount_ of information provided by browsers through navigator properties has been reduced from what the older standard allowed for (as highlighted by the warning in the spec that "_user agent implementers are strongly urged to include as little information in this API as possible_", which all browsers have indeed taken to heart by only providing summary information rather than detailed information), the properties themselves have not been deprecated, and the use of `navigator` has in no way been marked as bad. As per the text for the navigator object itself, rather the opposite:

> In certain cases, despite the best efforts of the entire industry, web browsers have bugs and limitations that web authors are forced to work around.
>
> This section defines a collection of attributes that can be used to determine, from script, the kind of user agent in use, in order to work around these issues.

#### Test results and supporting details

- https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
- https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-vendor-dev
- https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-platform-dev

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/17322 (which incorrectly marked them as deprecated in 2022, when the spec already read what it reads today)
- https://github.com/mdn/content/issues/14429#issuecomment-3092444674 (link to a summary comment that tracks how this change happened, and how it probably shouldn't have)
