### PR TITLE
Clean up typed `attr()` data

### DIFF
--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -186,42 +186,6 @@
               }
             }
           },
-          "frequency": {
-            "__compat": {
-              "description": "&lt;frequency&gt;",
-              "tags": [
-                "web-features:attr"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1871821"
-                },
-                "firefox_android": "mirror",
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false,
-                  "impl_url": "https://webkit.org/b/26609"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror",
-                "webview_ios": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "integer": {
             "__compat": {
               "description": "&lt;integer&gt;",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This a stopgap for fixing false status calculations for `attr()` support in web-features, ahead of completing the work in https://github.com/mdn/browser-compat-data/pull/26624. Specifically, this:

- Cascades data from `css.types.attr.type-or-unit` to descendants (Chrome 133)
- Remove `css.types.attr.type-or-unit.url` and `css.types.attr.type-or-unit.frequency`

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

- Test cases (by me): https://codepen.io/ddbeck/pen/emJwRgg
- `css.types.attr.type-or-unit.url` is [forbidden by specification](https://drafts.csswg.org/css-values-5/#attr-security):

   > Using an [attr()-tainted](https://drafts.csswg.org/css-values-5/#attr-taint) value as or in a [<url>](https://drafts.csswg.org/css-values-4/#url-value) makes a declaration [invalid at computed-value time](https://drafts.csswg.org/css-values-5/#invalid-at-computed-value-time).

- The `<frequency>` type was removed as unimplemented in https://github.com/mdn/browser-compat-data/pull/24969. It doesn't make sense to retain data about a type that, functionally, does not exist.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/issues/3512
- https://github.com/mdn/browser-compat-data/issues/25618
- https://github.com/mdn/browser-compat-data/issues/26630
- https://github.com/mdn/browser-compat-data/pull/26624

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
