### PR TITLE
Updates for Chrome 141 beta

### DIFF
--- a/api/DigitalCredential.json
+++ b/api/DigitalCredential.json
@@ -5,7 +5,7 @@
         "spec_url": "https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "141"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -21,14 +21,16 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror",
+          "webview_android": {
+            "version_added": false
+          },
           "webview_ios": {
             "version_added": false,
             "impl_url": "https://webkit.org/b/293646"
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -38,7 +40,7 @@
           "spec_url": "https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential-data",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -54,14 +56,16 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": {
               "version_added": false,
               "impl_url": "https://webkit.org/b/293646"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -72,7 +76,7 @@
           "spec_url": "https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential-protocol",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -88,14 +92,16 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": {
               "version_added": false,
               "impl_url": "https://webkit.org/b/293646"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -106,7 +112,7 @@
           "spec_url": "https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -122,14 +128,16 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": {
               "version_added": false,
               "impl_url": "https://webkit.org/b/293646"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -141,7 +149,7 @@
           "spec_url": "https://w3c-fedid.github.io/digital-credentials/#dom-digitalcredential-useragentallowsprotocol",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -157,14 +165,16 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
             "webview_ios": {
               "version_added": false,
               "impl_url": "https://webkit.org/b/293646"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -252,6 +252,39 @@
           }
         }
       },
+      "getAllRecords": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-getallrecords①",
+          "support": {
+            "chrome": {
+              "version_added": "141"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/getKey",

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -537,6 +537,39 @@
           }
         }
       },
+      "getAllRecords": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbobjectstore-getallrecords",
+          "support": {
+            "chrome": {
+              "version_added": "141"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/getKey",

--- a/api/IDBRecord.json
+++ b/api/IDBRecord.json
@@ -1,0 +1,136 @@
+{
+  "api": {
+    "IDBRecord": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/IndexedDB/#record-interface",
+        "support": {
+          "chrome": {
+            "version_added": "141"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "key": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbrecord-key",
+          "support": {
+            "chrome": {
+              "version_added": "141"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "primaryKey": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbrecord-primarykey",
+          "support": {
+            "chrome": {
+              "version_added": "141"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "value": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbrecord-value",
+          "support": {
+            "chrome": {
+              "version_added": "141"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -754,8 +754,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/354881878"
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/RTCRtpScriptTransform.json
+++ b/api/RTCRtpScriptTransform.json
@@ -9,15 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "129",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "enable-experimental-web-platform-features",
-                "value_to_set": "enabled"
-              }
-            ],
-            "impl_url": "https://crbug.com/354881878"
+            "version_added": "141"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -52,7 +44,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/RTCRtpScriptTransformer.json
+++ b/api/RTCRtpScriptTransformer.json
@@ -9,8 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": false,
-            "impl_url": "https://crbug.com/354881878"
+            "version_added": "141"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -79,7 +78,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -114,7 +113,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -149,7 +148,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -184,7 +183,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -1136,8 +1136,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/354881878"
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/RTCTransformEvent.json
+++ b/api/RTCTransformEvent.json
@@ -9,8 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": false,
-            "impl_url": "https://crbug.com/354881878"
+            "version_added": "141"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -44,7 +43,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "141"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.14.1 found new features shipping in Chrome 141 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 30 features as shipping in Chrome 141:

- api.DigitalCredential
- api.DigitalCredential.data
- api.DigitalCredential.protocol
- api.DigitalCredential.toJSON
- api.DigitalCredential.userAgentAllowsProtocol_static
- api.IDBIndex.getAllRecords
- api.IDBObjectStore.getAllRecords
- api.IDBRecord
- api.IDBRecord.key
- api.IDBRecord.primaryKey
- api.IDBRecord.value
- api.RTCRtpReceiver.transform
- api.RTCRtpScriptTransform
- api.RTCRtpScriptTransform.RTCRtpScriptTransform
- api.RTCRtpScriptTransformer
- api.RTCRtpScriptTransformer.options
- api.RTCRtpScriptTransformer.readable
- api.RTCRtpScriptTransformer.sendKeyFrameRequest
- api.RTCRtpScriptTransformer.writable
- api.RTCRtpSender.transform
- api.RTCTransformEvent
- api.RTCTransformEvent.transformer

Marked for Chrome 141 in other PRs:

- webdriver.bidi.emulation.setScriptingEnabled
- webdriver.bidi.emulation.setScriptingEnabled.contexts_parameter
- webdriver.bidi.emulation.setScriptingEnabled.enabled_parameter
- webdriver.bidi.emulation.setScriptingEnabled.userContexts_parameter
- webdriver.bidi.network.setExtraHeaders
- webdriver.bidi.network.setExtraHeaders.contexts_parameter
- webdriver.bidi.network.setExtraHeaders.headers_parameter
- webdriver.bidi.network.setExtraHeaders.userContexts_parameter

See also the 141 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-141-beta

Looks like we're missing `ariaNotify`. Unfortunately, the spec that brings the relevant IDL doesn't seem to have merged yet https://github.com/w3c/aria/pull/2577, so our tooling (or rather webref) did not yet pick this up.