### PR TITLE
Chrome 141 ariaNotify() method

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -728,6 +728,42 @@
           }
         }
       },
+      "ariaNotify": {
+        "__compat": {
+          "description": "`ariaNotify() method`",
+          "support": {
+            "chrome": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": [
+                "Fully supported on Windows only.",
+                "Method exposed on macOS, but notifications are not reliably spoken."
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "beforescriptexecute_event": {
         "__compat": {
           "description": "`beforescriptexecute` event",

--- a/api/Element.json
+++ b/api/Element.json
@@ -1929,6 +1929,42 @@
           }
         }
       },
+      "ariaNotify": {
+        "__compat": {
+          "description": "`ariaNotify() method`",
+          "support": {
+            "chrome": {
+              "version_added": "141",
+              "partial_implementation": true,
+              "notes": [
+                "Fully supported on Windows only.",
+                "Method exposed on macOS, but notifications are not reliably spoken."
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "ariaOrientation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaOrientation",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 141 adds support for the `ariaNotify()` method; see https://chromestatus.com/feature/5745430754230272.

This method is currently non-standard, but will be added to the specs imminently; see https://github.com/w3c/aria/pull/2577.

I have put it down as a partial implementation; in tests (see https://chrisdavidmills.github.io/ariaNotify-demo/, test in Windows with a screenreader on), I have found it to work well on Windows with both the Narrator and NVDA screenreaders, in both Chrome and Edge. On macOS, however, it doesn't seem to read out the notifications reliably at all. I've asked about Linux support.



<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
