### PR TITLE
Add CSS caret properties: caret-shape and caret shorthand

### DIFF
--- a/css/properties/caret-shape.json
+++ b/css/properties/caret-shape.json
@@ -1,0 +1,172 @@
+{
+    "css": {
+        "properties": {
+            "caret-shape": {
+                "__compat": {
+                    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caret-shape",
+                    "spec_url": "https://drafts.csswg.org/css-ui/#propdef-caret-shape",
+                    "support": {
+                        "chrome": {
+                            "version_added": "140"
+                        },
+                        "chrome_android": "mirror",
+                        "edge": {
+                            "version_added": false
+                        },
+                        "firefox": {
+                            "version_added": false
+                        },
+                        "firefox_android": "mirror",
+                        "oculus": "mirror",
+                        "opera": "mirror",
+                        "opera_android": "mirror",
+                        "safari": {
+                            "version_added": false
+                        },
+                        "safari_ios": "mirror",
+                        "samsunginternet_android": "mirror",
+                        "webview_android": "mirror",
+                        "webview_ios": "mirror"
+                    },
+                    "status": {
+                        "experimental": true,
+                        "standard_track": true,
+                        "deprecated": false
+                    }
+                },
+                "auto": {
+                    "__compat": {
+                        "spec_url": "https://drafts.csswg.org/css-ui/#valdef-caret-shape-auto",
+                        "support": {
+                            "chrome": {
+                                "version_added": "140"
+                            },
+                            "chrome_android": "mirror",
+                            "edge": {
+                                "version_added": false
+                            },
+                            "firefox": {
+                                "version_added": false
+                            },
+                            "firefox_android": "mirror",
+                            "oculus": "mirror",
+                            "opera": "mirror",
+                            "opera_android": "mirror",
+                            "safari": {
+                                "version_added": false
+                            },
+                            "safari_ios": "mirror",
+                            "samsunginternet_android": "mirror",
+                            "webview_android": "mirror",
+                            "webview_ios": "mirror"
+                        },
+                        "status": {
+                            "experimental": true,
+                            "standard_track": true,
+                            "deprecated": false
+                        }
+                    }
+                },
+                "bar": {
+                    "__compat": {
+                        "spec_url": "https://drafts.csswg.org/css-ui/#valdef-caret-shape-bar",
+                        "support": {
+                            "chrome": {
+                                "version_added": "140"
+                            },
+                            "chrome_android": "mirror",
+                            "edge": {
+                                "version_added": false
+                            },
+                            "firefox": {
+                                "version_added": false
+                            },
+                            "firefox_android": "mirror",
+                            "oculus": "mirror",
+                            "opera": "mirror",
+                            "opera_android": "mirror",
+                            "safari": {
+                                "version_added": false
+                            },
+                            "safari_ios": "mirror",
+                            "samsunginternet_android": "mirror",
+                            "webview_android": "mirror",
+                            "webview_ios": "mirror"
+                        },
+                        "status": {
+                            "experimental": true,
+                            "standard_track": true,
+                            "deprecated": false
+                        }
+                    }
+                },
+                "block": {
+                    "__compat": {
+                        "spec_url": "https://drafts.csswg.org/css-ui/#valdef-caret-shape-block",
+                        "support": {
+                            "chrome": {
+                                "version_added": "140"
+                            },
+                            "chrome_android": "mirror",
+                            "edge": {
+                                "version_added": false
+                            },
+                            "firefox": {
+                                "version_added": false
+                            },
+                            "firefox_android": "mirror",
+                            "oculus": "mirror",
+                            "opera": "mirror",
+                            "opera_android": "mirror",
+                            "safari": {
+                                "version_added": false
+                            },
+                            "safari_ios": "mirror",
+                            "samsunginternet_android": "mirror",
+                            "webview_android": "mirror",
+                            "webview_ios": "mirror"
+                        },
+                        "status": {
+                            "experimental": true,
+                            "standard_track": true,
+                            "deprecated": false
+                        }
+                    }
+                },
+                "underscore": {
+                    "__compat": {
+                        "spec_url": "https://drafts.csswg.org/css-ui/#valdef-caret-shape-underscore",
+                        "support": {
+                            "chrome": {
+                                "version_added": "140"
+                            },
+                            "chrome_android": "mirror",
+                            "edge": {
+                                "version_added": false
+                            },
+                            "firefox": {
+                                "version_added": false
+                            },
+                            "firefox_android": "mirror",
+                            "oculus": "mirror",
+                            "opera": "mirror",
+                            "opera_android": "mirror",
+                            "safari": {
+                                "version_added": false
+                            },
+                            "safari_ios": "mirror",
+                            "samsunginternet_android": "mirror",
+                            "webview_android": "mirror",
+                            "webview_ios": "mirror"
+                        },
+                        "status": {
+                            "experimental": true,
+                            "standard_track": true,
+                            "deprecated": false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/css/properties/caret.json
+++ b/css/properties/caret.json
@@ -1,0 +1,40 @@
+{
+    "css": {
+        "properties": {
+            "caret": {
+                "__compat": {
+                    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caret",
+                    "spec_url": "https://drafts.csswg.org/css-ui/#propdef-caret",
+                    "support": {
+                        "chrome": {
+                            "version_added": false
+                        },
+                        "chrome_android": "mirror",
+                        "edge": {
+                            "version_added": false
+                        },
+                        "firefox": {
+                            "version_added": false
+                        },
+                        "firefox_android": "mirror",
+                        "oculus": "mirror",
+                        "opera": "mirror",
+                        "opera_android": "mirror",
+                        "safari": {
+                            "version_added": false
+                        },
+                        "safari_ios": "mirror",
+                        "samsunginternet_android": "mirror",
+                        "webview_android": "mirror",
+                        "webview_ios": "mirror"
+                    },
+                    "status": {
+                        "experimental": true,
+                        "standard_track": true,
+                        "deprecated": false
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add caret-shape property with Chrome 140+ experimental support
  - Supports auto, bar, block, underscore values
- Add caret shorthand property
- Both properties follow CSS UI Module Level 4 specification

I recently added them to mdn/content via https://github.com/mdn/content/pull/41084