### PR TITLE
Mark Deno support for `Window.close()` as partial, remove `Window.open()`

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -885,7 +885,7 @@
             "deno": {
               "version_added": "1.0",
               "partial_implementation": true,
-              "notes": "The behavior differs from the other browsers."
+              "notes": "Exits the current Deno process."
             },
             "edge": {
               "version_added": "12",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

- Removed deno from `Window.open()` support table
- Changed deno to partial support for `Window.close()`

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Related issues

Closes #27577

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
