### PR TITLE
Chrome 140 rejects duplicate `requestDevice()` calls on `GPUDevice`

### DIFF
--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -387,10 +387,17 @@
                   "Before Chrome 140, lost `GPUDevice` is returned on duplicate calls."
                 ]
               },
-              "chrome_android": {
-                "version_added": "121",
-                "notes": "Before Chrome Android 140, lost `GPUDevice` is returned on duplicate calls."
-              },
+              "chrome_android": [
+                {
+                  "version_added": "140"
+                },
+                {
+                  "version_added": "121",
+                  "version_removed": "140",
+                  "partial_implementation": true,
+                  "notes": "Duplicate calls don't reject; instead, lost `GPUDevice` is returned on duplicate calls."
+                }
+              ],
               "deno": [
                 {
                   "version_added": "1.39",
@@ -400,7 +407,8 @@
                       "name": "--unstable-webgpu"
                     }
                   ],
-                  "notes": "Duplicate calls don't reject; instead, lost `GPUDevice`s are returned on duplicate calls."
+                  "partial_implementation": true,
+                  "notes": "Duplicate calls don't reject; instead, lost `GPUDevice` is returned on duplicate calls."
                 },
                 {
                   "version_added": "1.8",
@@ -417,7 +425,8 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "26",
-                "notes": "Duplicate calls don't reject; instead, lost `GPUDevice`s are returned on duplicate calls."
+                "partial_implementation": true,
+                "notes": "Duplicate calls don't reject; instead, lost `GPUDevice` is returned on duplicate calls."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

From Chrome 140 onwards, calling `GPUAdapter.requestDevice()` multiple times on the same adapter causes the returned promise to reject. This is because the adapter is consumed by the first call. See https://developer.chrome.com/blog/new-in-webgpu-140#device_requests_consume_adapter.

Previously, you could call `GPUAdapter.requestDevice()` multiple times on the same adapter, but multiple calls would result in lost devices.

This PR tries to capture the old and new behavior in a single data point, rather than adding multiple data points for a behavior change, which would be rather odd. Let me know if you think this works, or if we should do it a different way.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
