### PR TITLE
Updates for Firefox 145 beta

### DIFF
--- a/api/RTCEncodedAudioFrame.json
+++ b/api/RTCEncodedAudioFrame.json
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "145"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCEncodedVideoFrame.json
+++ b/api/RTCEncodedVideoFrame.json
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "145"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/ToggleEvent.json
+++ b/api/ToggleEvent.json
@@ -154,7 +154,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "145"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -169,7 +169,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -673,15 +673,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "140",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.atomics_wait_async",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1467846"
+                "version_added": "145"
               },
               "firefox_android": "mirror",
               "nodejs": {


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.16.0 found new features shipping in Firefox 145 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 20 features as shipping in Firefox 145:

- api.ToggleEvent.source (https://bugzilla.mozilla.org/show_bug.cgi?id=1968987)
- javascript.builtins.Atomics.waitAsync (https://bugzilla.mozilla.org/show_bug.cgi?id=1884148)
- api.RTCEncodedAudioFrame.RTCEncodedAudioFrame (https://bugzilla.mozilla.org/show_bug.cgi?id=1975032)
- api.RTCEncodedVideoFrame.RTCEncodedVideoFrame (https://bugzilla.mozilla.org/show_bug.cgi?id=1975032)

Updated in other PRs:

- api.CSSStyleRule.style.returns_CSSStyleProperties
- api.HTMLElement.style.returns_CSSStyleProperties
- api.MathMLElement.style.returns_CSSStyleProperties
- api.SVGElement.style.returns_CSSStyleProperties
- api.Window.getComputedStyle.returns_CSSStyleProperties
- webdriver.bidi.browsingContext.downloadEnd_event
- webdriver.bidi.browsingContext.downloadEnd_event.context_parameter
- webdriver.bidi.browsingContext.downloadEnd_event.filepath_parameter
- webdriver.bidi.browsingContext.downloadEnd_event.navigation_parameter
- webdriver.bidi.browsingContext.downloadEnd_event.status_parameter
- webdriver.bidi.browsingContext.downloadEnd_event.timestamp_parameter
- webdriver.bidi.browsingContext.downloadEnd_event.url_parameter
- webdriver.bidi.emulation.setUserAgentOverride
- webdriver.bidi.emulation.setUserAgentOverride.contexts_parameter
- webdriver.bidi.emulation.setUserAgentOverride.userAgent_parameter
- webdriver.bidi.emulation.setUserAgentOverride.userContexts_parameter

See also https://github.com/mdn/mdn/issues/735 and https://www.mozilla.org/en-US/firefox/145.0beta/releasenotes/

Notes:

- I also see Trusted Types working, but in https://bugzilla.mozilla.org/show_bug.cgi?id=1992941 it says early beta, so I'm not marking it for release for now.