### PR TITLE
Chromium 142 adds WebGPU `primitive-index` feature

### DIFF
--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -491,7 +491,7 @@
       },
       "feature_primitive-index": {
         "__compat": {
-          "description": "`indirect-primitive-index` feature",
+          "description": "`primitive-index` feature",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpufeaturename-primitive-index",
           "tags": [
             "web-features:webgpu"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 142 adds support for the WebGPU [`primitive-index`](https://gpuweb.github.io/gpuweb/#dom-gpufeaturename-primitive-index) feature. See https://chromestatus.com/feature/6467722716250112.

This PR adds a data point for the new feature.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
