### PR TITLE
Chrome does support FCP and FCP

### DIFF
--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -43,23 +43,9 @@
             "web-features:paint-timing"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "116",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--enable-blink-features",
-                    "value_to_set": "SoftNavigationHeuristicsExposeFPAndFCP"
-                  }
-                ],
-                "notes": "See [bug 40066208](https://crbug.com/40066208)."
-              },
-              {
-                "version_added": "60",
-                "version_removed": "116"
-              }
-            ],
+            "chrome": {
+              "version_added": "60"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -93,23 +79,9 @@
             "web-features:paint-timing"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "116",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--enable-blink-features",
-                    "value_to_set": "SoftNavigationHeuristicsExposeFPAndFCP"
-                  }
-                ],
-                "notes": "See [bug 40066208](https://crbug.com/40066208)."
-              },
-              {
-                "version_added": "60",
-                "version_removed": "116"
-              }
-            ],
+            "chrome": {
+              "version_added": "60"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes: #28052

Reverts #26858 for incorrect issues #26857

The [commit it refers to](https://chromiumdash.appspot.com/commit/a2ef10dead3b21a1409e6be64f60b6a870306058) was specifically for the Soft Navigations version of FP and FCP (which are very experimental):
https://issues.chromium.org/issues/40280852

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

If you run the test suggested in issue #26857 then you see it:

<img width="833" height="625" alt="image" src="https://github.com/user-attachments/assets/9b020da0-0f7f-4ea8-bc3f-ec04b6699505" />

> For any loaded webpage in Chrome, performance.getEntriesByType("paint") will always return an empty array.
> When Chrome is launched with the aforementioned flag, the array will contain the aforementioned named paint entries.

I'm not sure why these tests were not run to prove this Issue was wrong when they listed it? @whalderman


<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->


Reverts PR #26858 
Issue #26857

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
