### PR TITLE
Chromium 141 IDB getAll() and getAllKeys() direction option

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -220,9 +220,6 @@
           "__compat": {
             "description": "Object as parameter",
             "spec_url": "https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions",
-            "tags": [
-              "web-features:indexeddb"
-            ],
             "support": {
               "chrome": {
                 "version_added": "141"
@@ -254,9 +251,6 @@
             "__compat": {
               "description": "`direction` property",
               "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbgetalloptions-direction",
-              "tags": [
-                "web-features:indexeddb"
-              ],
               "support": {
                 "chrome": {
                   "version_added": "141"
@@ -325,9 +319,6 @@
           "__compat": {
             "description": "Object as parameter",
             "spec_url": "https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions",
-            "tags": [
-              "web-features:indexeddb"
-            ],
             "support": {
               "chrome": {
                 "version_added": "141"
@@ -359,9 +350,6 @@
             "__compat": {
               "description": "`direction` property",
               "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbgetalloptions-direction",
-              "tags": [
-                "web-features:indexeddb"
-              ],
               "support": {
                 "chrome": {
                   "version_added": "141"

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -215,6 +215,76 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "object_parameter": {
+          "__compat": {
+            "description": "Object as parameter",
+            "spec_url": "https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions",
+            "tags": [
+              "web-features:indexeddb"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "141"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "direction": {
+            "__compat": {
+              "description": "`direction` property",
+              "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbgetalloptions-direction",
+              "tags": [
+                "web-features:indexeddb"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "141"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
         }
       },
       "getAllKeys": {
@@ -250,6 +320,76 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "object_parameter": {
+          "__compat": {
+            "description": "Object as parameter",
+            "spec_url": "https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions",
+            "tags": [
+              "web-features:indexeddb"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "141"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "direction": {
+            "__compat": {
+              "description": "`direction` property",
+              "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbgetalloptions-direction",
+              "tags": [
+                "web-features:indexeddb"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "141"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
         }
       },
       "getAllRecords": {
@@ -260,9 +400,7 @@
               "version_added": "141"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -503,9 +503,6 @@
           "__compat": {
             "description": "Object as parameter",
             "spec_url": "https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions",
-            "tags": [
-              "web-features:indexeddb"
-            ],
             "support": {
               "chrome": {
                 "version_added": "141"
@@ -537,9 +534,6 @@
             "__compat": {
               "description": "`direction` property",
               "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbgetalloptions-direction",
-              "tags": [
-                "web-features:indexeddb"
-              ],
               "support": {
                 "chrome": {
                   "version_added": "141"
@@ -610,9 +604,6 @@
           "__compat": {
             "description": "Object as parameter",
             "spec_url": "https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions",
-            "tags": [
-              "web-features:indexeddb"
-            ],
             "support": {
               "chrome": {
                 "version_added": "141"
@@ -644,9 +635,6 @@
             "__compat": {
               "description": "`direction` property",
               "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbgetalloptions-direction",
-              "tags": [
-                "web-features:indexeddb"
-              ],
               "support": {
                 "chrome": {
                   "version_added": "141"

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -498,6 +498,76 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "object_parameter": {
+          "__compat": {
+            "description": "Object as parameter",
+            "spec_url": "https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions",
+            "tags": [
+              "web-features:indexeddb"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "141"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "direction": {
+            "__compat": {
+              "description": "`direction` property",
+              "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbgetalloptions-direction",
+              "tags": [
+                "web-features:indexeddb"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "141"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
         }
       },
       "getAllKeys": {
@@ -535,6 +605,76 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "object_parameter": {
+          "__compat": {
+            "description": "Object as parameter",
+            "spec_url": "https://w3c.github.io/IndexedDB/#dictdef-idbgetalloptions",
+            "tags": [
+              "web-features:indexeddb"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "141"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "direction": {
+            "__compat": {
+              "description": "`direction` property",
+              "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbgetalloptions-direction",
+              "tags": [
+                "web-features:indexeddb"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "141"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
         }
       },
       "getAllRecords": {
@@ -545,9 +685,7 @@
               "version_added": "141"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chromium 141 adds support for the following features in `IDBIndex` and `IDBObjectStore`:

1. The new `getAllRecords()` method.
2. The `direction` option in the `getAll()` and `getAllKeys()` methods.

See https://chromestatus.com/feature/5124331450138624, and also see https://patrickbrosset.com/articles/2024-11-19-even-faster-indexeddb-reads-with-getallrecords/ for the context behind the additions.

This PR:

- Updates the existing data points for `getAllRecords()` to mark Edge as mirroring Chrome. It was previously set to `false`, but I've confirmed that it works in tests, and I don't see why it would be enabled in a different version. I tested it using @captainbrosset's demo at https://microsoftedge.github.io/Demos/idb-getallrecords/.
- Adds data points for the `direction` option in `getAll()` and `getAllKeys()`. Note that, in each case, I've added a sub-data point for the whole concept of passing in the options as an object rather than separate parameters (this was not previously mentioned on MDN at all), then a sub-sub data point for `direction` itself.
  - I can't find any evidence that the former was added earlier than the latter, so I am assuming they happened at the same time.
  - I don't really want to add separate data points for the `count` and `query` properties, as I think it might give readers the impression that they weren't previously available at all, whereas actually they've been available as separate parameters for quite some time. Let me know if you disagree with this.


<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
