### PR TITLE
Safari TP 224 added `hidden="until-found"` support

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -614,7 +614,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/238266"
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The PR https://github.com/WebKit/WebKit/pull/47284 mentioned in https://bugs.webkit.org/show_bug.cgi?id=238266 has been merged on June 27 and is that for part of [Safari Technology Preview 224](https://webkit.org/blog/17210/release-notes-for-safari-technology-preview-224/) according to the mentioned changes: https://github.com/WebKit/WebKit/compare/b847aa758aa9c20b9140c0696f7297cc1dd9c842...c2fd70ad613f1ba0dce4deb3678fbce717c0fe5e

#### Test results and supporting details

I've verified this on a very simple [JSBin](https://jsbin.com/gerotay/1/edit?html,output) (borrowed the HTML code by [web.dev codepen](https://codepen.io/web-dot-dev/pen/oNpmaXV)) with the newest Safari Technology Preview version.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
