### PR TITLE
Chromium 135 allows `null` values for WebGPU `BindGroupLayouts`

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -704,7 +704,7 @@
             "deprecated": false
           }
         },
-        "descriptor_bindGroupLayouts_accepts_null_values": {
+        "descriptor_bindGroupLayouts_parameter_accepts_null_values": {
           "__compat": {
             "description": "`bindGroupLayouts` array accepts `null` values.",
             "tags": [


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

[`GPUDevice.createPipelineLayout`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createPipelineLayout) now supports `null` entries in the `bindGroupLayouts` array. See https://developer.chrome.com/blog/new-in-webgpu-135#allow_creating_pipeline_layout_with_null_bind_group_layout for details.

This PR adds a data point for this new feature.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
