### PR TITLE
Enable invalid-issue-closer spam detection

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -11,8 +11,8 @@ jobs:
   close-issues-if-invalid:
     runs-on: ubuntu-latest
     steps:
-      - uses: queengooborg/invalid-issue-closer@43bf1ddff3e83d208b77a3e364f7b5e22f6a9657 # v1.6.0
-        id: spam-check
+      - uses: queengooborg/invalid-issue-closer@v1.6.0
+        id: blank-body-check
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: "spam"
@@ -21,7 +21,19 @@ jobs:
             This issue has been identified as spam and has been automatically closed and locked.  Do not use this repository for posting spam.
           normalize-newlines: true
           body-is-blank: true
-      - uses: queengooborg/invalid-issue-closer@43bf1ddff3e83d208b77a3e364f7b5e22f6a9657 # v1.6.0
+      - uses: queengooborg/invalid-issue-closer@v1.6.0
+        if: steps.blank-body-check.outputs.was-closed == 'false'
+        id: spam-check
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "spam"
+          comment: |
+            This issue has been identified as spam and has been automatically closed.  Please do not use this repository for posting spam.
+
+            Please note that false positives may occur. If this issue is not actually spam, please post a follow-up comment.  A maintainer will review your issue and reopen it if needed.
+          normalize-newlines: true
+          is-spammy: true
+      - uses: queengooborg/invalid-issue-closer@v1.6.0
         if: steps.spam-check.outputs.was-closed == 'false'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR enables the new spam detection feature of the invalid issue closer, in order to automatically close spam issues.

As discussed in the previous BCD meeting, automatic locking has not been enabled in case false positives occur.  Issues with blank bodies will still be automatically closed and locked as spam, as they are guaranteed to be spam due to the issue template requirement.
