### PR TITLE
Firefox 141 supports Intl.Locale.prototype.variants

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -1071,6 +1071,46 @@
                 "deprecated": false
               }
             }
+          },
+          "variants": {
+            "__compat": {
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants",
+              "tags": [
+                "web-features:intl-locale"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "141"
+                },
+                "firefox_android": "mirror",
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
#### Summary

Now supported:

```js
const ja = new Intl.Locale("ja-Jpan-JP-hepburn");
console.log(ja.variants);
// hepburn
```

#### Test results and supporting details

- __Spec:__ https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
- __Bugzilla:__ [1970161](https://bugzilla.mozilla.org/show_bug.cgi?id=1970161)
- __Pen:__ https://codepen.io/bsmth/pen/gbarbKd?editors=0011

Tested `false` entries manually.

#### Related issues

- [ ] https://github.com/mdn/content/issues/40467
- [ ] https://github.com/mdn/content/pull/40497
