### PR TITLE
Firefox 143 supports `Set-Cookie` Http prefixes

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -564,7 +564,7 @@
                   "version_added": "142",
                   "version_removed": "143",
                   "partial_implementation": true,
-                  "notes": "`__Host-Http-` is named `__HostHttp-`."
+                  "notes": "`__Host-Http-` is supported under its original name `__HostHttp-`. See [bug 1982555](https://bugzil.la/1982555)."
                 }
               ],
               "firefox_android": "mirror",

--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -556,9 +556,17 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "143"
+                },
+                {
+                  "version_added": "142",
+                  "version_removed": "143",
+                  "partial_implementation": true,
+                  "notes": "`__Host-Http-` is named `__HostHttp-`."
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
@@ -572,7 +580,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF142 added support for  `__Http-` and `__HostHttp-` cookie prefixes in https://bugzilla.mozilla.org/show_bug.cgi?id=1974979. FF143 renamed `__HostHttp-`  to  `__Host-Http-` in https://bugzilla.mozilla.org/show_bug.cgi?id=1982555.

This updates the subfeature twice, once with a partial implementation.