### PR TITLE
ci(dependabot): merge npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,33 +5,15 @@ updates:
     schedule:
       interval: daily
       time: "11:00"
-    allow:
-      - dependency-name: "@ddbeck/mdn-content-inventory"
-      - dependency-name: web-features
-      - dependency-name: web-specs
-    commit-message:
-      prefix: chore
-      include: scope
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    ignore:
-      - dependency-name: "@ddbeck/mdn-content-inventory"
-      - dependency-name: web-features
-      - dependency-name: web-specs
     groups:
-      prod:
-        dependency-type: production
+      minor-patch:
         update-types:
           - minor
           - patch
-      dev:
-        dependency-type: development
-        update-types:
-          - minor
-          - patch
+        exclude-patterns:
+          - "@ddbeck/mdn-content-inventory"
+          - web-features
+          - web-specs
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Merges the separate Dependabot configs for npm in the root directory.

#### Test results and supporting details

Dependabot does not support overlapping entries.

Also, BCD only has devDependencies, so should be no need to separate prod/dev into two separate groups.

#### Related issues

Follow-up of:

- https://github.com/mdn/browser-compat-data/pull/28387

Dependabot config check does not run on PRs, see: https://github.com/dependabot/dependabot-core/issues/4605