### PR TITLE
Deno 2.5 adds `hex/base64` methods on `Uint8Array`

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -373,9 +373,23 @@
         "2.3.2": {
           "release_date": "2025-05-16",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v2.3.3",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "13.7"
+        },
+        "2.4.0": {
+          "release_date": "2025-07-01",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v2.4.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "13.7"
+        },
+        "2.5.0": {
+          "release_date": "2025-09-10",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v2.5.0",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "14.0"
         }
       }
     }

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -232,7 +232,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.5.0"
               },
               "edge": "mirror",
               "firefox": {
@@ -276,7 +276,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.5.0"
               },
               "edge": "mirror",
               "firefox": {
@@ -320,7 +320,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.5.0"
               },
               "edge": "mirror",
               "firefox": {
@@ -364,7 +364,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.5.0"
               },
               "edge": "mirror",
               "firefox": {
@@ -408,7 +408,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.5.0"
               },
               "edge": "mirror",
               "firefox": {
@@ -452,7 +452,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "2.5.0"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

Adds browser info for Deno 2.4 and Deno 2.5 - mainly about newly `hex/base64` methods on `Uint8Array`
that became available in V8 14.0 that Deno v2.5 uses..

#### Test results and supporting details

https://deno.com/blog/v2.5#v8-140-and-typescript-592

Fixes https://github.com/mdn/browser-compat-data/issues/27991.