### PR TITLE
Safari TP percent-encodes trailing space in pathname

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -622,7 +622,8 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40251904"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -630,7 +631,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1951963"
               },
               "firefox_android": "mirror",
               "nodejs": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -608,6 +608,51 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "encodes_trailing_space_in_opaque_path": {
+          "__compat": {
+            "description": "Percent-encodes trailing space in opaque path with query or fragment",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/pathname#pathname_with_opaque_path",
+            "spec_url": "https://url.spec.whatwg.org/#cannot-be-a-base-url-path-state",
+            "tags": [
+              "web-features:url"
+            ],
+            "support": {
+              "bun": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "port": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a `api.URL.pathname` subfeature `encodes_trailing_space_in_opaque_path` to document a spec evolution that is now implemented in Safari TP.

#### Test results and supporting details

See:

- https://github.com/whatwg/url/pull/844

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27856.