### PR TITLE
Note Firefox's partial support of console.timeStamp

### DIFF
--- a/api/_globals/console.json
+++ b/api/_globals/console.json
@@ -1392,9 +1392,18 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "39"
-            },
+            "firefox": [
+              {
+                "version_added": "98",
+                "impl_url": "https://bugzil.la/1387528",
+                "partial_implementation": true,
+                "notes": "Even though `console.timeStamp` is defined, it is not used in performance profile. See [bug 1387528](https://bugzil.la/1387528)."
+              },
+              {
+                "version_added": "39",
+                "version_removed": "97"
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "11"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Firefox's new profiler doesn't support `console.timeStamp`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Start a trace, call that, end trace.
Note no timestamps.

@canova and @julienw can also confirm this is not currently supported.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
