### PR TITLE
Update WebAuthn PRF support for Safari 18.0+

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -628,8 +628,7 @@
                   "opera": "mirror",
                   "opera_android": "mirror",
                   "safari": {
-                    "version_added": false,
-                    "impl_url": "https://webkit.org/b/259934"
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",


### PR DESCRIPTION
Reference: https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes

#### Summary

Marks the [`prf` extension for the CredentialsContainers API](https://caniuse.com/?search=prf) as available in Safari for macOS and iOS as of Safari 18.

#### Test results and supporting details

This feature is cited in the [Safari 18.0 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes#Authentication):

> ### [Authentication](https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes#Authentication)
> 
> #### New Features
>
> - Added support for the WebAuthn PRF extension. (119057355)

I've tested it with [this gist](https://gist.github.com/MasterKale/dbe39a01438251f0cbd55576304731fd) on Safari 18.6 running on macOS, and Safari 18.6 running on iOS (unfortunately I have no access to earlier versions). Both versions worked as expected when tested both with Apple's own password manager and with a third-party password manager (1Password).

The [WebKit source has a feature gate referencing the iOS and macOS versions of Safari in which it was made available](https://github.com/WebKit/WebKit/blob/a05032c6961001c252d02445bd513060f09b360b/Source/WTF/wtf/PlatformHave.h#L1350C14-L1355).

Confusingly, the [WebKit bug 259934](https://bugs.webkit.org/show_bug.cgi?id=259934) that is currently referenced in this definition remains open with no updates from Apple. However, the feature is present, definitely works, and has been publicly announced by Apple in their own changelog 11 months ago. And the bug in the WebKit tracker has not been updated by Apple since 2023. So my assumption is that they forgot to close it :) 

#### Related issues

None as far as I can tell.
