### PR TITLE
Add member data to webextensions.api.types.BrowserSetting for Issue 26521

### DIFF
--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -25,7 +25,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "≤58",
+                "notes": "This type is provided as `ChromeSetting`."
               },
               "edge": "mirror",
               "firefox": {
@@ -44,7 +45,8 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/clear",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "≤58",
+                  "notes": "This type is provided as `ChromeSetting`."
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -66,7 +68,8 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/get",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "≤58",
+                  "notes": "This type is provided as `ChromeSetting`."
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -88,7 +91,8 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "≤58",
+                  "notes": "This type is provided as `ChromeSetting`."
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -110,7 +114,8 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set",
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "≤58",
+                  "notes": "This type is provided as `ChromeSetting`."
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -63,7 +63,7 @@
           },
           "get": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSettingget",
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/get",
               "support": {
                 "chrome": {
                   "version_added": "≤58"

--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -39,9 +39,75 @@
               "safari_ios": "mirror"
             }
           },
+          "clear": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/clear",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "72"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "get": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSettingget",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "72"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "onChange": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange",
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "72"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "set": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set",
               "support": {
                 "chrome": {
                   "version_added": "≤58"


### PR DESCRIPTION
#### Summary

Adds data for the clear, get, and set methods of webextensions.api.types.BrowserSetting. This enables compatibility data to be correctly displayed on MDN.

#### Related issues

Fixes #26521
Related MDN content change in https://github.com/mdn/content/pull/40989.