### PR TITLE
Fix console mdn_urls

### DIFF
--- a/api/_globals/console.json
+++ b/api/_globals/console.json
@@ -1657,7 +1657,7 @@
         "trackGroup_parameter": {
           "__compat": {
             "description": "`trackGroup` parameter",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timeStamp_static#trackGroup",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timeStamp_static#trackgroup",
             "support": {
               "chrome": {
                 "version_added": "134"
@@ -1695,7 +1695,7 @@
         "trackName_parameter": {
           "__compat": {
             "description": "`trackName` parameter",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timeStamp_static#trackName",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timeStamp_static#trackname",
             "support": {
               "chrome": {
                 "version_added": "134"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes the casing of two mdn URLs introduced in https://github.com/mdn/browser-compat-data/pull/28270.

#### Test results and supporting details

The Linter reported these as warnings, but this was not noticed in the PR.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
