### PR TITLE
Bug-1828220 add browser_action.onUserSettingsChanged event

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -450,9 +450,12 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "142"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "142",
+                "notes": "Never fires as there is no toolbar to pin extensions to in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false,

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -526,7 +526,7 @@
               },
               "firefox_android": {
                 "version_added": "142",
-                "notes": "Never fires as extensions can't be pinned to the bookmarks toolbar in Firefox for Android."
+                "notes": "Never fires as there is no toolbar to pin extensions to in Firefox for Android."
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -514,6 +514,28 @@
             }
           }
         },
+        "onUserSettingsChanged": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": {
+                "version_added": "142",
+                "notes": "Never fires as extensions can't be pinned to the bookmarks toolbar in Firefox for Android."
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "openPopup": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup",


### PR DESCRIPTION
#### Summary

Adds details for the addition of the `browser_action.onUserSettingsChanged` event. Addresses the dev-doc-needed requirements of [Bug 1828220](https://bugzilla.mozilla.org/show_bug.cgi?id=1828220) Implement onUserSettingsChanged event.

#### Related issues

See https://github.com/mdn/content/pull/40488 for details of the documentation changes.
