### PR TITLE
Add Level 5 spec for CSS `@supports`

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -6,6 +6,7 @@
           "description": "`@supports`",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@supports",
           "spec_url": [
+            "https://drafts.csswg.org/css-conditional-5/#at-supports-ext",
             "https://drafts.csswg.org/css-conditional-4/#at-supports-ext",
             "https://drafts.csswg.org/css-conditional-3/#at-supports"
           ],


### PR DESCRIPTION
#### Summary

Adds CSS L5 spec for `@supports` that includes `tech()` and `font-format()`

#### Test results and supporting details

Since `tech()` and `font-format()` are not featured in L3 and L4 specs.

#### Related issues

Initially [reported on Mastodon](https://mastodon.scot/@svgeesus/115441401362386127) by @svgeesus