### PR TITLE
Add impl_url to orphans and widows for Firefox.

### DIFF
--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -17,7 +17,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/137367"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/widows.json
+++ b/css/properties/widows.json
@@ -20,7 +20,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/137367"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Adds a missing impl_url.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The MDN page does not currently list a link to the Firefox bug to implement the feature, this would fix that: https://developer.mozilla.org/en-US/docs/Web/CSS/orphans#browser_compatibility

#### Related issues

 Fixes #27918.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
