### PR TITLE
Bug-1679997 CSS origin for registered content scripts

### DIFF
--- a/webextensions/api/contentScripts.json
+++ b/webextensions/api/contentScripts.json
@@ -98,6 +98,25 @@
               }
             }
           },
+          "cssOrigin": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "144"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "matchOriginAsFallback": {
             "__compat": {
               "support": {

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -119,6 +119,25 @@
               "safari_ios": "mirror"
             }
           },
+          "cssOrigin": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "144"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "matchOriginAsFallback": {
             "__compat": {
               "support": {

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -132,7 +132,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/manifest/content_scripts.json
+++ b/webextensions/manifest/content_scripts.json
@@ -81,7 +81,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "144"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Add details of support added in Firefox 144 for the ability to determine the precedence of injected CSS through the  [`"content_scripts"` manifest key](http://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts), in [scripting.registerContentScripts()](http://developer.mozilla.orgdeveloper.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/registerContentScripts) with the `cssOrigin` property on [scripting.RegisteredContentScript](http://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/RegisteredContentScript), and the `cssOrigin` property in [contentScripts.register](http://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/contentScripts/register). 

Addresses the dev-docs-needed requirements of [Bug 1679997](https://bugzilla.mozilla.org/show_bug.cgi?id=1679997) Add cssOrigin to declarative contentScripts API (manifest.json, scripting, contentScripts)

#### Related issues

MDN documentation provided in https://github.com/mdn/content/pull/40955
