### PR TITLE
De-standardize `:closed` pseudo-class

### DIFF
--- a/css/selectors/closed.json
+++ b/css/selectors/closed.json
@@ -4,7 +4,6 @@
       "closed": {
         "__compat": {
           "description": "`:closed`",
-          "spec_url": "https://drafts.csswg.org/selectors-4/#open-state",
           "tags": [
             "web-features:open-closed"
           ],
@@ -33,9 +32,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
#### Summary

This was dropped from the specification. Developers shouldn't use it and it has unshipped from all browsers anyway.

#### Related issues

- https://github.com/w3c/csswg-drafts/pull/11326
- https://github.com/web-platform-dx/web-features/pull/3238
