### PR TITLE
Revert "Remove `iconURL` and `name` from `FederatedCredential`"

### DIFF
--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -72,6 +72,76 @@
           }
         }
       },
+      "iconURL": {
+        "__compat": {
+          "tags": [
+            "web-features:federated-credentials"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "tags": [
+            "web-features:federated-credentials"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "protocol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FederatedCredential/protocol",

--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -74,6 +74,7 @@
       },
       "iconURL": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-credential-management/#dom-credentialuserdata-iconurl",
           "tags": [
             "web-features:federated-credentials"
           ],
@@ -109,6 +110,7 @@
       },
       "name": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-credential-management/#dom-credentialuserdata-name",
           "tags": [
             "web-features:federated-credentials"
           ],


### PR DESCRIPTION
Reverts mdn/browser-compat-data#27733
My fault. I didn't see that this comes via a mixin. 

If it had spec_urls I would have seen this. 