### PR TITLE
Mark all WebGPU features as partial in Chrome

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -111,6 +113,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -166,6 +169,7 @@
             "support": {
               "chrome": {
                 "version_added": "115",
+                "partial_implementation": true,
                 "notes": "Currently supported on dual GPU macOS devices only."
               },
               "chrome_android": {
@@ -205,6 +209,7 @@
           "support": {
             "chrome": {
               "version_added": "115",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "127",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -165,6 +168,7 @@
             "chrome": {
               "version_added": "113",
               "version_removed": "140",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -210,6 +214,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -320,6 +325,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -374,7 +380,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "116"
+                "version_added": "116",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -426,6 +434,7 @@
             "support": {
               "chrome": {
                 "version_added": "133",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -111,6 +113,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -162,6 +165,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -248,6 +252,7 @@
           "support": {
             "chrome": {
               "version_added": "134",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
@@ -288,6 +293,7 @@
           "support": {
             "chrome": {
               "version_added": "134",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
@@ -328,6 +334,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -180,6 +183,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -237,6 +241,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -294,6 +299,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -351,6 +357,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -408,6 +415,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -465,6 +473,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -54,6 +55,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -99,6 +101,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": [
                 "Currently supported on ChromeOS, macOS, and Windows only.",
                 "The `rgba8unorm` format is currently not supported on macOS. See [bug 40823053](https://crbug.com/40823053)."
@@ -146,6 +149,7 @@
             "support": {
               "chrome": {
                 "version_added": "129",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
@@ -186,6 +190,7 @@
           "support": {
             "chrome": {
               "version_added": "131",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
@@ -229,6 +234,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -274,6 +280,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -122,6 +124,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -164,6 +167,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -220,6 +224,7 @@
             "support": {
               "chrome": {
                 "version_added": "125",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -260,6 +265,7 @@
             "support": {
               "chrome": {
                 "version_added": "123",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -301,6 +307,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -343,6 +350,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -400,6 +408,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -455,6 +464,7 @@
             "support": {
               "chrome": {
                 "version_added": "137",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -497,6 +507,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -554,6 +565,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -611,6 +623,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -668,6 +681,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -725,6 +739,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -782,6 +797,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -839,6 +855,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -896,6 +913,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -953,6 +971,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -54,6 +55,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -54,6 +55,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -99,6 +101,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -144,6 +147,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -189,6 +193,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -234,6 +239,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -279,6 +285,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -180,6 +183,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -237,6 +241,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -294,6 +299,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -351,6 +357,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -408,6 +415,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -465,6 +473,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -520,6 +529,7 @@
             "support": {
               "chrome": {
                 "version_added": "117",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -562,6 +572,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -614,6 +625,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -65,7 +66,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "132"
+              "version_added": "132",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -105,6 +108,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -160,6 +164,7 @@
             "support": {
               "chrome": {
                 "version_added": "137",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -202,6 +207,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -257,7 +263,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "124"
+                "version_added": "124",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -296,6 +304,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -338,6 +347,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -395,6 +405,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -452,6 +463,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -507,6 +519,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
@@ -547,6 +560,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -602,6 +616,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
@@ -642,6 +657,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -699,6 +715,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -755,6 +772,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -797,6 +815,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -854,6 +873,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -910,6 +930,7 @@
             "support": {
               "chrome": {
                 "version_added": "130",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -950,6 +971,7 @@
             "support": {
               "chrome": {
                 "version_added": "120",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -990,6 +1012,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
@@ -1029,6 +1052,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1069,6 +1093,7 @@
             "support": {
               "chrome": {
                 "version_added": "131",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
@@ -1108,6 +1133,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1150,6 +1176,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1206,6 +1233,7 @@
             "support": {
               "chrome": {
                 "version_added": "130",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1246,6 +1274,7 @@
             "support": {
               "chrome": {
                 "version_added": "120",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1286,6 +1315,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
@@ -1325,6 +1355,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1365,6 +1396,7 @@
             "support": {
               "chrome": {
                 "version_added": "131",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
@@ -1404,6 +1436,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1446,6 +1479,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1503,6 +1537,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1560,6 +1595,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1616,6 +1652,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1658,6 +1695,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1715,6 +1753,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1772,6 +1811,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1815,6 +1855,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1855,6 +1896,7 @@
             "support": {
               "chrome": {
                 "version_added": "116",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1899,6 +1941,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1956,6 +1999,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -2013,6 +2057,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -2070,6 +2115,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -2127,6 +2173,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -2184,6 +2231,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -2242,6 +2290,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -54,6 +55,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUInternalError.json
+++ b/api/GPUInternalError.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -55,6 +56,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -67,6 +68,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -55,6 +56,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -97,7 +99,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "113"
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -143,6 +147,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -180,6 +183,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -237,6 +241,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -293,6 +298,7 @@
             "support": {
               "chrome": {
                 "version_added": "121",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -120,7 +122,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "118"
+                "version_added": "118",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -159,7 +163,9 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "116"
+                "version_added": "116",
+                "partial_implementation": true,
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -213,6 +219,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -270,6 +277,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -327,6 +335,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -382,6 +391,7 @@
             "support": {
               "chrome": {
                 "version_added": "126",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
@@ -422,6 +432,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -479,6 +490,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPURenderBundle.json
+++ b/api/GPURenderBundle.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -180,6 +183,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -225,6 +229,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -282,6 +287,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -339,6 +345,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -396,6 +403,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -453,6 +461,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -510,6 +519,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -567,6 +577,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -622,6 +633,7 @@
             "support": {
               "chrome": {
                 "version_added": "117",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -664,6 +676,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -721,6 +734,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -778,6 +792,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -833,6 +848,7 @@
             "support": {
               "chrome": {
                 "version_added": "117",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -180,6 +183,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -237,6 +241,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -294,6 +299,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -351,6 +357,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -408,6 +415,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -465,6 +473,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -522,6 +531,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -579,6 +589,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -636,6 +647,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -693,6 +705,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -750,6 +763,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -805,6 +819,7 @@
             "support": {
               "chrome": {
                 "version_added": "117",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -847,6 +862,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -904,6 +920,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -961,6 +978,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1018,6 +1036,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1075,6 +1094,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1132,6 +1152,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1187,6 +1208,7 @@
             "support": {
               "chrome": {
                 "version_added": "117",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -1241,6 +1263,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1293,6 +1316,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -123,6 +125,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -111,6 +113,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -64,7 +65,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "113"
+              "version_added": "113",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -120,7 +123,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "113"
+              "version_added": "113",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -160,7 +165,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "131"
+              "version_added": "131",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "deno": {
@@ -199,7 +206,11 @@
           "support": {
             "chrome": {
               "version_added": "139",
-              "notes": "Currently available on all adapters and enabled automatically on all devices even if not requested."
+              "partial_implementation": true,
+              "notes": [
+                "Currently supported on ChromeOS, macOS, and Windows only.",
+                "Currently available on all adapters and enabled automatically on all devices even if not requested."
+              ]
             },
             "chrome_android": "mirror",
             "deno": {
@@ -241,7 +252,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "113"
+              "version_added": "113",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -281,7 +294,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "113"
+              "version_added": "113",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -321,7 +336,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "130"
+              "version_added": "130",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "deno": {
@@ -359,7 +376,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "132"
+              "version_added": "132",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "deno": {
@@ -397,7 +416,9 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "119"
+              "version_added": "119",
+              "partial_implementation": true,
+              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -167,6 +169,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -224,6 +227,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -281,6 +285,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -326,6 +331,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -371,6 +377,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -428,6 +435,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -485,6 +493,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -542,6 +551,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -599,6 +609,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -656,6 +667,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -713,6 +725,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -770,6 +783,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -879,6 +893,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -924,6 +939,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -981,6 +997,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1038,6 +1055,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1095,6 +1113,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1152,6 +1171,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1209,6 +1229,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1266,6 +1287,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1323,6 +1345,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1380,6 +1403,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1437,6 +1461,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1494,6 +1519,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1551,6 +1577,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1608,6 +1635,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1665,6 +1693,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1722,6 +1751,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -1779,6 +1809,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -122,6 +124,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -163,6 +166,7 @@
             "support": {
               "chrome": {
                 "version_added": "132",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -205,6 +209,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -262,6 +267,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -319,6 +325,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -376,6 +383,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -432,6 +440,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
@@ -474,6 +483,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -531,6 +541,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -588,6 +599,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -645,6 +657,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -702,6 +715,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -759,6 +773,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -66,6 +67,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -55,6 +56,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -100,6 +102,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "113",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -67,6 +68,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -745,6 +745,7 @@
             "support": {
               "chrome": {
                 "version_added": "113",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1830,6 +1830,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -369,6 +369,7 @@
             "support": {
               "chrome": {
                 "version_added": "113",
+                "partial_implementation": true,
                 "notes": "Currently supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -10,6 +10,7 @@
         "support": {
           "chrome": {
             "version_added": "115",
+            "partial_implementation": true,
             "notes": "Currently supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
@@ -48,6 +49,7 @@
           "support": {
             "chrome": {
               "version_added": "115",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -88,6 +90,7 @@
           "support": {
             "chrome": {
               "version_added": "123",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
@@ -124,6 +127,7 @@
           "support": {
             "chrome": {
               "version_added": "123",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
@@ -160,6 +164,7 @@
           "support": {
             "chrome": {
               "version_added": "124",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
@@ -196,6 +201,7 @@
           "support": {
             "chrome": {
               "version_added": "123",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
@@ -231,6 +237,7 @@
           "support": {
             "chrome": {
               "version_added": "115",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -270,6 +277,7 @@
           "support": {
             "chrome": {
               "version_added": "115",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -309,6 +317,7 @@
           "support": {
             "chrome": {
               "version_added": "115",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -348,6 +357,7 @@
           "support": {
             "chrome": {
               "version_added": "115",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -387,6 +397,7 @@
           "support": {
             "chrome": {
               "version_added": "115",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
@@ -427,6 +438,7 @@
           "support": {
             "chrome": {
               "version_added": "115",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -305,6 +305,7 @@
           "support": {
             "chrome": {
               "version_added": "113",
+              "partial_implementation": true,
               "notes": "Currently supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marks all WebGPU features as partial in Chrome, duplicating OS `notes` from parent features where necessary.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27942.