### PR TITLE
Safari 26 supports CSS `@position-try`

### DIFF
--- a/css/at-rules/position-try.json
+++ b/css/at-rules/position-try.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": 26
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/at-rules/position-try.json
+++ b/css/at-rules/position-try.json
@@ -32,7 +32,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/at-rules/position-try.json
+++ b/css/at-rules/position-try.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": 26
+              "version_added": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
I believe this was missed in #27087. This was implemented in Safari 26 as part of the anchor positioning work.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I tested adding a `@position-try` rule to a CSS file on a website I built and it showed up as a valid rule in Safari 26:

<img width="1361" height="525" alt="Screenshot 2025-09-27 at 9 28 32 PM" src="https://github.com/user-attachments/assets/d02056a6-9b73-49ee-bfc7-288d8ef00cd6" />

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

See the WPT tests for @position-try in Safari: 

- [WPT tests for allowed declarations](https://wpt.fyi/results/css/css-anchor-position/at-position-try-allowed-declarations.html?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bstable%5D&aligned)
- [WPT tests for anchor positioning overall, including many for "at-position-try"](https://wpt.fyi/results/css/css-anchor-position?label=master&label=stable&product=safari&aligned)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
