### PR TITLE
Bug-1385832 getBytesInUse supported in local and managed storage

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -153,8 +153,9 @@
                 "firefox": {
                   "version_added": "78",
                   "notes": [
-                    "Supported by the `sync` and, from Firefox 131, `session` storage areas.",
-                    "Not implemented in `local`, see [bug 1385832](https://bugzil.la/1385832)"
+                    "Supported by the `sync` storage area from Firefox 78.",
+                    "Supported by the `session` storage area from Firefox 131.",
+                    "Supported by the `local` and `managed` storage areas from Firefox 144."
                   ]
                 },
                 "firefox_android": {
@@ -461,8 +462,7 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1385832"
+                  "version_added": "144"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -682,9 +682,11 @@
                 },
                 "edge": "mirror",
                 "firefox": {
+                  "version_added": "144"
+                },
+                "firefox_android": {
                   "version_added": false
                 },
-                "firefox_android": "mirror",
                 "opera": {
                   "version_added": false
                 },


### PR DESCRIPTION
#### Summary

Add details of support for `getBytesInUse()` supported in `local` and `managed` storage. Addresses the dev-docs-needed requirements of [Bug 1385832](https://bugzilla.mozilla.org/show_bug.cgi?id=1385832) getBytesInUse() is not supported in `local` and `managed` storage areas

#### Related issues

Release note in TBD
