### PR TITLE
Add Chrome/Safari impl url for CSS `white-space` in SVG

### DIFF
--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -352,7 +352,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40362378"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -370,7 +371,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/293213"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

<!-- #### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

<!-- #### Test results and supporting details

👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Fixes #27080 
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
