### PR TITLE
Remove `document.designMode` from the DOM feature

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2634,9 +2634,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/designMode",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-document-designmode-dev",
-          "tags": [
-            "web-features:dom"
-          ],
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
It is defined by HTML and is related to contenteditable: https://html.spec.whatwg.org/multipage/interaction.html#making-entire-documents-editable:-the-designmode-idl-attribute

It's not clear if it should be part of the contenteditable feature, so just untag it for now.