### PR TITLE
Firefox 135 adds `Idempotency-Key` HTTP header behind pref

### DIFF
--- a/http/headers/Idempotency-Key.json
+++ b/http/headers/Idempotency-Key.json
@@ -3,7 +3,7 @@
     "headers": {
       "Idempotency-Key": {
         "__compat": {
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header/",
+          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header/#name-the-idempotency-key-http-re",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
FF135 added support  for the `Idempotency-Key` header in https://bugzilla.mozilla.org/show_bug.cgi?id=1830022 behind the preference `network.http.idempotencyKey.enabled`.

There was an attempt to ship in 145 in  https://bugzilla.mozilla.org/show_bug.cgi?id=1991641 but this has been withdrawn

This has a spec https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/ but adding it results in an error. 

1. Can you remind me how to get an exception?

The key is sent in requests to indicate that a POST/PATCH is a particular unique command. If the server gets the same request with the same key it ignores it. 
As specified the server defines the requirements for the key, which would be expected therefore to be unknown to the browser, and set by Javascript.
As such you wouldn't expect a browser integration, and hence no BCD entry.

However FF automatically attaches a key if one is not attached. This is non standard. But it does mean that the browser **does something**, so there is an integration and compatibility story.

Related docs work can be tracked in https://github.com/mdn/content/issues/41497
