### PR TITLE
Chrome/Firefox/Safari added weak `container-type` containment

### DIFF
--- a/css/properties/container-type.json
+++ b/css/properties/container-type.json
@@ -170,6 +170,41 @@
               "deprecated": false
             }
           }
+        },
+        "weak_containment": {
+          "__compat": {
+            "description": "Applies style and size containment, but no layout containment.",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#container-type:~:text=containers%20no%20longer%20apply%20layout%20containment",
+            "tags": [
+              "web-features:container-queries"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "129"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a `weak_containment` subfeature to `css.properties.container-type`, which [Chrome 129](https://chromiumdash.appspot.com/commit/e28cd00c20c78b8fd11546d59fd6c82243ce7115), [Firefox 133](https://bugzilla.mozilla.org/show_bug.cgi?id=1922900), and [WebKit 18.4](https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#:~:text=dropped%20layout%20containment) support.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27766.