### PR TITLE
Chrome 141 new `echoCancellation` MediaStreamTrack constraint values

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -341,7 +341,7 @@
           },
           "remote-only": {
             "__compat": {
-              "description": "`remote-only` value",
+              "description": "`\"remote-only\"` value",
               "spec_url": "https://w3c.github.io/mediacapture-main/#dom-echocancellationmodeenum-remote-only",
               "tags": [
                 "web-features:media-capture"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 141 adds support for the new `all` and `remote-only` values of the [`MediaTrackConstraints/echoCancellation`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/echoCancellation) constraint. See https://chromestatus.com/feature/5585747985563648.

This PR in particular adds data points for these as sub-values of `MediaStreamTrack.applyConstraints()` and `MediaStreamTrack.getCapabilities()`. The former is used as the data for the `MediaTrackConstraints` pages, but the latter is used to query the platform for constraint support, and I'm pretty sure it must be available there too.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
