### PR TITLE
Bug-1986688 Cookies expirationDate includes milliseconds

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -47,6 +47,31 @@
               }
             }
           },
+          "expirationDate": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "6"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45",
+                  "notes": "Includes milliseconds in the fractional part from Firefox 142."
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "notes": "Includes milliseconds in the fractional part from Firefox 142."
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
           "firstPartyDomain": {
             "__compat": {
               "support": {
@@ -712,6 +737,31 @@
                   ]
                 }
               ]
+            }
+          },
+          "expirationDate": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "6"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45",
+                  "notes": "Can include milliseconds in the fractional part from Firefox 142."
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "notes": "Can include milliseconds in the fractional part from Firefox 142."
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
             }
           },
           "firstPartyDomain": {


### PR DESCRIPTION
#### Summary

Addresses the dev-docs-needed requirement of [Bug 1986688](https://bugzilla.mozilla.org/show_bug.cgi?id=1986688) Cookies are returned with a fractional expirationDate for the change made in [Bug 1972757](https://bugzilla.mozilla.org/show_bug.cgi?id=1972757) Store cookie expiry value as msec.

Related MDN changes in https://github.com/mdn/content/pull/41097.
