### PR TITLE
Update Chromium data for css.properties.timeline-scope.all

### DIFF
--- a/css/properties/timeline-scope.json
+++ b/css/properties/timeline-scope.json
@@ -44,7 +44,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "116"
+                "version_added": "116",
+                "version_removed": "138"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `all` member of the `timeline-scope` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.14.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/timeline-scope/all
