### PR TITLE
Updates for Firefox 143 beta

### DIFF
--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -175,7 +175,8 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "9",
+              "version_removed": "143"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/details-content.json
+++ b/css/selectors/details-content.json
@@ -16,15 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.details-content.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1901037"
+              "version_added": "143"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.14.0 found new features shipping in Firefox 143 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 18 features as shipping in Firefox 143:

- api.CompositionEvent.locale ([removal](https://bugzilla.mozilla.org/show_bug.cgi?id=1700969))
- css.selectors.details-content ([bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1941406))

Updated in other PRs:

- webdriver.bidi.network.addDataCollector
- webdriver.bidi.network.addDataCollector.collectorType_parameter
- webdriver.bidi.network.addDataCollector.contexts_parameter
- webdriver.bidi.network.addDataCollector.dataTypes_parameter
- webdriver.bidi.network.addDataCollector.maxEncodedDataSize_parameter
- webdriver.bidi.network.addDataCollector.userContexts_parameter
- webdriver.bidi.network.disownData
- webdriver.bidi.network.disownData.collector_parameter
- webdriver.bidi.network.disownData.dataType_parameter
- webdriver.bidi.network.disownData.request_parameter
- webdriver.bidi.network.getData
- webdriver.bidi.network.getData.collector_parameter
- webdriver.bidi.network.getData.dataType_parameter
- webdriver.bidi.network.getData.disown_parameter
- webdriver.bidi.network.getData.request_parameter
- webdriver.bidi.network.removeDataCollector

See also https://github.com/mdn/mdn/issues/712 and https://www.mozilla.org/en-US/firefox/142.0beta/releasenotes/