### PR TITLE
Add Firefox bug about `datetime-local` input behaviour

### DIFF
--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -20,17 +20,7 @@
               },
               "firefox": {
                 "version_added": "93",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.forms.datetime.timepicker",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": [
-                  "Before Firefox 144, only displays a date picker without a time picker, see [bug 1726108](https://bugzil.la/1726108).",
-                  "There is an issue when a `min` and/or `max` attribute is set with a time value the time picker has no values, see [bug 1990226](https://bugzil.la/1990226)."
-                ]
+                "notes": "Before Firefox 144, only displays a date picker without a time picker, see [bug 1726107](https://bugzil.la/1726107) and [bug 1726108](https://bugzil.la/1726108)."
               },
               "firefox_android": {
                 "version_added": "93"

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -20,6 +20,13 @@
               },
               "firefox": {
                 "version_added": "93",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.forms.datetime.timepicker",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": [
                   "Before Firefox 144, only displays a date picker without a time picker, see [bug 1726108](https://bugzil.la/1726108).",
                   "There is an issue when a `min` and/or `max` attribute is set with a time value the time picker has no values, see [bug 1990226](https://bugzil.la/1990226)."

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -20,7 +20,10 @@
               },
               "firefox": {
                 "version_added": "93",
-                "notes": "Before Firefox 144, only displays a date picker without a time picker, see [bug 1726108](https://bugzil.la/1726108)."
+                "notes": [
+                  "Before Firefox 144, only displays a date picker without a time picker, see [bug 1726108](https://bugzil.la/1726108).",
+                  "There is an issue when a `min` and/or `max` attribute is set with a time value the time picker has no values, see [bug 1990226](https://bugzil.la/1990226)."
+                ]
               },
               "firefox_android": {
                 "version_added": "93"


### PR DESCRIPTION
#### Summary

- Added flag for `datetime-local` input field
- Added note about timepicker values

#### Test results and supporting details

- Tested using [datetime-local test code pen](https://codepen.io/CodeRedDigital/pen/qEbdpOw?editors=1100) using the flag `dom.forms.datetime.timepicker`, in:
  - Firefox beta 144
  - Firefox Developer Edition 144
  - Firefox Nightly 145

#### Related issues

- [MDN issue #41140](https://github.com/mdn/content/issues/41140)
- [Firefox release note PR](https://github.com/mdn/content/pull/41346)