### PR TITLE
Correct `windowAudio` default for Chrome and Edge

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -473,7 +473,7 @@
                 "version_added": "141",
                 "partial_implementation": true,
                 "notes": [
-                  "Defaults to `\"exclude\"`. Before Chrome 142 it defaulted to `\"system\"`.",
+                  "Defaults to `\"system\"`.",
                   "Only supports values `\"exclude\"` and `\"system\"`, not `\"window\"`."
                 ]
               },
@@ -485,7 +485,7 @@
                 "version_removed": "143",
                 "partial_implementation": true,
                 "notes": [
-                  "Defaults to `\"system\"`. Before Chrome 143 it defaulted to `\"exclude\"`.",
+                  "Defaults to `\"system\"`. Before Edge 142, it defaulted to `\"exclude\"`.",
                   "Only supports values `\"exclude\"` and `\"system\"`, not `\"window\"`."
                 ]
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As per https://github.com/mdn/browser-compat-data/pull/28130#issuecomment-3421572401, I managed to get the data on windowAudio option default values wrong. This PR aims to correct the data.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
