### PR TITLE
add disables_invalid_values_in_picker_ui sub-feature to input type=date

### DIFF
--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -44,6 +44,30 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "disables_invalid_values_in_picker_ui": {
+            "__compat": {
+              "description": "Disables invalid values in picker UI",
+              "support": {
+                "chrome": {
+                  "version_added": "20"
+                },
+                "firefox": {
+                  "version_added": "57"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Added a sub-feature to `html.elements.input.type_date` to indicate when browsers prevent picking dates outside the min/max range in the date picker UI.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
As cited in https://github.com/mdn/browser-compat-data/issues/26656#issuecomment-2867357979 .
Please @caugner, confirm the versions.
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" --> 
Fixes #26656 
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
