### PR TITLE
Add spec_url for <selectedcontent> element

### DIFF
--- a/html/elements/selectedcontent.json
+++ b/html/elements/selectedcontent.json
@@ -4,6 +4,7 @@
       "selectedcontent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/selectedcontent",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-selectedcontent-element",
           "tags": [
             "web-features:customizable-select"
           ],
@@ -30,7 +31,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The [`<selectedcontent>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/selectedcontent) element is now [properly specified](https://html.spec.whatwg.org/multipage/form-elements.html#the-selectedcontent-element)

This PR gives it a `spec_url` field and changes `standard_track` to `true`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
