### PR TITLE
Update Chromium data for api.Request.targetAddressSpace

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -1616,7 +1616,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "124"
+              "version_added": "124",
+              "version_removed": "138"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `targetAddressSpace` member of the `Request` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.14.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Request/targetAddressSpace
