### PR TITLE
Narrow `VersionValue` to omit `true` values

### DIFF
--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -165,7 +165,7 @@ const compile = async (
   const ts = [
     header,
     await generateBrowserNames(),
-    'export type VersionValue = string | boolean | null;',
+    'export type VersionValue = string | false | null;',
     transformTS(browserTS, compatTS),
     generateCompatDataTypes(),
   ].join('\n\n');


### PR DESCRIPTION
#### Summary

BCD's published types don't match the JSON Schema; this PR partially fixes this.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

`VersionValue` has the type `string | boolean | null`; it _should_ have the type `string | false`.

Unfortunately, setting `VesionValue` to `string | false` causes several type errors in linter code. And it's not just dead code either; replacing places `true` or `null` returns into thrown exceptions causes many errors.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/24174#issuecomment-2621295812

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
