### PR TITLE
Chrome 137 supports Canvas `colorType` setting

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -898,7 +898,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "134"
+                  "version_added": "137"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds data for the new `colorType` option under `api.HTMLCanvasElement.getContext.2d_context`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27877.