### PR TITLE
Add WebGPU 3D compressed texture features

### DIFF
--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -662,7 +662,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -744,7 +744,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 139 adds support for 3D textures using BC and ASTC compressed formats. See https://chromestatus.com/feature/5080855386783744, and also see https://developer.chrome.com/blog/new-in-webgpu-139#3d_texture_support_for_bc_and_astc_compressed_formats for a bit more explanation.

This PR adds a data point for the WebGPU `GPUSupportedFeatures` required to enable these texture usages.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
