### PR TITLE
Firefox 145 ships `font-family: math`

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -63,7 +63,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "145"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -78,7 +78,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
### Description

CSS `font-family: math` is enabled in Fx by default in 145.

#### Test results and supporting details

- https://bugzilla.mozilla.org/show_bug.cgi?id=1788937

#### Related issues

- [ ] Parent https://github.com/mdn/content/issues/41506