### PR TITLE
Add a description for IdentityProvider.resolve()

### DIFF
--- a/api/IdentityProvider.json
+++ b/api/IdentityProvider.json
@@ -105,6 +105,7 @@
       },
       "resolve_static": {
         "__compat": {
+          "description": "`resolve()` static method",
           "spec_url": "https://w3c-fedid.github.io/FedCM/#dom-identityprovider-resolve",
           "support": {
             "chrome": {


### PR DESCRIPTION
Otherwise the compat table rendering on MDN looks poor: https://developer.mozilla.org/en-US/docs/Web/API/IdentityProvider#browser_compatibility

(should we have a linter for this? I think we do lint for event descriptions, for instance)