### PR TITLE
Add missing sub features for CSS hyphens property

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -2282,6 +2282,98 @@
               "deprecated": false
             }
           }
+        },
+        "manual": {
+          "__compat": {
+            "description": "`manual` value",
+            "tags": [
+              "web-features:hyphens"
+            ],
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "88"
+                },
+                {
+                  "version_added": "55",
+                  "version_removed": "88",
+                  "partial_implementation": true,
+                  "notes": "Only supported on macOS."
+                }
+              ],
+              "chrome_android": {
+                "version_added": "55"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "6"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "description": "`none` value",
+            "tags": [
+              "web-features:hyphens"
+            ],
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "88"
+                },
+                {
+                  "version_added": "55",
+                  "version_removed": "88",
+                  "partial_implementation": true,
+                  "notes": "Only supported on macOS."
+                }
+              ],
+              "chrome_android": {
+                "version_added": "55"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "6"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Adds missing sub features for the CSS hyphens property as found by the mdn-bcd-collector. Assumes support shipped with the initial implementation.