### PR TITLE
ImageData - constructor now accepts Float16Array as data

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -148,6 +148,37 @@
                 "deprecated": false
               }
             }
+          },
+          "pixelFormat_option": {
+            "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#canvascolortype",
+              "support": {
+                "chrome": {
+                  "version_added": "137"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       },

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -179,6 +179,37 @@
                 "deprecated": false
               }
             }
+          },
+          "[dataArray_parameter_]accepts_Float16Array": {
+            "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#canvascolortype",
+              "support": {
+                "chrome": {
+                  "version_added": "137"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
#### Summary

This adds a new `ImageData` constructor argument type (`Float16`).
Already added to MDN: https://github.com/mdn/content/pull/40680

#### Test results and supporting details

In the browser console

```

new ImageData(new Float16Array(4), 1, 1, {pixelFormat:"rgba-float16"})
```

Further links a part of the related issue and the related MDN changes: https://github.com/mdn/content/issues/40639

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27547#issuecomment-3214471118

Documents https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#the-imagedata-interface