### PR TITLE
ci(CODEOWNERS): add Engineering for config/scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,18 @@
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 /schemas/ @mdn/bcd-owners
-/.github/workflows/ @mdn/engineering
-/.github/CODEOWNERS @mdn/engineering
+
+/.github/ @mdn/engineering
+/.vscode/ @mdn/engineering
+/lint/    @mdn/engineering
+/scripts/ @mdn/engineering
+/types/   @mdn/engineering
+/utils/   @mdn/engineering
+/*        @mdn/engineering
+/package.json      @mdn/engineering @mdn-bot
+/package-lock.json @mdn/engineering @mdn-bot
+
+# Exclude some paths
+/.github/ISSUE_TEMPLATE/
+/.github/PULL_REQUESET_TEMPLATE.md
+/*.md


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds the MDN Engineering team as code owner for scripts, and config files.

#### Test results and supporting details

Ensures that the MDN Engineering team reviews changes to these files.

#### Related issues

Part of https://github.com/mdn/fred/issues/872.