### PR TITLE
Clarify Safari time picker behavior for `datetime-local`

### DIFF
--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -32,7 +32,7 @@
               },
               "safari": {
                 "version_added": "14.1",
-                "notes": "Safari only displays a date picker and does not display a time picker."
+                "notes": "Safari displays a date picker but not a time picker; requiring manual time entry is an intentional design decision. See [bug 261744](https://webkit.org/b/261744)."
               },
               "safari_ios": {
                 "version_added": "5"

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -32,7 +32,7 @@
               },
               "safari": {
                 "version_added": "14.1",
-                "notes": "Safari displays a date picker but not a time picker; requiring manual time entry is an intentional design decision. See [bug 261744](https://webkit.org/b/261744)."
+                "notes": "Safari displays a date picker but not a time picker; entering time manually is an intentional design decision. See [bug 261744](https://webkit.org/b/261744)."
               },
               "safari_ios": {
                 "version_added": "5"


### PR DESCRIPTION
#### Summary

Safari 14.1 and newer displays a time picker for `datetime-local`.
`datetime-local` was not working correctly in one of the Safari tech previews but was fixed before the final 14.1 release.

#### Test results and supporting details

See the Safari 14.1 release note (https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes)
> Added support for HTML date, time, and datetime-local input types in macOS, enabling date and time controls in forms.

This is confirmed by the according issue (comment 27): https://bugs.webkit.org/show_bug.cgi?id=214946#c27

More confirmations:
- With screenshot: https://github.com/Fyrd/caniuse/pull/5646#issuecomment-715180664
- https://github.com/Fyrd/caniuse/pull/5669

A jsfiddle to test yourself: https://jsfiddle.net/8gw2yk5e/


#### Related issues

- https://bugs.webkit.org/show_bug.cgi?id=214946#c27 (see comment 27)