### PR TITLE
ci(CODEOWNERS): allow releasers to approve releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,8 +14,8 @@
 /types/   @mdn/engineering
 /utils/   @mdn/engineering
 /*        @mdn/engineering
-/package.json      @mdn/engineering @mdn-bot
-/package-lock.json @mdn/engineering @mdn-bot
+/package.json      @mdn/engineering @mdn-bot @mdn/bcd-releasers
+/package-lock.json @mdn/engineering @mdn-bot @mdn/bcd-releasers
 
 # Exclude some paths
 /.github/ISSUE_TEMPLATE/


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds the `@mdn/bcd-releasers` team as code owner for `package.json` and `package-lock.json`, so that they can approve release PRs.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Follow-up of https://github.com/mdn/browser-compat-data/pull/28339.