### PR TITLE
Chrome 138 size requirement changes for GPUBuffers mapped at creation

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -348,7 +348,10 @@
             "chrome": {
               "version_added": "113",
               "partial_implementation": true,
-              "notes": "Supported on ChromeOS, macOS, and Windows only."
+              "notes": [
+                "Supported on ChromeOS, macOS, and Windows only.",
+                "Before version 138, this method does not throw a `RangeError` exception when `mappedAtCreation` is true but `size` is not a multiple of 4; it generates a validation error instead."
+              ]
             },
             "chrome_android": {
               "version_added": "121"
@@ -392,47 +395,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "throws_RangeError_if_mappedAtCreation_and_size_not_multiple_of_4": {
-          "__compat": {
-            "description": "`RangeError` thrown if `mappedAtCreation` is `true` and `size` is not a multiple of `4`.",
-            "tags": [
-              "web-features:webgpu"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "138",
-                "partial_implementation": true,
-                "notes": "Supported on ChromeOS, macOS, and Windows only."
-              },
-              "chrome_android": {
-                "version_added": "138"
-              },
-              "deno": {
-                "version_added": false
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In Chrome 138, the size requirements for `GPUBuffer`s mapped at creation have changed. During a [`GPUDevice.createBuffer()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createBuffer) call, if `mappedAtCreation` is set `true` and `size` is not a multiple of `4`, a `RangeError` exception is thrown.

See https://developer.chrome.com/blog/new-in-webgpu-138#size_requirement_changes_for_buffers_mapped_at_creation.

This PR adds a data point for the change.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
