### PR TITLE
chore(github): add code owners for schema/workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,9 @@
-# See GOVERNANCE.md for more about this repository's owners and this project's
-# governance.
+# See GOVERNANCE.md for more about this repository's owners 
+# and this project's governance.
 
-# Schema, linter and infrastructure changes must be reviewed by an owner:
-# ======================================================================
-# /test/    TODO: insert @ handles for owners
-# /schemas/ TODO: insert @ handles for owners
-# /.github/ TODO: insert @ handles for owners
+# Order is important: The last matching pattern takes precedence.
+# For more detailed information, see:
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-## This pattern will only match files in the root directory:
-# /*        TODO: insert @ handles for owners
+/schemas/ @mdn/bcd-owners
+/.github/workflows/ @mdn/core-dev


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the (empty) `CODEOWNERS` file, establishing the following ownerships:

1. `/schemas/` is owned by BCD owners,
2. `/.github/workflows/` is owned by the MDN Engineering team.

The most important change is (2), which ensures that workflow changes undergo review by the team that is responsible for keeping our GitHub Actions secure.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
