### PR TITLE
FF144 before/afterscriptexecute events - remove

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -375,7 +375,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "9"
+              "version_added": "9",
+              "version_removed": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -775,7 +776,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "9"
+              "version_added": "9",
+              "version_removed": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -198,7 +198,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "2"
+              "version_added": "2",
+              "version_removed": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -3090,7 +3091,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "2"
+              "version_added": "2",
+              "version_removed": "144"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
FF144 removed support for [`afterscriptexecute` event in `Document`](https://developer.mozilla.org/en-US/docs/Web/API/Document/afterscriptexecute_event), [`afterscriptexecute` event in `Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element/afterscriptexecute_event), [`beforescriptexecute` event in `Document`](https://developer.mozilla.org/en-US/docs/Web/API/Document/beforescriptexecute_event), [`beforescriptexecute` event in `Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforescriptexecute_event) in https://bugzilla.mozilla.org/show_bug.cgi?id=1584269.

This marks those features as removed.

Related docs work can be tracked in https://github.com/mdn/content/issues/41141
