### PR TITLE
Bug-1910669 fix to StorageArea.getKeys() Firefox implementation version

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -181,7 +181,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "142"
+                  "version_added": "143"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -485,7 +485,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "142"
+                  "version_added": "143"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -703,7 +703,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "142"
+                  "version_added": "143"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -945,7 +945,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "142"
+                  "version_added": "143"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -1209,7 +1209,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "142"
+                  "version_added": "143"
                 },
                 "firefox_android": "mirror",
                 "opera": {


### PR DESCRIPTION
#### Summary

Fixes incorrect version number from https://github.com/mdn/browser-compat-data/pull/27442