### PR TITLE
Firefox renamed invoker commands feature flag

### DIFF
--- a/api/CommandEvent.json
+++ b/api/CommandEvent.json
@@ -18,10 +18,11 @@
             "flags": [
               {
                 "type": "preference",
-                "name": "dom.element.invokers.enabled",
+                "name": "dom.element.commandfor.enabled",
                 "value_to_set": "true"
               }
-            ]
+            ],
+            "impl_url": "https://bugzil.la/1983523"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -61,10 +62,11 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.element.invokers.enabled",
+                  "name": "dom.element.commandfor.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1983523"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -105,10 +107,11 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.element.invokers.enabled",
+                  "name": "dom.element.commandfor.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1983523"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -147,10 +150,11 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.element.invokers.enabled",
+                  "name": "dom.element.commandfor.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1983523"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -111,10 +111,11 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.element.invokers.enabled",
+                  "name": "dom.element.commandfor.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1983523"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -148,8 +149,15 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1950359"
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.element.commandfor.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1983523"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -189,10 +197,11 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.element.invokers.enabled",
+                  "name": "dom.element.commandfor.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1983523"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -694,10 +694,11 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.element.invokers.enabled",
+                  "name": "dom.element.commandfor.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1983523"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -61,10 +61,11 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "dom.element.invokers.enabled",
+                    "name": "dom.element.commandfor.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1983523"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -145,10 +146,11 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "dom.element.invokers.enabled",
+                    "name": "dom.element.commandfor.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1983523"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
Also adds the bug that enables the pref as impl_url.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the name of a Firefox bug:

```patch
-dom.element.invokers.enabled
+dom.element.commandfor.enabled
```

Also adds the shipping bug: https://bugzil.la/1983523

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Extracted from https://github.com/mdn/browser-compat-data/pull/27628.
