### PR TITLE
Update Chromium data for -webkit-slider-runnable-track CSS selector

### DIFF
--- a/css/selectors/-webkit-slider-runnable-track.json
+++ b/css/selectors/-webkit-slider-runnable-track.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-slider-runnable-track",
           "support": {
             "chrome": {
-              "version_added": "≤83"
+              "version_added": "26"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `-webkit-slider-runnable-track` CSS selector. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code:

```css
::-webkit-slider-runnable-track {
  background: linear-gradient(to right, black, white);
}
```
