### PR TITLE
Add toJSON and userAgentAllowsProtocol to DigitalCredential

### DIFF
--- a/api/DigitalCredential.json
+++ b/api/DigitalCredential.json
@@ -100,6 +100,75 @@
             "deprecated": false
           }
         }
+      },
+      "toJSON": {
+        "__compat": {
+          "spec_url": "https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "26"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": {
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/293646"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "userAgentAllowsProtocol_static": {
+        "__compat": {
+          "description": "`userAgentAllowsProtocol()` static method",
+          "spec_url": "https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential-useragentallowsprotocol",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "26"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": {
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/293646"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
More Digital Credential API is shipping in Safari 26 beta.