### PR TITLE
Chrome 141 adds `aria-notify` permission (also updates notes)

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -737,7 +737,7 @@
               "version_added": "141",
               "partial_implementation": true,
               "notes": [
-                "Fully supported on Windows only.",
+                "Fully supported on Windows and Linux, no support on ChromeOS.",
                 "Method exposed on macOS, but notifications are not reliably spoken."
               ]
             },

--- a/api/Element.json
+++ b/api/Element.json
@@ -1938,7 +1938,7 @@
               "version_added": "141",
               "partial_implementation": true,
               "notes": [
-                "Fully supported on Windows only.",
+                "Fully supported on Windows and Linux, no support on ChromeOS.",
                 "Method exposed on macOS, but notifications are not reliably spoken."
               ]
             },

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -110,6 +110,38 @@
             }
           }
         },
+        "aria-notify": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "141",
+                "partial_implementation": true,
+                "notes": "Not supported on ChromeOS."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "attribution-reporting": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/attribution-reporting",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Following on from https://github.com/mdn/browser-compat-data/pull/27819, I'm editing the `ariaNotify()` data to make it clear that it is supported on Linux, but not on ChromeOS.

I've also added a data point for the related `aria-notify` Permissions Policy descriptor.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
