### PR TITLE
Updates to Web Speech API data

### DIFF
--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -14,16 +14,29 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": {
-            "version_added": "44",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.webspeech.recognition.enable",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "142",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "142",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
@@ -55,16 +68,29 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webspeech.recognition.enable",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "142",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.recognition.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "142",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.recognition.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
@@ -100,7 +126,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
+              "version_added": "142",
               "flags": [
                 {
                   "type": "preference",
@@ -144,7 +170,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
+              "version_added": "142",
               "flags": [
                 {
                   "type": "preference",

--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -3,6 +3,7 @@
     "SpeechGrammar": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammar",
+        "spec_url": "https://webaudio.github.io/web-speech-api/#speechreco-speechgrammar",
         "tags": [
           "web-features:speech-recognition-grammar"
         ],
@@ -88,6 +89,7 @@
       "src": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammar/src",
+          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechgrammar-src",
           "tags": [
             "web-features:speech-recognition-grammar"
           ],
@@ -131,6 +133,7 @@
       "weight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammar/weight",
+          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechgrammar-weight",
           "tags": [
             "web-features:speech-recognition-grammar"
           ],

--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -21,8 +21,7 @@
                 "name": "media.webspeech.recognition.enable",
                 "value_to_set": "true"
               }
-            ],
-            "notes": "Note that currently only the speech synthesis part is available in Firefox Desktop - the speech recognition part will be available soon, once the required internal permissions are sorted out."
+            ]
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -40,7 +39,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": true
         }
       },
@@ -63,8 +62,7 @@
                   "name": "media.webspeech.recognition.enable",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Note that currently only the speech synthesis part is available in Firefox Desktop - the speech recognition part will be available soon, once the required internal permissions are sorted out."
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -107,8 +105,7 @@
                   "name": "media.webspeech.recognition.enable",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Note that currently only the speech synthesis part is available in Firefox Desktop - the speech recognition part will be available soon, once the required internal permissions are sorted out."
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -126,7 +123,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -151,8 +148,7 @@
                   "name": "media.webspeech.recognition.enable",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "Note that currently only the speech synthesis part is available in Firefox Desktop - the speech recognition part will be available soon, once the required internal permissions are sorted out."
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -170,7 +166,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }

--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -20,7 +20,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "44",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.webspeech.recognition.enable",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -39,9 +46,9 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "SpeechGrammarList": {
@@ -65,7 +72,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -84,9 +98,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -104,7 +118,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -123,9 +144,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -143,7 +164,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -162,9 +190,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -182,7 +210,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -201,9 +236,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -221,7 +256,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -240,9 +282,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -19,16 +19,29 @@
           ],
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": {
-            "version_added": "142",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.webspeech.recognition.enable",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "142",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "142",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": {
@@ -71,16 +84,29 @@
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "142",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webspeech.recognition.enable",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "142",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.recognition.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "142",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.recognition.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": {

--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -20,7 +20,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "44",
+            "version_added": "142",
             "flags": [
               {
                 "type": "preference",
@@ -72,7 +72,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
+              "version_added": "142",
               "flags": [
                 {
                   "type": "preference",
@@ -118,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
+              "version_added": "142",
               "flags": [
                 {
                   "type": "preference",
@@ -164,7 +164,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
+              "version_added": "142",
               "flags": [
                 {
                   "type": "preference",
@@ -210,7 +210,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
+              "version_added": "142",
               "flags": [
                 {
                   "type": "preference",
@@ -256,7 +256,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
+              "version_added": "142",
               "flags": [
                 {
                   "type": "preference",

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -211,9 +211,11 @@
           "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-available",
           "support": {
             "chrome": {
-              "version_added": "139"
+              "version_added": "142"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -395,9 +397,11 @@
           "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-install",
           "support": {
             "chrome": {
-              "version_added": "139"
+              "version_added": "142"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -565,14 +569,49 @@
           }
         }
       },
+      "phrases": {
+        "__compat": {
+          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-phrases",
+          "support": {
+            "chrome": {
+              "version_added": "142"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "processLocally": {
         "__compat": {
           "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-processlocally",
           "support": {
             "chrome": {
-              "version_added": "139"
+              "version_added": "142"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -823,6 +862,43 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "audioTrack": {
+          "__compat": {
+            "description": "`audioTrack` parameter",
+            "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-start-audiotrack-audiotrack",
+            "tags": [
+              "web-features:speech-recognition"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "135"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -21,7 +21,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "143",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.webspeech.recognition.enable",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -63,7 +70,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -106,7 +120,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -145,7 +166,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -184,7 +212,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -257,7 +292,14 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -296,7 +338,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -335,7 +384,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -370,7 +426,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -439,7 +502,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -474,7 +544,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -509,7 +586,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -548,7 +632,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -653,7 +744,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -692,7 +790,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -731,7 +836,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -770,7 +882,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -809,7 +928,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -844,7 +970,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -920,7 +1053,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -955,7 +1095,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "143",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -20,16 +20,29 @@
           ],
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": {
-            "version_added": "143",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.webspeech.recognition.enable",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "142",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "142",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.webspeech.recognition.enable",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
@@ -69,16 +82,29 @@
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "143",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webspeech.recognition.enable",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "142",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.recognition.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "142",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.webspeech.recognition.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": {

--- a/api/SpeechRecognitionPhrase.json
+++ b/api/SpeechRecognitionPhrase.json
@@ -1,37 +1,28 @@
 {
   "api": {
-    "SpeechRecognitionEvent": {
+    "SpeechRecognitionPhrase": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent",
-        "spec_url": "https://webaudio.github.io/web-speech-api/#speechreco-event",
+        "spec_url": "https://webaudio.github.io/web-speech-api/#speechrecognitionphrase",
         "tags": [
           "web-features:speech-recognition"
         ],
         "support": {
-          "chrome": [
-            {
-              "version_added": "139"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "33"
-            }
-          ],
-          "chrome_android": "mirror",
+          "chrome": {
+            "version_added": "142"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": {
-            "version_added": "14.1"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -39,82 +30,35 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
       },
-      "SpeechRecognitionEvent": {
+      "SpeechRecognitionPhrase": {
         "__compat": {
-          "description": "`SpeechRecognitionEvent()` constructor",
-          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-speechrecognition",
-          "tags": [
-            "web-features:speech-recognition"
-          ],
-          "support": {
-            "chrome": [
-              {
-                "version_added": "139"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "33"
-              }
-            ],
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": "14.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "resultIndex": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/resultIndex",
-          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionevent-resultindex",
+          "description": "`SpeechRecognitionPhrase()` constructor",
+          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionphrase-speechrecognitionphrase",
           "tags": [
             "web-features:speech-recognition"
           ],
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": "142"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -122,38 +66,35 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "results": {
+      "boost": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/results",
-          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionevent-results",
+          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionphrase-boost",
           "tags": [
             "web-features:speech-recognition"
           ],
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": "142"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -161,7 +102,43 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "phrase": {
+        "__compat": {
+          "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionphrase-phrase",
+          "tags": [
+            "web-features:speech-recognition"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "142"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -893,7 +893,7 @@
           "__compat": {
             "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-stop#:~:text=on-device-speech-recognition",
             "tags": [
-              "web-features:web-midi"
+              "web-features:speech-recognition"
             ],
             "support": {
               "chrome": {

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -891,7 +891,7 @@
         },
         "on-device-speech-recognition": {
           "__compat": {
-            "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-stop#:~:text=on-device-speech-recognition",
+            "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-available#:~:text=on-device-speech-recognition",
             "tags": [
               "web-features:speech-recognition"
             ],

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -889,6 +889,42 @@
             }
           }
         },
+        "on-device-speech-recognition": {
+          "__compat": {
+            "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-stop#:~:text=on-device-speech-recognition",
+            "tags": [
+              "web-features:web-midi"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "142"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "otp-credentials": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/otp-credentials",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR makes several changes to the Web Speech API data:

- On-device speech recognition (https://chromestatus.com/feature/6090916291674112). The ChromeStatus entry says 139, but the engineer said it has been slipped to a 142 release because of some bugs. It is also only supported on Chrome desktop for now, not Android/WebView
  - The on-device-speech-recognition Permissions-Policy directive - newly added
  - SpeechRecognition.processLocally - already in, but updated Chrome support from 139 to 142 and set Android support to false
  - SpeechRecognition.available() - already in, but updated Chrome support from 139 to 142 and set Android support to false
  - SpeechRecognition.install() - already in, but updated Chrome support from 139 to 142 and set Android support to false
- Web speech API contextual biasing (https://chromestatus.com/feature/5225615177023488). ChromeStatus says 142, which is correct according to the engineer
  - SpeechRecognition.phrases - newly added
  - SpeechRecognitionPhrase interface - newly added
- Speech recognition from a MediaStreamTrack (https://chromestatus.com/feature/5178378197139456). ChromeStatus says 135, which is correct according to the engineer
  - SpeechRecognition.start() audioTrack parameter - newly added
- Removes the following items (as far as the engineer can tell, these were removed from the Chromium implementation and the spec about 5 years ago):
  - SpeechRecognitionEvent.emma
  - SpeechRecognitionEvent.interpretation
- Changes the standards-track settings for SpeechGrammar and SpeechGrammarList
  - All documented features are still in the spec except for the SpeechGrammar() constructor, so that one should be `"standard_track": false` but the others should all be `"standard_track": true`. All of them should be `"deprecated": true`.
  - I've also removed the weird Firefox support notes that say Speech Synthesis is supported in Firefox (doesn't make sense to say it in Speech Recognition features)
  - I've also made the Firefox support data consistent between these two interfaces (it really doesn't make sense for Firefox to have implemented one of these but not the other, so I think they were implemented at the same time)

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
