### PR TITLE
Firefox 144 adds `CSSStyleProperties` (aka `CSS2Properties`)

### DIFF
--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -85,7 +85,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -74,7 +74,8 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CSSStyleProperties.json
+++ b/api/CSSStyleProperties.json
@@ -9,9 +9,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": {
-            "version_added": "144"
-          },
+          "firefox": [
+            {
+              "version_added": "144"
+            },
+            {
+              "alternative_name": "CSS2Properties",
+              "version_added": "≤2",
+              "version_removed": "144"
+            }
+          ],
           "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",

--- a/api/CSSStyleProperties.json
+++ b/api/CSSStyleProperties.json
@@ -15,7 +15,7 @@
             },
             {
               "alternative_name": "CSS2Properties",
-              "version_added": "≤2",
+              "version_added": "1",
               "version_removed": "144"
             }
           ],

--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -238,7 +238,6 @@
         "returns_CSSStyleProperties": {
           "__compat": {
             "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule/style",
             "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylerule-style",
             "support": {
               "chrome": {

--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -247,7 +247,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "145"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -234,6 +234,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_CSSStyleProperties": {
+          "__compat": {
+            "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule/style",
+            "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylerule-style",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "styleMap": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2534,6 +2534,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_CSSStyleProperties": {
+          "__compat": {
+            "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/style",
+            "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "145"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "tabIndex": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2538,7 +2538,6 @@
         "returns_CSSStyleProperties": {
           "__compat": {
             "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/style",
             "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
             "support": {
               "chrome": {

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -281,7 +281,6 @@
         "returns_CSSStyleProperties": {
           "__compat": {
             "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/MathMLElement/style",
             "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
             "support": {
               "chrome": {

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -277,6 +277,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_CSSStyleProperties": {
+          "__compat": {
+            "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/MathMLElement/style",
+            "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "145"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "tabIndex": {

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -555,7 +555,6 @@
         "returns_CSSStyleProperties": {
           "__compat": {
             "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/style",
             "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
             "support": {
               "chrome": {

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -551,6 +551,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_CSSStyleProperties": {
+          "__compat": {
+            "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/style",
+            "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "145"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "tabIndex": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -2213,7 +2213,6 @@
         "returns_CSSStyleProperties": {
           "__compat": {
             "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle",
             "spec_url": "https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle",
             "support": {
               "chrome": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -2209,6 +2209,39 @@
               "deprecated": false
             }
           }
+        },
+        "returns_CSSStyleProperties": {
+          "__compat": {
+            "description": "Returns `CSSStyleProperties` (not `CSSStyleDeclaration`)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle",
+            "spec_url": "https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "145"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getDefaultComputedStyle": {


### PR DESCRIPTION
FF144 added support for `CSSStyleProperties` in https://bugzilla.mozilla.org/show_bug.cgi?id=1919582 , as updated in #27902

However as explained in https://bugzilla.mozilla.org/show_bug.cgi?id=1919582#c30 the  `CSSStyleProperties` was renamed from a preexisting `CSS2Properties`. This adds the alternative name to the feature for Firefox. Note that the developer indicates this was from version 2 (checked) but might have been version 1.

FF145 added support for returning this from `.style` in elements (HTML, SVG, MathML) and also in `getComputedStyle()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1989925. I have set these to have a subfeature indicating the new return type.

It is not clear if FF returns it from `CSSStyleRule.style` - I am asking in https://bugzilla.mozilla.org/show_bug.cgi?id=1989925#c4

Chrome hasn't added support for `CSSStyleProperties` as far as I can tell.

Safari has been marked as supporting  `CSSStyleProperties` in 26 already, but the return methods were not marked. I have set all of them to working in that version though I have not tested it (they appear to be updated in source though, and 26 was the version the interface went in).

In addition, the spec changed to move the `cssFloat` attribute from `CSSStyleDeclaration` to `CSSStyleProperties`. This won't affect FF which never implemented that, but it does affect Safari. So I've marked it as removed and also now non-standard and deprecated.

Related docs work can be tracked in https://github.com/mdn/content/issues/41133