### PR TITLE
Update Chromium data for picker-icon CSS selector

### DIFF
--- a/css/selectors/picker-icon.json
+++ b/css/selectors/picker-icon.json
@@ -11,7 +11,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "135"
+              "version_added": "133"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `picker-icon` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.14.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/picker-icon
