### PR TITLE
Bug-1910669 add StorageArea.getKeys()

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -711,7 +711,7 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "18.4"
+                  "version_added": false
                 },
                 "safari_ios": "mirror"
               }


### PR DESCRIPTION
#### Summary

Add details of support for the StorageArea.getKeys() method.

This address is the dev-docs-needed requirements of [Bug 1910669](https://bugzilla.mozilla.org/show_bug.cgi?id=1910669) Implement StorageArea.getKeys() in extension storage API

#### Related issues

MDM document changes in https://github.com/mdn/content/pull/40560