### PR TITLE
Firefox 141 supported `GPUQueue.onSubmittedWorkDone()`

### DIFF
--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -292,7 +292,7 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": "144",
+              "version_added": "141",
               "partial_implementation": true,
               "notes": "Currently supported on Windows only, in all contexts except for service workers."
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Corrects the Firefox statement for `GPUQueue.onSubmittedWorkDone()`.

#### Test results and supporting details

Support was set to 144 in https://github.com/mdn/browser-compat-data/pull/27902, but this was likely due to a newly introduced collector test, and the method was already supported from Firefox 141 (together with `GPUQueue` itself), as [confirmed by a Firefox developer](https://github.com/mdn/browser-compat-data/pull/27902#issuecomment-3299803882).

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
