### PR TITLE
Bug-1960011 adds tabs.onUpdated.filter.cookieStoreId

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3213,6 +3213,27 @@
                 "safari_ios": "mirror"
               }
             },
+            "cookieStoreId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "141"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "properties": {
               "__compat": {
                 "support": {


### PR DESCRIPTION
#### Summary

Documents that change is made in [Bug 1960011](https://bugzilla.mozilla.org/show_bug.cgi?id=1960011) Filter tabs.onUpdated events by cookieStoreId.

### Related issues and pull requests

Related content changes in https://github.com/mdn/content/pull/40838.
