### PR TITLE
Mark WebGPU feature as partial in Chrome

### DIFF
--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -499,6 +499,8 @@
           "support": {
             "chrome": {
               "version_added": "142"
+              "partial_implementation": true,
+              "notes": "Supported on ChromeOS, macOS, and Windows only."
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marks a newly added WebGPU features as partial in Chrome, duplicating OS `notes` from the parent feature.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Follow-up of https://github.com/mdn/browser-compat-data/pull/28206.

See also:

- https://github.com/mdn/browser-compat-data/pull/28184