### PR TITLE
Move discrete animation stuff under transition-behavior

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -112,41 +112,6 @@
             }
           }
         },
-        "is_transitionable": {
-          "__compat": {
-            "description": "Transitionable when setting `transition-behavior: allow-discrete`",
-            "spec_url": "https://drafts.csswg.org/css-contain/#content-visibility-animation",
-            "tags": [
-              "web-features:display-animation"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "117"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "18"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "keyframe_animatable": {
           "__compat": {
             "description": "`@keyframe` animatable",

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -605,41 +605,6 @@
             }
           }
         },
-        "is_transitionable": {
-          "__compat": {
-            "description": "Transitionable when setting `transition-behavior: allow-discrete`",
-            "spec_url": "https://drafts.csswg.org/css-display-4/#display-animation",
-            "tags": [
-              "web-features:display-animation"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "117"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "18"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "keyframe_animatable": {
           "__compat": {
             "description": "`@keyframe` animatable",

--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -34,6 +34,76 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "makes_content_visibility_transitionable": {
+          "__compat": {
+            "description": "Makes `content-visibility` transitionable when setting `transition-behavior: allow-discrete`",
+            "spec_url": "https://drafts.csswg.org/css-contain/#content-visibility-animation",
+            "tags": [
+              "web-features:display-animation"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "117"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "makes_display_transitionable": {
+          "__compat": {
+            "description": "Makes `display` transitionable when setting `transition-behavior: allow-discrete`",
+            "spec_url": "https://drafts.csswg.org/css-display-4/#display-animation",
+            "tags": [
+              "web-features:display-animation"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "117"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The current structure seems to be confusing folks, as it isn't clear that `transition-behavior: allow-discrete` doesn't impact all discrete properties in all browsers.

I see why the current structure was chosen, but when `display` doesn't transition when `transition-behavior: allow-discrete` is set, developers seem to assume this is a lack of support for `transition-behavior: allow-discrete`, rather than a lack of support for `display`.

- https://github.com/mdn/browser-compat-data/issues/26155
- https://bsky.app/profile/michaelwarren.dev/post/3lwr2dhod4s2o

I'm not sure if this should impact the `web-features` tag.