### PR TITLE
Mark `CookieStore.get()` return values as experimental/non-standard

### DIFF
--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -181,7 +181,6 @@
         "domain_return_property": {
           "__compat": {
             "description": "`domain` in return value",
-            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookielistitem-domain",
             "tags": [
               "web-features:cookie-store"
             ],
@@ -207,8 +206,8 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -216,7 +215,6 @@
         "expires_return_property": {
           "__compat": {
             "description": "`expires` in return value",
-            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookielistitem-expires",
             "tags": [
               "web-features:cookie-store"
             ],
@@ -242,8 +240,8 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -251,7 +249,7 @@
         "name_return_property": {
           "__compat": {
             "description": "`name` in return value",
-            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookielistitem-name",
+            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookiestore-get",
             "tags": [
               "web-features:cookie-store"
             ],
@@ -286,7 +284,6 @@
         "partitioned_return_property": {
           "__compat": {
             "description": "`partitioned` in return value",
-            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookielistitem-partitioned",
             "tags": [
               "web-features:partitioned-cookies"
             ],
@@ -312,8 +309,8 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -321,7 +318,6 @@
         "path_return_property": {
           "__compat": {
             "description": "`path` in return value",
-            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookielistitem-path",
             "tags": [
               "web-features:cookie-store"
             ],
@@ -347,8 +343,8 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -356,7 +352,6 @@
         "sameSite_return_property": {
           "__compat": {
             "description": "`sameSite` in return value",
-            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookielistitem-samesite",
             "tags": [
               "web-features:cookie-store"
             ],
@@ -382,8 +377,8 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -391,7 +386,6 @@
         "secure_return_property": {
           "__compat": {
             "description": "`secure` in return value",
-            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookielistitem-secure",
             "tags": [
               "web-features:cookie-store"
             ],
@@ -417,8 +411,8 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -426,7 +420,7 @@
         "value_return_property": {
           "__compat": {
             "description": "`value` in return value",
-            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookielistitem-value",
+            "spec_url": "https://cookiestore.spec.whatwg.org/#dom-cookiestore-get",
             "tags": [
               "web-features:cookie-store"
             ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marks several `CookieStore.get()` return values (only supported by Chrome/Edge) as experimental/non-standard.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27529.