### PR TITLE
Fix shadowrootclonable, shadowrootdelegatesfocus & shadowrootserializable Safari compat data

### DIFF
--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -57,7 +57,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": "17.5",
+              "safari": {
+                "version_added": "17.5"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -90,7 +92,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": "16.4",
+              "safari": {
+                "version_added": "16.4"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -165,7 +169,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": "18",
+              "safari": {
+                "version_added": "18"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -178,7 +178,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -57,9 +57,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
+              "safari": "17.5",
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -92,9 +90,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
+              "safari": "16.4",
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -165,9 +165,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
+              "safari": "18",
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",


### PR DESCRIPTION
According to Apple's bug tracking system, this is when the content attributes landed.

The JS properties were added afterwards in Safari 18 (which MDN correctly reflects).

* shadowrootdelegatesfocus content attribute was added with the initial implementation of declarative shadow DOM in 16.4: https://github.com/WebKit/WebKit/commit/46837e56d6f57f7e52bf92c9534cc7683909eee5
* shadowrootclonable content attribute: https://github.com/WebKit/WebKit/commit/79d2dec92caef6f7df33125ab34bd70e36c982c2
* shadowrootserializable content attribute & JS property: https://github.com/WebKit/WebKit/commit/de64e62a2a5041b0d59b985feba7e080993c36b8
* shadowrootdelegatesfocus & shadowrootclonable JS properties: https://github.com/WebKit/WebKit/commit/db0669a6fa034ab98e120208f72fd232948b1fcc