### PR TITLE
FF144 cross-origin iframe requires user interaction for top-navigation

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1611,7 +1611,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "13",
-                "notes": "If a top-navigation is blocked, an error is reported in the developer console (only)."
+                "notes": "If a top-navigation is blocked, no redirect occurs, and an error is reported in the developer console."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
FF144 adds support for cross-origin `<iframe>` to require sticky activation and user permission before it can do `Window.top` navigation (i.e. set `top.location`) in https://bugzilla.mozilla.org/show_bug.cgi?id=1419501

This was originally supported in Chrome 68 (https://chromestatus.com/feature/5851021045661696) and Safari 13 (https://bugs.webkit.org/show_bug.cgi?id=193076). 

Note that this is not standard though AFAIK. There are discussions in https://github.com/whatwg/html/issues/8013 and all the main browsers comply, but no place to point in the HTML spec. Further there are tests, but these aren't all passed by anyone and are marked as experimental.

Note that according to https://bugzilla.mozilla.org/show_bug.cgi?id=1419501#c28 if the redirect is blocked then Chrome and FF will prompt for user permission to navigate and log the error in console, while Safari just blocks the navigation and reports and error in the dev console.

Related work can be tracked in https://github.com/mdn/content/issues/41138