### PR TITLE
MediaDevices.getUserMedia() add constraints

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -585,6 +585,531 @@
               "deprecated": false
             }
           }
+        },
+        "constraints_aspectRatio_parameter": {
+          "__compat": {
+            "description": "`constraints.aspectRatio` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-aspectratio",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_autoGainControl_parameter": {
+          "__compat": {
+            "description": "`constraints.autoGainControl` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-autogaincontrol",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_channelCount_parameter": {
+          "__compat": {
+            "description": "`constraints.channelCount` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-channelcount",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_deviceId_parameter": {
+          "__compat": {
+            "description": "`constraints.deviceId` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-deviceid",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_echoCancellation_parameter": {
+          "__compat": {
+            "description": "`constraints.echoCancellation` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-echocancellation",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_facingMode_parameter": {
+          "__compat": {
+            "description": "`constraints.facingMode` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-facingmode",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_frameRate_parameter": {
+          "__compat": {
+            "description": "`constraints.frameRate` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-framerate",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_groupId_parameter": {
+          "__compat": {
+            "description": "`constraints.groupId` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-groupId",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.6"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_height_parameter": {
+          "__compat": {
+            "description": "`constraints.height` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-height",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_latency_parameter": {
+          "__compat": {
+            "description": "`constraints.latency` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-latency",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_noiseSuppression_parameter": {
+          "__compat": {
+            "description": "`constraints.noiseSuppression` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-noisesuppression",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_resizeMode_parameter": {
+          "__compat": {
+            "description": "`constraints.resizeMode` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-resizemode",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "144"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_sampleRate_parameter": {
+          "__compat": {
+            "description": "`constraints.sampleRate` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-samplerate",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.6"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_sampleSize_parameter": {
+          "__compat": {
+            "description": "`constraints.sampleSize` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-samplesize",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.6"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constraints_width_parameter": {
+          "__compat": {
+            "description": "`constraints.width` parameter",
+            "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-width",
+            "tags": [
+              "web-features:web-audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "≤75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤65"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "selectAudioOutput": {


### PR DESCRIPTION
FF144 added a new constraint parameter for use with [`MediaDevices.getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia). 

We haven't documented the constraints before so this attempts to do so. The results are based on the test https://wpt.live/mediacapture-streams/MediaDevices-getSupportedConstraints.https.html, and more specifically, by bisecting based on the wpt results using product tests like:

- Chrome: https://wpt.fyi/results/mediacapture-streams/MediaDevices-getSupportedConstraints.https.html?label=master&product=chrome-80&aligned
- Firefox https://wpt.fyi/results/mediacapture-streams/MediaDevices-getSupportedConstraints.https.html?label=master&product=firefox-115&aligned
- Safari https://wpt.fyi/results/mediacapture-streams/MediaDevices-getSupportedConstraints.https.html?label=master&product=safari-12&aligned

The tests and results do not run on the earliest version that constraints should be supported for, so I have used `≤` to indicate the earliest version I could test in each case.

Note that there are some constraints I have not documented:
- `backgroundBlur` is in spec but not in tests. Assuming it is not implemented though it might be.
- `volume` is not in spec, but shows up in some very old builds. Ignoring.
- `voiceIsolation` is supported by Chrome but is not in spec. Ignoring.


Note that there a related test https://wpt.live/mediacapture-streams/MediaDevices-getUserMedia.https.html but everything passes in this for things that support the associated constraint, so this does not lead to any compatibility difference to record.

Related docs work can be tracked in https://github.com/mdn/content/issues/41132

