### PR TITLE
Bun's release notes should come from the blog, not GitHub

### DIFF
--- a/browsers/bun.json
+++ b/browsers/bun.json
@@ -8,711 +8,711 @@
       "releases": {
         "1.0.0": {
           "release_date": "2023-09-08",
-          "release_notes": "https://bun.com/blog/bun-v1.0.0",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.0",
           "status": "retired"
         },
         "1.0.1": {
           "release_date": "2023-09-12",
-          "release_notes": "https://bun.com/blog/bun-v1.0.1",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.1",
           "status": "retired"
         },
         "1.0.2": {
           "release_date": "2023-09-15",
-          "release_notes": "https://bun.com/blog/bun-v1.0.2",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.2",
           "status": "retired"
         },
         "1.0.3": {
           "release_date": "2023-09-22",
-          "release_notes": "https://bun.com/blog/bun-v1.0.3",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.3",
           "status": "retired"
         },
         "1.0.4": {
           "release_date": "2023-10-03",
-          "release_notes": "https://bun.com/blog/bun-v1.0.4",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.4",
           "status": "retired"
         },
         "1.0.5": {
           "release_date": "2023-10-11",
-          "release_notes": "https://bun.com/blog/bun-v1.0.5",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.5",
           "status": "retired"
         },
         "1.0.6": {
           "release_date": "2023-10-12",
-          "release_notes": "https://bun.com/blog/bun-v1.0.6",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.6",
           "status": "retired"
         },
         "1.0.7": {
           "release_date": "2023-10-20",
-          "release_notes": "https://bun.com/blog/bun-v1.0.7",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.7",
           "status": "retired"
         },
         "1.0.8": {
           "release_date": "2023-11-03",
-          "release_notes": "https://bun.com/blog/bun-v1.0.8",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.8",
           "status": "retired"
         },
         "1.0.9": {
           "release_date": "2023-11-05",
-          "release_notes": "https://bun.com/blog/bun-v1.0.9",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.9",
           "status": "retired"
         },
         "1.0.10": {
           "release_date": "2023-11-07",
-          "release_notes": "https://bun.com/blog/bun-v1.0.10",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.10",
           "status": "retired"
         },
         "1.0.11": {
           "release_date": "2023-11-08",
-          "release_notes": "https://bun.com/blog/bun-v1.0.11",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.11",
           "status": "retired"
         },
         "1.0.12": {
           "release_date": "2023-11-16",
-          "release_notes": "https://bun.com/blog/bun-v1.0.12",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.12",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.13": {
           "release_date": "2023-11-18",
-          "release_notes": "https://bun.com/blog/bun-v1.0.13",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.13",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.14": {
           "release_date": "2023-11-23",
-          "release_notes": "https://bun.com/blog/bun-v1.0.14",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.14",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.15": {
           "release_date": "2023-12-02",
-          "release_notes": "https://bun.com/blog/bun-v1.0.15",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.15",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.16": {
           "release_date": "2023-12-10",
-          "release_notes": "https://bun.com/blog/bun-v1.0.16",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.16",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.17": {
           "release_date": "2023-12-12",
-          "release_notes": "https://bun.com/blog/bun-v1.0.17",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.17",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.18": {
           "release_date": "2023-12-14",
-          "release_notes": "https://bun.com/blog/bun-v1.0.18",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.18",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.19": {
           "release_date": "2023-12-22",
-          "release_notes": "https://bun.com/blog/bun-v1.0.19",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.19",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.20": {
           "release_date": "2023-12-24",
-          "release_notes": "https://bun.com/blog/bun-v1.0.20",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.20",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.21": {
           "release_date": "2024-01-02",
-          "release_notes": "https://bun.com/blog/bun-v1.0.21",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.21",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.22": {
           "release_date": "2024-01-10",
-          "release_notes": "https://bun.com/blog/bun-v1.0.22",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.22",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.23": {
           "release_date": "2024-01-16",
-          "release_notes": "https://bun.com/blog/bun-v1.0.23",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.23",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.24": {
           "release_date": "2024-01-20",
-          "release_notes": "https://bun.com/blog/bun-v1.0.24",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.24",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.25": {
           "release_date": "2024-01-21",
-          "release_notes": "https://bun.com/blog/bun-v1.0.25",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.25",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.26": {
           "release_date": "2024-02-03",
-          "release_notes": "https://bun.com/blog/bun-v1.0.26",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.26",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.27": {
           "release_date": "2024-02-17",
-          "release_notes": "https://bun.com/blog/bun-v1.0.27",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.27",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.28": {
           "release_date": "2024-02-19",
-          "release_notes": "https://bun.com/blog/bun-v1.0.28",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.28",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.29": {
           "release_date": "2024-02-23",
-          "release_notes": "https://bun.com/blog/bun-v1.0.29",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.29",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.30": {
           "release_date": "2024-03-04",
-          "release_notes": "https://bun.com/blog/bun-v1.0.30",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.30",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.31": {
           "release_date": "2024-03-15",
-          "release_notes": "https://bun.com/blog/bun-v1.0.31",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.31",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.32": {
           "release_date": "2024-03-17",
-          "release_notes": "https://bun.com/blog/bun-v1.0.32",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.32",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.33": {
           "release_date": "2024-03-18",
-          "release_notes": "https://bun.com/blog/bun-v1.0.33",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.33",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.34": {
           "release_date": "2024-03-22",
-          "release_notes": "https://bun.com/blog/bun-v1.0.34",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.34",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.35": {
           "release_date": "2024-03-22",
-          "release_notes": "https://bun.com/blog/bun-v1.0.35",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.35",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.36": {
           "release_date": "2024-03-29",
-          "release_notes": "https://bun.com/blog/bun-v1.0.36",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.0.36",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.0": {
           "release_date": "2024-04-01",
-          "release_notes": "https://bun.com/blog/bun-v1.1.0",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.0",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.1": {
           "release_date": "2024-04-04",
-          "release_notes": "https://bun.com/blog/bun-v1.1.1",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.1",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.2": {
           "release_date": "2024-04-06",
-          "release_notes": "https://bun.com/blog/bun-v1.1.2",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.2",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.3": {
           "release_date": "2024-04-08",
-          "release_notes": "https://bun.com/blog/bun-v1.1.3",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.3",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.4": {
           "release_date": "2024-04-16",
-          "release_notes": "https://bun.com/blog/bun-v1.1.4",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.4",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.5": {
           "release_date": "2024-04-26",
-          "release_notes": "https://bun.com/blog/bun-v1.1.5",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.5",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.6": {
           "release_date": "2024-04-28",
-          "release_notes": "https://bun.com/blog/bun-v1.1.6",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.6",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.7": {
           "release_date": "2024-05-03",
-          "release_notes": "https://bun.com/blog/bun-v1.1.7",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.7",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.8": {
           "release_date": "2024-05-10",
-          "release_notes": "https://bun.com/blog/bun-v1.1.8",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.8",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.9": {
           "release_date": "2024-05-22",
-          "release_notes": "https://bun.com/blog/bun-v1.1.9",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.9",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.10": {
           "release_date": "2024-05-25",
-          "release_notes": "https://bun.com/blog/bun-v1.1.10",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.10",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.11": {
           "release_date": "2024-06-01",
-          "release_notes": "https://bun.com/blog/bun-v1.1.11",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.11",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.12": {
           "release_date": "2024-06-01",
-          "release_notes": "https://bun.com/blog/bun-v1.1.12",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.12",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.13": {
           "release_date": "2024-06-12",
-          "release_notes": "https://bun.com/blog/bun-v1.1.13",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.13",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.14": {
           "release_date": "2024-06-19",
-          "release_notes": "https://bun.com/blog/bun-v1.1.14",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.14",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.15": {
           "release_date": "2024-06-19",
-          "release_notes": "https://bun.com/blog/bun-v1.1.15",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.15",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.16": {
           "release_date": "2024-06-23",
-          "release_notes": "https://bun.com/blog/bun-v1.1.16",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.16",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.17": {
           "release_date": "2024-06-25",
-          "release_notes": "https://bun.com/blog/bun-v1.1.17",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.17",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.18": {
           "release_date": "2024-07-03",
-          "release_notes": "https://bun.com/blog/bun-v1.1.18",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.18",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.22"
         },
         "1.1.19": {
           "release_date": "2024-07-12",
-          "release_notes": "https://bun.com/blog/bun-v1.1.19",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.19",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.22"
         },
         "1.1.20": {
           "release_date": "2024-07-13",
-          "release_notes": "https://bun.com/blog/bun-v1.1.20",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.20",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.22"
         },
         "1.1.21": {
           "release_date": "2024-07-27",
-          "release_notes": "https://bun.com/blog/bun-v1.1.21",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.21",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.22"
         },
         "1.1.22": {
           "release_date": "2024-08-07",
-          "release_notes": "https://bun.com/blog/bun-v1.1.22",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.22",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.23": {
           "release_date": "2024-08-14",
-          "release_notes": "https://bun.com/blog/bun-v1.1.23",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.23",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.24": {
           "release_date": "2024-08-14",
-          "release_notes": "https://bun.com/blog/bun-v1.1.24",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.24",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.25": {
           "release_date": "2024-08-21",
-          "release_notes": "https://bun.com/blog/bun-v1.1.25",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.25",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.26": {
           "release_date": "2024-08-24",
-          "release_notes": "https://bun.com/blog/bun-v1.1.26",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.26",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.27": {
           "release_date": "2024-09-07",
-          "release_notes": "https://bun.com/blog/bun-v1.1.27",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.27",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.28": {
           "release_date": "2024-09-18",
-          "release_notes": "https://bun.com/blog/bun-v1.1.28",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.28",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.1"
         },
         "1.1.29": {
           "release_date": "2024-09-20",
-          "release_notes": "https://bun.com/blog/bun-v1.1.29",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.29",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.1"
         },
         "1.1.30": {
           "release_date": "2024-10-08",
-          "release_notes": "https://bun.com/blog/bun-v1.1.30",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.30",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.3"
         },
         "1.1.31": {
           "release_date": "2024-10-18",
-          "release_notes": "https://bun.com/blog/bun-v1.1.31",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.31",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.4"
         },
         "1.1.32": {
           "release_date": "2024-10-21",
-          "release_notes": "https://bun.com/blog/bun-v1.1.32",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.32",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.4"
         },
         "1.1.33": {
           "release_date": "2024-10-24",
-          "release_notes": "https://bun.com/blog/bun-v1.1.33",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.33",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.4"
         },
         "1.1.34": {
           "release_date": "2024-11-02",
-          "release_notes": "https://bun.com/blog/bun-v1.1.34",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.34",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.35": {
           "release_date": "2024-11-19",
-          "release_notes": "https://bun.com/blog/bun-v1.1.35",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.35",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.36": {
           "release_date": "2024-11-19",
-          "release_notes": "https://bun.com/blog/bun-v1.1.36",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.36",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.37": {
           "release_date": "2024-11-26",
-          "release_notes": "https://bun.com/blog/bun-v1.1.37",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.37",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.38": {
           "release_date": "2024-11-29",
-          "release_notes": "https://bun.com/blog/bun-v1.1.38",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.38",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.39": {
           "release_date": "2024-12-17",
-          "release_notes": "https://bun.com/blog/bun-v1.1.39",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.39",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.9"
         },
         "1.1.40": {
           "release_date": "2024-12-18",
-          "release_notes": "https://bun.com/blog/bun-v1.1.40",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.40",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.9"
         },
         "1.1.41": {
           "release_date": "2024-12-20",
-          "release_notes": "https://bun.com/blog/bun-v1.1.41",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.41",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.9"
         },
         "1.1.42": {
           "release_date": "2024-12-21",
-          "release_notes": "https://bun.com/blog/bun-v1.1.42",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.42",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.9"
         },
         "1.1.43": {
           "release_date": "2025-01-08",
-          "release_notes": "https://bun.com/blog/bun-v1.1.43",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.43",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.10"
         },
         "1.1.44": {
           "release_date": "2025-01-17",
-          "release_notes": "https://bun.com/blog/bun-v1.1.44",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.44",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.1.45": {
           "release_date": "2025-01-17",
-          "release_notes": "https://bun.com/blog/bun-v1.1.45",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.1.45",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.2.0": {
           "release_date": "2025-01-22",
-          "release_notes": "https://bun.com/blog/bun-v1.2.0",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.0",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.2.1": {
           "release_date": "2025-01-27",
-          "release_notes": "https://bun.com/blog/bun-v1.2.1",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.1",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.2.2": {
           "release_date": "2025-02-01",
-          "release_notes": "https://bun.com/blog/bun-v1.2.2",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.2",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.2.3": {
           "release_date": "2025-02-22",
-          "release_notes": "https://bun.com/blog/bun-v1.2.3",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.3",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.3"
         },
         "1.2.4": {
           "release_date": "2025-02-26",
-          "release_notes": "https://bun.com/blog/bun-v1.2.4",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.4",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.3"
         },
         "1.2.5": {
           "release_date": "2025-03-11",
-          "release_notes": "https://bun.com/blog/bun-v1.2.5",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.5",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.7"
         },
         "1.2.6": {
           "release_date": "2025-03-25",
-          "release_notes": "https://bun.com/blog/bun-v1.2.6",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.6",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.7"
         },
         "1.2.7": {
           "release_date": "2025-03-27",
-          "release_notes": "https://bun.com/blog/bun-v1.2.7",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.7",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.7"
         },
         "1.2.8": {
           "release_date": "2025-03-31",
-          "release_notes": "https://bun.com/blog/bun-v1.2.8",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.8",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.7"
         },
         "1.2.9": {
           "release_date": "2025-04-09",
-          "release_notes": "https://bun.com/blog/bun-v1.2.9",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.9",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.10"
         },
         "1.2.10": {
           "release_date": "2025-04-17",
-          "release_notes": "https://bun.com/blog/bun-v1.2.10",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.10",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.10"
         },
         "1.2.11": {
           "release_date": "2025-04-29",
-          "release_notes": "https://bun.com/blog/bun-v1.2.11",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.11",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.11"
         },
         "1.2.12": {
           "release_date": "2025-05-04",
-          "release_notes": "https://bun.com/blog/bun-v1.2.12",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.12",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.11"
         },
         "1.2.13": {
           "release_date": "2025-05-10",
-          "release_notes": "https://bun.com/blog/bun-v1.2.13",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.13",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.12"
         },
         "1.2.14": {
           "release_date": "2025-05-21",
-          "release_notes": "https://bun.com/blog/bun-v1.2.14",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.14",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.12"
         },
         "1.2.15": {
           "release_date": "2025-05-28",
-          "release_notes": "https://bun.com/blog/bun-v1.2.15",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.15",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.15"
         },
         "1.2.16": {
           "release_date": "2025-06-12",
-          "release_notes": "https://bun.com/blog/bun-v1.2.16",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.16",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.16"
         },
         "1.2.17": {
           "release_date": "2025-06-21",
-          "release_notes": "https://bun.com/blog/bun-v1.2.17",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.17",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.17"
         },
         "1.2.18": {
           "release_date": "2025-07-03",
-          "release_notes": "https://bun.com/blog/bun-v1.2.18",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.18",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.19"
         },
         "1.2.19": {
           "release_date": "2025-07-19",
-          "release_notes": "https://bun.com/blog/bun-v1.2.19",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.19",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.19"
         },
         "1.2.20": {
           "release_date": "2025-08-10",
-          "release_notes": "https://bun.com/blog/bun-v1.2.20",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.20",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "623.1.3"
         },
         "1.2.21": {
           "release_date": "2025-08-25",
-          "release_notes": "https://bun.com/blog/bun-v1.2.21",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.2.21",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "623.1.5"

--- a/browsers/bun.json
+++ b/browsers/bun.json
@@ -8,711 +8,711 @@
       "releases": {
         "1.0.0": {
           "release_date": "2023-09-08",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.0",
+          "release_notes": "https://bun.com/blog/bun-v1.0.0",
           "status": "retired"
         },
         "1.0.1": {
           "release_date": "2023-09-12",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.1",
+          "release_notes": "https://bun.com/blog/bun-v1.0.1",
           "status": "retired"
         },
         "1.0.2": {
           "release_date": "2023-09-15",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.2",
+          "release_notes": "https://bun.com/blog/bun-v1.0.2",
           "status": "retired"
         },
         "1.0.3": {
           "release_date": "2023-09-22",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.3",
+          "release_notes": "https://bun.com/blog/bun-v1.0.3",
           "status": "retired"
         },
         "1.0.4": {
           "release_date": "2023-10-03",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.4",
+          "release_notes": "https://bun.com/blog/bun-v1.0.4",
           "status": "retired"
         },
         "1.0.5": {
           "release_date": "2023-10-11",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.5",
+          "release_notes": "https://bun.com/blog/bun-v1.0.5",
           "status": "retired"
         },
         "1.0.6": {
           "release_date": "2023-10-12",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.6",
+          "release_notes": "https://bun.com/blog/bun-v1.0.6",
           "status": "retired"
         },
         "1.0.7": {
           "release_date": "2023-10-20",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.7",
+          "release_notes": "https://bun.com/blog/bun-v1.0.7",
           "status": "retired"
         },
         "1.0.8": {
           "release_date": "2023-11-03",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.8",
+          "release_notes": "https://bun.com/blog/bun-v1.0.8",
           "status": "retired"
         },
         "1.0.9": {
           "release_date": "2023-11-05",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.9",
+          "release_notes": "https://bun.com/blog/bun-v1.0.9",
           "status": "retired"
         },
         "1.0.10": {
           "release_date": "2023-11-07",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.10",
+          "release_notes": "https://bun.com/blog/bun-v1.0.10",
           "status": "retired"
         },
         "1.0.11": {
           "release_date": "2023-11-08",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.11",
+          "release_notes": "https://bun.com/blog/bun-v1.0.11",
           "status": "retired"
         },
         "1.0.12": {
           "release_date": "2023-11-16",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.12",
+          "release_notes": "https://bun.com/blog/bun-v1.0.12",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.13": {
           "release_date": "2023-11-18",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.13",
+          "release_notes": "https://bun.com/blog/bun-v1.0.13",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.14": {
           "release_date": "2023-11-23",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.14",
+          "release_notes": "https://bun.com/blog/bun-v1.0.14",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.15": {
           "release_date": "2023-12-02",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.15",
+          "release_notes": "https://bun.com/blog/bun-v1.0.15",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.16": {
           "release_date": "2023-12-10",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.16",
+          "release_notes": "https://bun.com/blog/bun-v1.0.16",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.17": {
           "release_date": "2023-12-12",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.17",
+          "release_notes": "https://bun.com/blog/bun-v1.0.17",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.18": {
           "release_date": "2023-12-14",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.18",
+          "release_notes": "https://bun.com/blog/bun-v1.0.18",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.19": {
           "release_date": "2023-12-22",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.19",
+          "release_notes": "https://bun.com/blog/bun-v1.0.19",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.20": {
           "release_date": "2023-12-24",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.20",
+          "release_notes": "https://bun.com/blog/bun-v1.0.20",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.21": {
           "release_date": "2024-01-02",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.21",
+          "release_notes": "https://bun.com/blog/bun-v1.0.21",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.22": {
           "release_date": "2024-01-10",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.22",
+          "release_notes": "https://bun.com/blog/bun-v1.0.22",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.23": {
           "release_date": "2024-01-16",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.23",
+          "release_notes": "https://bun.com/blog/bun-v1.0.23",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.24": {
           "release_date": "2024-01-20",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.24",
+          "release_notes": "https://bun.com/blog/bun-v1.0.24",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.25": {
           "release_date": "2024-01-21",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.25",
+          "release_notes": "https://bun.com/blog/bun-v1.0.25",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.26": {
           "release_date": "2024-02-03",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.26",
+          "release_notes": "https://bun.com/blog/bun-v1.0.26",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.27": {
           "release_date": "2024-02-17",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.27",
+          "release_notes": "https://bun.com/blog/bun-v1.0.27",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.28": {
           "release_date": "2024-02-19",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.28",
+          "release_notes": "https://bun.com/blog/bun-v1.0.28",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.29": {
           "release_date": "2024-02-23",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.29",
+          "release_notes": "https://bun.com/blog/bun-v1.0.29",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.30": {
           "release_date": "2024-03-04",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.30",
+          "release_notes": "https://bun.com/blog/bun-v1.0.30",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.31": {
           "release_date": "2024-03-15",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.31",
+          "release_notes": "https://bun.com/blog/bun-v1.0.31",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.32": {
           "release_date": "2024-03-17",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.32",
+          "release_notes": "https://bun.com/blog/bun-v1.0.32",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.33": {
           "release_date": "2024-03-18",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.33",
+          "release_notes": "https://bun.com/blog/bun-v1.0.33",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.34": {
           "release_date": "2024-03-22",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.34",
+          "release_notes": "https://bun.com/blog/bun-v1.0.34",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.35": {
           "release_date": "2024-03-22",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.35",
+          "release_notes": "https://bun.com/blog/bun-v1.0.35",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.0.36": {
           "release_date": "2024-03-29",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.0.36",
+          "release_notes": "https://bun.com/blog/bun-v1.0.36",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.0": {
           "release_date": "2024-04-01",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.0",
+          "release_notes": "https://bun.com/blog/bun-v1.1.0",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.1": {
           "release_date": "2024-04-04",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.1",
+          "release_notes": "https://bun.com/blog/bun-v1.1.1",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.2": {
           "release_date": "2024-04-06",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.2",
+          "release_notes": "https://bun.com/blog/bun-v1.1.2",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.3": {
           "release_date": "2024-04-08",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.3",
+          "release_notes": "https://bun.com/blog/bun-v1.1.3",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.4": {
           "release_date": "2024-04-16",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.4",
+          "release_notes": "https://bun.com/blog/bun-v1.1.4",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.5": {
           "release_date": "2024-04-26",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.5",
+          "release_notes": "https://bun.com/blog/bun-v1.1.5",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.6": {
           "release_date": "2024-04-28",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.6",
+          "release_notes": "https://bun.com/blog/bun-v1.1.6",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.7": {
           "release_date": "2024-05-03",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.7",
+          "release_notes": "https://bun.com/blog/bun-v1.1.7",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.8": {
           "release_date": "2024-05-10",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.8",
+          "release_notes": "https://bun.com/blog/bun-v1.1.8",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.9": {
           "release_date": "2024-05-22",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.9",
+          "release_notes": "https://bun.com/blog/bun-v1.1.9",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.10": {
           "release_date": "2024-05-25",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.10",
+          "release_notes": "https://bun.com/blog/bun-v1.1.10",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.11": {
           "release_date": "2024-06-01",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.11",
+          "release_notes": "https://bun.com/blog/bun-v1.1.11",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.12": {
           "release_date": "2024-06-01",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.12",
+          "release_notes": "https://bun.com/blog/bun-v1.1.12",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "617.1.3"
         },
         "1.1.13": {
           "release_date": "2024-06-12",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.13",
+          "release_notes": "https://bun.com/blog/bun-v1.1.13",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.14": {
           "release_date": "2024-06-19",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.14",
+          "release_notes": "https://bun.com/blog/bun-v1.1.14",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.15": {
           "release_date": "2024-06-19",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.15",
+          "release_notes": "https://bun.com/blog/bun-v1.1.15",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.16": {
           "release_date": "2024-06-23",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.16",
+          "release_notes": "https://bun.com/blog/bun-v1.1.16",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.17": {
           "release_date": "2024-06-25",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.17",
+          "release_notes": "https://bun.com/blog/bun-v1.1.17",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.13"
         },
         "1.1.18": {
           "release_date": "2024-07-03",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.18",
+          "release_notes": "https://bun.com/blog/bun-v1.1.18",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.22"
         },
         "1.1.19": {
           "release_date": "2024-07-12",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.19",
+          "release_notes": "https://bun.com/blog/bun-v1.1.19",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.22"
         },
         "1.1.20": {
           "release_date": "2024-07-13",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.20",
+          "release_notes": "https://bun.com/blog/bun-v1.1.20",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.22"
         },
         "1.1.21": {
           "release_date": "2024-07-27",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.21",
+          "release_notes": "https://bun.com/blog/bun-v1.1.21",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "619.1.22"
         },
         "1.1.22": {
           "release_date": "2024-08-07",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.22",
+          "release_notes": "https://bun.com/blog/bun-v1.1.22",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.23": {
           "release_date": "2024-08-14",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.23",
+          "release_notes": "https://bun.com/blog/bun-v1.1.23",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.24": {
           "release_date": "2024-08-14",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.24",
+          "release_notes": "https://bun.com/blog/bun-v1.1.24",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.25": {
           "release_date": "2024-08-21",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.25",
+          "release_notes": "https://bun.com/blog/bun-v1.1.25",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.26": {
           "release_date": "2024-08-24",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.26",
+          "release_notes": "https://bun.com/blog/bun-v1.1.26",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.27": {
           "release_date": "2024-09-07",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.27",
+          "release_notes": "https://bun.com/blog/bun-v1.1.27",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "620.1.2"
         },
         "1.1.28": {
           "release_date": "2024-09-18",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.28",
+          "release_notes": "https://bun.com/blog/bun-v1.1.28",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.1"
         },
         "1.1.29": {
           "release_date": "2024-09-20",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.29",
+          "release_notes": "https://bun.com/blog/bun-v1.1.29",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.1"
         },
         "1.1.30": {
           "release_date": "2024-10-08",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.30",
+          "release_notes": "https://bun.com/blog/bun-v1.1.30",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.3"
         },
         "1.1.31": {
           "release_date": "2024-10-18",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.31",
+          "release_notes": "https://bun.com/blog/bun-v1.1.31",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.4"
         },
         "1.1.32": {
           "release_date": "2024-10-21",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.32",
+          "release_notes": "https://bun.com/blog/bun-v1.1.32",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.4"
         },
         "1.1.33": {
           "release_date": "2024-10-24",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.33",
+          "release_notes": "https://bun.com/blog/bun-v1.1.33",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.4"
         },
         "1.1.34": {
           "release_date": "2024-11-02",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.34",
+          "release_notes": "https://bun.com/blog/bun-v1.1.34",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.35": {
           "release_date": "2024-11-19",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.35",
+          "release_notes": "https://bun.com/blog/bun-v1.1.35",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.36": {
           "release_date": "2024-11-19",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.36",
+          "release_notes": "https://bun.com/blog/bun-v1.1.36",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.37": {
           "release_date": "2024-11-26",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.37",
+          "release_notes": "https://bun.com/blog/bun-v1.1.37",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.38": {
           "release_date": "2024-11-29",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.38",
+          "release_notes": "https://bun.com/blog/bun-v1.1.38",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.5"
         },
         "1.1.39": {
           "release_date": "2024-12-17",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.39",
+          "release_notes": "https://bun.com/blog/bun-v1.1.39",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.9"
         },
         "1.1.40": {
           "release_date": "2024-12-18",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.40",
+          "release_notes": "https://bun.com/blog/bun-v1.1.40",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.9"
         },
         "1.1.41": {
           "release_date": "2024-12-20",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.41",
+          "release_notes": "https://bun.com/blog/bun-v1.1.41",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.9"
         },
         "1.1.42": {
           "release_date": "2024-12-21",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.42",
+          "release_notes": "https://bun.com/blog/bun-v1.1.42",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.9"
         },
         "1.1.43": {
           "release_date": "2025-01-08",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.43",
+          "release_notes": "https://bun.com/blog/bun-v1.1.43",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.10"
         },
         "1.1.44": {
           "release_date": "2025-01-17",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.44",
+          "release_notes": "https://bun.com/blog/bun-v1.1.44",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.1.45": {
           "release_date": "2025-01-17",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.1.45",
+          "release_notes": "https://bun.com/blog/bun-v1.1.45",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.2.0": {
           "release_date": "2025-01-22",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.0",
+          "release_notes": "https://bun.com/blog/bun-v1.2.0",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.2.1": {
           "release_date": "2025-01-27",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.1",
+          "release_notes": "https://bun.com/blog/bun-v1.2.1",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.2.2": {
           "release_date": "2025-02-01",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.2",
+          "release_notes": "https://bun.com/blog/bun-v1.2.2",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "621.1.11"
         },
         "1.2.3": {
           "release_date": "2025-02-22",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.3",
+          "release_notes": "https://bun.com/blog/bun-v1.2.3",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.3"
         },
         "1.2.4": {
           "release_date": "2025-02-26",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.4",
+          "release_notes": "https://bun.com/blog/bun-v1.2.4",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.3"
         },
         "1.2.5": {
           "release_date": "2025-03-11",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.5",
+          "release_notes": "https://bun.com/blog/bun-v1.2.5",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.7"
         },
         "1.2.6": {
           "release_date": "2025-03-25",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.6",
+          "release_notes": "https://bun.com/blog/bun-v1.2.6",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.7"
         },
         "1.2.7": {
           "release_date": "2025-03-27",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.7",
+          "release_notes": "https://bun.com/blog/bun-v1.2.7",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.7"
         },
         "1.2.8": {
           "release_date": "2025-03-31",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.8",
+          "release_notes": "https://bun.com/blog/bun-v1.2.8",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.7"
         },
         "1.2.9": {
           "release_date": "2025-04-09",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.9",
+          "release_notes": "https://bun.com/blog/bun-v1.2.9",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.10"
         },
         "1.2.10": {
           "release_date": "2025-04-17",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.10",
+          "release_notes": "https://bun.com/blog/bun-v1.2.10",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.10"
         },
         "1.2.11": {
           "release_date": "2025-04-29",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.11",
+          "release_notes": "https://bun.com/blog/bun-v1.2.11",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.11"
         },
         "1.2.12": {
           "release_date": "2025-05-04",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.12",
+          "release_notes": "https://bun.com/blog/bun-v1.2.12",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.11"
         },
         "1.2.13": {
           "release_date": "2025-05-10",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.13",
+          "release_notes": "https://bun.com/blog/bun-v1.2.13",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.12"
         },
         "1.2.14": {
           "release_date": "2025-05-21",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.14",
+          "release_notes": "https://bun.com/blog/bun-v1.2.14",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.12"
         },
         "1.2.15": {
           "release_date": "2025-05-28",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.15",
+          "release_notes": "https://bun.com/blog/bun-v1.2.15",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.15"
         },
         "1.2.16": {
           "release_date": "2025-06-12",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.16",
+          "release_notes": "https://bun.com/blog/bun-v1.2.16",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.16"
         },
         "1.2.17": {
           "release_date": "2025-06-21",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.17",
+          "release_notes": "https://bun.com/blog/bun-v1.2.17",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.17"
         },
         "1.2.18": {
           "release_date": "2025-07-03",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.18",
+          "release_notes": "https://bun.com/blog/bun-v1.2.18",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.19"
         },
         "1.2.19": {
           "release_date": "2025-07-19",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.19",
+          "release_notes": "https://bun.com/blog/bun-v1.2.19",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "622.1.19"
         },
         "1.2.20": {
           "release_date": "2025-08-10",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.20",
+          "release_notes": "https://bun.com/blog/bun-v1.2.20",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "623.1.3"
         },
         "1.2.21": {
           "release_date": "2025-08-25",
-          "release_notes": "https://github.com/oven-sh/bun/releases/tag/bun-v1.2.21",
+          "release_notes": "https://bun.com/blog/bun-v1.2.21",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "623.1.5"

--- a/scripts/update-browser-releases/bun.ts
+++ b/scripts/update-browser-releases/bun.ts
@@ -16,24 +16,25 @@ import {
 
 import type { CompatData } from '../../types/types.js';
 
-type BunVersionInfo = {
-  status: 'current' | 'retired';
-  release_date: string;
-  release_notes: string;
-} & (
-  | {
-      versions?: never;
-      revision?: never;
-    }
-  | {
-      versions: Record<(string & {}) | 'webkit', string>;
-      revision: string;
-    }
-);
-
 interface BunVersionsResponse {
   $note: string;
-  releases: Record<string, BunVersionInfo>;
+  releases: Record<
+    string,
+    {
+      status: 'current' | 'retired';
+      release_date: string;
+      release_notes: string;
+    } & (
+      | {
+          versions?: never;
+          revision?: never;
+        }
+      | {
+          versions: Record<(string & {}) | 'webkit', string>;
+          revision: string;
+        }
+    )
+  >;
 }
 
 const VERSIONS_API = 'https://bun.com/versions.json';
@@ -44,7 +45,7 @@ const webkitVersionCache = new Map<string, string | undefined>();
  * Fetches Bun version information from the versions.json endpoint.
  * @returns The versions response object.
  */
-const fetchVersions = async (): Promise<BunVersionsResponse> => {
+const fetchVersions = async () => {
   const res = await fetch(VERSIONS_API, {
     headers: {
       'User-Agent':
@@ -82,7 +83,6 @@ const fetchWebKitVersion = async (
     const githubToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
     if (githubToken) {
       headers['Authorization'] = `token ${githubToken}`;
-      console.log(chalk`{gray Using GitHub token for API requests}`);
     }
 
     const res = await fetch(url, { headers });
@@ -173,7 +173,7 @@ const fetchWebKitVersion = async (
  * @returns An object containing webkitRev and bunRevision, if available.
  */
 const getBunInfoFromVersionData = async (
-  versionInfo: BunVersionInfo,
+  versionInfo: BunVersionsResponse['releases'][string],
 ): Promise<{ webkitRev?: string; bunRevision?: string }> => {
   const webkitCommitHash = versionInfo.versions?.webkit;
   const bunRevision = versionInfo.revision;
@@ -181,12 +181,6 @@ const getBunInfoFromVersionData = async (
 
   if (webkitCommitHash) {
     webkitRev = await fetchWebKitVersion(webkitCommitHash);
-  }
-
-  if (webkitRev || bunRevision) {
-    console.log(
-      chalk`{gray Bun: webkit=${webkitRev ?? 'unknown'} bun-revision=${bunRevision || 'unknown'}}`,
-    );
   }
 
   return { webkitRev, bunRevision };
@@ -231,14 +225,10 @@ export const updateBunReleases = async (options: {
     );
   }
 
-  interface Stable {
+  const stableReleases: (BunVersionsResponse['releases'][string] & {
     version: string;
-    date?: string;
-    url?: string;
-    info: BunVersionInfo;
-  }
+  })[] = [];
 
-  const stableReleases: Stable[] = [];
   let latestVersion: string | null = null;
 
   for (const [version, info] of Object.entries(versionsData.releases)) {
@@ -249,9 +239,7 @@ export const updateBunReleases = async (options: {
 
     stableReleases.push({
       version,
-      date: info.release_date,
-      url: info.release_notes,
-      info,
+      ...info,
     });
 
     if (info.status === 'current') {
@@ -285,14 +273,14 @@ export const updateBunReleases = async (options: {
       status,
       undefined,
       undefined,
-      rel.date,
-      rel.url,
+      rel.release_date,
+      rel.release_notes,
     );
 
     const entry = data.browsers[browser].releases[rel.version];
 
     if (entry) {
-      const { webkitRev } = await getBunInfoFromVersionData(rel.info);
+      const { webkitRev } = await getBunInfoFromVersionData(rel);
 
       if (webkitRev) {
         entry.engine = 'WebKit';


### PR DESCRIPTION
This PR makes changes to the scripts/update-browser-releases/bun.ts file as per comments here: https://github.com/mdn/browser-compat-data/pull/27682#discussion_r2303425469

Exact changes:

- Bun's release notes URL should be our blog
- Remove unnecessary/spammy console.logs which pollute the output in automated pull request comments

The `release_notes` values were automatically updated without changes to this script, because I made changes to https://bun.com/versions.json