### PR TITLE
Clarify notes for Safari `setHTMLUnsafe()` and friends

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5860,7 +5860,7 @@
                 "version_added": "17.4",
                 "version_removed": "26",
                 "partial_implementation": true,
-                "notes": "Won't work when parsed HTML contains web components ([bug 296420](https://webkit.org/b/296420).)"
+                "notes": "If there are custom elements in the parsed HTML, then the elements' constructors and `connectedCallback()` methods are not called ([bug 296420](https://webkit.org/b/296420))."
               }
             ],
             "safari_ios": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -10190,7 +10190,7 @@
                 "version_added": "17.4",
                 "version_removed": "26",
                 "partial_implementation": true,
-                "notes": "Won't work when HTML contains web components ([bug 296420](https://webkit.org/b/296420).)"
+                "notes": "If there are custom elements in the parsed HTML, then the elements' constructors and `connectedCallback()` methods are not called ([bug 296420](https://webkit.org/b/296420))."
               }
             ],
             "safari_ios": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -816,7 +816,7 @@
                 "version_added": "17.4",
                 "version_removed": "26",
                 "partial_implementation": true,
-                "notes": "Won't work when parsed HTML contains web components ([bug 296420](https://webkit.org/b/296420).)"
+                "notes": "If there are custom elements in the parsed HTML, then the elements' constructors and `connectedCallback()` methods are not called ([bug 296420](https://webkit.org/b/296420))."
               }
             ],
             "safari_ios": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The existing text doesn't actually say what the problem is, just that it "won't work." This PR attempts to add some substance to "won't work."

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I encountered this in https://github.com/web-platform-dx/web-features/pull/3200/, where the note text wasn't helpful in understanding whether there ought to be a Baseline regression and I had to read the complete bug anyway.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/27392
- https://github.com/web-platform-dx/web-features/pull/3200/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
