### PR TITLE
Deno 2.2.10 + Node.js 24 support `DisposableStack`/`AsyncDisposableStack`

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -356,6 +356,13 @@
           "engine": "V8",
           "engine_version": "13.4"
         },
+        "2.2.10": {
+          "release_date": "2025-04-15",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v2.2.10",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "13.4"
+        },
         "2.3.0": {
           "release_date": "2025-05-01",
           "release_notes": "https://deno.com/blog/v2.3",

--- a/javascript/builtins/AsyncDisposableStack.json
+++ b/javascript/builtins/AsyncDisposableStack.json
@@ -14,7 +14,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "2.2.10"
             },
             "edge": "mirror",
             "firefox": {
@@ -22,7 +22,7 @@
             },
             "firefox_android": "mirror",
             "nodejs": {
-              "version_added": false
+              "version_added": "24.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -54,7 +54,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -62,7 +62,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -95,7 +95,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -103,7 +103,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -136,7 +136,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -144,7 +144,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -177,7 +177,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -185,7 +185,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -218,7 +218,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -226,7 +226,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -259,7 +259,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -267,7 +267,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -300,7 +300,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -308,7 +308,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -340,7 +340,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -348,7 +348,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/DisposableStack.json
+++ b/javascript/builtins/DisposableStack.json
@@ -14,7 +14,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "2.2.10"
             },
             "edge": "mirror",
             "firefox": {
@@ -22,7 +22,7 @@
             },
             "firefox_android": "mirror",
             "nodejs": {
-              "version_added": false
+              "version_added": "24.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -54,7 +54,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -62,7 +62,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -95,7 +95,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -103,7 +103,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -136,7 +136,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -144,7 +144,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -177,7 +177,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -185,7 +185,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -218,7 +218,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -226,7 +226,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -259,7 +259,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -267,7 +267,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -300,7 +300,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -308,7 +308,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -340,7 +340,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.2.10"
               },
               "edge": "mirror",
               "firefox": {
@@ -348,7 +348,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "24.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Added missed supported versions for `DisposableStack` and `AsyncDisposableStack`

#### Related issues

Node.js - https://github.com/nodejs/node/pull/58070
Deno - https://github.com/denoland/deno/issues/20821