### PR TITLE
enhance(build): validate data against schemas

### DIFF
--- a/lint/linter/test-schema.ts
+++ b/lint/linter/test-schema.ts
@@ -1,27 +1,15 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import { Ajv } from 'ajv';
-import ajvErrors from 'ajv-errors';
-import ajvFormats from 'ajv-formats';
 import betterAjvErrors from 'better-ajv-errors';
 
+import { createAjv } from '../../utils/index.js';
 import { Linter, Logger, LinterData } from '../utils.js';
 
 import compatDataSchema from './../../schemas/compat-data.schema.json' with { type: 'json' };
 import browserDataSchema from './../../schemas/browsers.schema.json' with { type: 'json' };
 
-const ajv = new Ajv({ allErrors: true });
-// We use 'fast' because as a side effect that makes the "uri" format more lax.
-// By default the "uri" format rejects ① and similar in URLs.
-ajvFormats.default(ajv, { mode: 'fast' });
-// Allow for custom error messages to provide better directions for contributors
-ajvErrors.default(ajv);
-
-// Define keywords for schema->TS converter
-ajv.addKeyword('tsEnumNames');
-ajv.addKeyword('tsName');
-ajv.addKeyword('tsType');
+const ajv = createAjv();
 
 export default {
   name: 'JSON Schema',

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -39,10 +39,8 @@
         "$ref": "#/definitions/browser_statement"
       },
       "minProperties": 1,
-      "maxProperties": 1,
       "errorMessage": {
-        "minProperties": "A browser must be described within the file.",
-        "maxProperties": "Each browser JSON file may only describe one browser."
+        "minProperties": "A browser must be described within the file."
       },
       "tsType": "Record<BrowserName, BrowserStatement>"
     },

--- a/scripts/build/index.ts
+++ b/scripts/build/index.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises';
 import { relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import betterAjvErrors from 'better-ajv-errors';
 import esMain from 'es-main';
 import stringify from 'fast-json-stable-stringify';
 import { compareVersions } from 'compare-versions';
@@ -13,7 +14,9 @@ import { marked } from 'marked';
 import { InternalSupportStatement } from '../../types/index.js';
 import { BrowserName, CompatData, VersionValue } from '../../types/types.js';
 import compileTS from '../generate-types.js';
-import { walk } from '../../utils/index.js';
+import compatDataSchema from '../../schemas/compat-data.schema.json' with { type: 'json' };
+import browserDataSchema from '../../schemas/browsers.schema.json' with { type: 'json' };
+import { createAjv, walk } from '../../utils/index.js';
 import { WalkOutput } from '../../utils/walk.js';
 import bcd from '../../index.js';
 
@@ -219,6 +222,35 @@ export const createDataBundle = async (): Promise<CompatData> => {
   };
 };
 
+/**
+ * Validates the given data against the schema.
+ * @param data - The data to validate.
+ */
+const validate = (data: CompatData) => {
+  const ajv = createAjv();
+
+  for (const [key, value] of Object.entries(data)) {
+    if (key === '__meta') {
+      // Not covered by the schema.
+      continue;
+    }
+
+    const schema = key === 'browsers' ? browserDataSchema : compatDataSchema;
+    const data = { [key]: value };
+    if (!ajv.validate(schema, data)) {
+      const errors = ajv.errors || [];
+      if (!errors.length) {
+        console.error(`${key} data failed validation with unknown errors!`);
+      }
+      // Output messages by one since better-ajv-errors wrongly joins messages
+      // (see https://github.com/atlassian/better-ajv-errors/pull/21)
+      errors.forEach((e) => {
+        console.error(betterAjvErrors(schema, data, [e], { indent: 2 }));
+      });
+    }
+  }
+};
+
 /* c8 ignore start */
 
 /**
@@ -227,6 +259,7 @@ export const createDataBundle = async (): Promise<CompatData> => {
 const writeData = async () => {
   const dest = new URL('data.json', targetdir);
   const data = await createDataBundle();
+  validate(data);
   await fs.writeFile(dest, stringify(data));
   logWrite(dest, 'data');
 };
@@ -383,5 +416,3 @@ const main = async () => {
 if (esMain(import.meta)) {
   await main();
 }
-
-/* c8 ignore stop */

--- a/utils/ajv.ts
+++ b/utils/ajv.ts
@@ -1,0 +1,23 @@
+import { Ajv } from 'ajv';
+import ajvErrors from 'ajv-errors';
+import ajvFormats from 'ajv-formats';
+
+/**
+ * Returns a new pre-configured Ajv instance.
+ * @returns the Ajv instance.
+ */
+export const createAjv = (): Ajv => {
+  const ajv = new Ajv({ allErrors: true });
+  // We use 'fast' because as a side effect that makes the "uri" format more lax.
+  // By default the "uri" format rejects ① and similar in URLs.
+  ajvFormats.default(ajv, { mode: 'fast' });
+  // Allow for custom error messages to provide better directions for contributors
+  ajvErrors.default(ajv);
+
+  // Define keywords for schema->TS converter
+  ajv.addKeyword('tsEnumNames');
+  ajv.addKeyword('tsName');
+  ajv.addKeyword('tsType');
+
+  return ajv;
+};

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,6 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
+import { createAjv } from './ajv.js';
 import iterSupport from './iter-support.js';
 import query from './query.js';
 import spawn from './spawn.js';
@@ -8,4 +9,12 @@ import spawnAsync from './spawn-async.js';
 import walk from './walk.js';
 import normalizePath from './normalize-path.js';
 
-export { iterSupport, normalizePath, query, spawn, spawnAsync, walk };
+export {
+  createAjv,
+  iterSupport,
+  normalizePath,
+  query,
+  spawn,
+  spawnAsync,
+  walk,
+};


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Validates the built `data.json` against the schemas.

#### Test results and supporting details

This revealed two minor issues:

1. The browsers schema was requiring a maximum of one browser defined in `browsers`. This requirement only applies to the individual `browser/*.json` files, not the built `data.json`, so this requirement was removed.
2. The `__meta` object in the built `data.json` is not currently covered by the schema, so we cannot validate it.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27564.
