### PR TITLE
Remove experimental Node.js notes for `SubtleCrypto`

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -306,8 +306,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -590,8 +589,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -854,8 +852,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -897,8 +894,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1017,8 +1013,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1060,8 +1055,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1186,8 +1180,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1229,8 +1222,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1332,8 +1324,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1507,8 +1498,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)."
+                "version_added": "16.17.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removes obsolete Node.js notes for `SubtleCrypto` algorithms.

#### Test results and supporting details

As of Node 20, those are no longer experimental.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27964.