### PR TITLE
Remove nonreal values from typedefs, linters and scripts

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,18 +24,21 @@ For more information on the schema for browser data, see [`browsers-schema.md`](
 
 ## Generate statistics
 
-To see how changes will affect the statistics of real (either `false` or a version number, as defined in [issue 3555](https://github.com/mdn/browser-compat-data/issues/3555)), true, and null values, you can run `npm run stats [folder]`. This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on. The script also takes an optional argument regarding a specific folder (such as `api` or `javascript`), which will print statistics result for only that folder. Additionally, you can run the script with `--all` to get statistics for all browsers tracked in BCD, not just the primary eight.
+To see how changes will affect the statistics of exact (formerly "real") and ranged values, you can run `npm run stats [folder]`. This generates a Markdown-formatted table of the percentages of exact and ranged values for the eight primary browsers that browser-compat-data is focusing on. The script also takes an optional argument regarding a specific folder (such as `api` or `javascript`), which will print statistics result for only that folder. Additionally, you can run the script with `--all` to get statistics for all browsers tracked in BCD, not just the primary eight.
+
+> [!NOTE]
+> Originally, this script was designed to track "real" (either `false` or a version number, as defined in [issue 3555](https://github.com/mdn/browser-compat-data/issues/3555)), ranged, true, and null values in order to track the progress of a project to eliminate "non-real" (true and null) values. Since the project was completed, the script was simplified to display just exact and ranged values.
 
 ## Traverse features
 
-To find all the entries that are non-real, or of a specified value, you can run `npm run traverse -- [options] [folder]`.
+To find all the entries that are of a specified value, you can run `npm run traverse -- [options] [folder]`.
 
-By default, the script will traverse and print the dotted path to every feature. One or more positional arguments can limit the traversal to a specific folder (for example, `api`). Additional options can limit the features listed to features with data matching specific browser and version values (for example, `--non-real`).
+By default, the script will traverse and print the dotted path to every feature. One or more positional arguments can limit the traversal to a specific folder (for example, `api`). Additional options can limit the features listed to features with data matching specific browser and version values.
 
 Run `npm run traverse -- --help` for a complete list of options and examples.
 
 The `-b` or `--browser` argument may be any browser in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/main/browsers/). This argument may be repeated to traverse multiple browsers. By default, the script will traverse all browsers.
 
-The `-f` or `--filter` argument may be any value accepted by `version_added` or `version_removed`. This argument may be repeated to test multiple values. By default, the script will traverse all features regardless of their value. The `-n` or `--non-real` argument may be included as a convenience alias for `-f null -f true`.
+The `-f` or `--filter` argument may be any value accepted by `version_added` or `version_removed`. This argument may be repeated to test multiple values. By default, the script will traverse all features regardless of their value.
 
-Examples: to search for all Safari entries that are non-real, run `npm run traverse -- -b safari --non-real`. To search for all WebView entries that are marked as `true` in `api` and `javascript`, run `npm run traverse api,javascript -- -b webview_android -f true`. To search for all Firefox entries supported since `10` across all folders, run `npm run traverse -- -b firefox -f 10`.
+Examples: to search for all Safari entries that are not supported, run `npm run traverse -- -b safari -f false`. To search for all WebView entries that are mirroring from upstream in `api` and `javascript`, run `npm run traverse api,javascript -- -b webview_android -f mirror`. To search for all Firefox entries supported since `10` across all folders, run `npm run traverse -- -b firefox -f 10`.

--- a/lint/linter/test-consistency.test.ts
+++ b/lint/linter/test-consistency.test.ts
@@ -8,21 +8,14 @@ import { ConsistencyChecker } from './test-consistency.js';
 const check = new ConsistencyChecker();
 
 describe('ConsistencyChecker.getVersionAdded()', () => {
-  it('returns null for non-real values', () => {
-    assert.equal(
-      check.getVersionAdded({ chrome: { version_added: null } }, 'chrome'),
-      null,
-    );
-  });
-
-  it('returns null for "preview" values', () => {
+  it('returns false for "preview" values', () => {
     assert.equal(
       check.getVersionAdded({ chrome: { version_added: 'preview' } }, 'chrome'),
-      null,
+      false,
     );
   });
 
-  it('returns the value for real and ranged values', () => {
+  it('returns the value for exact and ranged values', () => {
     assert.equal(
       check.getVersionAdded({ chrome: { version_added: '12' } }, 'chrome'),
       '12',
@@ -33,7 +26,7 @@ describe('ConsistencyChecker.getVersionAdded()', () => {
     );
   });
 
-  it('returns the earliest real value for an array support statement', () => {
+  it('returns the earliest exact value for an array support statement', () => {
     assert.equal(
       check.getVersionAdded(
         { chrome: [{ version_added: '≤11' }, { version_added: '101' }] },
@@ -51,19 +44,19 @@ describe('ConsistencyChecker.getVersionAdded()', () => {
         },
         'chrome',
       ),
-      null,
+      false,
     );
     assert.equal(
       check.getVersionAdded(
         {
           chrome: [
-            { version_added: true },
+            { version_added: '20' },
             { version_added: '≤11', flags: [] },
           ],
         },
         'chrome',
       ),
-      null,
+      '20',
     );
     assert.equal(
       check.getVersionAdded(

--- a/lint/linter/test-consistency.ts
+++ b/lint/linter/test-consistency.ts
@@ -20,6 +20,7 @@ import {
 } from '../../types/index.js';
 import { query } from '../../utils/index.js';
 import mirrorSupport from '../../scripts/build/mirror.js';
+import bcd from '../../index.js';
 
 type ErrorType =
   | 'unsupported'
@@ -180,53 +181,6 @@ export class ConsistencyChecker {
       }
     });
 
-    // Test whether sub-features are supported when basic support is not implemented
-    // For all unsupported browsers (basic support == false), sub-features should be set to false
-    const supportUnknownInParent = this.extractSupportUnknownBrowsers(
-      data.__compat,
-    );
-    inconsistentSubfeaturesByBrowser = {};
-
-    for (const subfeature of subfeatures) {
-      const supportUnknownInChild = this.extractSupportNotTrueBrowsers(
-        query(subfeature, data).__compat,
-      );
-
-      const browsers = supportUnknownInParent.filter(
-        (x) => !supportUnknownInChild.includes(x),
-      ) as BrowserName[];
-
-      for (const browser of browsers) {
-        inconsistentSubfeaturesByBrowser[browser] =
-          inconsistentSubfeaturesByBrowser[browser] || [];
-        const subfeature_value = this.getVersionAdded(
-          query(subfeature, data).__compat.support,
-          browser,
-        );
-        inconsistentSubfeaturesByBrowser[browser]?.push([
-          subfeature,
-          subfeature_value,
-        ]);
-      }
-    }
-
-    // Add errors
-    Object.keys(inconsistentSubfeaturesByBrowser).forEach((browser) => {
-      const subfeatures =
-        inconsistentSubfeaturesByBrowser[browser as BrowserName];
-      if (subfeatures) {
-        errors.push({
-          type: 'support_unknown',
-          browser: browser as BrowserName,
-          parentValue: this.getVersionAdded(
-            data?.__compat?.support,
-            browser as BrowserName,
-          ),
-          subfeatures,
-        });
-      }
-    });
-
     // Test whether sub-features are supported at an earlier version than basic support
     const supportInParent = this.extractSupportedBrowsersWithVersion(
       data.__compat,
@@ -302,33 +256,6 @@ export class ConsistencyChecker {
   }
 
   /**
-   * Get all of the browsers with unknown support in a feature
-   * @param compatData The compat data to process
-   * @returns The list of browsers with unknown support
-   */
-  extractSupportUnknownBrowsers(compatData?: CompatStatement): BrowserName[] {
-    return this.extractBrowsers(
-      compatData,
-      (data) => data.version_added === null,
-    );
-  }
-
-  /**
-   * Get all of the browsers with either unknown or no support in a feature
-   * @param compatData The compat data to process
-   * @returns The list of browsers with non-truthy (false or null) support
-   */
-  extractSupportNotTrueBrowsers(compatData?: CompatStatement): BrowserName[] {
-    return this.extractBrowsers(
-      compatData,
-      (data) =>
-        data.version_added === false ||
-        data.version_added === null ||
-        (typeof data.version_removed !== 'undefined' &&
-          data.version_removed !== false),
-    );
-  }
-  /**
    * Get all of the browsers with a version number in a feature.
    * @param compatData The compat data to process
    * @returns The list of browsers with an exact version number
@@ -353,12 +280,12 @@ export class ConsistencyChecker {
     browser: BrowserName,
   ): VersionValue {
     if (!supportBlock) {
-      return null;
+      return false;
     }
 
     const supportStatement = supportBlock[browser];
     if (!supportStatement) {
-      return null;
+      return false;
     }
 
     if (supportStatement === 'mirror') {
@@ -369,16 +296,15 @@ export class ConsistencyChecker {
     }
 
     /**
-     * A convenience function to squash non-real values and previews into null
+     * A convenience function to squash preview and flag support into `false`
      * @param statement The statement to use
-     * @returns The version number or 'null'
+     * @returns The version number or `false`
      */
     const resolveVersionAddedValue = (
       statement: SimpleSupportStatement,
     ): VersionValue =>
-      [true, false, 'preview', null].includes(statement?.version_added) ||
-      statement.flags
-        ? null
+      statement?.version_added == 'preview' || statement.flags
+        ? false
         : statement?.version_added;
 
     // Handle simple support statements
@@ -387,35 +313,27 @@ export class ConsistencyChecker {
     }
 
     // Handle array support statements
-    let selectedValue: string | boolean | null = null;
+    let selectedValue: string | false = false;
     for (const statement of supportStatement) {
       const resolvedValue = resolveVersionAddedValue(statement);
 
-      if (resolvedValue === null) {
+      if (resolvedValue === false) {
         // We're not going to get a more specific version, so bail out now
         continue;
       }
 
-      if (selectedValue !== null) {
-        if (
-          typeof resolvedValue === 'string' &&
-          typeof selectedValue === 'string'
-        ) {
-          // Earlier value takes precedence
-          const resolvedIsEarlier = compare(
-            resolvedValue.replace('≤', ''),
-            selectedValue.replace('≤', ''),
-            '<',
-          );
-          if (resolvedIsEarlier) {
-            selectedValue = resolvedValue;
-          }
-        } else if (typeof resolvedValue === 'string') {
-          // If selectedValue is bool/null but resolvedValue is string
+      if (
+        typeof resolvedValue === 'string' &&
+        typeof selectedValue === 'string'
+      ) {
+        // Earlier value takes precedence
+        const resolvedIsEarlier = compare(
+          resolvedValue.replace('≤', ''),
+          selectedValue.replace('≤', ''),
+          '<',
+        );
+        if (resolvedIsEarlier) {
           selectedValue = resolvedValue;
-        } else {
-          // If neither are version numbers, assign to the truthiest value
-          selectedValue = selectedValue || resolvedValue;
         }
       } else {
         selectedValue = resolvedValue;
@@ -479,21 +397,23 @@ export class ConsistencyChecker {
       return [];
     }
 
-    return (Object.keys(compatData.support) as BrowserName[]).filter(
-      (browser) => {
-        let browserData: InternalSupportStatement = compatData.support[browser];
-        if ((browserData as InternalSupportStatement) === 'mirror') {
-          browserData = mirrorSupport(browser, compatData.support);
-        }
+    return (Object.keys(bcd.browsers) as BrowserName[]).filter((browser) => {
+      if (!(browser in compatData.support)) {
+        return callback({ version_added: false });
+      }
 
-        if (Array.isArray(browserData)) {
-          return browserData.every(callback);
-        } else if (typeof browserData === 'object') {
-          return callback(browserData);
-        }
-        return false;
-      },
-    );
+      let browserData: InternalSupportStatement = compatData.support[browser];
+      if ((browserData as InternalSupportStatement) === 'mirror') {
+        browserData = mirrorSupport(browser, compatData.support);
+      }
+
+      if (Array.isArray(browserData)) {
+        return browserData.every(callback);
+      } else if (typeof browserData === 'object') {
+        return callback(browserData);
+      }
+      return false;
+    });
   }
 }
 

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -165,7 +165,7 @@ const compile = async (
   const ts = [
     header,
     await generateBrowserNames(),
-    'export type VersionValue = string | boolean | null;',
+    'export type VersionValue = string | false;',
     transformTS(browserTS, compatTS),
     generateCompatDataTypes(),
   ].join('\n\n');

--- a/scripts/statistics.ts
+++ b/scripts/statistics.ts
@@ -19,8 +19,8 @@ import { getRefDate } from './release/utils.js';
 
 interface VersionStatsEntry {
   all: number;
+  exact: number;
   range: number;
-  real: number;
 }
 
 type VersionStats = Record<string, VersionStatsEntry>;
@@ -65,7 +65,7 @@ const checkSupport = (
 };
 
 /**
- * Iterate through all of the browsers and count the number of true, null, real, and ranged values for each browser
+ * Iterate through all of the browsers and count the number of exact ranged values for each browser
  * @param data The data to process and count stats for
  * @param browsers The browsers to test
  * @param stats The stats object to update
@@ -83,8 +83,8 @@ const processData = (
         stats[browser].range++;
         stats.total.range++;
       } else {
-        stats[browser].real++;
-        stats.total.real++;
+        stats[browser].exact++;
+        stats.total.exact++;
       }
     });
   }
@@ -138,10 +138,10 @@ const getStats = (
         ] as BrowserName[]);
 
   const stats: VersionStats = {
-    total: { all: 0, range: 0, real: 0 },
+    total: { all: 0, range: 0, exact: 0 },
   };
   browsers.forEach((browser) => {
-    stats[browser] = { all: 0, range: 0, real: 0 };
+    stats[browser] = { all: 0, range: 0, exact: 0 };
   });
 
   if (folder) {
@@ -215,12 +215,12 @@ const printStats = (
     }}: \n`,
   );
 
-  const header = ['browser', 'real', 'ranged'];
+  const header = ['browser', 'exact', 'ranged'];
   const align = ['l', 'r', 'r'];
   const rows = Object.keys(stats).map((entry) =>
     [
       entry,
-      getStat(stats[entry], 'real', counts),
+      getStat(stats[entry], 'exact', counts),
       getStat(stats[entry], 'range', counts),
     ].map(String),
   );
@@ -233,7 +233,7 @@ const printStats = (
 if (esMain(import.meta)) {
   const { argv }: { argv } = yargs(hideBin(process.argv)).command(
     '$0 [folder]',
-    'Print a markdown-formatted table displaying the statistics of real, ranged, true, and null values for each browser',
+    'Print a markdown-formatted table displaying the statistics of exact and values for each browser',
     (yargs) => {
       yargs
         .positional('folder', {

--- a/utils/iter-support.test.ts
+++ b/utils/iter-support.test.ts
@@ -6,24 +6,32 @@ import assert from 'node:assert/strict';
 import iterSupport from './iter-support.js';
 
 describe('iterSupport()', () => {
-  it('returns a `"version_added": null` support statement for non-existent browsers', () => {
+  it('returns a `"version_added": false` support statement for non-existent browsers', () => {
     assert.deepEqual(iterSupport({ support: { firefox: [] } }, 'chrome'), [
-      { version_added: null },
+      { version_added: false },
     ]);
   });
 
   it('returns a single support statement as an array', () => {
     assert.deepEqual(
-      iterSupport({ support: { firefox: { version_added: true } } }, 'firefox'),
-      [{ version_added: true }],
+      iterSupport({ support: { firefox: { version_added: '1' } } }, 'firefox'),
+      [{ version_added: '1' }],
     );
   });
 
   it('returns an array of support statements as an array', () => {
     const compatObj = {
-      support: { firefox: [{ version_added: true }, { version_added: '1' }] },
+      support: {
+        firefox: [
+          { version_added: '1' },
+          { version_added: '2', prefix: '-moz-' },
+        ],
+      },
     };
-    const support = [{ version_added: true }, { version_added: '1' }];
+    const support = [
+      { version_added: '1' },
+      { version_added: '2', prefix: '-moz-' },
+    ];
 
     assert.deepEqual(iterSupport(compatObj, 'firefox'), support);
   });

--- a/utils/iter-support.ts
+++ b/utils/iter-support.ts
@@ -24,5 +24,5 @@ export default (
     }
   }
 
-  return [{ version_added: null }];
+  return [{ version_added: false }];
 };


### PR DESCRIPTION
This PR removes the last remnants of nonreal values, which were left within the typedefs, linters and scripts.  This is the very last step to remove nonreal values from BCD altogether.

Since nonreal values are no longer a thing, this PR also updates the terminology in documentation.  Rather than calling them "real values", this PR opts to call non-ranged version numbers "exact values".

Depends on #27427.
