### PR TITLE
Remove "Currently " prefix from notes

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -911,7 +911,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "75",
-              "notes": "Currently only the getter is supported"
+              "notes": "Only the getter is supported"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -919,7 +919,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "13.1",
-              "notes": "Currently only the getter is supported"
+              "notes": "Only the getter is supported"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Cache.json
+++ b/api/Cache.json
@@ -183,7 +183,7 @@
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.26",
-              "notes": "Currently doesn't support query options"
+              "notes": "Doesn't support query options"
             },
             "edge": {
               "version_added": "16"
@@ -264,7 +264,7 @@
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.26",
-              "notes": "Currently doesn't support query options"
+              "notes": "Doesn't support query options"
             },
             "edge": {
               "version_added": "16"

--- a/api/GPU.json
+++ b/api/GPU.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -80,7 +80,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -114,7 +114,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -170,7 +170,7 @@
               "chrome": {
                 "version_added": "115",
                 "partial_implementation": true,
-                "notes": "Currently supported on dual GPU macOS devices only."
+                "notes": "Supported on dual GPU macOS devices only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -210,7 +210,7 @@
             "chrome": {
               "version_added": "115",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -222,7 +222,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "127",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "127"
@@ -135,7 +135,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -169,7 +169,7 @@
               "version_added": "113",
               "version_removed": "140",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -181,7 +181,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -215,7 +215,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -239,7 +239,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -292,7 +292,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -326,7 +326,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -350,7 +350,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -382,7 +382,7 @@
               "chrome": {
                 "version_added": "116",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -435,7 +435,7 @@
               "chrome": {
                 "version_added": "133",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "133"

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -80,7 +80,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -114,7 +114,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -132,7 +132,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -166,7 +166,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -184,7 +184,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -219,7 +219,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -253,14 +253,14 @@
             "chrome": {
               "version_added": "134",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -294,14 +294,14 @@
             "chrome": {
               "version_added": "134",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -335,7 +335,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -353,7 +353,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -150,7 +150,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -184,7 +184,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -208,7 +208,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -242,7 +242,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -266,7 +266,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -300,7 +300,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -324,7 +324,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -358,7 +358,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -382,7 +382,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -416,7 +416,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -440,7 +440,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -474,7 +474,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -498,7 +498,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -23,7 +23,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -68,7 +68,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -103,7 +103,7 @@
               "version_added": "113",
               "partial_implementation": true,
               "notes": [
-                "Currently supported on ChromeOS, macOS, and Windows only.",
+                "Supported on ChromeOS, macOS, and Windows only.",
                 "The `rgba8unorm` format is currently not supported on macOS. See [bug 40823053](https://crbug.com/40823053)."
               ]
             },
@@ -117,7 +117,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -150,7 +150,7 @@
               "chrome": {
                 "version_added": "129",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -191,7 +191,7 @@
             "chrome": {
               "version_added": "131",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "deno": {
@@ -201,7 +201,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -235,7 +235,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -247,7 +247,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -281,7 +281,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -293,7 +293,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -125,7 +125,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -168,7 +168,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -192,7 +192,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -225,7 +225,7 @@
               "chrome": {
                 "version_added": "125",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "125"
@@ -266,7 +266,7 @@
               "chrome": {
                 "version_added": "123",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "123"
@@ -308,7 +308,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -351,7 +351,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -375,7 +375,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -409,7 +409,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -433,7 +433,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -465,7 +465,7 @@
               "chrome": {
                 "version_added": "137",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "137"
@@ -508,7 +508,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -532,7 +532,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -566,7 +566,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -590,7 +590,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -624,7 +624,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -648,7 +648,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -682,7 +682,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -706,7 +706,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -740,7 +740,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -764,7 +764,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -798,7 +798,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -822,7 +822,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -856,7 +856,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -880,7 +880,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -914,7 +914,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -938,7 +938,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -972,7 +972,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -996,7 +996,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1049,7 +1049,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -23,7 +23,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -68,7 +68,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -23,7 +23,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -68,7 +68,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -102,7 +102,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -114,7 +114,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -148,7 +148,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -160,7 +160,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -194,7 +194,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -206,7 +206,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -240,7 +240,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -252,7 +252,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -286,7 +286,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -298,7 +298,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -150,7 +150,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -184,7 +184,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -208,7 +208,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -242,7 +242,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -266,7 +266,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -300,7 +300,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -324,7 +324,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -358,7 +358,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -382,7 +382,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -416,7 +416,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -440,7 +440,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -474,7 +474,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -498,7 +498,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -530,7 +530,7 @@
               "chrome": {
                 "version_added": "117",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -573,7 +573,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -597,7 +597,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -626,7 +626,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -150,7 +150,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,14 +68,14 @@
             "chrome": {
               "version_added": "132",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -109,7 +109,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -133,7 +133,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -165,7 +165,7 @@
               "chrome": {
                 "version_added": "137",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "137"
@@ -208,7 +208,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -232,7 +232,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -265,7 +265,7 @@
               "chrome": {
                 "version_added": "124",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -305,7 +305,7 @@
               "chrome": {
                 "version_added": "119",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -348,7 +348,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -372,7 +372,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -406,7 +406,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -430,7 +430,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -464,7 +464,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -488,7 +488,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -520,7 +520,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -561,7 +561,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -585,7 +585,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -617,7 +617,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -658,7 +658,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -682,7 +682,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -716,7 +716,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -740,7 +740,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -773,7 +773,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -816,7 +816,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -840,7 +840,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -874,7 +874,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -898,7 +898,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -931,7 +931,7 @@
               "chrome": {
                 "version_added": "130",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "130"
@@ -972,7 +972,7 @@
               "chrome": {
                 "version_added": "120",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1013,7 +1013,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -1053,7 +1053,7 @@
               "chrome": {
                 "version_added": "119",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1094,7 +1094,7 @@
               "chrome": {
                 "version_added": "131",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -1134,7 +1134,7 @@
               "chrome": {
                 "version_added": "119",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1177,7 +1177,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1201,7 +1201,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1234,7 +1234,7 @@
               "chrome": {
                 "version_added": "130",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "130"
@@ -1275,7 +1275,7 @@
               "chrome": {
                 "version_added": "120",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1316,7 +1316,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -1356,7 +1356,7 @@
               "chrome": {
                 "version_added": "119",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1397,7 +1397,7 @@
               "chrome": {
                 "version_added": "131",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -1437,7 +1437,7 @@
               "chrome": {
                 "version_added": "119",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1480,7 +1480,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1504,7 +1504,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1538,7 +1538,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1562,7 +1562,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1596,7 +1596,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1620,7 +1620,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1653,7 +1653,7 @@
               "chrome": {
                 "version_added": "119",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1696,7 +1696,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1720,7 +1720,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1754,7 +1754,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1778,7 +1778,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1812,7 +1812,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1824,7 +1824,7 @@
             "firefox": {
               "version_added": "144",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1856,7 +1856,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1897,7 +1897,7 @@
               "chrome": {
                 "version_added": "116",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1942,7 +1942,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1966,7 +1966,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -2000,7 +2000,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -2024,7 +2024,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -2058,7 +2058,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -2082,7 +2082,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -2116,7 +2116,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -2140,7 +2140,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -2174,7 +2174,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -2198,7 +2198,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -2232,7 +2232,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -2256,7 +2256,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -2291,7 +2291,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -2303,7 +2303,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -150,7 +150,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -23,7 +23,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -68,7 +68,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUInternalError.json
+++ b/api/GPUInternalError.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -23,7 +23,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -57,7 +57,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -69,7 +69,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -69,7 +69,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -93,7 +93,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -23,7 +23,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -57,7 +57,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -69,7 +69,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -101,7 +101,7 @@
               "chrome": {
                 "version_added": "113",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -113,7 +113,7 @@
               "firefox": {
                 "version_added": "141",
                 "partial_implementation": true,
-                "notes": "Currently supported on Windows only, in all contexts except for service workers."
+                "notes": "Supported on Windows only, in all contexts except for service workers."
               },
               "firefox_android": {
                 "version_added": false
@@ -148,7 +148,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -160,7 +160,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -150,7 +150,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -184,7 +184,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -208,7 +208,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -242,7 +242,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -266,7 +266,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -299,7 +299,7 @@
               "chrome": {
                 "version_added": "121",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -124,7 +124,7 @@
               "chrome": {
                 "version_added": "118",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -165,7 +165,7 @@
               "chrome": {
                 "version_added": "116",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -220,7 +220,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -244,7 +244,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -278,7 +278,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -302,7 +302,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -336,7 +336,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -360,7 +360,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -392,7 +392,7 @@
               "chrome": {
                 "version_added": "126",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": "mirror",
               "deno": {
@@ -433,7 +433,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -457,7 +457,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -491,7 +491,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -515,7 +515,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderBundle.json
+++ b/api/GPURenderBundle.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -150,7 +150,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -184,7 +184,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -196,7 +196,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -230,7 +230,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -254,7 +254,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -288,7 +288,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -312,7 +312,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -346,7 +346,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -370,7 +370,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -404,7 +404,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -428,7 +428,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -462,7 +462,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -486,7 +486,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -520,7 +520,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -544,7 +544,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -578,7 +578,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -602,7 +602,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -634,7 +634,7 @@
               "chrome": {
                 "version_added": "117",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -677,7 +677,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -701,7 +701,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -735,7 +735,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -759,7 +759,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -793,7 +793,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -817,7 +817,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -849,7 +849,7 @@
               "chrome": {
                 "version_added": "117",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -150,7 +150,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -184,7 +184,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -208,7 +208,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -242,7 +242,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -266,7 +266,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -300,7 +300,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -324,7 +324,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -358,7 +358,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -382,7 +382,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -416,7 +416,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -440,7 +440,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -474,7 +474,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -498,7 +498,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -532,7 +532,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -556,7 +556,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -590,7 +590,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -614,7 +614,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -648,7 +648,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -672,7 +672,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -706,7 +706,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -730,7 +730,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -764,7 +764,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -788,7 +788,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -820,7 +820,7 @@
               "chrome": {
                 "version_added": "117",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -863,7 +863,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -887,7 +887,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -921,7 +921,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -945,7 +945,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -979,7 +979,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1003,7 +1003,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1037,7 +1037,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1061,7 +1061,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1095,7 +1095,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1119,7 +1119,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1153,7 +1153,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1177,7 +1177,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1209,7 +1209,7 @@
               "chrome": {
                 "version_added": "117",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -1264,7 +1264,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1288,7 +1288,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1317,7 +1317,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -126,7 +126,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -150,7 +150,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -80,7 +80,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -114,7 +114,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -67,7 +67,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -91,7 +91,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -125,7 +125,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -167,7 +167,7 @@
             "chrome": {
               "version_added": "131",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "deno": {
@@ -208,8 +208,8 @@
               "version_added": "139",
               "partial_implementation": true,
               "notes": [
-                "Currently supported on ChromeOS, macOS, and Windows only.",
-                "Currently available on all adapters and enabled automatically on all devices even if not requested."
+                "Supported on ChromeOS, macOS, and Windows only.",
+                "Available on all adapters and enabled automatically on all devices even if not requested."
               ]
             },
             "chrome_android": "mirror",
@@ -220,7 +220,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -254,7 +254,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -296,7 +296,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -338,7 +338,7 @@
             "chrome": {
               "version_added": "130",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "deno": {
@@ -378,7 +378,7 @@
             "chrome": {
               "version_added": "132",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "deno": {
@@ -418,7 +418,7 @@
             "chrome": {
               "version_added": "119",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -666,7 +666,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -748,7 +748,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -881,7 +881,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -936,7 +936,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -991,7 +991,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1046,7 +1046,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1101,7 +1101,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1157,7 +1157,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -136,7 +136,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -170,7 +170,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -194,7 +194,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -228,7 +228,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -252,7 +252,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -286,7 +286,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -298,7 +298,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -332,7 +332,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -344,7 +344,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -378,7 +378,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -402,7 +402,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -436,7 +436,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -460,7 +460,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -494,7 +494,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -518,7 +518,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -552,7 +552,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -576,7 +576,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -610,7 +610,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -634,7 +634,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -668,7 +668,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -692,7 +692,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -726,7 +726,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -750,7 +750,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -784,7 +784,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -808,7 +808,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -894,7 +894,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -906,7 +906,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -940,7 +940,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -964,7 +964,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -998,7 +998,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1022,7 +1022,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1056,7 +1056,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1080,7 +1080,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1114,7 +1114,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1138,7 +1138,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1172,7 +1172,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1196,7 +1196,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1230,7 +1230,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1254,7 +1254,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1288,7 +1288,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1312,7 +1312,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1346,7 +1346,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1370,7 +1370,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1404,7 +1404,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1428,7 +1428,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1462,7 +1462,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1486,7 +1486,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1520,7 +1520,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1544,7 +1544,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1578,7 +1578,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1602,7 +1602,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1636,7 +1636,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1660,7 +1660,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1694,7 +1694,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1718,7 +1718,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1752,7 +1752,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1776,7 +1776,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -1810,7 +1810,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1834,7 +1834,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -125,7 +125,7 @@
               "chrome": {
                 "version_added": "119",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -167,7 +167,7 @@
               "chrome": {
                 "version_added": "132",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "132"
@@ -210,7 +210,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -234,7 +234,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -268,7 +268,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -292,7 +292,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -326,7 +326,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -350,7 +350,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -384,7 +384,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -408,7 +408,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -441,7 +441,7 @@
               "chrome": {
                 "version_added": "119",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -484,7 +484,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -508,7 +508,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -542,7 +542,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -566,7 +566,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -600,7 +600,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -624,7 +624,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -658,7 +658,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -682,7 +682,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -716,7 +716,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -740,7 +740,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -774,7 +774,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -798,7 +798,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -68,7 +68,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -92,7 +92,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -23,7 +23,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -57,7 +57,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -69,7 +69,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false
@@ -103,7 +103,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -115,7 +115,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "113",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -35,7 +35,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": {
             "version_added": false
@@ -69,7 +69,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -93,7 +93,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": {
               "version_added": false

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -212,7 +212,7 @@
             "chrome_android": {
               "version_added": "55",
               "version_removed": "80",
-              "notes": "Currently supported only by Google Daydream."
+              "notes": "Supported only by Google Daydream."
             },
             "edge": {
               "version_added": "15",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -746,7 +746,7 @@
               "chrome": {
                 "version_added": "113",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -755,7 +755,7 @@
               "firefox": {
                 "version_added": "141",
                 "partial_implementation": true,
-                "notes": "Currently supported on Windows only, in all contexts except for service workers."
+                "notes": "Supported on Windows only, in all contexts except for service workers."
               },
               "firefox_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1722,7 +1722,7 @@
             "chrome_android": {
               "version_added": "79",
               "version_removed": "80",
-              "notes": "Currently supported only by Google Daydream."
+              "notes": "Supported only by Google Daydream."
             },
             "edge": {
               "version_added": "15",
@@ -1831,7 +1831,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -1855,7 +1855,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only."
+              "notes": "Supported on Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -370,7 +370,7 @@
               "chrome": {
                 "version_added": "113",
                 "partial_implementation": true,
-                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+                "notes": "Supported on ChromeOS, macOS, and Windows only."
               },
               "chrome_android": {
                 "version_added": "121"
@@ -379,7 +379,7 @@
               "firefox": {
                 "version_added": "141",
                 "partial_implementation": true,
-                "notes": "Currently supported on Windows only, in all contexts except for service workers."
+                "notes": "Supported on Windows only, in all contexts except for service workers."
               },
               "firefox_android": {
                 "version_added": false

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -638,7 +638,7 @@
                     "value_to_set": "Enabled"
                   }
                 ],
-                "notes": "Currently doesn't work, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior (see [bug 487288](https://crbug.com/40417861#comment25))."
+                "notes": "Broken, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior (see [bug 487288](https://crbug.com/40417861#comment25))."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1772,7 +1772,7 @@
                     "value_to_set": "Enabled"
                   }
                 ],
-                "notes": "Currently doesn't work, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior (see [bug 487288](https://crbug.com/40417861#comment25))."
+                "notes": "Broken, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior (see [bug 487288](https://crbug.com/40417861#comment25))."
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -11,7 +11,7 @@
           "chrome": {
             "version_added": "115",
             "partial_implementation": true,
-            "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+            "notes": "Supported on ChromeOS, macOS, and Windows only."
           },
           "chrome_android": {
             "version_added": "121"
@@ -20,7 +20,7 @@
           "firefox": {
             "version_added": "141",
             "partial_implementation": true,
-            "notes": "Currently supported on Windows only, in all contexts except for service workers."
+            "notes": "Supported on Windows only, in all contexts except for service workers."
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -50,7 +50,7 @@
             "chrome": {
               "version_added": "115",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -59,7 +59,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -91,7 +91,7 @@
             "chrome": {
               "version_added": "123",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -128,7 +128,7 @@
             "chrome": {
               "version_added": "123",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -165,7 +165,7 @@
             "chrome": {
               "version_added": "124",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -202,7 +202,7 @@
             "chrome": {
               "version_added": "123",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -238,7 +238,7 @@
             "chrome": {
               "version_added": "115",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -247,7 +247,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -278,7 +278,7 @@
             "chrome": {
               "version_added": "115",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -287,7 +287,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -318,7 +318,7 @@
             "chrome": {
               "version_added": "115",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -327,7 +327,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -358,7 +358,7 @@
             "chrome": {
               "version_added": "115",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -367,7 +367,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -398,7 +398,7 @@
             "chrome": {
               "version_added": "115",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -407,7 +407,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -439,7 +439,7 @@
             "chrome": {
               "version_added": "115",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -448,7 +448,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -306,7 +306,7 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": {
               "version_added": "121"
@@ -330,7 +330,7 @@
             "firefox": {
               "version_added": "141",
               "partial_implementation": true,
-              "notes": "Currently supported on Windows only, in all contexts except for service workers."
+              "notes": "Supported on Windows only, in all contexts except for service workers."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -65,7 +65,7 @@
                 "firefox": {
                   "version_added": "143",
                   "partial_implementation": true,
-                  "notes": "Currently the value will always be converted to the hex format."
+                  "notes": "Value will always be converted to the hex format."
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removes the `Currently ` prefix from notes, as it does not provide any value.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
