### PR TITLE
FF144 RTCDataChannel closing event

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -353,7 +353,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
FF144 supports the [`RTCDataChannel`](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel) [`closing` event](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/closing_event) in in https://bugzilla.mozilla.org/show_bug.cgi?id=1611953. This updates the feature version.

Related docs work can be tracked in https://github.com/mdn/content/issues/41135