### PR TITLE
FF141 - WebGPU not supported in service-worker contexts

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -78,7 +78,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -135,7 +135,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -217,7 +217,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -78,7 +78,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -129,7 +129,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -180,7 +180,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -215,7 +215,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -255,7 +255,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -295,7 +295,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -346,7 +346,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -66,7 +66,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -114,7 +114,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -196,7 +196,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -241,7 +241,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -286,7 +286,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -66,7 +66,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -66,7 +66,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -111,7 +111,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -156,7 +156,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -201,7 +201,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -246,7 +246,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -291,7 +291,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -147,7 +147,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -147,7 +147,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -66,7 +66,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUInternalError.json
+++ b/api/GPUInternalError.json
@@ -67,7 +67,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -91,7 +91,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -67,7 +67,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -155,7 +155,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -147,7 +147,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -204,7 +204,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -261,7 +261,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderBundle.json
+++ b/api/GPURenderBundle.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -147,7 +147,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -78,7 +78,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -135,7 +135,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -88,7 +88,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -733,7 +733,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -788,7 +788,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -843,7 +843,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -898,7 +898,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -953,7 +953,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1009,7 +1009,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -134,7 +134,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -191,7 +191,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -248,7 +248,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -293,7 +293,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -338,7 +338,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -395,7 +395,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -452,7 +452,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -509,7 +509,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -566,7 +566,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -623,7 +623,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -680,7 +680,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -737,7 +737,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -794,7 +794,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -891,7 +891,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -948,7 +948,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1005,7 +1005,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1062,7 +1062,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1119,7 +1119,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1176,7 +1176,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1233,7 +1233,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1290,7 +1290,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1347,7 +1347,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1404,7 +1404,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1461,7 +1461,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1518,7 +1518,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1575,7 +1575,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1632,7 +1632,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1689,7 +1689,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1746,7 +1746,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1803,7 +1803,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -90,7 +90,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -67,7 +67,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false
@@ -112,7 +112,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -91,7 +91,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -57,7 +57,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -240,7 +240,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -279,7 +279,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -318,7 +318,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -357,7 +357,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -396,7 +396,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -436,7 +436,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -329,7 +329,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Currently supported on Windows only. Not supported in service-workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
WebGPU correctly reports that FF is a partial implementation on Windows. What it omits is that the implementation is supposed to work on workers, but does not support service-worker contexts.
I _think_ that is relevant, though this might not be how you want to report it.
Note that I search-replaced on the strings, then removed the comment from `Navigator.gpu` where it is irrelevant.

Supporting comment in https://bugzilla.mozilla.org/show_bug.cgi?id=1972486#c20

Related docs work can be tracked in https://github.com/mdn/content/issues/40473