### PR TITLE
Chrome 138 viewport segment media features and env variables

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -757,6 +757,37 @@
             }
           }
         },
+        "horizontal-viewport-segments": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/mediaqueries-5/#mf-horizontal-viewport-segments",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "hover": {
           "__compat": {
             "description": "`hover` media feature",
@@ -1674,6 +1705,37 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "vertical-viewport-segments": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/mediaqueries-5/#mf-vertical-viewport-segments",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/env.json
+++ b/css/types/env.json
@@ -394,6 +394,198 @@
               "deprecated": false
             }
           }
+        },
+        "viewport-segment-bottom": {
+          "__compat": {
+            "description": "Viewport segment variable `viewport-segment-bottom`",
+            "spec_url": "https://drafts.csswg.org/css-env/#valdef-env-viewport-segment-bottom",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport-segment-height": {
+          "__compat": {
+            "description": "Viewport segment variable `viewport-segment-height`",
+            "spec_url": "https://drafts.csswg.org/css-env/#valdef-env-viewport-segment-height",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport-segment-left": {
+          "__compat": {
+            "description": "Viewport segment variable `viewport-segment-left`",
+            "spec_url": "https://drafts.csswg.org/css-env/#valdef-env-viewport-segment-left",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport-segment-right": {
+          "__compat": {
+            "description": "Viewport segment variable `viewport-segment-right`",
+            "spec_url": "https://drafts.csswg.org/css-env/#valdef-env-viewport-segment-right",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport-segment-top": {
+          "__compat": {
+            "description": "Viewport segment variable `viewport-segment-top`",
+            "spec_url": "https://drafts.csswg.org/css-env/#valdef-env-viewport-segment-top",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport-segment-width": {
+          "__compat": {
+            "description": "Viewport segment variable `viewport-segment-width`",
+            "spec_url": "https://drafts.csswg.org/css-env/#valdef-env-viewport-segment-width",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 138 adds the Viewport Segments API, which provides a way to access the position and dimensions of logically separate viewport regions. Viewport segments are created when the viewport is split by one or more hardware features (such as a fold or a hinge between separate displays).

The API is made up of several related features:

- The [Viewport interface](https://drafts.csswg.org/css-viewport/#the-viewport-interface) and `segments` property.
- [Viewport segment media features](https://drafts.csswg.org/mediaqueries-5/#mf-horizontal-viewport-segments).
- [Viewport segment environment variables](https://drafts.csswg.org/css-env/#viewport-segments).

See also the related ChromeStatus entry: https://chromestatus.com/feature/5170498990243840

This PR adds data for the second and third items listed above. (The first one is already available in the data).

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
