### PR TITLE
Ff142 inbound-rtp stats

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -2484,6 +2484,41 @@
             }
           }
         },
+        "estimatedPlayoutTimestamp": {
+          "__compat": {
+            "description": "`estimatedPlayoutTimestamp` in 'inbound-rtp' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-estimatedplayouttimestamp",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "fecPacketsDiscarded": {
           "__compat": {
             "description": "`fecPacketsDiscarded` in 'inbound-rtp' stats",
@@ -2586,6 +2621,41 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "framesAssembledFromMultiplePackets": {
+          "__compat": {
+            "description": "`framesAssembledFromMultiplePackets` in 'inbound-rtp' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-framesassembledfrommultiplepackets",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -2728,6 +2798,41 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "freezeCount": {
+          "__compat": {
+            "description": "`freezeCount` in 'inbound-rtp' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-freezecount",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -3303,6 +3408,41 @@
             }
           }
         },
+        "pauseCount": {
+          "__compat": {
+            "description": "`pauseCount` in 'inbound-rtp' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-pausecount",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "playoutId": {
           "__compat": {
             "description": "`playoutId` in 'inbound-rtp' stats",
@@ -3551,6 +3691,41 @@
             }
           }
         },
+        "totalAssemblyTime": {
+          "__compat": {
+            "description": "`totalAssemblyTime` in 'inbound-rtp' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-totalassemblytime",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "totalAudioEnergy": {
           "__compat": {
             "description": "`totalAudioEnergy` in 'inbound-rtp' stats",
@@ -3621,6 +3796,41 @@
             }
           }
         },
+        "totalFreezesDuration": {
+          "__compat": {
+            "description": "`totalFreezesDuration` in 'inbound-rtp' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-totalfreezesduration",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "totalInterFrameDelay": {
           "__compat": {
             "description": "`totalInterFrameDelay` in 'inbound-rtp' stats",
@@ -3651,6 +3861,41 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "totalPausesDuration": {
+          "__compat": {
+            "description": "`totalPausesDuration` in 'inbound-rtp' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-totalpausesduration",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -2958,7 +2958,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "142"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -2973,7 +2973,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2993,7 +2993,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "142"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -3008,7 +3008,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -3028,7 +3028,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "142"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -3043,7 +3043,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF144 adds support for the following `inbound-rtp` stats in https://bugzilla.mozilla.org/show_bug.cgi?id=1926622:
- (new features) pauseCount, totalPausesDuration, freezeCount, totalFreezesDuration, estimatedPlayoutTimestamp, framesAssembledFromMultiplePackets, totalAssemblyTime
- (Existing features) keyFramesDecoded, jitterBufferTargetDelay/jitterBufferMinimumDelay

This adds the features.

Related docs work can be tracked in https://github.com/mdn/content/issues/40478