### PR TITLE
Chrome 94 added `keyboard-inset-*` CSS env variables

### DIFF
--- a/css/types/env.json
+++ b/css/types/env.json
@@ -46,8 +46,8 @@
         "keyboard-inset-bottom": {
           "__compat": {
             "description": "Keyboard inset variable `keyboard-inset-bottom`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env",
-            "spec_url": "https://w3c.github.io/virtual-keyboard/#keyboard-inset-variables",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env#keyboard-inset-top",
+            "spec_url": "https://w3c.github.io/virtual-keyboard/#dfn-keyboard-inset-bottom",
             "tags": [
               "web-features:virtual-keyboard"
             ],
@@ -82,8 +82,8 @@
         "keyboard-inset-height": {
           "__compat": {
             "description": "Keyboard inset variable `keyboard-inset-height`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env",
-            "spec_url": "https://w3c.github.io/virtual-keyboard/#keyboard-inset-variables",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env#keyboard-inset-top",
+            "spec_url": "https://w3c.github.io/virtual-keyboard/#dfn-keyboard-inset-height",
             "tags": [
               "web-features:virtual-keyboard"
             ],
@@ -118,8 +118,8 @@
         "keyboard-inset-left": {
           "__compat": {
             "description": "Keyboard inset variable `keyboard-inset-left`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env",
-            "spec_url": "https://w3c.github.io/virtual-keyboard/#keyboard-inset-variables",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env#keyboard-inset-top",
+            "spec_url": "https://w3c.github.io/virtual-keyboard/#dfn-keyboard-inset-left",
             "tags": [
               "web-features:virtual-keyboard"
             ],
@@ -154,8 +154,8 @@
         "keyboard-inset-right": {
           "__compat": {
             "description": "inset variable `keyboard-inset-right`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env",
-            "spec_url": "https://w3c.github.io/virtual-keyboard/#keyboard-inset-variables",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env#keyboard-inset-top",
+            "spec_url": "https://w3c.github.io/virtual-keyboard/#dfn-keyboard-inset-right",
             "tags": [
               "web-features:virtual-keyboard"
             ],
@@ -190,8 +190,8 @@
         "keyboard-inset-top": {
           "__compat": {
             "description": "inset variable `keyboard-inset-top`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env",
-            "spec_url": "https://w3c.github.io/virtual-keyboard/#keyboard-inset-variables",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env#keyboard-inset-top",
+            "spec_url": "https://w3c.github.io/virtual-keyboard/#dfn-keyboard-inset-top",
             "tags": [
               "web-features:virtual-keyboard"
             ],
@@ -226,8 +226,8 @@
         "keyboard-inset-width": {
           "__compat": {
             "description": "Keyboard inset variable `keyboard-inset-width`",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env",
-            "spec_url": "https://w3c.github.io/virtual-keyboard/#keyboard-inset-variables",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/env#keyboard-inset-top",
+            "spec_url": "https://w3c.github.io/virtual-keyboard/#dfn-keyboard-inset-width",
             "tags": [
               "web-features:virtual-keyboard"
             ],


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/23922

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add keyboard-inset-* variables that are defined in Virtual Keyboard API (https://w3c.github.io/virtual-keyboard/#keyboard-inset-variables).

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Chrome 94. Google has published about this as https://developer.chrome.com/docs/web-platform/virtual-keyboard.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
