### PR TITLE
Add webkit impl_url to `sibling-count()` and `sibling-index()`

### DIFF
--- a/css/types/sibling-count.json
+++ b/css/types/sibling-count.json
@@ -24,7 +24,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugs.webkit.org/show_bug.cgi?id=294895"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/types/sibling-count.json
+++ b/css/types/sibling-count.json
@@ -25,7 +25,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "impl_url": "https://bugs.webkit.org/show_bug.cgi?id=294895"
+              "impl_url": "https://webkit.org/b/294895"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/types/sibling-index.json
+++ b/css/types/sibling-index.json
@@ -24,7 +24,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugs.webkit.org/show_bug.cgi?id=294895"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/types/sibling-index.json
+++ b/css/types/sibling-index.json
@@ -25,7 +25,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "impl_url": "https://bugs.webkit.org/show_bug.cgi?id=294895"
+              "impl_url": "https://webkit.org/b/294895"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

CSS `sibling-count()` and `sibling-index()` is missing the webkit `impl_url`. This PR adds this link.

