### PR TITLE
Chrome 140 unships `GPUAdapter.isFallbackAdapter`

### DIFF
--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -164,6 +164,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "version_removed": "140",
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `isFallbackAdapter` member of the `GPUAdapter` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.15.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/GPUAdapter/isFallbackAdapter
