### PR TITLE
Mark `http.headers.Content-Security-Policy.require-trusted-types-for` as supported in Firefox preview only

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -860,7 +860,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "145"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I think this was an oversight in the originating PR, since no other part of trusted types appears to have gone to stable in Firefox yet.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://github.com/mdn/browser-compat-data/pull/28302 made this change. Every other value in that PR was `"preview"` and this one wasn't. Since there was no mention of the exception in the PR (or linked bug) and it wasn't commented upon in review, I assumed this to be an oversight. I did not test it.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Discovered via https://github.com/web-platform-dx/web-features/pull/3536/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
