### PR TITLE
fix(scripts/diff-flat): fetch `pull/*/merge`, not `pull/*/head`

### DIFF
--- a/scripts/diff-flat.ts
+++ b/scripts/diff-flat.ts
@@ -686,6 +686,13 @@ if (esMain(import.meta)) {
       const remoteRef = `gh pr view ${ref} --json headRefOid -q '.headRefOid'`;
       gitFetch(remoteRef);
       return remoteRef;
+    } else if (/^[0-9a-f]{40}$/.test(ref)) {
+      try {
+        gitRevParse(ref);
+      } catch {
+        gitFetch(ref);
+      }
+      return ref;
     }
 
     return gitRevParse(ref);

--- a/scripts/diff-flat.ts
+++ b/scripts/diff-flat.ts
@@ -640,7 +640,7 @@ if (esMain(import.meta)) {
   const options = argv as any;
 
   if (/^\d+$/.test(options.base)) {
-    options.head = `pull/${options.base}/head`;
+    options.head = `pull/${options.base}/merge`;
     options.base = 'origin/main';
   }
 


### PR DESCRIPTION
#### Summary

Changes the `diff:flat` script to fetch the `/merge` tip of the PR, rather than the `/head` tip.

#### Test results and supporting details

##### Background

After merging https://github.com/mdn/browser-compat-data/pull/25352, the PR Review Companion started failing most of the time.

##### Problem

The workflow uses `diff:flat` to compare the PR tip with the `main` branch. For this, it needs the merge base, **but** the checkout by default doesn't fetch any history, so the merge base was likely not fetched unless the PR was based on the latest `main` commit.

##### Solution

Compare the _result_ of merging the PR into the `main` branch, with the `main` branch.

Note: Tested this with a local shallow clone of BCD.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
