### PR TITLE
Safari 26 supports Trusted Types CSP (+ Firefox 144 behind flag)

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -874,7 +874,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1049,8 +1049,14 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1940493"
+                  "version_added": "144",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.trusted_types.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -1350,7 +1356,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Update Trusted Types CSP support data
This shipped in Safari 26, and Firefox also supports the new "trusted-types-eval" source expression

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
