### PR TITLE
Add Safari bug for DOM `moveBefore` API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5753,7 +5753,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/281223"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -326,7 +326,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/281223"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -7184,7 +7184,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/281223"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Add WebKit implementation ticket link for `Document.moveBefore`, `DocumentFragment.moveBefore`, and `Element.moveBefore`.

#### Test results and supporting details

It looks to me there is a single WebKit bug to track implementation of `moveBefore` across `Document`, `DocumentFragment`, and `Element`: https://webkit.org/b/281223

This is my first time contributing to this repo, so please let me know if there are any issues with the PR format, content, etc. I tried to format this change to be similar to #28056. Thanks!

#### Related issues

n/a