### PR TITLE
Firefox 144 added `GPUDevice.importExternalTextures()`

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -1782,7 +1782,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "141",
+              "version_added": "144",
               "partial_implementation": true,
               "notes": "Currently supported on Windows only, in all contexts except for service workers."
             },

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -20,7 +20,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "144",
+            "version_added": "141",
             "partial_implementation": true,
             "notes": "Currently supported on Windows only, in all contexts except for service workers."
           },

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -20,7 +20,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "141",
+            "version_added": "144",
             "partial_implementation": true,
             "notes": "Currently supported on Windows only, in all contexts except for service workers."
           },


### PR DESCRIPTION
We indicated that support for `GPUDevice.importExternalTexture()` and `GPUExternalTexture` was in FF141 in #27372.

According to https://bugzilla.mozilla.org/show_bug.cgi?id=1979100#c12 these were implemented behind a preference in 143, and shipped in FF144 in https://bugzilla.mozilla.org/show_bug.cgi?id=1983594. Given that FF144 is now in beta I've skipped the 143 and pref feature and just updated these two as released in FF144.

Related docs work can be tracked in https://github.com/mdn/content/issues/40774