### PR TITLE
Chrome 138 ships CSS sign()

### DIFF
--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -11,8 +11,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40253181"
+              "version_added": "138"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/27362