### PR TITLE
FF142 Integrity-Policy support partial and style

### DIFF
--- a/http/headers/Integrity-Policy-Report-Only.json
+++ b/http/headers/Integrity-Policy-Report-Only.json
@@ -12,7 +12,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Reporting `endpoints` are ignored (violations are logged to console)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -27,9 +29,80 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "blocked-destinations_script": {
+          "__compat": {
+            "description": "`script` in `blocked-destinations`",
+            "spec_url": "https://w3c.github.io/webappsec-subresource-integrity/#blocked-destinations",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "blocked-destinations_style": {
+          "__compat": {
+            "description": "`style` in `blocked-destinations`",
+            "spec_url": "https://w3c.github.io/webappsec-subresource-integrity/#blocked-destinations",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "security.integrity_policy.stylesheet.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/http/headers/Integrity-Policy.json
+++ b/http/headers/Integrity-Policy.json
@@ -12,7 +12,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Reporting `endpoints` are ignored (violations are logged to console)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -27,9 +29,80 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "blocked-destinations_script": {
+          "__compat": {
+            "description": "`script` in `blocked-destinations`",
+            "spec_url": "https://w3c.github.io/webappsec-subresource-integrity/#blocked-destinations",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "blocked-destinations_style": {
+          "__compat": {
+            "description": "`style` in `blocked-destinations`",
+            "spec_url": "https://w3c.github.io/webappsec-subresource-integrity/#blocked-destinations",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "security.integrity_policy.stylesheet.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
This follows on from #27530, adding new information from developers.

FF142 adds support for [Integrity-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy) and [Integrity-Policy-Report-Only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy-Report-Only) on nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1976656 [behind pref `security.integrity_policy.enabled` enabled in nightly).

BUT, reporting endpoints are not plugged in as per https://bugzilla.mozilla.org/show_bug.cgi?id=1976656#c14 - so I have marked the support as partial and added a note.
In addition, this is only in one proper release so it is experimental still. 

In addition, Firefox has implemented support for `style` as a blocked-destination behind a preference in https://bugzilla.mozilla.org/show_bug.cgi?id=1974247, so this adds `style` and `script` as subfeatures. 

Related docs work can be tracked in https://github.com/mdn/content/issues/40667