### PR TITLE
Add version_removed for theme-color for Safari

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -539,7 +539,8 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "15"
+                  "version_added": "15",
+                  "version_removed": "26"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Added version_removed to the theme-color metadata tag for Safari 26

#### Test results and supporting details

See https://caniuse.com/?search=theme-color