### PR TITLE
created BCD files for :heading and ;heading() selectors

### DIFF
--- a/css/selectors/heading.json
+++ b/css/selectors/heading.json
@@ -1,0 +1,49 @@
+{
+  "css": {
+    "selectors": {
+      "heading": {
+        "__compat": {
+          "description": "`:heading`",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:heading",
+          "spec_url": "https://drafts.csswg.org/selectors-5/#headings",
+          "tags": [
+            "web-features:heading"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.heading-selector.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/headingfunction.json
+++ b/css/selectors/headingfunction.json
@@ -1,0 +1,49 @@
+{
+  "css": {
+    "selectors": {
+      "headingfunction": {
+        "__compat": {
+          "description": "`:heading()`",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/:heading-function",
+          "spec_url": "https://drafts.csswg.org/selectors-5/#headings",
+          "tags": [
+            "web-features:heading"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.heading-selector.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

- Created the following BCD files:
  - `:heading` pseudo-class - css/selectors/heading.json
  - `:heading` pseudo-class function - css/selectors/headingfunction.json

#### Test results and supporting details

- Not supported in:
  - Google Chrome
  - Safari
  - Opera
- Tested in Firefox with this [CodePen](https://codepen.io/CodeRedDigital/pen/KwdmRNV?editors=0100) using the feature flag `layout.css.heading-selector.enabled`:
  - Firefox 141.0.2 - flag not present
  - Firefox Beta 142.0b7 - works as expected
  - Firefox Developer Edition 142.0b7 - works as expected
  - Firefox Nightly 143.0a1 - works as expected

#### Related issues

- [MDN Issue #40483](https://github.com/mdn/content/issues/40483)
- [Bugzilla #1974386](https://bugzil.la/1974386)
- Content PR - Coming soon
- Firefox Release Note PR - Coming soon
