### PR TITLE
Update Meta Quest (Oculus) data

### DIFF
--- a/api/XRAnchor.json
+++ b/api/XRAnchor.json
@@ -110,6 +110,39 @@
             "deprecated": false
           }
         }
+      },
+      "requestPersistentHandle": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/anchors/#dom-xranchor-requestpersistenthandle",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/XRCompositionLayer.json
+++ b/api/XRCompositionLayer.json
@@ -110,6 +110,39 @@
           }
         }
       },
+      "forceMonoPresentation": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrcompositionlayer-forcemonopresentation",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "layout": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRCompositionLayer/layout",
@@ -203,6 +236,72 @@
             "firefox_android": "mirror",
             "oculus": {
               "version_added": "16.1"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "opacity": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrcompositionlayer-opacity",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "quality": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrcompositionlayer-quality",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XRDepthInformation.json
+++ b/api/XRDepthInformation.json
@@ -124,7 +124,9 @@
               "version_added": false
             },
             "firefox_android": "mirror",
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": "33.3"
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -194,7 +196,9 @@
               "version_added": false
             },
             "firefox_android": "mirror",
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": "33.3"
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -76,6 +76,72 @@
           }
         }
       },
+      "detectedMeshes": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/real-world-meshing/#dom-xrframe-detectedmeshes",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "detectedPlanes": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrframe-detectedplanes",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fillJointRadii": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRFrame/fillJointRadii",
@@ -424,6 +490,39 @@
             "webview_android": {
               "version_added": false
             },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "predictedDisplayTime": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrframe-predicteddisplaytime",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/XRInputSource.json
+++ b/api/XRInputSource.json
@@ -238,6 +238,39 @@
           }
         }
       },
+      "skipRendering": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrinputsource-skiprendering",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "40.0"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "targetRayMode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRInputSource/targetRayMode",

--- a/api/XRPlane.json
+++ b/api/XRPlane.json
@@ -1,28 +1,20 @@
 {
   "api": {
-    "XRHand": {
+    "XRPlane": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRHand",
-        "spec_url": "https://immersive-web.github.io/webxr-hand-input/#xrhand-interface",
-        "tags": [
-          "web-features:webxr-hand-input"
-        ],
+        "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#xrplane",
         "support": {
           "chrome": {
-            "version_added": "131"
+            "version_added": false
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "93",
-            "version_removed": "111",
-            "notes": "Hololens 2 only."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },
           "firefox_android": "mirror",
           "oculus": {
-            "version_added": "15.1"
+            "version_added": "31.2"
           },
           "opera": "mirror",
           "opera_android": "mirror",
@@ -35,32 +27,26 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
       },
-      "entries": {
+      "lastChangedTime": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
+          "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrplane-lastchangedtime",
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -79,27 +65,21 @@
           }
         }
       },
-      "forEach": {
+      "orientation": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
+          "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrplane-orientation",
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -118,27 +98,21 @@
           }
         }
       },
-      "get": {
+      "planeSpace": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
+          "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrplane-planespace",
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -157,27 +131,21 @@
           }
         }
       },
-      "keys": {
+      "polygon": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
+          "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrplane-polygon",
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -196,106 +164,21 @@
           }
         }
       },
-      "size": {
+      "semanticLabel": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
+          "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrplane-semanticlabel",
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
-            },
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "values": {
-        "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "131"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "oculus": {
-              "version_added": "15.1"
-            },
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "@@iterator": {
-        "__compat": {
-          "description": "[Symbol.iterator]",
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "131"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XRPlaneSet.json
+++ b/api/XRPlaneSet.json
@@ -1,28 +1,20 @@
 {
   "api": {
-    "XRHand": {
+    "XRPlaneSet": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRHand",
-        "spec_url": "https://immersive-web.github.io/webxr-hand-input/#xrhand-interface",
-        "tags": [
-          "web-features:webxr-hand-input"
-        ],
+        "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#xrplaneset",
         "support": {
           "chrome": {
-            "version_added": "131"
+            "version_added": false
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "93",
-            "version_removed": "111",
-            "notes": "Hololens 2 only."
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },
           "firefox_android": "mirror",
           "oculus": {
-            "version_added": "15.1"
+            "version_added": "31.2"
           },
           "opera": "mirror",
           "opera_android": "mirror",
@@ -35,32 +27,25 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
       },
       "entries": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -81,25 +66,18 @@
       },
       "forEach": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -118,27 +96,20 @@
           }
         }
       },
-      "get": {
+      "has": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -159,25 +130,18 @@
       },
       "keys": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -198,25 +162,18 @@
       },
       "size": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -237,25 +194,18 @@
       },
       "values": {
         "__compat": {
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -276,26 +226,18 @@
       },
       "@@iterator": {
         "__compat": {
-          "description": "[Symbol.iterator]",
-          "tags": [
-            "web-features:webxr-hand-input"
-          ],
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "93",
-              "version_removed": "111",
-              "notes": "Hololens 2 only."
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": {
-              "version_added": "15.1"
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XRProjectionLayer.json
+++ b/api/XRProjectionLayer.json
@@ -36,6 +36,39 @@
           "deprecated": false
         }
       },
+      "deltaPose": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrprojectionlayer-deltapose",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fixedFoveation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRProjectionLayer/fixedFoveation",

--- a/api/XRRenderState.json
+++ b/api/XRRenderState.json
@@ -221,6 +221,39 @@
             "deprecated": false
           }
         }
+      },
+      "passthroughFullyObscured": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrrenderstate-passthroughfullyobscured",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "38.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -79,6 +79,39 @@
           }
         }
       },
+      "deletePersistentAnchor": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/anchors/#dom-xrsession-deletepersistentanchor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "depthActive": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-depthactive",
@@ -92,7 +125,9 @@
               "version_added": false
             },
             "firefox_android": "mirror",
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": "33.3"
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -415,6 +450,72 @@
           }
         }
       },
+      "frameRate": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-framerate",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initiateRoomCapture": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrsession-initiateroomcapture",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "inputSources": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/inputSources",
@@ -534,6 +635,39 @@
           }
         }
       },
+      "isSystemKeyboardSupported": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-issystemkeyboardsupported",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pauseDepthSensing": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-pausedepthsensing",
@@ -547,7 +681,9 @@
               "version_added": false
             },
             "firefox_android": "mirror",
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": "33.3"
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -558,6 +694,39 @@
             "webview_android": {
               "version_added": false
             },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "persistentAnchors": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/anchors/#dom-xrsession-persistentanchors",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -836,6 +1005,39 @@
           }
         }
       },
+      "restorePersistentAnchor": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/anchors/#dom-xrsession-restorepersistentanchor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "resumeDepthSensing": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-resumedepthsensing",
@@ -849,7 +1051,9 @@
               "version_added": false
             },
             "firefox_android": "mirror",
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": "33.3"
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -1121,6 +1325,72 @@
           }
         }
       },
+      "supportedFrameRates": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-supportedframerates",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "trackedSources": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-trackedsources",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "34.1"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "updateRenderState": {
         "__compat": {
           "description": "`updateRenderState()`",
@@ -1152,6 +1422,39 @@
             "webview_android": {
               "version_added": false
             },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "updateTargetFrameRate": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-updatetargetframerate",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -255,6 +255,39 @@
           }
         }
       },
+      "foveateBoundTexture": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrwebglbinding-foveateboundtexture",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "38.1"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getCameraImage": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/raw-camera-access/#dom-xrwebglbinding-getcameraimage",
@@ -458,6 +491,39 @@
             "firefox_android": "mirror",
             "oculus": {
               "version_added": "16.1"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "usesDepthValues": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrwebglbinding-usesdepthvalues",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XRWebGLDepthInformation.json
+++ b/api/XRWebGLDepthInformation.json
@@ -37,6 +37,39 @@
           "deprecated": false
         }
       },
+      "imageIndex": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrwebgldepthinformation-imageindex",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "texture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRWebGLDepthInformation/texture",
@@ -65,6 +98,39 @@
             "webview_android": {
               "version_added": false
             },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "textureType": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrwebgldepthinformation-texturetype",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/XRWebGLSubImage.json
+++ b/api/XRWebGLSubImage.json
@@ -184,6 +184,72 @@
           }
         }
       },
+      "depthStencilTextureHeight": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrwebglsubimage-depthstenciltextureheight",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "depthStencilTextureWidth": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrwebglsubimage-depthstenciltexturewidth",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "imageIndex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRWebGLSubImage/imageIndex",
@@ -203,6 +269,105 @@
             "firefox_android": "mirror",
             "oculus": {
               "version_added": "16.1"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "motionVectorTexture": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrwebglsubimage-motionvectortexture",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "motionVectorTextureHeight": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrwebglsubimage-motionvectortextureheight",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "motionVectorTextureWidth": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrwebglsubimage-motionvectortexturewidth",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": {
+              "version_added": "31.2"
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -9,112 +9,125 @@
       "accepts_webextensions": false,
       "releases": {
         "5.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-50",
+          "release_date": "2019-05-07",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "66"
         },
         "5.4": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-54",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "66"
         },
         "6.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-60",
+          "release_date": "2019-07-16",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "74"
         },
         "7.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-70",
+          "release_date": "2019-12-06",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "77"
         },
         "7.1": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-71",
+          "release_date": "2019-12-17",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "77"
         },
         "8.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-80",
+          "release_date": "2020-02-04",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "79"
         },
         "8.1": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-81",
+          "release_date": "2020-02-18",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "79"
         },
         "9.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-90",
+          "release_date": "2020-04-25",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "81"
         },
         "10.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-100",
+          "release_date": "2020-06-22",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "83"
         },
         "11.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-110",
+          "release_date": "2020-08-04",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "84"
         },
         "12.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-120",
+          "release_date": "2020-10-26",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "86"
         },
         "13.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-130",
+          "release_date": "2020-11-13",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "87"
         },
         "14.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-140",
+          "release_date": "2021-01-29",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "88"
         },
         "15.0": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-150",
+          "release_date": "2021-03-30",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "89"
         },
         "15.1": {
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-151",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "89"
         },
         "16.0": {
-          "release_date": "2021-06-14",
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-160",
+          "release_date": "2021-06-07",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "91"
         },
         "16.1": {
           "release_date": "2021-06-22",
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-161",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "91"
         },
         "16.2": {
           "release_date": "2021-07-06",
-          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes#oculus-browser-162",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "91"
@@ -179,11 +192,97 @@
           "engine": "Blink",
           "engine_version": "102"
         },
-        "23.0": {
-          "release_date": "2022-08-15",
+        "31.2": {
+          "release_date": "2024-01-16",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "120"
+        },
+        "32": {
+          "release_date": "2024-03-03",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "122"
+        },
+        "33": {
+          "release_date": "2024-05-02",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "124"
+        },
+        "33.3": {
+          "release_date": "2024-06-05",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "124"
+        },
+        "34": {
+          "release_date": "2024-06-26",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "126"
+        },
+        "34.1": {
+          "release_date": "2024-07-09",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "126"
+        },
+        "35": {
+          "release_date": "2024-09-12",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "128"
+        },
+        "36": {
+          "release_date": "2024-11-07",
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "130"
+        },
+        "37": {
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "132"
+        },
+        "38": {
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "134"
+        },
+        "38.1": {
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "134"
+        },
+        "38.2": {
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "134"
+        },
+        "39": {
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "136"
+        },
+        "40.0": {
+          "release_notes": "https://developers.meta.com/horizon/release-notes/web",
           "status": "current",
           "engine": "Blink",
-          "engine_version": "104"
+          "engine_version": "138"
         }
       }
     }


### PR DESCRIPTION
This PR updates MDN browser compatibility data for the Meta Quest Browser (Oculus). The data was collected using the @openwebdocs BCD collector project using a Meta Quest 2 device. Additional sources:

Release dates: https://en.wikipedia.org/wiki/Meta_Quest_Browser
Release notes: https://developers.meta.com/horizon/release-notes/web

@jacobrossi @cabanier @davehill00, would anyone of you be interested in helping to review this data?