### PR TITLE
Remove impl_url for details `name` attribute

### DIFF
--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -46,22 +46,19 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "120",
-                "impl_url": "https://crbug.com/40267522"
+                "version_added": "120"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "130",
-                "impl_url": "https://bugzil.la/1856460"
+                "version_added": "130"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "17.2",
-                "impl_url": "https://webkit.org/b/262187"
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

This removes the impl_url for details `name` attribute as the linked bugs have been marked as fixed and implemented.