### PR TITLE
Chromium 141 adds `NavigateEvent.intercept()` `precommitHandler` option

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -363,6 +363,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "precommitHandler_option": {
+          "__compat": {
+            "description": "`precommitHandler` option",
+            "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationinterceptoptions-precommithandler",
+            "tags": [
+              "web-features:navigation"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "141"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "navigationType": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chromium 141 adds support for the `precommitHandler` option of the [`NavigateEvent.intercept()`](https://developer.mozilla.org/en-US/docs/Web/API/NavigateEvent/intercept) method. See https://chromestatus.com/feature/5134734612496384.

This PR adds a data point for the new option.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
