### PR TITLE
Firefox Android supports Global Privacy Control

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1797,7 +1797,8 @@
               "notes": "Opt-in to GPC using the Website Privacy Preference setting (`about:preferences#privacy`) checkbox 'Tell websites not to sell or share my data', or by setting the preference `privacy.globalprivacycontrol.enabled` to `true`."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "122",
+              "notes": "Opt-in to GPC using the Enhanced Tracking Protection toggle 'Tell web sites not to share & sell data', or by setting the preference `privacy.globalprivacycontrol.enabled` to `true`."
             },
             "nodejs": {
               "version_added": false

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -275,7 +275,8 @@
               "notes": "Opt-in to GPC by setting the preference `privacy.globalprivacycontrol.enabled` to `true`."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "122",
+              "notes": "Opt-in to GPC using the Enhanced Tracking Protection toggle 'Tell web sites not to share & sell data', or by setting the preference `privacy.globalprivacycontrol.enabled` to `true`."
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -19,7 +19,8 @@
               "notes": "Opt-in to GPC using the Website Privacy Preference setting (`about:preferences#privacy`) checkbox 'Tell websites not to sell or share my data', or by setting the preference `privacy.globalprivacycontrol.enabled` to `true`."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "122",
+              "notes": "Opt-in to GPC using the Enhanced Tracking Protection toggle 'Tell web sites not to share & sell data', or by setting the preference `privacy.globalprivacycontrol.enabled` to `true`."
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds support for Global Privacy Control (GPC) for Firefox for Android

#### Test results and supporting details

- Tested using https://global-privacy-control.vercel.app/ on Firefox for Android (screenshots to follow)
- https://hg-edge.mozilla.org/mozilla-central/rev/b11b486b43c871be5ab3268cb8bb84423342d792#l1.12 shows the feature was enabled in 122