### PR TITLE
Chrome 115 / Firefox 131 added `WebAssembly.JSTag` attribute

### DIFF
--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -48,6 +48,8 @@
       "JSTag_static": {
         "__compat": {
           "support": {
+            "description": "`JSTag` static attribute",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-jstag",
             "chrome": {
               "version_added": "115"
             },

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -45,6 +45,36 @@
           "deprecated": false
         }
       },
+      "JSTag_static": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "115"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "131"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "compile_static": {
         "__compat": {
           "description": "`compile()` static method",

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -47,9 +47,9 @@
       },
       "JSTag_static": {
         "__compat": {
+          "description": "`JSTag` static attribute",
+          "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-jstag",
           "support": {
-            "description": "`JSTag` static attribute",
-            "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-jstag",
             "chrome": {
               "version_added": "115"
             },


### PR DESCRIPTION
This PR adds the missing `JSTag_static` WebAssembly interface. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.15.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/api/JSTag_static
