### PR TITLE
Firefox for Android 145 adds `<hr>` in `<select>`

### DIFF
--- a/html/elements/hr.json
+++ b/html/elements/hr.json
@@ -141,7 +141,9 @@
                 "partial_implementation": true,
                 "notes": "Does not expose the `<hr>` within the accessibility tree."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "145"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -203,8 +203,7 @@
                 "notes": "Does not expose the `<hr>` within the accessibility tree."
               },
               "firefox_android": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1867045"
+                "version_added": "145"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Adding `<hr>` in `<select>` compat for Firefox for Android.

__Question:__ Should I copy across the partial impl note? I'm not sure what AT is supposed to do for hr in select on Android. Tested with TalkBack, but I can't tell what's expected.


#### Related issues

- [x] relnote https://github.com/mdn/content/pull/41822
- [ ] parent https://github.com/mdn/content/issues/41817

See also:

- [x] https://github.com/mdn/browser-compat-data/pull/21652