### PR TITLE
Move Trusted Types subfeatures into `HTMLScriptElement`

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1755,50 +1755,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "enforces_trusted_types": {
-          "__compat": {
-            "description": "Requires `TrustedScript` instance in `HTMLScriptElement` when trusted types are enforced.",
-            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
-            "tags": [
-              "web-features:trusted-types"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "83"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "26"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "inputMode": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -876,6 +876,49 @@
           }
         }
       },
+      "textContent": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
+          "tags": [
+            "web-features:trusted-types"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "26"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/type",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -411,43 +411,84 @@
       "innerText": {
         "__compat": {
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
-          "tags": [
-            "web-features:trusted-types"
-          ],
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "45"
             },
             "firefox_android": "mirror",
+            "ie": {
+              "version_added": "5.5"
+            },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "9.6"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
-              "version_added": "26"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": "3"
+            },
             "webview_ios": "mirror"
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "enforces_trusted_types": {
+          "__compat": {
+            "description": "Requires `TrustedScript` instance when trusted types are enforced",
+            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
+            "tags": [
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "135",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -879,35 +920,34 @@
       "textContent": {
         "__compat": {
           "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
-          "tags": [
-            "web-features:trusted-types"
-          ],
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "1"
             },
             "firefox_android": "mirror",
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "26"
+            "ie": {
+              "version_added": "9"
             },
-            "safari_ios": "mirror",
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "9"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -916,6 +956,50 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "enforces_trusted_types": {
+          "__compat": {
+            "description": "Requires `TrustedScript` instance in `HTMLScriptElement` when trusted types are enforced.",
+            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
+            "tags": [
+              "web-features:trusted-types"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "135",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.trusted_types.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -408,6 +408,49 @@
           }
         }
       },
+      "innerText": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
+          "tags": [
+            "web-features:trusted-types"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "135",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.trusted_types.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "26"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "integrity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/integrity",

--- a/api/Node.json
+++ b/api/Node.json
@@ -1383,50 +1383,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "enforces_trusted_types": {
-          "__compat": {
-            "description": "Requires `TrustedScript` instance in `HTMLScriptElement` when trusted types are enforced.",
-            "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-textcontent",
-            "tags": [
-              "web-features:trusted-types"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "83"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "26"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
On `HTMLScriptElement` you can access the `innerText` and `textContent` properties. We had documented these as inherited, but in fact they are duplicated and have their own IDL https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext

This change makes that more clear, and makes the data more usable.

I'll be adding new docs for these too.

Related work can be tracked in https://github.com/mdn/content/issues/37518