### PR TITLE
Fix PR Review Companion

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR should fix the review companion by specifying to grab all commits, instead of the default which is just the latest commit.