### PR TITLE
Chrome hasn't shipped `:has-slotted`

### DIFF
--- a/css/selectors/has-slotted.json
+++ b/css/selectors/has-slotted.json
@@ -11,7 +11,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "134"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

Chrome doesn't support `:has-slotted`

#### Test results and supporting details

Chrome tried to ship it in the past and marked the milestone as 134.
But it keeps delaying over and over again.

For now, it doesn't have an exact milestone value (see activity in the feature).

[Feature status](https://chromestatus.com/feature/5134941143433216)
[Tracking bug](https://issues.chromium.org/issues/369883705) (in progress for now)

#### Related issues

This reverts part of #25866

----

What's more, suggest not to include the beta status of features.
It may be modified in the future.