### PR TITLE
Update api/Sensor.json: reflect latest spec_url

### DIFF
--- a/api/Sensor.json
+++ b/api/Sensor.json
@@ -3,7 +3,7 @@
     "Sensor": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor",
-        "spec_url": "https://w3c.github.io/sensors/#the-sensor-interface",
+        "spec_url": "https://www.w3.org/TR/generic-sensor/",
         "tags": [
           "web-features:orientation-sensor"
         ],


### PR DESCRIPTION
#### Summary

This PR updates `spec_url` to reflect more formal W3C's page.

#### Test results and supporting details

I have identified they are same by confirming CRD's "Editor's Draft" URL.

#### Related issues

None, as far as I know.
