### PR TITLE
Add `block_context` for `justify-self` and `justify-items`

### DIFF
--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -79,6 +79,41 @@
             }
           }
         },
+        "block_context": {
+          "__compat": {
+            "description": "Supported in Block Layout",
+            "spec_url": [
+              "https://drafts.csswg.org/css-align/#justify-items-property",
+              "https://drafts.csswg.org/css-align/#justify-block"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -110,6 +110,38 @@
             }
           }
         },
+        "block_context": {
+          "__compat": {
+            "description": "Supported in Block Layout",
+            "spec_url": "https://drafts.csswg.org/css-align/#justify-block",
+            "support": {
+              "chrome": {
+                "version_added": "130"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add behavioral subfeatures for `justify-self` and `justify-items` support in block layouts

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I used test cases derived from https://github.com/web-platform-dx/web-features/issues/3497#issuecomment-3489900255:

- https://codepen.io/ddbeck/pen/EaPzjMv
- https://codepen.io/ddbeck/pen/RNrmPEe

I tested them in various versions of Chrome on Windows in Browser Stack until I found the initial version number (comments in the [Chromium bug 40310972](https://issues.chromium.org/issues/40310972) were a little bit misleading about when it shipped).

On the basis of [WPT](https://wpt.fyi/results/css/css-align/blocks?label=experimental&label=master&aligned&q=justify-self%7Cjustify-items) and Patrick's suggestion that this is Chromium only, I presumed these to be unsupported on the other browsers (also, it didn't work in Firefox beta).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28379

Towards https://github.com/web-platform-dx/web-features/pull/3505 and https://github.com/web-platform-dx/web-features/issues/3497.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
