### PR TITLE
Firefox Nightly enabled Trusted Types

### DIFF
--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -145,14 +145,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/Document.json
+++ b/api/Document.json
@@ -5983,14 +5983,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8981,14 +8974,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "133",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -9108,14 +9094,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "133",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -6068,14 +6068,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -6321,14 +6314,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -7361,14 +7347,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -10360,14 +10339,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -1210,14 +1210,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -463,14 +463,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -764,14 +757,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -888,14 +874,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -974,14 +953,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/Range.json
+++ b/api/Range.json
@@ -525,14 +525,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -152,14 +152,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "136",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -421,14 +421,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "136",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -538,14 +538,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -844,14 +837,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/TrustedTypePolicyFactory.json
+++ b/api/TrustedTypePolicyFactory.json
@@ -14,15 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "133",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.security.trusted_types.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "impl_url": "https://bugzil.la/1508286"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -196,14 +188,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "133",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -238,14 +223,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "133",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -226,14 +226,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "136",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -122,14 +122,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -122,14 +122,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "135",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.trusted_types.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/_globals/trustedTypes.json
+++ b/api/_globals/trustedTypes.json
@@ -14,15 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "135",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.security.trusted_types.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "impl_url": "https://bugzil.la/1508286"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -860,14 +860,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "135",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "145"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -1049,14 +1042,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "144",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.trusted_types.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -1340,14 +1326,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "138",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.trusted_types.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF145 enables the `dom.security.trusted_types.enabled` preference in nightly in  https://bugzilla.mozilla.org/show_bug.cgi?id=1992941

This updates all the existing features that have the preference to say preview. There might be some more things to discover but this should be the bulk of it.

The relevant list is:

Document
- [`Document.parseHTMLUnsafe()`](https://developer.mozilla.org/docs/Web/API/Document/parseHTMLUnsafe_static)
- [`Document.write()`](https://developer.mozilla.org/docs/Web/API/Document/write)
- [`Document.writeln()`](https://developer.mozilla.org/docs/Web/API/Document/writeln)

DOMPArser
- [`DOMParser.parseFromString()`](https://developer.mozilla.org/docs/Web/API/DOMParser/parseFromString)

Element
- [`Element.setHTMLUnsafe()`](https://developer.mozilla.org/docs/Web/API/Element/setHTMLUnsafe)
- [`Element.outerHTML`](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
- [`Element.insertAdjacentHTML()`](https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentHTML)
- [`Element.innerHTML`](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)

HTMLIFrameElement
- [`HTMLIFrameElement.srcdoc`](https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/srcdoc)

HTMLScriptElement
- [`HTMLScriptElement.textContent`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/textContent)
- [`HTMLScriptElement.text`](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/text)
- [`HTMLScriptElement.src`](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/src)
- [`HTMLScriptElement.innerText`](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/innerText)

Range
- [`Range.createContextualFragment()`](https://developer.mozilla.org/docs/Web/API/Range/createContextualFragment)

ServiceWorkerContainer
- [`ServiceWorkerContainer.register()`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/register)

ShadowRoot
- [`ShadowRoot.setHTMLUnsafe()`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/setHTMLUnsafe)
- [`ShadowRoot.innerHTML`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/innerHTML)

SVGAnimatedString
- [`SVGAnimatedString.baseVal`](https://developer.mozilla.org/docs/Web/API/SVGAnimatedString/baseVal)

[`TrustedTypePolicyFactory`](https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory)
- [`TrustedTypePolicyFactory.getPropertyType`](https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/getPropertyType)
- [`TrustedTypePolicyFactory.getAttributeType()`](https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/getAttributeType)

WorkerGlobalScope
- [`WorkerGlobalScope.importScripts`](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/importScripts)
- [`Window.setInterval()` code param](https://developer.mozilla.org/docs/Web/API/Window/setInterval)
- [`Window.setTimeout()` code param`](https://developer.mozilla.org/docs/Web/API/Window/setTimeout)

trustedTypes
- [`Window.trustedTypes`](https://developer.mozilla.org/docs/Web/API/Window/trustedTypes)

Content-Security-Policy
- [`CSP: trusted-types`](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/trusted-types)
- [`CSP: trusted-types-eval`](??) https://w3c.github.io/webappsec-csp/#grammardef-trusted-types-eval - needs docs
- [`CSP: require-trusted-types-for`](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for)


Related docs work can be tracked in https://github.com/mdn/content/issues/41507