### PR TITLE
Update Safari iOS notes about CSS `resize` property

### DIFF
--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -20,7 +20,7 @@
             "firefox_android": {
               "version_added": "4",
               "version_removed": "79",
-              "notes": "The value is recognized, but has no effect. See [bug 1776834](https://bugzil.la/1776834)."
+              "notes": "The property is recognized, but has no effect. See [bug 1776834](https://bugzil.la/1776834)."
             },
             "oculus": "mirror",
             "opera": {
@@ -32,7 +32,7 @@
             },
             "safari_ios": {
               "version_added": false,
-              "notes": "The value is recognized, but has no effect."
+              "notes": "The property is recognized, but has no effect. See [bug 211994](https://webkit.org/b/211994)."
             },
             "samsunginternet_android": "mirror",
             "webview_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mention the WebKit bug that provides context for why CSS `resize` is not supported on Safari iOS.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #27403.
