### PR TITLE
Update `KeyboardEvent.repeat` compat on chrome

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1141,11 +1141,18 @@
             "web-features:keyboard-events"
           ],
           "support": {
-            "chrome": {
-              "version_added": "32",
-              "partial_implementation": true,
-              "notes": "On Windows and Linux, if multiple keys are held down, a `keydown` event for the most recently pressed key will trigger with `repeat` incorrectly set to `false`. See [bug 40940886](https://crbug.com/40940886)."
-            },
+            "chrome": [
+              {
+                "version_added": "137",
+                "notes": "Before Chrome 139, on Linux under X11, if multiple keys are held down, a `keydown` event for the most recently pressed key will trigger with `repeat` incorrectly set to `false`. See [bug 40940886](https://crbug.com/40940886)."
+              },
+              {
+                "version_added": "32",
+                "version_removed": "137",
+                "partial_implementation": true,
+                "notes": "On Windows and Linux, if multiple keys are held down, a `keydown` event for the most recently pressed key will trigger with `repeat` incorrectly set to `false`. See [bug 40940886](https://crbug.com/40940886)."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Updated KeyboardEvent.repeat support on chrome: previously was partial support, now full support.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
Tested in Chrome on Windows, could not replicate stated bug.
Ref [bug 40940886](https://crbug.com/40940886)

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Fixes #27634

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
