### PR TITLE
Bug 1954524 data collection permissions key in manifest

### DIFF
--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -87,27 +87,6 @@
               },
               "safari_ios": "mirror"
             }
-          },
-          "data_collection_permissions": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "142"
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
           }
         },
         "safari": {


### PR DESCRIPTION
#### Summary

Add details of the `data_collection_permissions` property of `gecko` to the `browser_specific_settings` manifest key. This feature was implemented in [Bug 1954524](https://bugzilla.mozilla.org/show_bug.cgi?id=1954524) Add support for data collection permissions in the manifest.

#### Related issues

Fixes #28211

Related MDM documentation included in PR TBC