### PR TITLE
Updates for Chrome 140 beta

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -590,7 +590,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "140"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -610,7 +610,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -84,7 +84,7 @@
           "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-depthactive",
           "support": {
             "chrome": {
-              "version_added": "139"
+              "version_added": "140"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -154,7 +154,7 @@
           "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-depthtype",
           "support": {
             "chrome": {
-              "version_added": "139"
+              "version_added": "140"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -539,7 +539,7 @@
           "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-pausedepthsensing",
           "support": {
             "chrome": {
-              "version_added": "139"
+              "version_added": "140"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -841,7 +841,7 @@
           "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-resumedepthsensing",
           "support": {
             "chrome": {
-              "version_added": "139"
+              "version_added": "140"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -502,8 +502,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/40398871"
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -673,8 +672,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/40398871"
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/caret-animation.json
+++ b/css/properties/caret-animation.json
@@ -1,0 +1,105 @@
+{
+  "css": {
+    "properties": {
+      "caret-animation": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-ui/#propdef-caret-animation",
+          "support": {
+            "chrome": {
+              "version_added": "140"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui/#valdef-caret-animation-auto",
+            "support": {
+              "chrome": {
+                "version_added": "140"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "manual": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui/#valdef-caret-animation-manual",
+            "support": {
+              "chrome": {
+                "version_added": "140"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/scroll-target-group.json
+++ b/css/properties/scroll-target-group.json
@@ -1,0 +1,105 @@
+{
+  "css": {
+    "properties": {
+      "scroll-target-group": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-overflow-5/#scroll-target-group",
+          "support": {
+            "chrome": {
+              "version_added": "140"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overflow-5/#valdef-scroll-target-group-auto",
+            "support": {
+              "chrome": {
+                "version_added": "140"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overflow-5/#valdef-scroll-target-group-none",
+            "support": {
+              "chrome": {
+                "version_added": "140"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -9,7 +9,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "140"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -29,7 +29,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -144,7 +144,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -164,7 +164,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -178,7 +178,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -198,7 +198,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/view-transition-group.json
+++ b/css/properties/view-transition-group.json
@@ -1,0 +1,135 @@
+{
+  "css": {
+    "properties": {
+      "view-transition-group": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#view-transition-group-prop",
+          "support": {
+            "chrome": {
+              "version_added": "140"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "contain": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "140"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "nearest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "140"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "normal": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "140"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -213,8 +213,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/42204568"
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -255,8 +254,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/42204568"
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -297,8 +295,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/42204568"
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -339,8 +336,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/42204568"
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -381,8 +377,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/42204568"
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -423,8 +418,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/42204568"
+                "version_added": "140"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.14.0 found new features shipping in Chrome 140 beta which was released last week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 57 features as shipping in Chrome 140:

- api.Element.scrollIntoView.options_container_parameter
- api.FontFace.variationSettings
- api.HighlightRegistry.highlightsFromPoint
- api.ReadableStreamBYOBReader.read.options_min_parameter
- api.ToggleEvent.source
- api.XRSession.depthActive **(was 139)**
- api.XRSession.depthType **(was 139)**
- api.XRSession.pauseDepthSensing **(was 139)**
- api.XRSession.resumeDepthSensing **(was 139)**
- css.at-rules.font-face.font-feature-settings
- css.at-rules.font-face.font-variation-settings
- css.properties.caret-animation
- css.properties.caret-animation.auto
- css.properties.caret-animation.manual
- css.properties.scroll-target-group
- css.properties.scroll-target-group.auto
- css.properties.scroll-target-group.none
- css.properties.text-autospace
- css.properties.text-autospace.no-autospace
- css.properties.text-autospace.normal
- css.properties.view-transition-group
- css.properties.view-transition-group.contain
- css.properties.view-transition-group.nearest
- css.properties.view-transition-group.normal
- javascript.builtins.Uint8Array.fromBase64
- javascript.builtins.Uint8Array.fromHex
- javascript.builtins.Uint8Array.setFromBase64
- javascript.builtins.Uint8Array.setFromHex
- javascript.builtins.Uint8Array.toBase64
- javascript.builtins.Uint8Array.toHex

Updated from a different PR (https://github.com/mdn/browser-compat-data/pull/27295 and https://github.com/mdn/browser-compat-data/pull/27345)

- webdriver.bidi.browser.createUserContext.unhandledPromptBehavior_parameter
- webdriver.bidi.emulation.setLocaleOverride
- webdriver.bidi.emulation.setLocaleOverride.contexts_parameter
- webdriver.bidi.emulation.setLocaleOverride.locale_parameter
- webdriver.bidi.emulation.setLocaleOverride.userContexts_parameter
- webdriver.bidi.emulation.setScreenOrientationOverride
- webdriver.bidi.emulation.setScreenOrientationOverride.contexts_parameter
- webdriver.bidi.emulation.setScreenOrientationOverride.screenOrientation_parameter
- webdriver.bidi.emulation.setScreenOrientationOverride.userContexts_parameter
- webdriver.bidi.emulation.setTimezoneOverride
- webdriver.bidi.emulation.setTimezoneOverride.contexts_parameter
- webdriver.bidi.emulation.setTimezoneOverride.timezone_parameter
- webdriver.bidi.emulation.setTimezoneOverride.userContexts_parameter
- webdriver.bidi.network.addDataCollector
- webdriver.bidi.network.addDataCollector.collectorType_parameter
- webdriver.bidi.network.addDataCollector.contexts_parameter
- webdriver.bidi.network.addDataCollector.dataTypes_parameter
- webdriver.bidi.network.addDataCollector.userContexts_parameter
- webdriver.bidi.network.disownData.collector_parameter
- webdriver.bidi.network.disownData.dataType_parameter
- webdriver.bidi.network.disownData.request_parameter
- webdriver.bidi.network.getData.collector_parameter
- webdriver.bidi.network.getData.dataType_parameter
- webdriver.bidi.network.getData.disown_parameter
- webdriver.bidi.network.getData.request_parameter
- webdriver.bidi.network.removeDataCollector
- webdriver.bidi.network.removeDataCollector.collector_parameter

See also the 140 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-140-beta

https://chromestatus.com/feature/5074096916004864 is the one where it would be good to get help from @rachelandrew. Rachel, from the collector it looks like this is only in 140 and not in 139. Can you confirm?