### PR TITLE
Update del.json with Safari support note

### DIFF
--- a/html/elements/del.json
+++ b/html/elements/del.json
@@ -27,7 +27,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤4"
+              "version_added": "≤4",
+              "partial_implementation": true,
+              "notes": "As of Safari 18, VoiceOver does not announce text preceding `<del>` when using read-all. See [bug 286267](https://bugs.webkit.org/show_bug.cgi?id=286267)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Reflects support for `<del>` as of Safari 18.

#### Test results and supporting details

https://bugs.webkit.org/show_bug.cgi?id=286267

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27443
