### PR TITLE
Chrome 139 corner-shape types

### DIFF
--- a/css/types/corner-shape-value.json
+++ b/css/types/corner-shape-value.json
@@ -1,0 +1,256 @@
+{
+  "css": {
+    "types": {
+      "corner-shape-value": {
+        "__compat": {
+          "description": "`<corner-shape-value>`",
+          "spec_url": "https://drafts.csswg.org/css-borders-4/#typedef-corner-shape-value",
+          "support": {
+            "chrome": {
+              "version_added": "139"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "bevel": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-borders-4/#valdef-corner-shape-value-bevel",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "notch": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-borders-4/#valdef-corner-shape-value-notch",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "round": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-borders-4/#valdef-corner-shape-value-round",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scoop": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-borders-4/#valdef-corner-shape-value-scoop",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "square": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-borders-4/#valdef-corner-shape-value-square",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "squircle": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-borders-4/#valdef-corner-shape-value-squircle",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "superellipse": {
+          "__compat": {
+            "description": "`superellipse()` function",
+            "spec_url": "https://drafts.csswg.org/css-borders-4/#valdef-corner-shape-value-superellipse-k",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/superellipse.json
+++ b/css/types/superellipse.json
@@ -1,0 +1,38 @@
+{
+  "css": {
+    "types": {
+      "superellipse": {
+        "__compat": {
+          "description": "`superellipse()`",
+          "spec_url": "https://drafts.csswg.org/css-borders-4/#funcdef-superellipse",
+          "support": {
+            "chrome": {
+              "version_added": "139"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 139 adds support for the [`corner-shape`](https://drafts.csswg.org/css-borders-4/#corner-shaping) property, and its related shorthands and longhands. See https://chromestatus.com/feature/5357329815699456.

The properties have already been added to BCD by the collector, but the types that it can take as values have not.

This PR adds data for the types.

Note that I have included two data points for `superellipse()` — one for the function itself, and one for the use of `superellipse()` as a `<corner-shape-value>`. I thought this was a good idea in case `superellipse()` has more parameter options added, or is used as a possible value for other properties in the future.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
