### PR TITLE
feat(manifest): add ./types export with separate type and default entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "./forLegacyNode": {
       "types": "./build/import.d.mts",
       "default": "./build/legacynode.mjs"
+    },
+    "./types": {
+      "types": "./build/types.d.ts",
+      "default": "./build/types.d.ts"
     }
   },
   "types": "./build/require.d.ts",

--- a/scripts/build/index.ts
+++ b/scripts/build/index.ts
@@ -307,6 +307,10 @@ export const createManifest = (): any => {
         types: './import.d.mts',
         default: './legacynode.mjs',
       },
+      './types': {
+        types: './types.d.ts',
+        default: './build/types.d.ts',
+      },
     },
     types: 'require.d.ts',
   };

--- a/scripts/build/index.ts
+++ b/scripts/build/index.ts
@@ -309,7 +309,7 @@ export const createManifest = (): any => {
       },
       './types': {
         types: './types.d.ts',
-        default: './build/types.d.ts',
+        default: './types.d.ts',
       },
     },
     types: 'require.d.ts',


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
This PR adds a new `./types` subpath export to the generated manifest. It separates the `types` and default fields to better support tools and consumers that reference type definitions directly.
#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See Node.js package exports documentation: https://nodejs.org/api/packages.html#exports
#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
Fixes failing tests at https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/2104