### PR TITLE
Firefox 144 ships `ScreenOrientation.{lock,unlock}()`

### DIFF
--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -124,28 +124,22 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "144"
               },
               {
                 "version_added": "43",
+                "version_removed": "144",
                 "partial_implementation": true,
                 "notes": "Always throws `NotSupportedError`."
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.screenorientation.allow-lock",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
               {
+                "version_added": "144"
+              },
+              {
                 "version_added": "79",
-                "version_removed": "97",
+                "version_removed": "144",
                 "partial_implementation": true,
                 "notes": "The API exists but returns `NS_ERROR_UNEXPECTED`."
               },
@@ -224,15 +218,24 @@
               "version_added": "38"
             },
             "edge": "mirror",
-            "firefox": {
-              "version_added": "43",
-              "partial_implementation": true,
-              "notes": "Always throws `NotSupportedError`."
-            },
+            "firefox": [
+              {
+                "version_added": "144"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "144",
+                "partial_implementation": true,
+                "notes": "Always throws `NotSupportedError`."
+              }
+            ],
             "firefox_android": [
               {
+                "version_added": "144"
+              },
+              {
                 "version_added": "79",
-                "version_removed": "97",
+                "version_removed": "144",
                 "partial_implementation": true,
                 "notes": "The API exists but returns `NS_ERROR_UNEXPECTED`."
               },


### PR DESCRIPTION
FF144 supports [`ScreenOrientation.lock()`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock) and [`ScreenOrientation.unlock()`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock) in https://bugzilla.mozilla.org/show_bug.cgi?id=1983483

This updates the feature. 

Related docs work can be tracked in https://github.com/mdn/content/issues/41142