### PR TITLE
ci(workflows): avoid `github.actor` in conditions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
           sync-labels: true
 
   label-by-size:
-    if: github.actor != 'dependabot[bot]' && !startsWith(github.event.pull_request.title, 'Release v')
+    if: github.secret_source == 'Actions' && !startsWith(github.event.pull_request.title, 'Release v')
     needs: label-py-path
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   manage-release-pr:
-    if: github.repository == 'mdn/browser-compat-data' && github.actor != 'dependabot[bot]' && !startsWith(github.event.head_commit.message, 'Release v')
+    if: github.repository == 'mdn/browser-compat-data' && github.secret_source == 'Actions' && !startsWith(github.event.head_commit.message, 'Release v')
     name: Manage release PR
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Replace `github.actor != 'dependabot[bot]'` with `github.secret_source == 'Actions'`.

#### Test results and supporting details

See: https://github.com/mdn/fred/issues/872#issuecomment-3397373527

#### Related issues

Part of https://github.com/mdn/fred/issues/872.