### PR TITLE
chore(npm): migrate to Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ env:
 
 permissions:
   contents: write
+  id-token: write # OIDC for npm Trusted Publishing
   issues: write
 
 jobs:
@@ -62,9 +63,7 @@ jobs:
 
       - run: npm run build
 
-      - run: npm publish build/ --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish build/ --access public --provenance
 
       - name: Add JSON as a release asset
         run: gh release upload ${GITHUB_REF#refs/*/} build/data.json


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Migrates the `release` workflow from token-based to [Trusted publishing](https://docs.npmjs.com/trusted-publishers).

Note: Trusted publishing has already been configured on npmjs.com.

### Motivation

> Trusted publishing eliminates long-lived tokens entirely by using temporary, job-specific credentials from your CI/CD provider.

### Additional details

See: https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/#looking-ahead-trusted-publishers

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1018.
