### PR TITLE
Consolidate `only`  keyword into a single sub feature of color-scheme

### DIFF
--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -134,49 +134,9 @@
             }
           }
         },
-        "only_dark": {
+        "only": {
           "__compat": {
-            "description": "`only dark` keyword",
-            "tags": [
-              "web-features:color-scheme"
-            ],
-            "support": {
-              "chrome": [
-                {
-                  "version_added": "98"
-                },
-                {
-                  "version_added": "81",
-                  "version_removed": "85"
-                }
-              ],
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "96"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "13"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "only_light": {
-          "__compat": {
-            "description": "`only light` keyword",
+            "description": "`only` keyword",
             "tags": [
               "web-features:color-scheme"
             ],


### PR DESCRIPTION
We only need one sub feature for the `only` keyword here.