### PR TITLE
Mark Safari `::details-content` support as partial

### DIFF
--- a/css/selectors/details-content.json
+++ b/css/selectors/details-content.json
@@ -23,7 +23,10 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.4"
+              "version_added": "18.4",
+              "impl_url": "https://webkit.org/b/283446",
+              "partial_implementation": true,
+              "notes": "Does not support chaining pseudo-elements after `::details-content`."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Mark safari support for `::details-content` as partial.

#### Test results and supporting details

https://wpt.live/html/rendering/the-details-element/details-pseudo-elements-004.html - Tested using this

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #27620

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
