### PR TITLE
Add APIs from the Explicit Resource Management

### DIFF
--- a/javascript/builtins/AsyncDisposableStack.json
+++ b/javascript/builtins/AsyncDisposableStack.json
@@ -3,6 +3,8 @@
     "builtins": {
       "AsyncDisposableStack": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Global_Objects/AsyncDisposableStack",
+          "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack-objects",
           "support": {
             "chrome": {
               "version_added": "134"
@@ -38,6 +40,8 @@
         },
         "AsyncDisposableStack": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/AsyncDisposableStack",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-properties-of-the-asyncdisposablestack-constructor",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -110,6 +114,8 @@
         },
         "defer": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/defer",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype.defer",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -146,6 +152,8 @@
         },
         "disposeAsync": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/disposeAsync",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype.disposeAsync",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -182,6 +190,8 @@
         },
         "disposed": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/disposed",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-get-asyncdisposablestack.prototype.disposed",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -218,6 +228,8 @@
         },
         "move": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/move",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype.move",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -254,6 +266,8 @@
         },
         "use": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/use",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype.use",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -286,6 +300,13 @@
               "standard_track": false,
               "deprecated": false
             }
+          }
+        },
+        "@@asyncDispose": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/Symbol.asyncDispose",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype-@@asyncDispose",
+            "support": {}
           }
         }
       }

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -42,6 +42,13 @@
             "deprecated": false
           }
         },
+        "@@asyncDispose": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator/Symbol.asyncDispose",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype-@@asyncDispose",
+            "support": {}
+          }
+        },
         "@@asyncIterator": {
           "__compat": {
             "description": "[Symbol.asyncIterator]",

--- a/javascript/builtins/DisposableStack.json
+++ b/javascript/builtins/DisposableStack.json
@@ -3,6 +3,8 @@
     "builtins": {
       "DisposableStack": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack",
+          "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-disposablestack-objects",
           "support": {
             "chrome": {
               "version_added": "134"
@@ -38,6 +40,8 @@
         },
         "DisposableStack": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack/DisposableStack",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-disposablestack-constructor",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -74,6 +78,8 @@
         },
         "adopt": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/adopt",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype.adopt",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -110,6 +116,8 @@
         },
         "defer": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/defer",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype.defer",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -146,6 +154,8 @@
         },
         "dispose": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack/dispose",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-disposablestack.prototype.dispose",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -182,6 +192,8 @@
         },
         "disposed": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack/disposed",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-get-disposablestack.prototype.disposed",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -218,6 +230,8 @@
         },
         "move": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack/move",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-disposablestack.prototype.move",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -254,6 +268,8 @@
         },
         "use": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack/use",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-disposablestack.prototype.use",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -286,6 +302,13 @@
               "standard_track": false,
               "deprecated": false
             }
+          }
+        },
+        "@@dispose": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack/Symbol.dispose",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-disposablestack.prototype-@@dispose",
+            "support": {}
           }
         }
       }

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -650,6 +650,13 @@
             }
           }
         },
+        "@@dispose": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Symbol.dispose",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-%iteratorprototype%-@@dispose",
+            "support": {}
+          }
+        },
         "@@iterator": {
           "__compat": {
             "description": "[Symbol.iterator]",

--- a/javascript/builtins/SuppressedError.json
+++ b/javascript/builtins/SuppressedError.json
@@ -3,6 +3,8 @@
     "builtins": {
       "SuppressedError": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SuppressedError",
+          "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-suppressederror-objects",
           "support": {
             "chrome": {
               "version_added": "134"
@@ -36,8 +38,24 @@
             "deprecated": false
           }
         },
+        "error": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SuppressedError/error",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-suppressederror",
+            "support": {}
+          }
+        },
+        "suppressed": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SuppressedError/suppressed",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-suppressederror",
+            "support": {}
+          }
+        },
         "SuppressedError": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SuppressedError/SuppressedError",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-suppressederror-constructor",
             "support": {
               "chrome": {
                 "version_added": "134"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -92,6 +92,8 @@
         },
         "asyncDispose": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncDispose",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#table-1",
             "support": {
               "chrome": {
                 "version_added": "127"
@@ -234,6 +236,8 @@
         },
         "dispose": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/dispose",
+            "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#table-1",
             "support": {
               "chrome": {
                 "version_added": "125"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -87,6 +87,14 @@
           }
         }
       },
+      "await_using": {
+        "__compat": {
+          "description": "`await using` declaration",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/await_using",
+          "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#prod-AwaitUsingDeclaration",
+          "support": {}
+        }
+      },
       "block": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/block",
@@ -2132,7 +2140,9 @@
       },
       "using": {
         "__compat": {
-          "description": "`using` keyword",
+          "description": "`using` declaration",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/using",
+          "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#prod-UsingDeclaration",
           "support": {
             "chrome": {
               "version_added": "134"


### PR DESCRIPTION
#### Summary

This goes along with the [MDN content PR](https://github.com/mdn/content/pull/38027) by @Josh-Cena.

- Adds new APIs from the [Explicit Resource Management](https://tc39.es/proposal-async-explicit-resource-management/) draft shipped by Firefox 141
- Adds missing spec URLs

⚠️ The seven new features added in this PR are missing the support info. This would be better added via collector.

#### Test results and supporting details

[To be added]

#### Related issues

- https://github.com/mdn/content/pull/38027
- [Bugzilla: Ship Explicit Resource Management](https://bugzilla.mozilla.org/show_bug.cgi?id=1967744)