### PR TITLE
Safari 26.2 supports Partitioned Cookies

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -142,9 +142,16 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": "26.2"
-              },
+              "safari": [
+                {
+                  "version_added": "26.2"
+                },
+                {
+                  "version_added": "18.4",
+                  "version_removed": "18.5",
+                  "impl_url": "https://webkit.org/b/292975"
+                }
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {


### PR DESCRIPTION
Safari supports partitioned cookies in 26.2:
https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#Privacy