### PR TITLE
Firefox 145 ships CSS `text-autospace` property

### DIFF
--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -253,10 +253,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "145",
-                "impl_url": "https://bugzil.la/1986500",
-                "partial_implementation": true,
-                "notes": "Passes parsing, but has no effect."
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1986500"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -290,10 +288,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "145",
-                "impl_url": "https://bugzil.la/1980111",
-                "partial_implementation": true,
-                "notes": "Passes parsing, but has no effect."
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1980111"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
### Description

The CSS `text-autospace` property is enabled in Fx by default in 145.

I'm setting the prop as supported in 145, with partial support for the following:

- `text-autospace: punctuation`
- `text-autospace: replace`

These pass parsing but don't do anything, as far as I see.

## Bugzilla

- `text-autospace` property https://bugzilla.mozilla.org/show_bug.cgi?id=1869577
  - [tree view](https://bugzilla.mozilla.org/showdependencytree.cgi?id=1869577&hide_resolved=1)

## Related issues and pull requests

- [ ] Parent https://github.com/mdn/content/issues/41501
- [x] Relnote https://github.com/mdn/content/pull/41633

