### PR TITLE
Remove obsolete features (autoplay, browser_style)

### DIFF
--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -49,57 +49,6 @@
             "deprecated": false
           }
         },
-        "autoplay": {
-          "__compat": {
-            "spec_url": "https://html.spec.whatwg.org/multipage/media.html#attr-media-autoplay",
-            "tags": [
-              "web-features:audio"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "3",
-                "version_removed": "67"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": "3.5",
-                "version_removed": "67"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "9"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "10.5",
-                "version_removed": "53"
-              },
-              "opera_android": {
-                "version_added": "11",
-                "version_removed": "53"
-              },
-              "safari": {
-                "version_added": "3.1",
-                "version_removed": "17"
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "controls": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/media.html#attr-media-controls",

--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -23,29 +23,6 @@
             "safari_ios": "mirror"
           }
         },
-        "browser_style": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "109",
-                "version_removed": "118",
-                "notes": "See [Browser styles](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles) for more details."
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
-            }
-          }
-        },
         "default_area": {
           "__compat": {
             "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removes two obsolete features, removed from all browsers dating back two or more years ago:

- `html.elements.audio.autoplay`
- `webextensions.manifest.action.browser_style`

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
