### PR TITLE
Bug-1946600 addition of webextension.api.browserSetting.verticalTabs

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -366,6 +366,25 @@
             }
           }
         },
+        "verticalTabs": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "webNotificationsDisabled": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/webNotificationsDisabled",


### PR DESCRIPTION
#### Summary

Add to the browser compatibility data for `browserSetting.verticalTabs` introduced by [Bug 1946600](https://bugzilla.mozilla.org/show_bug.cgi?id=1946600) Add a new browserSetting property that determines whether vertical tabs are enabled.

#### Related issues

Related MDN content changes in TBC