### PR TITLE
Update Firefox version_added for math-shift property

### DIFF
--- a/css/properties/math-shift.json
+++ b/css/properties/math-shift.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION

#### Summary

Firefox now supports compact-shift  since 144 version see : https://www.firefox.com/en-US/firefox/144.0/releasenotes/

#### Test results and supporting details

have not tested the changes, change from boolean to string, should be fine

