### PR TITLE
Remove obsolete `html.elements.input.mozactionhint`

### DIFF
--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -950,38 +950,6 @@
             }
           }
         },
-        "mozactionhint": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/input#non-standard_attributes",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "4",
-                "version_removed": "119"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "multiple": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Attributes/multiple",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removes the obsolete `html.elements.input.mozactionhint` feature.

#### Test results and supporting details

Reported by the linter:

```
Obsolete - 1 problem (0 errors, 1 warning):
 ✖ html.elements.input.mozactionhint - Warning → feature was implemented and has since been removed from all browsers dating back two or more years ago.
```

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
