### PR TITLE
Firefox 141 supports cross-origin LCP render time

### DIFF
--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -264,7 +264,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -249,7 +249,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -249,7 +249,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "122"
+                "version_added": "141"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Originally, cross-origin Largest Contentful Paint (LCP) images did not provide a `renderTime` and fell back to `loadTime` unless an HTTP `Timing-Allow-Origin` header was present.

This [was changed](https://github.com/w3c/largest-contentful-paint/issues/91) later to allow a coarsened-time cross-origin time and [Chrome implemented this in 133](https://github.com/mdn/browser-compat-data/pull/25735).

Since then Firefox added support for LCP with this addition, but this attributed was not updated at the same time despite Firefox supporting it.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Test case:
https://www.tunetheweb.com/experiments/lcp-cross-origin/

Note Firefox (like Chrome) returns a renderTime:

<img width="1031" height="705" alt="image" src="https://github.com/user-attachments/assets/a9a79b18-7085-4e3d-92fa-6ae66ded0774" />

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Cross-origin added: https://github.com/mdn/browser-compat-data/pull/225735
Firefox LCP added: https://github.com/mdn/browser-compat-data/pull/21678

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
