### PR TITLE
Ensure that version_removed: false does not get generated by mirroring

### DIFF
--- a/scripts/build/mirror.ts
+++ b/scripts/build/mirror.ts
@@ -41,7 +41,8 @@ const matchingSafariVersions = new Map([
  * Convert a version number to the matching version of the target browser
  * @param targetBrowser The browser to mirror to
  * @param sourceVersion The version from the source browser
- * @returns The matching browser version
+ * @returns The matching browser version, or `false` if no match is found
+ * @throws An error when the downstream browser has no upstream
  */
 export const getMatchingBrowserVersion = (
   targetBrowser: BrowserName,
@@ -240,7 +241,7 @@ export const bumpSupport = (
       sourceData.version_removed,
     );
 
-    // Ensure that version_removed is not present if it's not applicable
+    // Ensure that version_removed is not present if it's not applicable, such as when the upstream browser removed the feature in a newer release than a matching downstream browser
     if (newData.version_removed === false) {
       delete newData.version_removed;
     }

--- a/scripts/build/mirror.ts
+++ b/scripts/build/mirror.ts
@@ -239,6 +239,11 @@ export const bumpSupport = (
       destination,
       sourceData.version_removed,
     );
+
+    // Ensure that version_removed is not present if it's not applicable
+    if (newData.version_removed === false) {
+      delete newData.version_removed;
+    }
   }
 
   if (newData.version_added === newData.version_removed) {


### PR DESCRIPTION
This PR updates the mirroring script to check if the end result of `version_removed` is `false`, and if so, delete the key so that it is not generated in the final build output.  Fixes #27437.
