### PR TITLE
Firefox 146 supports `-webkit-fill-available` as keyword for CSS height & width props

### DIFF
--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -317,7 +317,7 @@
               "edge": "mirror",
               "firefox": {
                 "alternative_name": "-webkit-fill-available",
-                "version_added": "145",
+                "version_added": "146",
                 "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -393,7 +393,7 @@
               "edge": "mirror",
               "firefox": {
                 "alternative_name": "-webkit-fill-available",
-                "version_added": "145",
+                "version_added": "146",
                 "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",


### PR DESCRIPTION
### Description

This has been pushed back to 146, see https://bugzilla.mozilla.org/show_bug.cgi?id=1988938#c21

Follow-up from:

- [x] https://github.com/mdn/browser-compat-data/pull/28267

#### Related issues

- [ ] Parent https://github.com/mdn/content/issues/41502