### PR TITLE
Safari 26.2 removed UA styles in article, aside, nav, and section

### DIFF
--- a/html/elements/h1.json
+++ b/html/elements/h1.json
@@ -62,7 +62,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari 26.2 removed the UA styles for `<article>`, `<aside>`, `<nav>` and `<section>`:

https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#Deprecations