### PR TITLE
Update data for Popover API `source` option

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2385,7 +2385,7 @@
                   "version_added": "133",
                   "version_removed": "137",
                   "partial_implementation": true,
-                  "notes": "When using this option, the focus order didn't change, so the popover did not become the next focus element. See [bug 383343310](https://crbug.com/383343310)."
+                  "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 383343310](https://crbug.com/383343310)."
                 }
               ],
               "chrome_android": "mirror",
@@ -2398,7 +2398,7 @@
                   "version_added": "141",
                   "version_removed": "144",
                   "partial_implementation": true,
-                  "notes": "When using this option, the focus order didn't change, so the popover did not become the next focus element. See [bug 1984004](https://bugzil.la/1984004)."
+                  "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 1984004](https://bugzil.la/1984004)."
                 }
               ],
               "firefox_android": "mirror",
@@ -2413,7 +2413,7 @@
                   "version_added": "18.4",
                   "version_removed": "26",
                   "partial_implementation": true,
-                  "notes": "When using this option, the focus order didn't change, so the popover did not become the next focus element. See [bug 286575](https://webkit.org/b/286575)."
+                  "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 286575](https://webkit.org/b/286575)."
                 }
               ],
               "safari_ios": "mirror",
@@ -2922,7 +2922,7 @@
                   "version_added": "133",
                   "version_removed": "137",
                   "partial_implementation": true,
-                  "notes": "When using this option, the focus order didn't change, so the popover did not become the next focus element. See [bug 383343310](https://crbug.com/383343310)."
+                  "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 383343310](https://crbug.com/383343310)."
                 }
               ],
               "chrome_android": "mirror",
@@ -2935,7 +2935,7 @@
                   "version_added": "141",
                   "version_removed": "144",
                   "partial_implementation": true,
-                  "notes": "When using this option, the focus order didn't change, so the popover did not become the next focus element. See [bug 1984004](https://bugzil.la/1984004)."
+                  "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 1984004](https://bugzil.la/1984004)."
                 }
               ],
               "firefox_android": "mirror",
@@ -2950,7 +2950,7 @@
                   "version_added": "18.4",
                   "version_removed": "26",
                   "partial_implementation": true,
-                  "notes": "When using this option, the focus order didn't change, so the popover did not become the next focus element. See [bug 286575](https://webkit.org/b/286575)."
+                  "notes": "When using this option, the focus order doesn't change, so the popover does not become the next focus element. See [bug 286575](https://webkit.org/b/286575)."
                 }
               ],
               "safari_ios": "mirror",
@@ -2978,7 +2978,8 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1838746"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",


### PR DESCRIPTION
…ogglePopover.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Corrected Safari support to show it's released not just in preview.

Added the version that Chromium is no longer failing to do the focus fixup.

Added the version that Safari is no longer failing to do the focus fixup.

Showed that Firefox was initially failing to do the focus fixup, but also add the version it's fixed in.

Also add that Safari supports implicit anchoring with it since 26, and that Firefox doesn't support it despite being marked as supporting (Firefox doesn't support anchor positioning yet).

#### Test results and supporting details

Chromium commit with fix: https://chromiumdash.appspot.com/commit/de6eb169a3607c04e91aea81b478e58c74966083 - shows 137 version

Firefox bug with fix: https://bugzilla.mozilla.org/show_bug.cgi?id=1984004 - shows 144 version

WebKit fix isn't mentioned in release notes but I've checked and it was broken in 18.4 and is fixed in 26.

https://jsfiddle.net/e9f7x6Lm/ - shows the implicit anchor working if you test in Safari 26.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
