### PR TITLE
Firefox 144 adds `request-close` on `HTMLButtonElement.command`

### DIFF
--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -156,7 +156,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary

- Added version_added for `request-close` value of `command` attribute

#### Test results and supporting details

- Tested on [this code pen](https://codepen.io/CodeRedDigital/pen/NPxpvgY) on the following versions of Firefox:
  - Firefox 143.0.4 (only works with `dom.element.commandfor.enabled` set to `true`)
  - Firefox Beta 144.0b8
  - Firefox Developer Edition 144.0b9
  - Firefox Nightly 145.0a1

#### Related issues

- [MDN issue #41143](https://github.com/mdn/content/issues/41143)
- [Previous BCD PR](https://github.com/mdn/browser-compat-data/pull/27902)
- [Content PR](https://github.com/mdn/content/pull/41423)
- [Firefox Release PR](https://github.com/mdn/content/pull/41424)
