### PR TITLE
fix: correct the text-autospace support table for Safari

### DIFF
--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -32,7 +32,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.4"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -167,7 +167,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.4"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -269,7 +269,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.4"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -303,7 +303,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.4"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

According to #28020, it seems these text-autospace features (replace, punctation, insert, text-autospace) were never implemented.

Corrected by updating `version_added` to `false`

#### Test results and supporting details

See #28020. WIP.

#### Related issues

Fixes #28020