### PR TITLE
Firefox 57 shipped async generator methods/functions

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -721,7 +721,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "55"
+                "version_added": "57"
               },
               "firefox_android": "mirror",
               "nodejs": {

--- a/javascript/operators/async_generator_function.json
+++ b/javascript/operators/async_generator_function.json
@@ -22,7 +22,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "55"
+              "version_added": "57"
             },
             "firefox_android": "mirror",
             "nodejs": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -69,7 +69,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "55"
+              "version_added": "57"
             },
             "firefox_android": "mirror",
             "nodejs": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 57 shipped async generator methods/functions, not Firefox 52/55.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27774.