### PR TITLE
Update Chromium data for background-repeat-x CSS property

### DIFF
--- a/css/properties/background-repeat-x.json
+++ b/css/properties/background-repeat-x.json
@@ -6,7 +6,8 @@
           "spec_url": "https://drafts.csswg.org/css-backgrounds-4/#background-repeat-longhands",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "5",
+              "version_removed": "120"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `background-repeat-x` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.15.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/background-repeat-x
