### PR TITLE
Firefox 143 adds `::{before,after}::marker` nested pseudo-elements

### DIFF
--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -138,7 +138,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "143"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -153,7 +153,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -155,7 +155,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "143"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -170,7 +170,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary

- Added firefox support for `::before::marker` and removed experimental
- Added firefox support for `::after::marker` and removed experimental

#### Test results and supporting details

- Tested using the [`::before::marker`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before#beforemarker_nested_pseudo-elements) and [`::after::marker`](https://developer.mozilla.org/en-US/docs/Web/CSS/::after#aftermarker_nested_pseudo-elements) examples in:
  - Firefox Beta (143.0)
  - Firefox Deveoper Edition (143.0b9)
  - Firefox Nightly (144.0a1)

#### Related issues

- [MDN Issue #40779](https://github.com/mdn/content/issues/40779)
- [Firefox Release note PR](https://github.com/mdn/content/pull/41146)