### PR TITLE
Chrome 119 supports `rect()` + `xywh()` in `clip-path`

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -441,11 +441,14 @@
             "support": {
               "chrome": [
                 {
+                  "version_added": "119"
+                },
+                {
                   "version_added": "116",
+                  "version_removed": "119",
                   "partial_implementation": true,
                   "notes": "Only supported on the `offset-path` property."
-                },
-                { "version_added": "119" }
+                }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -530,11 +533,14 @@
             "support": {
               "chrome": [
                 {
+                  "version_added": "119"
+                },
+                {
                   "version_added": "116",
+                  "version_removed": "119",
                   "partial_implementation": true,
                   "notes": "Only supported on the `offset-path` property."
-                },
-                { "version_added": "119" }
+                }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

fix incorrect data for chromium's support of rect/xywh

#### Test results and supporting details

```html
<div></div>
```
```css
div {
  background: red;
  height: 20px;
  clip-path: xywh(0 0 20px 20px);
}
```

#### Related issues

fixes https://github.com/mdn/browser-compat-data/issues/27689