### PR TITLE
Firefox 146 ships `text-decoration-inset` CSS property

### DIFF
--- a/css/properties/text-decoration-inset.json
+++ b/css/properties/text-decoration-inset.json
@@ -3,7 +3,7 @@
     "properties": {
       "text-decoration-inset": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-text-decor-4/#text-decoration-inset-property",
+          "spec_url": "https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-inset",
           "tags": [
             "web-features:text-decoration"
           ],
@@ -14,8 +14,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "146",
-              "impl_url": "https://bugzil.la/1993043"
+              "version_added": "146"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -48,8 +47,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "146",
-                "impl_url": "https://bugzil.la/1993043"
+                "version_added": "146"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 146 onwards has the `text-decoration-inset` property enabled by default (see https://bugzilla.mozilla.org/show_bug.cgi?id=1993043; it was called `text-decoration-trim`, but it got renamed). I've tested it, and it doesn't work in Chrome/Safari yet.

This PR adds a data point for the new property.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
