### PR TITLE
Remove 'Error API' feature from `CredentialsContainer.get`

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -873,39 +873,6 @@
               }
             }
           },
-          "error_api": {
-            "__compat": {
-              "description": "Error API",
-              "support": {
-                "chrome": {
-                  "version_added": "120"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": false
-                },
-                "webview_ios": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": false
-              }
-            }
-          },
           "mode_option": {
             "__compat": {
               "description": "`identity.mode`",


### PR DESCRIPTION
This was added in https://github.com/mdn/browser-compat-data/pull/21721 

> The Error API, which mainly manifests as useful properties of the return error object when a FedCM get() call rejects.

What the FedCM Error API really is, though, is `IdentityCredentialError` and we already have compat data for that.

Remove this entry is it only appears without further explanation on https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/get#browser_compatibility. It's not even in web-features yet, either.

I'm creating MDN docs for `IdentityCredentialError` in https://github.com/mdn/content/pull/40986.