### PR TITLE
Unmark `CredentialsContainer` `prf` extension as partial in Safari

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -628,9 +628,7 @@
                   "opera": "mirror",
                   "opera_android": "mirror",
                   "safari": {
-                    "version_added": "18",
-                    "partial_implementation": true,
-                    "notes": "Only supported on macOS."
+                    "version_added": "18"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes the Safari support for the `CredentialsContainer` `prf` extension, assuming it was accidentally marked as partial.

#### Test results and supporting details

Safari is only available on macOS.

#### Related issues

Originally introduced in https://github.com/mdn/browser-compat-data/pull/27586.
