### PR TITLE
fix(update-browser-releases): use Edge release schedule page

### DIFF
--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -22,15 +22,27 @@ import {
  */
 const getFutureReleaseDate = async (release, releaseScheduleURL) => {
   // Fetch the MD of the release schedule
-  const scheduleMD = await fetch(releaseScheduleURL);
-  const text = await scheduleMD.text();
+  const scheduleHTML = await fetch(releaseScheduleURL);
+  const text = await scheduleHTML.text();
   if (!text) {
     throw chalk`{red \nRelease file not found.}`;
   }
-  // Find the line
-  //const regexp = new RegExp(`| ${release} |\\w*|\\w*| ?Week of (\\w*) ?|\\w*|`, 'i');
+  /**
+   * Find the table row:
+   *
+   * Example:
+   * ```html
+   * <tr>
+   * <td style="text-align: left;">142</td>                   <-- Version
+   * <td style="text-align: left;">Target release</td>
+   * <td style="text-align: left;">Week of 9-Oct-2025</td>
+   * <td style="text-align: left;">Week of 30-Oct-2025</td>   <-- Stable Channel
+   * <td style="text-align: left;">Week of 30-Oct-2025</td>
+   * </tr>
+   * ```
+   */
   const regexp = new RegExp(
-    `\\| ${release} \\|.*\\|.*\\| ?Week of (.*) ?\\|.*\\|`,
+    `<td[^>]*>${release}</td>\\s*<td[^>]*>.*</td>\\s*<td[^>]*>.*</td>\\s*<td[^>]*>?Week of (.*)</td>`,
     'i',
   );
   const result = text.match(regexp);

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -47,7 +47,7 @@ const getFutureReleaseDate = async (release, releaseScheduleURL) => {
   );
   const result = text.match(regexp);
   if (!result) {
-    throw chalk`{yellow \nRelease date not found for Edge ${release}.}`;
+    throw chalk`{yellow \nNo entry found for Edge ${release} on [this page](<${releaseScheduleURL}>).}`;
   }
   const releaseDateText = result[1];
 

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -151,7 +151,7 @@ const options = {
     edgeupdatesURL:
       'https://edgeupdates.microsoft.com/api/products?view=enterprise',
     releaseScheduleURL:
-      'https://raw.githubusercontent.com/MicrosoftDocs/Edge-Enterprise/public/edgeenterprise/microsoft-edge-release-schedule.md',
+      'https://learn.microsoft.com/en-us/deployedge/microsoft-edge-release-schedule',
   },
   firefox_desktop: {
     browserName: 'Firefox for Desktop',


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Edge release update script to use the HTML release schedule, as the MD release schedule is no longer accessible.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

See: https://github.com/mdn/browser-compat-data/pull/27682#issuecomment-3228321596
