### PR TITLE
Undeprecate Navigator members

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -231,7 +231,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -275,7 +275,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -319,7 +319,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -2051,7 +2051,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -2635,7 +2635,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         },
         "returns_plugin_type": {
@@ -2684,7 +2684,7 @@
             "status": {
               "experimental": false,
               "standard_track": false,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }
@@ -2830,7 +2830,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -2959,7 +2959,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -3003,7 +3003,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         },
         "returns_plugins": {
@@ -3052,7 +3052,7 @@
             "status": {
               "experimental": false,
               "standard_track": false,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }
@@ -3135,7 +3135,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -3175,7 +3175,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -5256,7 +5256,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -5585,7 +5585,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -5624,7 +5624,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
#### Summary

The following Navigator members provide limited value (e.g. return inaccurate values, or the same value in all browsers), but they are not formally discouraged.

- api.Navigator.appCodeName
- api.Navigator.appName
- api.Navigator.appVersion
- api.Navigator.javaEnabled
- api.Navigator.mimeTypes
- api.Navigator.mimeTypes.returns_plugin_type
- api.Navigator.oscpu
- api.Navigator.platform
- api.Navigator.plugins
- api.Navigator.plugins.returns_plugins
- api.Navigator.product
- api.Navigator.productSub
- api.Navigator.taintEnabled
- api.Navigator.vendor
- api.Navigator.vendorSub

#### Test results and supporting details

See: https://github.com/whatwg/html/issues/11558

#### Related issues

Supersedes https://github.com/mdn/browser-compat-data/pull/27342.
