### PR TITLE
Remove api.Permissions.permission_compute-pressure from BCD

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -327,43 +327,6 @@
           }
         }
       },
-      "permission_compute-pressure": {
-        "__compat": {
-          "description": "`compute-pressure` permission",
-          "spec_url": "https://w3c.github.io/compute-pressure/#policy-control",
-          "tags": [
-            "web-features:compute-pressure"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "125"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "permission_geolocation": {
         "__compat": {
           "description": "`geolocation` permission",


### PR DESCRIPTION
This PR removes the `permission_compute-pressure` member of the `Permissions` API from BCD. The feature is not supported in any browsers, which has been confirmed by the mdn-bcd-collector.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Permissions/permission_compute-pressure

Additional Notes: Source Code: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/permissions/permission_descriptor.idl;drc=a9d4580fce10260f5c0d3e3b6a0f286f6d282d5c
