### PR TITLE
Update Edge data for Summarizer API

### DIFF
--- a/api/Summarizer.json
+++ b/api/Summarizer.json
@@ -18,14 +18,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "138",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#edge-llm-summarization-api-for-phi-mini",
-                "value_to_set": "Enabled"
-              }
-            ]
+            "version_added": "138"
           },
           "firefox": {
             "version_added": false
@@ -71,14 +64,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -125,14 +111,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -179,14 +158,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -233,14 +205,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -287,14 +252,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -341,14 +299,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -395,14 +346,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -449,14 +393,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -503,14 +440,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -557,14 +487,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -611,14 +534,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -665,14 +581,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -719,14 +628,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -773,14 +675,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `Summarizer` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.6).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Summarizer
