### PR TITLE
Duplicate `is_transitionable` features to `transition-behavior`

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -619,7 +619,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1882408"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -34,6 +34,77 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "transitions_content-visibility": {
+          "__compat": {
+            "description": "Transitions `content-visibility` property when set to `allow-discrete`",
+            "spec_url": "https://drafts.csswg.org/css-contain/#content-visibility-animation",
+            "tags": [
+              "web-features:display-animation"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "117"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "transitions_display": {
+          "__compat": {
+            "description": "Transitions `display` property when set to `allow-discrete`",
+            "spec_url": "https://drafts.csswg.org/css-display-4/#display-animation",
+            "tags": [
+              "web-features:display-animation"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "117"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1882408"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -35,7 +35,7 @@
             "deprecated": false
           }
         },
-        "transitions_content-visibility": {
+        "transitionable_content-visibility": {
           "__compat": {
             "description": "Transitions `content-visibility` property when set to `allow-discrete`",
             "spec_url": "https://drafts.csswg.org/css-contain/#content-visibility-animation",
@@ -70,7 +70,7 @@
             }
           }
         },
-        "transitions_display": {
+        "transitionable_display": {
           "__compat": {
             "description": "Transitions `display` property when set to `allow-discrete`",
             "spec_url": "https://drafts.csswg.org/css-display-4/#display-animation",


### PR DESCRIPTION
#### Summary

Duplicates `{content-visibility,display}.is_transitionable` subfeatures into `transition-behavior`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/26155.
