### PR TITLE
Safari 26 removes MutationEvent

### DIFF
--- a/api/MutationEvent.json
+++ b/api/MutationEvent.json
@@ -32,7 +32,8 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "1",
+            "version_removed": "26"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -77,7 +78,8 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -123,7 +125,8 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -169,7 +172,8 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -215,7 +219,8 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -261,7 +266,8 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -307,7 +313,8 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/27621

I can confirm in Safari 26 beta. Unsure about earlier versions.