### PR TITLE
Firefox 146 adds `CSSCustomMediaRule` API behind flag

### DIFF
--- a/api/CSSCustomMediaRule.json
+++ b/api/CSSCustomMediaRule.json
@@ -2,7 +2,7 @@
   "api": {
     "CSSCustomMediaRule": {
       "__compat": {
-        "spec_url": "https://drafts.csswg.org/mediaqueries-5/#at-ruledef-custom-media",
+        "spec_url": "https://drafts.csswg.org/mediaqueries-5/#csscustommediarule",
         "support": {
           "chrome": {
             "version_added": false,


### PR DESCRIPTION
Relates to https://github.com/mdn/browser-compat-data/pull/28438

This PR adds `CSSCustomMediaRule` API.

Ref:
* https://github.com/mozilla-firefox/firefox/commit/f289eebba919#diff-5344d883f252f0d0fcde1443e722366428c6dec715f2dfa5a910d6d4fd088ce2
* https://bugzilla.mozilla.org/show_bug.cgi?id=1744292

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
