### PR TITLE
Add FF impl_url for CSS `overlay` property

### DIFF
--- a/css/properties/overlay.json
+++ b/css/properties/overlay.json
@@ -15,7 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "bugzilla.mozilla.org/show_bug.cgi?id=1841456"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/properties/overlay.json
+++ b/css/properties/overlay.json
@@ -16,7 +16,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "impl_url": "bugzilla.mozilla.org/show_bug.cgi?id=1841456"
+              "impl_url": "https://bugzil.la/1841456"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION

#### Summary

This PR adds a link point to tracking ticket on Bugzilla within `css/properties/overlay.json`.

#### Test results and supporting details

No tests have done; discussed in the issue.

#### Related issues

Fixes mdn#27678 .
