### PR TITLE
In Firefox, & inside at-scope blocks has no implicit specificity

### DIFF
--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -51,6 +51,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "at-scope": {
+          "__compat": {
+            "description": "`&amp;` treated as `:where(:scope)` in `@scope` blocks",
+            "tags": [
+              "web-features:nesting"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "142",
+                "impl_url": "https://bugzil.la/1975531"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
#### Summary

CSS WG have decided that `&` inside `@scope` blocks should be treated like `:where(:scope)`. This has specificity implications, see the updated docs: https://developer.mozilla.org/en-US/docs/Web/CSS/@scope#specificity_in_scope

#### Test results and supporting details

- __Spec:__ https://redirect.github.com/w3c/csswg-drafts/issues/9740 (WIP)
- __Bugzilla:__ [1975531](https://bugzilla.mozilla.org/show_bug.cgi?id=1975531)
- __WPT:__ https://redirect.github.com/web-platform-tests/wpt/pull/53831 (WIP)


#### Related issues

- [ ] https://github.com/mdn/content/issues/40481
- [x] https://github.com/mdn/content/pull/40809
- [x] https://github.com/mdn/content/pull/40814
