### PR TITLE
ci(workflows): rename `node.js` to `test`, run in merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Renames the `node.js` workflow to `test`, and additionally runs `on: merge_group`.

#### Test results and supporting details

Motivation:

1. The new workflow name (`test`) makes it consistent with other repos, allows it to be identified by tools such as [OSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#ci-tests).
2. Using a merge group (not yet enabled) ensures that the tests passes on `main`, even if a PR was behind by several commits.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
