### PR TITLE
Mark `Atomics.waitAsync()` as partial in Chrome <90

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -662,12 +662,28 @@
               "bun": {
                 "version_added": "1.0.0"
               },
-              "chrome": {
-                "version_added": "87"
-              },
-              "chrome_android": {
-                "version_added": "89"
-              },
+              "chrome": [
+                {
+                  "version_added": "90"
+                },
+                {
+                  "version_added": "87",
+                  "version_removed": "90",
+                  "partial_implementation": true,
+                  "notes": "The `Atomics.waitAsync()` method never times out. See [bug 40742782](https://crbug.com/40742782)."
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "90"
+                },
+                {
+                  "version_added": "89",
+                  "version_removed": "90",
+                  "partial_implementation": true,
+                  "notes": "The `Atomics.waitAsync()` method never times out. See [bug 40742782](https://crbug.com/40742782)."
+                }
+              ],
               "deno": {
                 "version_added": "1.4"
               },


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Captures a bug in `Atomics.waitAsync()` where the method never times out.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I used the test case in https://issues.chromium.org/issues/40742782 to test this on Chrome desktop on Browser Stack. It fails in Chrome 89, but not 90.

The report in https://github.com/mdn/browser-compat-data/issues/21110 and the Emscripten source notwithstanding, it appears that this bug was reported and fixed while Chrome 90 was still canary or beta, so it was fixed in Chrome 90, not Chrome 91.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21110

Discovered via https://github.com/web-platform-dx/web-features/pull/3536.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
