### PR TITLE
Mark `css.properties.text-decoration.blink` as deprecated

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -83,21 +83,24 @@
             "spec_url": "https://drafts.csswg.org/css2/#valdef-text-decoration-blink",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "≤31",
+                "notes": "The `blink` value does not have any effect."
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "3"
+                "version_added": "3",
+                "notes": "The `blink` value does not have any effect."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "The `blink` value does not have any effect."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mark `css.properties.text-decoration.blink` as deprecated and copy notes from the longhand property.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

The [longhand spec](https://drafts.csswg.org/css-text-decor/#text-decoration-property) says this value is deprecated, so it stands to reason that the shorthand value is too.

I've also copied the notes because in my testing the value for the shorthand also doesn't do anything in contemporary browsers. I didn't put any effort into figuring out when exactly they stopped working (if they ever did), as I don't think it's terribly important. We could always edit the notes if we ever found out otherwise.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

None

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
