### PR TITLE
Issue 27539 webextensions.api.scripting.executeScript - injectImmediately requires Chromium >= 102

### DIFF
--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -282,7 +282,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "88"
+                  "version_added": "102"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

Update webextensions.api.scripting.executeScript - injectImmediately support re [Chrome documentation](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-ScriptInjection).

#### Test results and supporting details

See issue #27539

#### Related issues

Fixes #27539