### PR TITLE
Unmark `<hr>` in `<select>` as partial

### DIFF
--- a/html/elements/hr.json
+++ b/html/elements/hr.json
@@ -126,10 +126,9 @@
             "support": {
               "chrome": {
                 "version_added": "119",
-                "partial_implementation": true,
                 "notes": [
-                  "Only exposes the `<hr>` visually in the page when the menu is expanded (arrowing within the collapsed menu does not show them).",
-                  "Does not expose the `<hr>` within the accessibility tree."
+                  "Exposes the `<hr>` visually in the page only when the menu is expanded (arrowing within the collapsed menu does not show them).",
+                  "Does not expose the `<hr>` in the accessibility tree."
                 ]
               },
               "chrome_android": {
@@ -138,8 +137,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "122",
-                "partial_implementation": true,
-                "notes": "Does not expose the `<hr>` within the accessibility tree."
+                "notes": "Does not expose the `<hr>` in the accessibility tree."
               },
               "firefox_android": {
                 "version_added": "145"
@@ -149,13 +147,11 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "17",
-                "partial_implementation": true,
-                "notes": "Does not expose the `<hr>` within the accessibility tree."
+                "notes": "Does not expose the `<hr>` in the accessibility tree."
               },
               "safari_ios": {
                 "version_added": "17.4",
-                "partial_implementation": true,
-                "notes": "Does not expose the `<hr>` within the accessibility tree."
+                "notes": "Does not expose the `<hr>` in the accessibility tree."
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -187,10 +187,9 @@
             "support": {
               "chrome": {
                 "version_added": "119",
-                "partial_implementation": true,
                 "notes": [
-                  "Only exposes the `<hr>` visually in the page when the menu is expanded (arrowing within the collapsed menu does not show them).",
-                  "Does not expose the `<hr>` within the accessibility tree."
+                  "Exposes the `<hr>` visually in the page only when the menu is expanded (arrowing within the collapsed menu does not show them).",
+                  "Does not expose the `<hr>` in the accessibility tree."
                 ]
               },
               "chrome_android": {
@@ -199,8 +198,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "122",
-                "partial_implementation": true,
-                "notes": "Does not expose the `<hr>` within the accessibility tree."
+                "notes": "Does not expose the `<hr>` in the accessibility tree."
               },
               "firefox_android": {
                 "version_added": "145"
@@ -210,13 +208,11 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "17",
-                "partial_implementation": true,
-                "notes": "Does not expose the `<hr>` within the accessibility tree."
+                "notes": "Does not expose the `<hr>` in the accessibility tree."
               },
               "safari_ios": {
                 "version_added": "17.4",
-                "partial_implementation": true,
-                "notes": "Does not expose the `<hr>` within the accessibility tree."
+                "notes": "Does not expose the `<hr>` in the accessibility tree."
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",


### PR DESCRIPTION
#### Summary

Based on current notes, not exposing the `<hr>` in the accessibility tree is the de-facto standard, so we should not mark any browser implementation as partial.

#### Test results and supporting details

To revert this, we would require bugs filed for all browsers, and need one browser actually implementing this exposure.

#### Related issues

Triggered by:

- https://github.com/mdn/browser-compat-data/pull/28401
