### PR TITLE
Add Firefox clipboardData note about only pasting first file

### DIFF
--- a/api/ClipboardEvent.json
+++ b/api/ClipboardEvent.json
@@ -16,7 +16,8 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "22"
+            "version_added": "22",
+            "notes": "When pasting multiple files, Firefox only returns the first file. See bug https://bugzil.la/1954680."
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Added a note under Firefox support for `ClipboardEvent.clipboardData` indicating that when pasting multiple files, Firefox only returns the first file. This is based on bug [1954680](https://bugzil.la/1954680).

#### Test results and supporting details

Tested locally using `npm test` in mdn/browser-compat-data. All tests pass successfully.

#### Related issues

Fixes #27687

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
