### PR TITLE
ci(update-browser-releases): install using lock file

### DIFF
--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -27,9 +27,7 @@ jobs:
           node-version-file: ".nvmrc"
           package-manager-cache: false
 
-      - run: npm install -D typescript
-
-      - run: npm install -D tsx
+      - run: npm ci
 
       - name: Run update-browser-releases script
         id: update


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the `update-browser-releases` workflow to run `npm ci` (using the lock file) instead of installing `typescript` and `tsx` directly.

Avoids installing vulnerable versions of transitive dependencies accidentally.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
