### PR TITLE
Pointer Lock `unadjustedMovement` is supported on macOS from Safari 18.4

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8823,9 +8823,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": {
                 "version_added": false
               },
-              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"


### PR DESCRIPTION
#### Summary

`options.unadjustedMovement` for pointer lock has been supported on macOS Safari 18.4 onwards.

#### Test results and supporting details

Release notes: https://webkit.org/blog/16574/webkit-features-in-safari-18-4/#:~:text=return%20a%20Promise.%20(-,139854530.

Tracking bug: https://bugs.webkit.org/show_bug.cgi?id=282849.

To test, refer to https://mdn.github.io/dom-examples/pointer-lock/. This demo uses the `unadjustmentMovement` option.