### PR TITLE
Fix a typo in http.headers.Supports-Loading-Mode.json

### DIFF
--- a/http/headers/Supports-Loading-Mode.json
+++ b/http/headers/Supports-Loading-Mode.json
@@ -68,9 +68,9 @@
             }
           }
         },
-        "fenced-frames": {
+        "fenced-frame": {
           "__compat": {
-            "description": "`fenced-frames` directive",
+            "description": "`fenced-frame` directive",
             "tags": [
               "web-features:speculation-rules"
             ],


### PR DESCRIPTION
- related PR https://github.com/mdn/browser-compat-data/pull/20294


#### Summary

There is an unwanted `s` in the `fenced-frame` value.

#### Supporting details

The following sources mentioned in the PR adding the feature do not use plural form of `fenced-frame`:
- https://wicg.github.io/fenced-frame/#supports-loading-mode
- https://privacysandbox.google.com/private-advertising/fenced-frame
- https://docs.google.com/document/d/1r27C2_yV8jb7N4-7MxLMHWCx9wHHaCw9HbBDcTyPnZs/edit?tab=t.0#heading=h.frl8u3cowbcx
- 

#### Related issues

- https://github.com/mdn/content/pull/41081/files#r2334974092
