### PR TITLE
Firefox Nightly adds CSS module scripts

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1756,7 +1756,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.module-scripts.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "impl_url": "https://bugzil.la/1720570"
                 },
                 "firefox_android": "mirror",


### PR DESCRIPTION
FF145 supports CSS module scripts and the [import attribute `type: "css"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with) in https://bugzilla.mozilla.org/show_bug.cgi?id=1720570

The support is only in preview, and is disabled by default. So I have put both preview and the preference in the issue.

Related docs work can be tracked in https://github.com/mdn/content/issues/41503