### PR TITLE
Mark css.selectors.host-context deprecated

### DIFF
--- a/css/selectors/host-context.json
+++ b/css/selectors/host-context.json
@@ -34,7 +34,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/38960

#### Summary

Spec guys have dropped the `:host-context()`.

#### Test results and supporting details

- https://github.com/w3c/csswg-drafts/issues/1914#issuecomment-2737310093
