### PR TITLE
Update Edge data for Translator API

### DIFF
--- a/api/Translator.json
+++ b/api/Translator.json
@@ -15,7 +15,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": false
+            "version_added": "138"
           },
           "firefox": {
             "version_added": false
@@ -58,7 +58,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -102,7 +102,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -146,7 +146,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -190,7 +190,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -234,7 +234,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -278,7 +278,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -322,7 +322,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -366,7 +366,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false
@@ -410,7 +410,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "138"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `Translator` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.13.6).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Translator
