### PR TITLE
Add Samsung Internet 29.0 Beta

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -306,6 +306,11 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "130"
+        },
+        "29.0": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "136"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Per https://www.apkmirror.com/apk/samsung-electronics-co-ltd/samsung-internet-beta/samsung-internet-browser-beta-29-0-0-27-release/#downloads, this beta came out August 7, 2025, but I don't think release dates for betas are listed. 

#### Test results and supporting details

After installing it on my Galaxy, per https://chromiumchecker.com/, it's Chromium 136. Unfortunately, as noted on https://forum.developer.samsung.com/t/why-has-there-not-been-a-samsung-internet-release-note-since-23-0-1-1/40856, there has not been a Samsung Internet release note since 23.0.1.1
