### PR TITLE
Firefox Nightly enabled Navigation API

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
@@ -51,7 +51,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -92,7 +93,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -127,7 +129,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -162,7 +165,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -197,7 +201,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -232,7 +237,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -267,7 +273,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -302,7 +309,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -344,7 +352,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -378,7 +387,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1777171"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -414,7 +424,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -456,7 +467,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -491,7 +503,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -525,7 +538,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -560,7 +574,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Navigation.json
+++ b/api/Navigation.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -86,7 +86,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -122,7 +122,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -158,7 +158,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -194,7 +194,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -231,7 +231,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -267,7 +267,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -303,7 +303,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -339,7 +339,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -376,7 +376,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -413,7 +413,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -450,7 +450,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -486,7 +486,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -522,7 +522,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -558,7 +558,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -594,7 +594,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",

--- a/api/NavigationActivation.json
+++ b/api/NavigationActivation.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
@@ -50,7 +50,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -85,7 +86,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -120,7 +122,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/NavigationCurrentEntryChangeEvent.json
+++ b/api/NavigationCurrentEntryChangeEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -87,7 +87,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -123,7 +123,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",

--- a/api/NavigationDestination.json
+++ b/api/NavigationDestination.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -86,7 +86,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -122,7 +122,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -158,7 +158,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -194,7 +194,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -230,7 +230,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",

--- a/api/NavigationHistoryEntry.json
+++ b/api/NavigationHistoryEntry.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -87,7 +87,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -123,7 +123,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -159,7 +159,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -195,7 +195,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -231,7 +231,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -267,7 +267,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",

--- a/api/NavigationPrecommitController.json
+++ b/api/NavigationPrecommitController.json
@@ -10,7 +10,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -40,7 +41,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/NavigationTransition.json
+++ b/api/NavigationTransition.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
@@ -46,7 +46,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -81,7 +82,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -117,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
@@ -153,7 +154,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 146 enables support for the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) in nightly only. See https://bugzilla.mozilla.org/show_bug.cgi?id=1979288, and also see https://bugzilla.mozilla.org/show_bug.cgi?id=1777171 for the implementation meta bug.

This PR flips Firefox support for all Navigation API features to `preview`, and also adds a consistent `impl_url` for all features.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
