### PR TITLE
Chrome 141 adds `MediaStreamTrack` `restrictOwnAudio` constraint

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -607,6 +607,43 @@
             }
           }
         },
+        "restrictOwnAudio_constraint": {
+          "__compat": {
+            "description": "`restrictOwnAudio` constraint",
+            "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediatrackconstraintset-restrictownaudio",
+            "tags": [
+              "web-features:media-capture"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "141"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "sampleRate_constraint": {
           "__compat": {
             "description": "`sampleRate` constraint",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 141 (desktop only) adds support for the `restrictOwnAudio` screen capture constrainable property. See https://chromestatus.com/feature/5128140732760064.

This PR adds a data point for the new constraint.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
