### PR TITLE
Safari fully supports global `autocorrect` HTML attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -137,12 +137,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1",
-              "partial_implementation": true,
-              "notes": [
-                "Takes values of `true`/`false` (instead of `on`/`off`).",
-                "Allowed on `<input type='password'>` elements."
-              ]
+              "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Correct Safari support data for autocorrect

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

From what I can see Safari *never* operated on the true or false string values for this attribute.

It *did* at one point "work" on input type password (and url and email), but I'm not sure that's bad enough to count as partial?

This is fixed as of latest version (fixed by https://github.com/WebKit/WebKit/commit/28a8a4b35f3332e595d58745699986a271dcd941) idk what version it was fixed in and I think for what people care about Safari has had support for a while?

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes #24972
