### PR TITLE
update `BroadcastChannel` for Deno 2.6

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -16,13 +16,7 @@
           },
           "chrome_android": "mirror",
           "deno": {
-            "version_added": "1.11",
-            "flags": [
-              {
-                "type": "runtime_flag",
-                "name": "--unstable-broadcast-channel"
-              }
-            ]
+            "version_added": "2.6"
           },
           "edge": "mirror",
           "firefox": {
@@ -74,13 +68,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--unstable-broadcast-channel"
-                }
-              ]
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {
@@ -124,13 +112,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--unstable-broadcast-channel"
-                }
-              ]
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {
@@ -178,13 +160,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--unstable-broadcast-channel"
-                }
-              ]
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {
@@ -232,13 +208,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--unstable-broadcast-channel"
-                }
-              ]
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {
@@ -284,13 +254,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--unstable-broadcast-channel"
-                }
-              ]
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {
@@ -334,13 +298,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.11",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--unstable-broadcast-channel"
-                }
-              ]
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
#### Summary

`BroadcastChannel` will be stabilized in Deno 2.6 and no longer require the `--unstable-broadcast-channel` feature flag.

#### Related issues

Towards https://github.com/denoland/deno/issues/30044
