### PR TITLE
Remove mention of null/true values in the browser removal guideline

### DIFF
--- a/docs/data-guidelines/browsers.md
+++ b/docs/data-guidelines/browsers.md
@@ -66,7 +66,7 @@ This decision was proposed in [#7238](https://github.com/mdn/browser-compat-data
 To maintain data quality, BCD's [owners](../../GOVERNANCE.md) may choose to remove a browser or engine from the project. To remove a browser from BCD, we need habitual (six months or more) evidence of (in decreasing order of importance):
 
 - negative/neutral downstream-consumer interest in the browser's data (e.g., MDN and caniuse don't object to removal)
-- poor data coverage with negative trends (e.g., our data for the browser covers only a few features, with limited/flat growth in more data being added for it, or few features with real version numbers rather than just `null` or `true`, etc.)
+- poor data coverage with negative trends (e.g., data for the browser covers only a few features, with limited/flat growth in more data being added for it)
 - infrequent community or vendor involvement in issues or PRs relating to the browser
 - infrequent new PRs relating to the browser (e.g., weeks or months go by without PRs touching the browser's data)
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The data guideline for removing a browser mentions `null` and `true` values. We don't do those anymore, so let's not mention it.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

N/A

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/issues/27049

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
