### PR TITLE
Firefox 146 adds CSS `@custom-media` at-rule behind flag

### DIFF
--- a/css/at-rules/custom-media.json
+++ b/css/at-rules/custom-media.json
@@ -20,8 +20,7 @@
                   "name": "layout.css.custom-media.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "impl_url": "https://bugzil.la/1744292"
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
#### Summary

Firefox 146 added supports for `@custom-media` at-rule.

#### Feature information

* Spec: https://www.w3.org/TR/mediaqueries-5/
* Definition: https://www.w3.org/TR/mediaqueries-5/#custom-mq
* Web Feature: https://web-platform-dx.github.io/web-features-explorer/features/custom-media-queries/

#### Browsers support

* Chrome: https://issues.chromium.org/issues/40781325
* WebKit: https://bugs.webkit.org/show_bug.cgi?id=233820
* FireFox: https://bugzilla.mozilla.org/show_bug.cgi?id=1744292

#### Related issues

Last year I added this feature to BCD - https://github.com/mdn/browser-compat-data/pull/24338

But because no browsers implemented it yet, the feature was deleted - https://github.com/mdn/browser-compat-data/pull/25125

Now that Firefox implemented this, we can add it back to BCD.