### PR TITLE
Chrome 138 pass GPUBuffer directly as binding resource

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -198,7 +198,7 @@
         },
         "descriptor_entries_resource_parameter_accepts_GPUTextureView": {
           "__compat": {
-            "description": "Bind `GPUTextureView` (2D, single subresource) in place of a `GPUExternalTexture`.",
+            "description": "`descriptor.entries.resource` parameter accepts `GPUTextureView` (2D, single subresource) in place of `GPUExternalTexture`.",
             "tags": [
               "web-features:webgpu"
             ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 138 adds the ability for a `GPUBuffer` to be passed directly into a [`GPUDevice.createBindGroup()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createBindGroup) call as a binding resource in place of a `GPUBufferBinding` object, provided the default `size` and `offset` values are being used.

See https://developer.chrome.com/blog/new-in-webgpu-138#shorthand_for_using_buffer_as_a_binding_resource.

This PR adds a data point for the new feature.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
