### PR TITLE
Updates for Chrome 143 beta

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -225,6 +225,37 @@
           }
         }
       },
+      "contentEncoding": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-contentencoding",
+          "support": {
+            "chrome": {
+              "version_added": "143"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "contentType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/contentType",

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -918,6 +918,37 @@
           }
         }
       },
+      "protocol": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-protocol",
+          "support": {
+            "chrome": {
+              "version_added": "143"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ready": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/ready",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1974,24 +1974,42 @@
             "web-features:gamepad"
           ],
           "support": {
-            "chrome": {
-              "version_added": "35",
-              "partial_implementation": true,
-              "notes": "The `ongamepadconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
-            },
-            "chrome_android": {
-              "version_added": "37",
-              "partial_implementation": true,
-              "notes": "The `ongamepadconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
-            },
+            "chrome": [
+              {
+                "version_added": "143"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "143",
+                "partial_implementation": true,
+                "notes": "The `ongamepadconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "143"
+              },
+              {
+                "version_added": "37",
+                "version_removed": "143",
+                "partial_implementation": true,
+                "notes": "The `ongamepadconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
+              }
+            ],
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "≤18",
-              "partial_implementation": true,
-              "notes": "The `ongamepadconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
-            },
+            "edge": [
+              {
+                "version_added": "143"
+              },
+              {
+                "version_added": "≤18",
+                "version_removed": "143",
+                "partial_implementation": true,
+                "notes": "The `ongamepadconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
+              }
+            ],
             "firefox": [
               {
                 "version_added": "89"
@@ -2049,24 +2067,42 @@
             "web-features:gamepad"
           ],
           "support": {
-            "chrome": {
-              "version_added": "35",
-              "partial_implementation": true,
-              "notes": "The `ongamepaddisconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
-            },
-            "chrome_android": {
-              "version_added": "37",
-              "partial_implementation": true,
-              "notes": "The `ongamepaddisconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
-            },
+            "chrome": [
+              {
+                "version_added": "143"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "143",
+                "partial_implementation": true,
+                "notes": "The `ongamepaddisconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "143"
+              },
+              {
+                "version_added": "37",
+                "version_removed": "143",
+                "partial_implementation": true,
+                "notes": "The `ongamepaddisconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
+              }
+            ],
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "≤18",
-              "partial_implementation": true,
-              "notes": "The `ongamepaddisconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
-            },
+            "edge": [
+              {
+                "version_added": "143"
+              },
+              {
+                "version_added": "≤18",
+                "version_removed": "143",
+                "partial_implementation": true,
+                "notes": "The `ongamepaddisconnected` event handler property is not supported. See [bug 40175074](https://crbug.com/40175074)."
+              }
+            ],
             "firefox": [
               {
                 "version_added": "89"

--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "143"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -28,7 +28,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/150081"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -39,6 +40,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "normal": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "143"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/150081"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -44,6 +44,7 @@
         },
         "normal": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-fonts-4/#font-language-override-normal-value",
             "support": {
               "chrome": {
                 "version_added": "143"


### PR DESCRIPTION
The @openwebdocs [BCD collector project](https://github.com/openwebdocs/mdn-bcd-collector) v10.16.0 found new features shipping in Chrome 143 beta which was released this week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment/isolated contexts, it is not considered here.

With this PR, BCD considers the following 28 features as shipping in Chrome 143:

- api.PerformanceResourceTiming.contentEncoding 
- api.WebTransport.protocol
- api.Window.gamepadconnected_event
- api.Window.gamepaddisconnected_event
- css.properties.font-language-override
- css.properties.font-language-override.normal

Marked for Chrome 143 in other PRs:

- css.properties.position-area.self-x-end
- css.properties.position-area.self-x-end (as x-self-end)
- css.properties.position-area.self-x-start
- css.properties.position-area.self-x-start (as x-self-start)
- css.properties.position-area.self-y-end
- css.properties.position-area.self-y-end (as y-self-end)
- css.properties.position-area.self-y-start
- css.properties.position-area.self-y-start (as y-self-start)
- css.properties.position-area.span-self-x-end
- css.properties.position-area.span-self-x-end (as span-x-self-end)
- css.properties.position-area.span-self-x-start
- css.properties.position-area.span-self-x-start (as span-x-self-start)
- css.properties.position-area.span-self-y-end
- css.properties.position-area.span-self-y-end (as span-y-self-end)
- css.properties.position-area.span-self-y-start
- css.properties.position-area.span-self-y-start (as span-y-self-start)
- webdriver.bidi.emulation.setNetworkConditions
- webdriver.bidi.emulation.setNetworkConditions.contexts_parameter
- webdriver.bidi.emulation.setNetworkConditions.networkConditions_parameter
- webdriver.bidi.emulation.setNetworkConditions.networkConditions_parameter.offline
- webdriver.bidi.emulation.setNetworkConditions.userContexts_parameter
- webdriver.bidi.permission.setPermission.embeddedOrigin_parameter

Notes:

- Chromestatus mentioned the Web Smart Card API for Isolated Web Apps (IWA). I think we don't document IWA on MDN and in BCD. Even if we decide to add IWA features, the collector is currently not able to collect them: https://github.com/openwebdocs/mdn-bcd-collector/issues/1905

See also the 143 "Enabled by default" column on https://chromestatus.com/roadmap and https://developer.chrome.com/blog/chrome-143-beta