### PR TITLE
Mark `char`/`charoff` HTML attrs as unsupported in all browsers

### DIFF
--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -87,11 +87,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -105,7 +108,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -127,11 +131,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -145,7 +152,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -167,7 +175,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": {

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -88,11 +88,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -106,7 +109,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -128,11 +132,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -146,7 +153,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -132,11 +132,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -150,7 +153,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -171,11 +175,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": "1",
@@ -189,7 +196,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -208,11 +208,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -226,7 +229,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -247,11 +251,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": "1",
@@ -265,7 +272,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -132,11 +132,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -150,7 +153,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -171,11 +175,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": "1",
@@ -189,7 +196,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -208,11 +208,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -226,7 +229,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -247,11 +251,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": "1",
@@ -265,7 +272,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -133,11 +133,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -151,7 +154,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -172,11 +176,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": "1",
@@ -190,7 +197,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -132,11 +132,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -150,7 +153,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -171,11 +175,14 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Since Chrome 1, the attribute can be set, but has no effect."
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Since Edge 79, the attribute can be set, but has no effect."
               },
               "firefox": {
                 "version_added": false,
@@ -189,7 +196,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": false,
+                "notes": "Since Safari 3, the attribute can be set, but has no effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marks the `char` and `charoff` HTML attributes as unsupported in Chrome, Firefox, and Safari, because they no longer have any specified behavior, and they (most likely) never had any visually observable effect in these browsers.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/15657.