### PR TITLE
FF142 RTCRtpSender.setParameters() encodings.codec param supported

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -698,6 +698,40 @@
               }
             }
           },
+          "codec": {
+            "__compat": {
+              "description": "`parameters.encodings.codec` parameter",
+              "tags": [
+                "web-features:webrtc"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "119"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "142"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "dtx": {
             "__compat": {
               "description": "`parameters.encodings.dtx` parameter",


### PR DESCRIPTION
FF142 adds support for the dictionary property `RTCRtpEncodingParameters.codec` in https://bugzilla.mozilla.org/show_bug.cgi?id=1894137

This is used when setting encodings in [`RTCRtpSender.setParameters(parameter.encodings)`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters#encodings) and [`RTCPeerConnection.addTransceiver(sendencodings)`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#sendencodings), and returned in [`RTCRtpSender/getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/getParameters#encodings) (`encodings.codec`).

This updates the `setParameters()`  - encodings - subfeature on the sender. The `getParameters()` and `RTCPeerConnection.addTransceiver` features don't go down to the same level - my assumption is that you don't want to record this because it would likely always duplicate.

The version values for chrome and safari were found by running https://wpt.live/webrtc/RTCRtpParameters-codec.html on browserstack.

Related docs work can be tracked in https://github.com/mdn/content/issues/40477