### PR TITLE
Update Chromium data for -webkit-slider-thumb CSS selector

### DIFF
--- a/css/selectors/-webkit-slider-thumb.json
+++ b/css/selectors/-webkit-slider-thumb.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-slider-thumb",
           "support": {
             "chrome": {
-              "version_added": "≤83"
+              "version_added": "32"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `-webkit-slider-thumb` CSS selector. The data comes from manual testing, running test code through BrowserStack, SauceLabs, custom VMs and/or locally.

Test Code:

```css
::-webkit-slider-thumb {
	padding: 1em;
}
```
