### PR TITLE
Chrome 136 adds CSS `dynamic-range-limit` + `dynamic-range-limit-mix()`

### DIFF
--- a/css/properties/dynamic-range-limit.json
+++ b/css/properties/dynamic-range-limit.json
@@ -62,9 +62,9 @@
             }
           }
         },
-        "dynamic-range-limit-mix": {
+        "dynamic-range-limit-mix_values": {
           "__compat": {
-            "description": "`dynamic-range-limit-mix()` function",
+            "description": "`<dynamic-range-limit-mix()>` values",
             "spec_url": "https://drafts.csswg.org/css-color-hdr/#funcdef-dynamic-range-limit-mix",
             "support": {
               "chrome": {

--- a/css/properties/dynamic-range-limit.json
+++ b/css/properties/dynamic-range-limit.json
@@ -62,6 +62,38 @@
             }
           }
         },
+        "dynamic-range-limit-mix": {
+          "__compat": {
+            "description": "`dynamic-range-limit-mix()` function",
+            "spec_url": "https://drafts.csswg.org/css-color-hdr/#funcdef-dynamic-range-limit-mix",
+            "support": {
+              "chrome": {
+                "version_added": "136"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "no-limit": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-color-hdr/#valdef-dynamic-range-limit-no-limit",

--- a/css/types/dynamic-range-limit-mix.json
+++ b/css/types/dynamic-range-limit-mix.json
@@ -1,0 +1,38 @@
+{
+  "css": {
+    "types": {
+      "dynamic-range-limit-mix": {
+        "__compat": {
+          "description": "`dynamic-range-limit-mix()`",
+          "spec_url": "https://drafts.csswg.org/css-color-hdr/#funcdef-dynamic-range-limit-mix",
+          "support": {
+            "chrome": {
+              "version_added": "136"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 136 introduces the CSS [`dynamic-range-limit`](https://drafts.csswg.org/css-color-hdr/#the-dynamic-range-limit-property) property; see https://chromestatus.com/feature/5146250411769856. This already had BCD.

<s>I'm pretty sure this support also includes the `dynamic-range-limit-mix()` function, but I've asked Chrome engineering to clarify.</s> UPDATE: Yes, it does.

I've already been told that the function is Chrome-only at the moment.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
