### PR TITLE
Chrome 141 supports width and height attributes on nested <svg> elements

### DIFF
--- a/svg/elements/svg.json
+++ b/svg/elements/svg.json
@@ -126,6 +126,40 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "supported_on_nested_svg_elements": {
+            "__compat": {
+              "description": "`height` attribute supported on nested `<svg>` elements",
+              "tags": [
+                "web-features:svg"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "141"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "preserveAspectRatio": {
@@ -346,6 +380,40 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "supported_on_nested_svg_elements": {
+            "__compat": {
+              "description": "`width` attribute supported on nested `<svg>` elements",
+              "tags": [
+                "web-features:svg"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "141"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 141 adds support for `width` and `height` presentational attributes on nested [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) elements. See https://chromestatus.com/feature/5178789386256384.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
