### PR TITLE
Update all browsers data for api.PerformancePaintTiming.toJSON

### DIFF
--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -201,19 +201,19 @@
           "spec_url": "https://w3c.github.io/paint-timing/#dom-performancepainttiming-tojson",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "60"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "140"
+              "version_added": "84"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -221,7 +221,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `toJSON` member of the `PerformancePaintTiming` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.14.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PerformancePaintTiming/toJSON
