### PR TITLE
Unmark `::details-content` as partial in Safari

### DIFF
--- a/css/selectors/details-content.json
+++ b/css/selectors/details-content.json
@@ -24,9 +24,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "18.4",
-              "impl_url": "https://webkit.org/b/283446",
-              "partial_implementation": true,
-              "notes": "Does not support chaining pseudo-elements after `::details-content`."
+              "notes": "Does not support chaining pseudo-elements after `::details-content`. See [bug 283446](https://webkit.org/b/283446)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Unmarks `::details-content` as partial in Safari, because the limitation w.r.t. to chaining pseudo-elements (meanwhile fixed in Safari TP) does not have demonstrable negative impact on web developers.

#### Test results and supporting details

This was the conclusion in the BCD meeting on 2025-10-14, following prior discussion on 2025-09-30.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27995.