### PR TITLE
Updates for Firefox 144 beta

### DIFF
--- a/api/CSSStyleProperties.json
+++ b/api/CSSStyleProperties.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "144"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -25,7 +25,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -40,7 +40,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -55,7 +55,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CommandEvent.json
+++ b/api/CommandEvent.json
@@ -14,15 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.element.commandfor.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "impl_url": "https://bugzil.la/1983523"
+            "version_added": "144"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -58,15 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.commandfor.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1983523"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -103,15 +87,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.commandfor.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1983523"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -146,15 +122,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.commandfor.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1983523"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Document.json
+++ b/api/Document.json
@@ -5712,7 +5712,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -5727,7 +5727,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -8261,21 +8261,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "140",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.viewTransitions.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "144"
+            },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -319,7 +319,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -334,7 +334,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -7188,7 +7188,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -7203,7 +7203,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -1865,7 +1865,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "144"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -1782,7 +1782,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "141",
+              "version_added": "144",
               "partial_implementation": true,
               "notes": "Currently supported on Windows only, in all contexts except for service workers."
             },
@@ -1867,7 +1867,9 @@
               "firefox": {
                 "version_added": "144"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -292,9 +292,13 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "144"
+              "version_added": "144",
+              "partial_implementation": true,
+              "notes": "Currently supported on Windows only, in all contexts except for service workers."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -292,7 +292,7 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -107,15 +107,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.commandfor.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1983523"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -193,15 +185,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.element.commandfor.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1983523"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -464,6 +464,37 @@
           }
         }
       },
+      "interactionCount": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/event-timing/#dom-performance-interactioncount",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "144"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mark": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/mark",

--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -98,7 +98,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ViewTransition.json
+++ b/api/ViewTransition.json
@@ -13,21 +13,9 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "140",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.viewTransitions.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "144"
+          },
           "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
@@ -59,21 +47,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "140",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.viewTransitions.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "144"
+            },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
@@ -106,21 +82,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "140",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.viewTransitions.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "144"
+            },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
@@ -154,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -224,7 +188,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/properties/view-transition-class.json
+++ b/css/properties/view-transition-class.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -48,7 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "144"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/view-transition-name.json
+++ b/css/properties/view-transition-name.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -47,21 +47,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "142",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.viewTransitions.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "144"
+              },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
@@ -75,7 +63,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -94,7 +82,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "144"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/selectors/view-transition-group.json
+++ b/css/selectors/view-transition-group.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/selectors/view-transition-image-pair.json
+++ b/css/selectors/view-transition-image-pair.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/selectors/view-transition-new.json
+++ b/css/selectors/view-transition-new.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/selectors/view-transition-old.json
+++ b/css/selectors/view-transition-old.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/selectors/view-transition.json
+++ b/css/selectors/view-transition.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -443,6 +443,68 @@
             }
           }
         },
+        "getOrInsert": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-upsert/#sec-map.prototype.getOrInsert",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "144"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getOrInsertComputed": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-upsert/#sec-map.prototype.getOrInsertComputed",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "144"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "groupBy": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy",

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -305,7 +305,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤144"
+                "version_added": "144"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -336,7 +336,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤144"
+                "version_added": "144"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -295,6 +295,68 @@
             }
           }
         },
+        "getOrInsert": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-upsert/#sec-weakmap.prototype.getOrInsert",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤144"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "getOrInsertComputed": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-upsert/#sec-weakmap.prototype.getOrInsertComputed",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤144"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/has",


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.15.0 found new features shipping in Firefox 144 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 47 features as shipping in Firefox 144:

- api.CSSStyleProperties
- api.CSSStyleProperties.cssFloat
- api.CommandEvent
- api.CommandEvent.CommandEvent
- api.CommandEvent.command
- api.CommandEvent.source
- api.Document.moveBefore
- api.Document.startViewTransition
- api.DocumentFragment.moveBefore
- api.Element.moveBefore
- api.GPUDevice.importExternalTexture.videoframe_source
- api.GPUQueue.onSubmittedWorkDone
- api.HTMLButtonElement.command
- api.HTMLButtonElement.commandForElement
- api.Performance.interactionCount
- api.PerformanceEventTiming.interactionId
- api.RTCDataChannel.transferable
- api.ViewTransition
- api.ViewTransition.finished
- api.ViewTransition.ready
- api.ViewTransition.skipTransition
- api.ViewTransition.updateCallbackDone
- css.properties.view-transition-class
- css.properties.view-transition-class.none
- css.properties.view-transition-name
- css.properties.view-transition-name.match-element
- css.properties.view-transition-name.none
- css.selectors.view-transition-group
- css.selectors.view-transition-image-pair
- css.selectors.view-transition-new
- css.selectors.view-transition-old
- css.selectors.view-transition
- javascript.builtins.Map.getOrInsert
- javascript.builtins.Map.getOrInsertComputed

Updated in other PRs:

- webdriver.bidi.browsingContext.downloadWillBegin_event
- webdriver.bidi.browsingContext.downloadWillBegin_event.context_parameter
- webdriver.bidi.browsingContext.downloadWillBegin_event.navigation_parameter
- webdriver.bidi.browsingContext.downloadWillBegin_event.suggestedFilename_parameter
- webdriver.bidi.browsingContext.downloadWillBegin_event.timestamp_parameter
- webdriver.bidi.browsingContext.downloadWillBegin_event.url_parameter
- webdriver.bidi.emulation.setTimezoneOverride
- webdriver.bidi.emulation.setTimezoneOverride.contexts_parameter
- webdriver.bidi.emulation.setTimezoneOverride.timezone_parameter
- webdriver.bidi.emulation.setTimezoneOverride.userContexts_parameter
- webextensions.api.contentScripts.register.cssOrigin
- webextensions.api.scripting.RegisteredContentScript.cssOrigin
- webextensions.manifest.content_scripts.css_origin


See also https://github.com/mdn/mdn/issues/723 and https://www.mozilla.org/en-US/firefox/144.0beta/releasenotes/