### PR TITLE
Chrome doesn't support `text-autospace: {punctuation,replace}`

### DIFF
--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -257,7 +257,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "140"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -291,7 +291,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "140"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
Discovered in the latest collector run.
See also https://groups.google.com/a/chromium.org/g/blink-dev/c/gwRvkPJ5pws/m/F3r-VeGoBAAJ where this talk about only shipping a subset.