### PR TITLE
Sync experimental status once

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -128,7 +128,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": false,
               "deprecated": false
             }

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -128,7 +128,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": false,
               "deprecated": false
             }

--- a/api/Document.json
+++ b/api/Document.json
@@ -1145,7 +1145,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -5150,7 +5150,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -7271,7 +7271,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -7309,7 +7309,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7348,7 +7348,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7387,7 +7387,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7426,7 +7426,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7465,7 +7465,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7504,7 +7504,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7543,7 +7543,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7582,7 +7582,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7621,7 +7621,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7660,7 +7660,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7699,7 +7699,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7738,7 +7738,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -7777,7 +7777,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/api/Element.json
+++ b/api/Element.json
@@ -9512,7 +9512,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1128,7 +1128,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/PaintRenderingContext2D.json
+++ b/api/PaintRenderingContext2D.json
@@ -623,7 +623,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -266,7 +266,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -57,7 +57,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -126,7 +126,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -168,7 +168,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -214,7 +214,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -260,7 +260,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -341,7 +341,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -387,7 +387,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -433,7 +433,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -475,7 +475,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -552,7 +552,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -594,7 +594,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -636,7 +636,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -682,7 +682,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -796,7 +796,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -842,7 +842,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -888,7 +888,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -934,7 +934,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -980,7 +980,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -1022,7 +1022,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -1105,7 +1105,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -1147,7 +1147,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/StorageAccessHandle.json
+++ b/api/StorageAccessHandle.json
@@ -33,7 +33,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -71,7 +71,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -110,7 +110,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -149,7 +149,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -188,7 +188,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -227,7 +227,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -266,7 +266,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -305,7 +305,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -344,7 +344,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -383,7 +383,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -422,7 +422,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -461,7 +461,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -390,7 +390,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/XRHand.json
+++ b/api/XRHand.json
@@ -35,7 +35,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/XRInputSource.json
+++ b/api/XRInputSource.json
@@ -154,7 +154,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/XRJointPose.json
+++ b/api/XRJointPose.json
@@ -35,7 +35,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -75,7 +75,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/XRJointSpace.json
+++ b/api/XRJointSpace.json
@@ -35,7 +35,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -75,7 +75,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -133,7 +133,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/color-interpolation.json
+++ b/css/properties/color-interpolation.json
@@ -63,7 +63,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -337,7 +337,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/mask-border-outset.json
+++ b/css/properties/mask-border-outset.json
@@ -38,7 +38,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/mask-border-repeat.json
+++ b/css/properties/mask-border-repeat.json
@@ -38,7 +38,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/mask-border-slice.json
+++ b/css/properties/mask-border-slice.json
@@ -38,7 +38,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/mask-border-source.json
+++ b/css/properties/mask-border-source.json
@@ -38,7 +38,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/mask-border-width.json
+++ b/css/properties/mask-border-width.json
@@ -38,7 +38,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/mask-border.json
+++ b/css/properties/mask-border.json
@@ -38,7 +38,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -356,7 +356,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -377,7 +377,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -358,7 +358,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -389,7 +389,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/position-area.json
+++ b/css/properties/position-area.json
@@ -675,7 +675,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -722,7 +722,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -769,7 +769,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -816,7 +816,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1386,7 +1386,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1429,7 +1429,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1472,7 +1472,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -1515,7 +1515,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/ruby-overhang.json
+++ b/css/properties/ruby-overhang.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -63,7 +63,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -97,7 +97,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/timeline-scope.json
+++ b/css/properties/timeline-scope.json
@@ -66,7 +66,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -413,7 +413,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/first-letter.json
+++ b/css/selectors/first-letter.json
@@ -157,7 +157,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -123,7 +123,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/h1.json
+++ b/html/elements/h1.json
@@ -70,7 +70,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1070,7 +1070,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -798,7 +798,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -1173,7 +1173,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -770,7 +770,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -2971,7 +2971,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/webdriver/classic/CreateVirtualPressureSource.json
+++ b/webdriver/classic/CreateVirtualPressureSource.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/webdriver/classic/CreateVirtualSensor.json
+++ b/webdriver/classic/CreateVirtualSensor.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/webdriver/classic/DeleteVirtualPressureSource.json
+++ b/webdriver/classic/DeleteVirtualPressureSource.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/webdriver/classic/DeleteVirtualSensor.json
+++ b/webdriver/classic/DeleteVirtualSensor.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/webdriver/classic/GetVirtualSensorInformation.json
+++ b/webdriver/classic/GetVirtualSensorInformation.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/webdriver/classic/UpdateVirtualPressureSource.json
+++ b/webdriver/classic/UpdateVirtualPressureSource.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/webdriver/classic/UpdateVirtualSensorReading.json
+++ b/webdriver/classic/UpdateVirtualSensorReading.json
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Sets `experimental: true` once for all single engine implementation less than 2 years old.

#### Test results and supporting details

Ran `npm run fix` in https://github.com/mdn/browser-compat-data/pull/28188:

- `api.Document.caretPositionFromPoint.options_parameter`
   only **Blink** for less than 2 years (since 2024-08-20)
- `api.Document.hasUnpartitionedCookieAccess`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_all_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_BroadcastChannel_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_caches_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_cookies_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_createObjectURL_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_estimate_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_getDirectory_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_indexedDB_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_localStorage_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_locks_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_revokeObjectURL_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_sessionStorage_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Document.requestStorageAccess.types_parameter.types_SharedWorker_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.Element.scrollIntoView.options_parameter.container_option`
   only **Blink** for less than 2 years (since 2025-09-02)
- `api.GPUCommandEncoder.writeTimestamp`
   only **Gecko** for less than 2 years (since 2025-07-22)
- `api.HTMLElement.command_event`
   only **Blink** for less than 2 years (since 2025-04-01)
- `api.HTMLImageElement.sizes.auto`
   only **Blink** for less than 2 years (since 2024-06-11)
- `api.PaintRenderingContext2D.imageSmoothingQuality`
   only **Blink** for less than 2 years (since 2025-03-04)
- `api.SharedWorker.SharedWorker.options_sameSiteCookies_parameter`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.SpeechGrammarList`
   only **Blink** for less than 2 years (since 2025-08-05)
- `api.SpeechGrammarList.SpeechGrammarList`
   only **Blink** for less than 2 years (since 2025-08-05)
- `api.SpeechRecognition`
   only **Blink** for less than 2 years (since 2025-08-05)
- `api.SpeechRecognition.SpeechRecognition`
   only **Blink** for less than 2 years (since 2025-08-05)
- `api.StorageAccessHandle`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.BroadcastChannel`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.SharedWorker`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.caches`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.createObjectURL`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.estimate`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.getDirectory`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.indexedDB`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.localStorage`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.locks`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.revokeObjectURL`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.StorageAccessHandle.sessionStorage`
   only **Blink** for less than 2 years (since 2024-05-14)
- `api.VisualViewport.scrollend_event`
   only **Blink** for less than 2 years (since 2024-06-11)
- `api.XRHand`
   only **Blink** for less than 2 years (since 2024-11-12)
- `api.XRInputSource.hand`
   only **Blink** for less than 2 years (since 2024-11-12)
- `api.XRJointPose`
   only **Blink** for less than 2 years (since 2024-11-12)
- `api.XRJointPose.radius`
   only **Blink** for less than 2 years (since 2024-11-12)
- `api.XRJointSpace`
   only **Blink** for less than 2 years (since 2024-11-12)
- `api.XRJointSpace.jointName`
   only **Blink** for less than 2 years (since 2024-11-12)
- `css.properties.background-clip.border-area`
   only **WebKit** for less than 2 years (since 2024-12-11)
- `css.properties.color-interpolation.linearGradient`
   only **Gecko** for less than 2 years (since 2024-02-20)
- `css.properties.height.stretch`
   only **Blink** for less than 2 years (since 2025-06-24)
- `css.properties.mask-border-outset`
   only **WebKit** for less than 2 years (since 2023-12-11)
- `css.properties.mask-border-repeat`
   only **WebKit** for less than 2 years (since 2023-12-11)
- `css.properties.mask-border-slice`
   only **WebKit** for less than 2 years (since 2023-12-11)
- `css.properties.mask-border-source`
   only **WebKit** for less than 2 years (since 2023-12-11)
- `css.properties.mask-border-width`
   only **WebKit** for less than 2 years (since 2023-12-11)
- `css.properties.mask-border`
   only **WebKit** for less than 2 years (since 2023-12-11)
- `css.properties.max-height.stretch`
   only **Blink** for less than 2 years (since 2025-06-24)
- `css.properties.max-width.stretch`
   only **Blink** for less than 2 years (since 2025-06-24)
- `css.properties.min-height.stretch`
   only **Blink** for less than 2 years (since 2025-06-24)
- `css.properties.min-width.stretch`
   only **Blink** for less than 2 years (since 2025-06-24)
- `css.properties.ruby-overhang`
   only **WebKit** for less than 2 years (since 2024-12-11)
- `css.properties.ruby-overhang.auto`
   only **WebKit** for less than 2 years (since 2024-12-11)
- `css.properties.ruby-overhang.none`
   only **WebKit** for less than 2 years (since 2024-12-11)
- `css.properties.timeline-scope.all`
   only **WebKit** for less than 2 years (since 2025-09-15)
- `css.properties.width.stretch`
   only **Blink** for less than 2 years (since 2025-06-24)
- `css.selectors.first-letter.svg_text_element`
   only **Gecko** for less than 2 years (since 2024-03-19)
- `css.selectors.first-line.svg_text_element`
   only **Gecko** for less than 2 years (since 2024-03-19)
- `html.elements.button.command`
   only **Blink** for less than 2 years (since 2025-04-01)
- `html.elements.button.command.request-close`
   only **Blink** for less than 2 years (since 2025-08-05)
- `html.elements.button.commandfor`
   only **Blink** for less than 2 years (since 2025-04-01)
- `html.elements.h1.no_ua_styles_in_article_aside_nav_section`
   only **Gecko** for less than 2 years (since 2025-06-24)
- `html.elements.iframe.allow.publickey-credentials-create`
   only **Gecko** for less than 2 years (since 2024-02-20)
- `html.elements.img.sizes.auto`
   only **Blink** for less than 2 years (since 2024-06-11)
- `http.headers.Feature-Policy.compute-pressure`
   only **Blink** for less than 2 years (since 2024-05-14)
- `http.headers.Feature-Policy.deferred-fetch`
   only **Blink** for less than 2 years (since 2025-04-01)
- `http.headers.Feature-Policy.deferred-fetch-minimal`
   only **Blink** for less than 2 years (since 2025-04-01)
- `javascript.builtins.Intl.Locale.variants`
   only **Gecko** for less than 2 years (since 2025-07-22)
- `svg.global_attributes.color-interpolation.linearGradient`
   only **Gecko** for less than 2 years (since 2024-02-20)
- `svg.global_attributes.transform.svg_root`
   only **Blink** for less than 2 years (since 2025-05-27)
- `webdriver.classic.CreateVirtualPressureSource`
   only **Blink** for less than 2 years (since 2024-09-17)
- `webdriver.classic.CreateVirtualSensor`
   only **Blink** for less than 2 years (since 2023-12-05)
- `webdriver.classic.DeleteVirtualPressureSource`
   only **Blink** for less than 2 years (since 2024-09-17)
- `webdriver.classic.DeleteVirtualSensor`
   only **Blink** for less than 2 years (since 2023-12-05)
- `webdriver.classic.GetVirtualSensorInformation`
   only **Blink** for less than 2 years (since 2023-12-05)
- `webdriver.classic.UpdateVirtualPressureSource`
   only **Blink** for less than 2 years (since 2024-09-17)
- `webdriver.classic.UpdateVirtualSensorReading`
   only **Blink** for less than 2 years (since 2023-12-05)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
