### PR TITLE
Bug 1988988 support for masque in `proxy` API

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -89,7 +89,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "60",
-                  "notes": "Support for MASQUE proxies added in Firefox 145."
+                  "notes": "Support for the \"masque\" type was added in Firefox 145."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
#### Summary

Adds details about the support of masque proxy in the `proxy` API in support of [Bug 1988988](https://bugzilla.mozilla.org/show_bug.cgi?id=1988988) Add extension API support for masque proxy.

#### Related issues

Related content changes in https://github.com/mdn/content/pull/41563