### PR TITLE
FF142 RTCIceCandidatePairStats - current/totalRTT and responsesRec

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -480,7 +480,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "142"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -952,7 +952,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "142"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -1102,7 +1102,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "142"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF142 adds support for the stats [`RTCIceCandidatePairStats.totalRoundTripTime`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/totalRoundTripTime), [`RTCIceCandidatePairStats.currentRoundTripTime`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/currentRoundTripTime), [`RTCIceCandidatePairStats.responsesReceived`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/responsesReceived) in https://bugzilla.mozilla.org/show_bug.cgi?id=1371391

This updates the subfeatures.

Related docs can be tracked in https://github.com/mdn/content/issues/40476