### PR TITLE
Chrome 99 allowed mutating `Document.adoptedStyleSheets`

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -281,6 +281,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "mutable": {
+          "__compat": {
+            "description": "Array value is mutable",
+            "tags": [
+              "web-features:constructed-stylesheets"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.5"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "adoptNode": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -285,6 +285,7 @@
         "mutable": {
           "__compat": {
             "description": "Array value is mutable",
+            "spec_url": "https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets",
             "tags": [
               "web-features:constructed-stylesheets"
             ],
@@ -302,7 +303,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "16.5"
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Add compatibility data of mutable `api.Document.adoptedStyleSheets`

#### Test results and supporting details

Compatibility info for Opera Android is unknown. (Removing the property can't pass test)

Compatibility info for Safari < 16.5 is unknown.

#### Related issues

Fixes #26918
