### PR TITLE
Firefox 144 ships View Transitions

### DIFF
--- a/css/at-rules/view-transition.json
+++ b/css/at-rules/view-transition.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "144",
               "impl_url": "https://bugzil.la/1860854"
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Updated the version in view transitions for firefox 

#### Test results and supporting details

* Can be seen here https://www.firefox.com/en-US/firefox/144.0beta/releasenotes/ and the RC build does have the flag enabled

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
