### PR TITLE
Issue-23090 manifest.optional_permissions topSites on Android

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -808,7 +808,16 @@
               "firefox": {
                 "version_added": "55"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "79",
+                  "notes": "Can be specified, but causes an error if an attempt is made to grant it."
+                },
+                {
+                  "version_added": "55",
+                  "version_removed": "68"
+                }
+              ],
               "opera": "mirror",
               "safari": {
                 "version_added": false

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -924,7 +924,10 @@
               "firefox": {
                 "version_added": "52"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "52",
+                "notes": "From Firefox 79, can be specified but has no effect."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false


### PR DESCRIPTION
#### Summary

Clarified the behavior of the topSites permission on Android. The API that the permission enables was removed in Firefox for Android 68. Tested and confirmed, using the permissions example, on an Android device that:

- topSites can be specified as a permission, but has no effect.
- topSites can be specified as an optional permission, but if an attempt is made to grant it an error occurs.

#### Related issues

Fixes #23090
