### PR TITLE
Chrome 143 / Safari 26.2 treat `&` as `:where(:scope)` in `@scope` blocks

### DIFF
--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -60,22 +60,19 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "143",
-                "impl_url": "https://crbug.com/445949406"
+                "version_added": "143"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "142",
-                "impl_url": "https://bugzil.la/1975531"
+                "version_added": "142"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "26.2",
-                "impl_url": "https://webkit.org/b/299017"
+                "version_added": "26.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This is a follow-up update to #27723.

- Chrome 143: https://chromiumdash.appspot.com/commit/f26938c66838eed1937746d942c7eec1a9d08ba0
- Safari TP 229([Safari 26.2](https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#:~:text=Fixed%20the%20behavior%20of%20the%20nesting%20selector%20%26%20directly%20inside%20%40scope%20to%20correctly%20act%20like%20%3Awhere(%3Ascope)%20for%20proper%20specificity%20handling.)): https://webkit.org/blog/17447/release-notes-for-safari-technology-preview-229/#:~:text=correctly%20act%20like-,%3Awhere(%3Ascope),-for%20proper%20specificity