### PR TITLE
Safari 17.2 allowed mixing percentages in `round/mod/rem()`

### DIFF
--- a/css/types/mod.json
+++ b/css/types/mod.json
@@ -56,17 +56,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "17.2"
-                },
-                {
-                  "version_added": "15.4",
-                  "version_removed": "17.2",
-                  "impl_url": "https://webkit.org/b/259714",
-                  "notes": "Mixing percentages with length/number arguments is not supported."
-                }
-              ],
+              "safari": {
+                "version_added": "17.2"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/css/types/mod.json
+++ b/css/types/mod.json
@@ -36,9 +36,9 @@
             "deprecated": false
           }
         },
-        "percentages": {
+        "mixed_type_parameters": {
           "__compat": {
-            "description": "`<percentage>` values",
+            "description": "Mix `<percentage>` with `<length>` and `<number>` parameters",
             "spec_url": "https://drafts.csswg.org/css-values/#funcdef-mod",
             "tags": [
               "web-features:round-mod-rem"

--- a/css/types/mod.json
+++ b/css/types/mod.json
@@ -35,6 +35,49 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "percentages": {
+          "__compat": {
+            "description": "`<percentage>` values",
+            "spec_url": "https://drafts.csswg.org/css-values/#funcdef-mod",
+            "tags": [
+              "web-features:round-mod-rem"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": [
+                {
+                  "version_added": "17.2"
+                },
+                {
+                  "version_added": "15.4",
+                  "version_removed": "17.2",
+                  "impl_url": "https://webkit.org/b/259714",
+                  "notes": "Mixing percentages with length/number arguments is not supported."
+                }
+              ],
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -56,17 +56,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "17.2"
-                },
-                {
-                  "version_added": "15.4",
-                  "version_removed": "17.2",
-                  "impl_url": "https://webkit.org/b/259714",
-                  "notes": "Mixing percentages with length/number arguments is not supported."
-                }
-              ],
+              "safari": {
+                "version_added": "17.2"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -36,9 +36,9 @@
             "deprecated": false
           }
         },
-        "percentages": {
+        "mixed_type_parameters": {
           "__compat": {
-            "description": "`<percentage>` values",
+            "description": "Mix `<percentage>` with `<length>` and `<number>` parameters",
             "spec_url": "https://drafts.csswg.org/css-values/#funcdef-rem",
             "tags": [
               "web-features:round-mod-rem"

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -35,6 +35,49 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "percentages": {
+          "__compat": {
+            "description": "`<percentage>` values",
+            "spec_url": "https://drafts.csswg.org/css-values/#funcdef-rem",
+            "tags": [
+              "web-features:round-mod-rem"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": [
+                {
+                  "version_added": "17.2"
+                },
+                {
+                  "version_added": "15.4",
+                  "version_removed": "17.2",
+                  "impl_url": "https://webkit.org/b/259714",
+                  "notes": "Mixing percentages with length/number arguments is not supported."
+                }
+              ],
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -56,17 +56,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "17.2"
-                },
-                {
-                  "version_added": "15.4",
-                  "version_removed": "17.2",
-                  "impl_url": "https://webkit.org/b/259714",
-                  "notes": "Mixing percentages with length/number arguments is not supported."
-                }
-              ],
+              "safari": {
+                "version_added": "17.2"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -35,6 +35,49 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "percentages": {
+          "__compat": {
+            "description": "`<percentage>` values",
+            "spec_url": "https://drafts.csswg.org/css-values/#funcdef-round",
+            "tags": [
+              "web-features:round-mod-rem"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": [
+                {
+                  "version_added": "17.2"
+                },
+                {
+                  "version_added": "15.4",
+                  "version_removed": "17.2",
+                  "impl_url": "https://webkit.org/b/259714",
+                  "notes": "Mixing percentages with length/number arguments is not supported."
+                }
+              ],
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -36,9 +36,9 @@
             "deprecated": false
           }
         },
-        "percentages": {
+        "mixed_type_parameters": {
           "__compat": {
-            "description": "`<percentage>` values",
+            "description": "Mix `<percentage>` with `<length>` and `<number>` parameters",
             "spec_url": "https://drafts.csswg.org/css-values/#funcdef-round",
             "tags": [
               "web-features:round-mod-rem"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds subfeatures `css.types.{mod,rem,round}.percentages` to record the partial support in Safari before 17.2.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27862.