### PR TITLE
FF142 Animation.commitStyles() - does not require fill: forwards

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -178,9 +178,9 @@
             "deprecated": false
           }
         },
-        "endpoint_inclusive_timing": {
+        "endpoint_inclusive_commitStyles": {
           "__compat": {
-            "description": "animation `fill` mode not needed",
+            "description": "`commitStyles()` automatically fills values",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/commitStyles",
             "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-commitstyles",
             "tags": [

--- a/api/Animation.json
+++ b/api/Animation.json
@@ -178,7 +178,7 @@
             "deprecated": false
           }
         },
-        "fill_endpoint_inclusive_timing": {
+        "endpoint_inclusive_timing": {
           "__compat": {
             "description": "animation `fill` mode not needed",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/commitStyles",

--- a/api/Animation.json
+++ b/api/Animation.json
@@ -178,9 +178,9 @@
             "deprecated": false
           }
         },
-        "endpoint_inclusive_timing": {
+        "fill_endpoint_inclusive_timing": {
           "__compat": {
-            "description": "`fill: 'forwards'` or `fill: 'both'` not needed",
+            "description": "animation `fill` mode not needed",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/commitStyles",
             "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-commitstyles",
             "tags": [

--- a/api/Animation.json
+++ b/api/Animation.json
@@ -177,6 +177,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "endpoint_inclusive_timing": {
+          "__compat": {
+            "description": "`fill: 'forwards'` or `fill: 'both'` not needed",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/commitStyles",
+            "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-commitstyles",
+            "tags": [
+              "web-features:web-animations"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "currentTime": {


### PR DESCRIPTION
[`Animation.commitStyles()`](https://developer.mozilla.org/en-US/docs/Web/API/Animation/commitStyles#examples) was modified in spec https://github.com/w3c/csswg-drafts/pull/11881 as a result of this discussion https://github.com/w3c/csswg-drafts/issues/5394#issuecomment-2954654330

I'm [clarifying](https://bugzilla.mozilla.org/show_bug.cgi?id=1973203#c8) but my understanding is that that the impact of the change is that you no longer need to specify a `fill: 'forwards'` on your animation in order to be able to commit the style after the animation has finished or been removed; instead the styles are captured at the end of the active stage.

My belief is that this is due to the first note in the spec https://drafts.csswg.org/web-animations-1/#dom-animation-commitstyles - essentially he process to calculate the styles that are written is endpoint **inclusive** - which means that they are copied at the endpoint of he active phase rather than at the beginning of the next phase, where the fill becomes relevant.

I mention all that because I'm not sure what the right name/description is, and this will help you help me.

Related docs work can be tracked in https://github.com/mdn/content/issues/40482