### PR TITLE
added firefox support for :active-view-transition

### DIFF
--- a/css/selectors/active-view-transition.json
+++ b/css/selectors/active-view-transition.json
@@ -16,21 +16,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "141",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.viewTransitions.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "144"
+            },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
#### Summary

- Added firefox support for the `:active-view-transition` selector

#### Test results and supporting details

- Tested using [this codepen](https://codepen.io/CodeRedDigital/pen/empOzLe), in the following browsers:
  - Firefox Nightly 145
  - Firefox Developer Edition 144
  - Firefox Beta 144

#### Related issues

- [MDN issue #41136](https://github.com/mdn/content/issues/41164)
- Firefox release note PR - coming soon
