### PR TITLE
Safari 26 ships GPUAdapter.isFallbackAdapter

### DIFF
--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -224,7 +224,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Probably forgot this in https://github.com/mdn/browser-compat-data/pull/27087