### PR TITLE
Firefox 145 adds CSS `{height,width}: -webkit-fill-available`

### DIFF
--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -316,7 +316,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "145",
                 "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -392,8 +392,9 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "alternative_name": "-moz-available",
-                "version_added": "3"
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "145",
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
### Description

The CSS `-webkit-fill-available` keyword is enabled in Fx by default in 145. It can be used like:

```css
height: -webkit-fill-available;
width: -webkit-fill-available;
```

It's been added back to Fx for backwards-compatibility reasons. 

#### Test results and supporting details

- https://wpt.fyi/results/css/css-sizing/stretch?label=master&product=firefox%5Bexperimental%5D&product=firefox%5Bstable%5D&aligned&q=stretch-alias-
- https://bugzilla.mozilla.org/show_bug.cgi?id=1988938

#### Related issues

- [ ] Parent https://github.com/mdn/content/issues/41502