### PR TITLE
Issue 24444 chrome.sidePanel

### DIFF
--- a/webextensions/api/sidePanel.json
+++ b/webextensions/api/sidePanel.json
@@ -1,0 +1,329 @@
+{
+  "webextensions": {
+    "api": {
+      "sidePanel": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "114"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "opera": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror"
+          }
+        },
+        "CloseOptions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "GetPanelOptions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "OpenOptions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "PanelBehavior": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "PanelLayout": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "PanelOpenedInfo": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "PanelOptions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "Side": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "SidePanel": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "getLayout": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "getOptions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "getPanelBehavior": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "onOpened": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "open": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "setOptions": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "setPanelBehavior": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -805,6 +805,25 @@
             }
           }
         },
+        "sidePanel": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "storage": {
           "__compat": {
             "support": {

--- a/webextensions/manifest/side_panel.json
+++ b/webextensions/manifest/side_panel.json
@@ -1,0 +1,44 @@
+{
+  "webextensions": {
+    "manifest": {
+      "side_panel": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "114"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "opera": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror"
+          }
+        },
+        "default_path": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

This change adds the browser compatibility data for the [chrome.sidePanel](https://developer.chrome.com/docs/extensions/reference/api/sidePanel) API, encompassing the `sidePanel`, permission, `side_panel` manifest key, and `sidePanel` API compatibility data.

#### Related issues

Fixes #24444