### PR TITLE
NodeJS 24+ supports `using` statement

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -2188,7 +2188,7 @@
             },
             "firefox_android": "mirror",
             "nodejs": {
-              "version_added": false
+              "version_added": "24.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
#### Summary

Set the compatibility data for NodeJS to `24.0.0` in the `using` statement section.

#### Test results and supporting details

1. https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V24.md#v8-136
2. https://github.com/nodejs/node/pull/58154
3. https://github.com/nodejs/node/pull/58296

#### Related issues

Closes #27631