### PR TITLE
Firefox 145 ships `Integrity-Policy` support for scripts

### DIFF
--- a/http/headers/Integrity-Policy-Report-Only.json
+++ b/http/headers/Integrity-Policy-Report-Only.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "145",
               "partial_implementation": true,
               "notes": "Reporting `endpoints` are ignored (violations are logged to console)."
             },
@@ -29,7 +29,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -45,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "145"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -60,7 +60,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/http/headers/Integrity-Policy.json
+++ b/http/headers/Integrity-Policy.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "145",
               "partial_implementation": true,
               "notes": "Reporting `endpoints` are ignored (violations are logged to console)."
             },
@@ -29,7 +29,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -45,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "145"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -60,7 +60,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF145 supports the `Integrity-Policy` for scripts in https://bugzilla.mozilla.org/show_bug.cgi?id=1984973 (note, not for styles, and implementation is partial because reporting doesn't work except via console).

This updates the features from preview that were previously updated in #27587. Note this did not get picked up in #28199

Related docs work can be tracked in https://github.com/mdn/content/issues/41511