### PR TITLE
Safari 26.2 supports `hidden=until-found`

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -609,8 +609,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview",
-                "impl_url": "https://webkit.org/b/238266"
+                "version_added": "26.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Support for hidden=until-found was added in 26.2:

https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#DOM
