### PR TITLE
Chrome 137 supports accepts_nodes_in_shadow_trees for associated methods (setBaseAndExtent, collapse etc)

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -225,7 +225,7 @@
             "description": "Accepts `node` parameter in any tree/shadow tree",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "137"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -245,7 +245,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -651,7 +651,7 @@
             "description": "Accepts `node` parameter in any tree/shadow tree",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "137"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -671,7 +671,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -1227,7 +1227,7 @@
             "description": "Accepts `anchorNode` and `focusNode` arguments in different shadow trees",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "137"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1247,7 +1247,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As discussed in https://github.com/mdn/browser-compat-data/pull/27369/#discussion_r2229826145 and https://bugzilla.mozilla.org/show_bug.cgi?id=1903870#c13 

These two tests show that Chrome supports accepts_nodes_in_shadow_trees for collapse, extend, setBaseAndExtent of the selection API (I bisected to v137):

- https://wpt.live/selection/shadow-dom/tentative/Selection-collapse-and-extend.html - Chrome 137
- https://wpt.live/selection/shadow-dom/tentative/Selection-getComposedRanges-range-update.html - Chrome 137