### PR TITLE
Update Edge data for CreateMonitor API

### DIFF
--- a/api/CreateMonitor.json
+++ b/api/CreateMonitor.json
@@ -16,14 +16,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "138",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#edge-llm-summarization-api-for-phi-mini",
-                "value_to_set": "Enabled"
-              }
-            ]
+            "version_added": "138"
           },
           "firefox": {
             "version_added": false
@@ -66,14 +59,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `CreateMonitor` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.6).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CreateMonitor

Additional Notes: It seems the preference is enabled by default.
