### PR TITLE
Firefox 144 now displays a time picker for `datetime-local`

### DIFF
--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -20,7 +20,7 @@
               },
               "firefox": {
                 "version_added": "93",
-                "notes": "Firefox only displays a date picker and does not display a time picker, see [bug 1726108](https://bugzil.la/1726108)."
+                "notes": "Before Firefox 144, only a date picker was displayed but no time picker, see [bug 1726108](https://bugzil.la/1726108)."
               },
               "firefox_android": {
                 "version_added": "93"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 144 now displays a time picker for `datetime-local`.

#### Test results and supporting details

The Bugzilla ticket was resolve as fixed a couple of hours ago as like "implemented in Firefox 144".

#### Related issues

https://bugzilla.mozilla.org/show_bug.cgi?id=1726108