### PR TITLE
Add Safari bug for `Set-Cookie` `Partitioned` attribute

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -142,13 +142,11 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "18.4",
-                  "version_removed": "18.5",
-                  "impl_url": "https://webkit.org/b/292975"
-                }
-              ],
+              "safari": {
+                "version_added": "18.4",
+                "version_removed": "18.5",
+                "impl_url": "https://webkit.org/b/292975"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {


### PR DESCRIPTION
#### Summary

I was wondering why the compat data mentioned it no longer being supported since 18.5, and I found a reported webkit bug which mentions specifically that version. I'm not sure entirely sure 

#### Test results and supporting details

I tried this out in Safari TP Release 222 (WebKit 20622.1.17.2) and got mixed results:
- On https://partitioned-cookies-parent.val.run/ partitioned cookies seem to get stored as expected.
- On https://narrow.one/ (a site I maintain) partitioned cookies do not get stored. I'm not sure what causes the discrepancy. But the reduced test case uses the same domain name and only differ in subdomain, so it's possible that that has something to do with it.

#### Related issues

#27031
