### PR TITLE
docs: added Safari implementation bugzilla URL

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -165,7 +165,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/284592"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the "dialog light dismiss behavior" (aka [`closedby` property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy)) has a Webkit Bugzilla URL implementation URL.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
