### PR TITLE
Add `RTCEncoded{Audio,Video}Frame` metadata support data

### DIFF
--- a/api/RTCEncodedAudioFrame.json
+++ b/api/RTCEncodedAudioFrame.json
@@ -229,10 +229,74 @@
             }
           }
         },
+        "options_metadata_receiveTime_parameter": {
+          "__compat": {
+            "description": "`options.metadata.receiveTime` parameter",
+            "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedframemetadata-receivetime",
+            "support": {
+              "chrome": {
+                "version_added": "127"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "options_metadata_rtpTimestamp_parameter": {
           "__compat": {
             "description": "`options.metadata.rtpTimestamp` parameter",
             "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedframemetadata-rtptimestamp",
+            "support": {
+              "chrome": {
+                "version_added": "127"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "145"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_metadata_sequenceNumber_parameter": {
+          "__compat": {
+            "description": "`options.metadata.sequenceNumber` parameter",
+            "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframemetadata-sequencenumber",
             "support": {
               "chrome": {
                 "version_added": "127"
@@ -526,10 +590,74 @@
             }
           }
         },
+        "return_object_property_receiveTime": {
+          "__compat": {
+            "description": "`receiveTime` property in returned object",
+            "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedframemetadata-receivetime",
+            "support": {
+              "chrome": {
+                "version_added": "127"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "return_object_property_rtpTimestamp": {
           "__compat": {
             "description": "`rtpTimestamp` property in returned object",
             "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedframemetadata-rtptimestamp",
+            "support": {
+              "chrome": {
+                "version_added": "127"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "145"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "return_object_property_sequenceNumber": {
+          "__compat": {
+            "description": "`sequenceNumber` property in returned object",
+            "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframemetadata-sequencenumber",
             "support": {
               "chrome": {
                 "version_added": "127"

--- a/api/RTCEncodedVideoFrame.json
+++ b/api/RTCEncodedVideoFrame.json
@@ -261,6 +261,38 @@
             }
           }
         },
+        "options_metadata_receiveTime_parameter": {
+          "__compat": {
+            "description": "`options.metadata.receiveTime` parameter",
+            "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedframemetadata-receivetime",
+            "support": {
+              "chrome": {
+                "version_added": "127"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "options_metadata_rtpTimestamp_parameter": {
           "__compat": {
             "description": "`options.metadata.rtpTimestamp` parameter",
@@ -670,6 +702,38 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "return_object_property_receiveTime": {
+          "__compat": {
+            "description": "`receiveTime` property in returned object",
+            "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedframemetadata-receivetime",
+            "support": {
+              "chrome": {
+                "version_added": "127"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
FF145 makes `RTCEncodedAudioFrame` and `RTCEncodeVideoFrame` get constructors in https://bugzilla.mozilla.org/show_bug.cgi?id=1975032

These include an `options.metadata` property that contains the same kind of object as returned by `getMetadata()`.
This adds the subfeatures for both cases which duplicate each other.

The results are based on test https://jsfiddle.net/jib1/5t1mehn4/ from https://bugzilla.mozilla.org/show_bug.cgi?id=1975032#c7 along with version support for the whole thing went into Safari (26 - https://webkit.org/blog/17333/webkit-features-in-safari-26-0/). 
The test worked for Chrome, but not in browserstack. Therefore I have assumed that except for audioLevel the properties were added in first release of the constructor.

Note that the last commit adds sequenceNumber and recieveTime. I cannot see these in the test above, but was able to observed them in WPT tests by debugging. https://github.com/mdn/browser-compat-data/pull/28242/commits/68f2acd5e373c411df4cfea2cad744e655d39f67 

Related docs work can be tracked in https://github.com/mdn/content/issues/41508