### PR TITLE
Remove `Fence.setReportEventDataForAutomaticBeacons.start_commit_eventType`

### DIFF
--- a/api/Fence.json
+++ b/api/Fence.json
@@ -137,41 +137,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "start_commit_eventType": {
-          "__compat": {
-            "description": "Separate `reserved.top_navigation_start` and `reserved.top_navigation_commit` `eventType` values",
-            "tags": [
-              "web-features:fencedframe"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "126",
-                "notes": "Previously only a single `eventType` was available, `reserved.top_navigation`, but this has been replaced by the new values."
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
I don't think we need this sub feature.

The method itself has the same compatibility data. This new behavior might have come late but it shipped at the same time as the method itself. The spec for `setReportEventDataForAutomaticBeacons` describes the behavior already.  