### PR TITLE
Updates for Firefox 142 beta

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -404,7 +404,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -828,7 +828,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "version_removed": "142"
             },
             "firefox_android": {
               "version_added": "24"

--- a/api/Scheduler.json
+++ b/api/Scheduler.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "142"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -98,7 +98,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -817,7 +817,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TaskController.json
+++ b/api/TaskController.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "142"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -49,7 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -84,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TaskPriorityChangeEvent.json
+++ b/api/TaskPriorityChangeEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "142"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -49,7 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -84,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "142"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -49,7 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -64,7 +64,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -84,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -123,7 +123,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -17,8 +17,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1731418"
+            "version_added": "142"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -56,7 +55,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -93,7 +92,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "142"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -132,7 +131,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -170,7 +169,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -208,7 +207,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -246,7 +245,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -284,7 +283,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -322,7 +321,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -360,7 +359,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -398,7 +397,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -436,7 +435,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -474,7 +473,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -512,7 +511,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "142"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/_globals/scheduler.json
+++ b/api/_globals/scheduler.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "142"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.13.5 found new features shipping in Firefox 141 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 31 features as shipping in Firefox 142:

- api.Animation.overallProgress
- api.RTCDataChannel.reliable (removal)
- api.Scheduler
- api.Scheduler.postTask
- api.Scheduler.yield
- api.Selection.getComposedRanges
- api.TaskController
- api.TaskController.TaskController
- api.TaskController.setPriority
- api.TaskPriorityChangeEvent
- api.TaskPriorityChangeEvent.TaskPriorityChangeEvent
- api.TaskPriorityChangeEvent.previousPriority
- api.TaskSignal
- api.TaskSignal.any_static
- api.TaskSignal.priority
- api.TaskSignal.prioritychange_event
- api.URLPattern
- api.URLPattern.URLPattern
- api.URLPattern.URLPattern.ignoreCase_option
- api.URLPattern.exec
- api.URLPattern.hash
- api.URLPattern.hasRegExpGroups
- api.URLPattern.hostname
- api.URLPattern.password
- api.URLPattern.pathname
- api.URLPattern.port
- api.URLPattern.protocol
- api.URLPattern.search
- api.URLPattern.test
- api.URLPattern.username
- api.scheduler

Notes:
- WebGPU apparently slipped to 142 and is not shipping in 141. I will open a separate PR shortly.

See also https://github.com/mdn/mdn/issues/704 and https://www.mozilla.org/en-US/firefox/142.0beta/releasenotes/