### PR TITLE
Chrome 124 added WEBGL_compressed_texture_pvrtc API

### DIFF
--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -9,7 +9,9 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "124"
+            "version_added": "124",
+            "partial_implementation": true,
+            "notes": "Supported on macOS only."
           },
           "chrome_android": {
             "version_added": "28"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_compressed_texture_pvrtc` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.14.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WEBGL_compressed_texture_pvrtc
