### PR TITLE
Chrome 140 / Safari 26 support "typed arithmetic"

### DIFF
--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -223,9 +223,9 @@
             }
           }
         },
-        "typed_arithmetic": {
+        "typed_division_produces_unitless_number": {
           "__compat": {
-            "description": "Typed arithmetic",
+            "description": "Divisions between typed values produce unitless number (\"typed arithmetic\")",
             "spec_url": "https://www.w3.org/TR/css-values-4/#calc-type-checking",
             "support": {
               "chrome": {

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -38,9 +38,9 @@
             "deprecated": false
           }
         },
-        "typed_arithmetic": {
+        "typed_division_produces_unitless_number": {
           "__compat": {
-            "description": "Typed arithmetic",
+            "description": "Divisions between typed values produce unitless number (\"typed arithmetic\")",
             "spec_url": "https://www.w3.org/TR/css-values-4/#calc-type-checking",
             "support": {
               "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 140 adds support for [CSS typed arithmetic](https://www.w3.org/TR/css-values-4/#calc-type-checking); see https://chromestatus.com/feature/4740780497043456.

It is not very clear what this is from the spec, but https://css-tricks.com/css-typed-arithmetic/ provides a good explanation.

Safari also supports it. The relevant bug appears to be https://bugs.webkit.org/show_bug.cgi?id=278244, which says Safari 18, but I've tried 18.5 and it doesn't work in that version. I upgraded to Safari 26, and it did work, so I've put the Safari support version down as 26.

In terms of what features this will be used in, it is mainly relevant to `calc()`. `sign()` also directly takes a calculation/expression as a value, and I've tested it works, so I've included the data point there as well.

In terms of including it in other function data, I don't know. I mean, you can technically use a `calc()` just about anywhere that accepts numeric units, but I didn't think it was worth including it in other places as it would get confusing. Opinions welcome.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
