### PR TITLE
Chrome allows `javascript:` URLs in `Navigation.navigate()`

### DIFF
--- a/api/Navigation.json
+++ b/api/Navigation.json
@@ -335,7 +335,7 @@
           "support": {
             "chrome": {
               "version_added": "102",
-              "notes": "Specification now disallows `javascript:` URLs, but they are still allowed in Chromium ([bug 439994590](https://crbug.com/439994590))."
+              "notes": "Chrome allows `javascript:` URLs when calling `navigate()`, contrary to the specification ([bug 439994590](https://crbug.com/439994590))."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
…te() calls

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`javascript:` URLs are no longer allowed in [`Navigation.navigate()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate) calls (see https://github.com/whatwg/html/pull/11533), and I thought this should be mentioned in BCD, as the state of support for this change differs across browsers:

- Firefox implemented it in Fx144 (https://bugzilla.mozilla.org/show_bug.cgi?id=1981104), but the Navigation API was only enabled in Nightly as of Fx146, so I didn't think a note was needed here. I tested this to verify.
- Chromium browsers still allow it (see https://issues.chromium.org/issues/439994590 for the removal bug), so I thought a note was needed there, so say it is still allowed. I tested this in Chrome Canary, and yup, it still works.
- Safari has fixed it in preview (see https://bugs.webkit.org/show_bug.cgi?id=297650). I tested this to verify. I've not added any Safari data because the whole API says it is not supported in Safari. Obviously, this needs updating, but I think it is out of scope for this PR.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
