### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance where possible

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Node

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          persist-credentials: false
           token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -30,7 +30,8 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GH_TOKEN }}
-          persist-credentials: false
+          # Need credentials to push the `release` branch.
+          persist-credentials: true
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout (BCD)
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Create release
         run: |

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -21,7 +21,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
-          persist-credentials: false
+          # Need credentials to push changes.
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          persist-credentials: false
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          persist-credentials: false
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/update-webdriver-bidi-data.yml
+++ b/.github/workflows/update-webdriver-bidi-data.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
  
Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
