### PR TITLE
Undeprecate the `unload` event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -7518,6 +7518,7 @@
       },
       "viewport": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/viewport",
           "spec_url": "https://drafts.csswg.org/css-viewport/#dom-window-viewport",
           "tags": [
             "web-features:viewport-segments"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`unload` is marked as deprecated, but it doesn't satisfy [the guidelines](https://github.com/mdn/browser-compat-data/tree/main/docs/data-guidelines#setting-deprecated).

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

- https://github.com/mdn/browser-compat-data/pull/21480 set the value in the first place, on the basis of **Chrome's deprecation**, not the spec.
- https://github.com/whatwg/html/issues/6026 is still open, where the question of `unload` deprecation does not have consensus, much less specification text.
- https://github.com/mozilla/standards-positions/issues/691#issuecomment-2621173371 seems to indicate that the effort to deprecate this event has been abandoned (closed without a position being given by Mozilla or WebKit).
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Given the evidence here, I think it's much too early to mark this event deprecated.

#### Related issues

n/a 

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
