### PR TITLE
Update Edge data for LanguageDetector API

### DIFF
--- a/api/LanguageDetector.json
+++ b/api/LanguageDetector.json
@@ -16,7 +16,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": false
+            "version_added": "138"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -103,7 +103,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -147,7 +147,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -235,7 +235,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -279,7 +279,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -323,7 +323,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `LanguageDetector` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.6).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/LanguageDetector
