### PR TITLE
fix(schemas): allow spec URLs without fragment

### DIFF
--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -187,7 +187,7 @@
     "spec_url_value": {
       "type": "string",
       "format": "uri",
-      "pattern": "(^https://[^#]+#.+)|(^https://github.com/WebAssembly/.+)|(^https://registry.khronos.org/webgl/extensions/[^/]+/)"
+      "pattern": "(^https://[^#]+(#.+)?$)|(^https://github.com/WebAssembly/.+)|(^https://registry.khronos.org/webgl/extensions/[^/]+/)"
     },
 
     "impl_url_value": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes the `spec_url_value` pattern in the compat data schema to allow spec URLs without a fragment.

#### Test results and supporting details

See failing check: https://github.com/mdn/browser-compat-data/actions/runs/18875856784/job/53865336337?pr=28219#step:5:33

```
JSON Schema - 3 problems (3 errors, 0 warnings):
 ✖ http/headers/Idempotency-Key.json - Error → PATTERN must match pattern "(^https://[^#]+#.+)|(^https://github.com/WebAssembly/.+)|(^[https://registry.khronos.org/webgl/extensions/[^/]+/)](https://registry.khronos.org/webgl/extensions/[%5E/]+/))"

  4 |       "Idempotency-Key": {
  5 |         "__compat": {
> 6 |           "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header/",
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 👈🏽  pattern must match pattern "(^https://[^#]+#.+)|(^https://github.com/WebAssembly/.+)|(^[https://registry.khronos.org/webgl/extensions/[^/]+/)](https://registry.khronos.org/webgl/extensions/[%5E/]+/))"
  7 |           "support": {
  8 |             "chrome": {
  9 |               "version_added": false
 ✖ http/headers/Idempotency-Key.json - Error → TYPE must be array
```

#### Related issues

Blocks https://github.com/mdn/browser-compat-data/pull/28219.