### PR TITLE
Firefox 145 text-decoration-trim

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -324,42 +324,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "User-Agent_reduction": {
-          "__compat": {
-            "description": "Provides limited information due to [User-agent](https://developer.mozilla.org/docs/Web/HTTP/Guides/User-agent_reduction) reduction.",
-            "spec_url": "https://compat.spec.whatwg.org/#ua-string-section",
-            "support": {
-              "chrome": {
-                "version_added": "110"
-              },
-              "chrome_android": {
-                "version_added": "113"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              },
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "audioSession": {
@@ -3006,42 +2970,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "User-Agent_reduction": {
-          "__compat": {
-            "description": "Provides limited/generic information due to [User-agent](https://developer.mozilla.org/docs/Web/HTTP/Guides/User-agent_reduction) reduction.",
-            "spec_url": "https://compat.spec.whatwg.org/#ua-string-section",
-            "support": {
-              "chrome": {
-                "version_added": "110"
-              },
-              "chrome_android": {
-                "version_added": "113"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              },
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "plugins": {
@@ -5558,42 +5486,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "User-Agent_reduction": {
-          "__compat": {
-            "description": "Provides limited information due to [User-agent](https://developer.mozilla.org/docs/Web/HTTP/Guides/User-agent_reduction) reduction.",
-            "spec_url": "https://compat.spec.whatwg.org/#ua-string-section",
-            "support": {
-              "chrome": {
-                "version_added": "110"
-              },
-              "chrome_android": {
-                "version_added": "113"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              },
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },

--- a/http/headers/User-Agent.json
+++ b/http/headers/User-Agent.json
@@ -39,42 +39,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "User-Agent_reduction": {
-          "__compat": {
-            "description": "Provides limited information due to [User-agent](https://developer.mozilla.org/docs/Web/HTTP/Guides/User-agent_reduction) reduction.",
-            "spec_url": "https://compat.spec.whatwg.org/#ua-string-section",
-            "support": {
-              "chrome": {
-                "version_added": "110"
-              },
-              "chrome_android": {
-                "version_added": "113"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              },
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 145 adds support for the CSS [`text-decoration-trim`](https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-trim) property (see https://bugzilla.mozilla.org/show_bug.cgi?id=1979915#c21), although it is currently behind a flag (verified by testing; see https://codepen.io/Chris-Mills/pen/XJXBpmp for a test case).

This PR adds a data point for this new property.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
