### PR TITLE
added version_removed for FF codebase attr for object element

### DIFF
--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -160,7 +160,8 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "142"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -153,11 +153,13 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#attr-object-codebase",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "≤62"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "≤80"
               },
               "firefox": {
                 "version_added": "1",
@@ -171,7 +173,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "3",
+                "version_removed": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

- Added `version_removed` for the `codebase` attribute of the `<object>` element in Firefox 142

#### Test results and supporting details

- Tested with this [code pen](https://codepen.io/CodeRedDigital/pen/GgpNgbM?editors=1000) in:
  - Firefox Stable (141) - works
  - Firefox Beta (142.0b3) - does not work as expected
  - Firefox Developer (142.0b3) - does not work as expected
  - Firefox Nightly (143.0a1) - does not work as expected
  - Via Browserstack:
    - Chrome (62) - does not work as expected
    - Safari (13.1) - does not work as expected
    - Edge (80) - does not work as expected
    - Opera (25) - does not work as expected

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/40557)