### PR TITLE
Chrome 120 supports `IdentityCredentialError.error` as `code`

### DIFF
--- a/api/IdentityCredentialError.json
+++ b/api/IdentityCredentialError.json
@@ -62,6 +62,38 @@
           }
         }
       },
+      "error": {
+        "__compat": {
+          "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identitycredentialerror-error",
+          "support": {
+            "chrome": {
+              "alternative_name": "code",
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "url": {
         "__compat": {
           "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identitycredentialerror-url",


### PR DESCRIPTION
Spec: https://w3c-fedid.github.io/FedCM/#dom-identitycredentialerror-error

Chrome implements this under the wrong property name `code`, see https://github.com/w3c-fedid/FedCM/issues/780 and https://issues.chromium.org/issues/427474985.

Docs: https://github.com/mdn/content/pull/40986