### PR TITLE
Update Chromium data for SpeechRecognition API

### DIFF
--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -272,7 +272,7 @@
           "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-available",
           "support": {
             "chrome": {
-              "version_added": "142"
+              "version_added": "139"
             },
             "chrome_android": {
               "version_added": false
@@ -486,7 +486,7 @@
           "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-install",
           "support": {
             "chrome": {
-              "version_added": "142"
+              "version_added": "139"
             },
             "chrome_android": {
               "version_added": false
@@ -726,7 +726,7 @@
           "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-processlocally",
           "support": {
             "chrome": {
-              "version_added": "142"
+              "version_added": "139"
             },
             "chrome_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SpeechRecognition` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.15.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SpeechRecognition

Additional Notes: This effectively reverts the parts of #27901 that relate to on-device speech recognition.
