### PR TITLE
Update all browsers data for global_attributes SVG feature

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -469,7 +469,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -481,7 +481,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -507,7 +507,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -519,7 +519,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -628,19 +628,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3.5"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "≤5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -710,23 +710,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80",
-              "partial_implementation": true,
-              "notes": "Only the default value of `sRGB` is implemented"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1",
-              "partial_implementation": true,
-              "notes": "Only the default value of `sRGB` is implemented"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -783,19 +779,19 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "3"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -819,19 +815,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -996,19 +992,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1031,7 +1027,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -1043,7 +1039,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1066,7 +1062,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤15"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -1078,7 +1074,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1576,7 +1572,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1611,7 +1607,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1761,19 +1757,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1796,19 +1792,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1831,19 +1827,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2160,19 +2156,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2297,19 +2293,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2367,7 +2363,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2379,7 +2375,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2402,7 +2398,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2414,7 +2410,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2437,7 +2433,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2449,7 +2445,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2472,7 +2468,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2484,7 +2480,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2507,7 +2503,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2519,7 +2515,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2542,7 +2538,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2554,7 +2550,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2577,7 +2573,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2589,7 +2585,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2612,19 +2608,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2987,7 +2983,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤83"
+              "version_added": "36"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2999,7 +2995,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1",
+              "version_added": "9",
               "partial_implementation": true,
               "notes": "Does not work with `transform` SVG presentation attribute. Only works with `transform` CSS property. See [bug 201854](https://webkit.org/b/201854)."
             },
@@ -3068,19 +3064,19 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "6"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "15"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `global_attributes` SVG feature. This replaces a majority of ranges within the SVG global attributes by copying data from the CSS property counterparts.
