### PR TITLE
Firefox 144 makes `RTCDataChannel` transferable

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -937,8 +937,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1209163"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
FF144 makes [`RTCDataChannel`](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel) transferrable in https://bugzilla.mozilla.org/show_bug.cgi?id=1209163. This updates the feature.

Related docs work can be tracked in https://github.com/mdn/content/issues/41135