### PR TITLE
Add `display-p3-linear` color space to CSS `<color>` type

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -109,9 +109,7 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "26.2"


### PR DESCRIPTION
#### Summary

- Added support data for `display-p3-linear` color space

#### Test results and supporting details

- Tested using [this codepen](https://codepen.io/CodeRedDigital/pen/wBGJQgP?editors=0100)
- Works in the following browsers:
  - Firefox Beta 146
  - Firefox Developer Edition 146
  - Firefox Nightly 147
  - Chrome Canary 144
  - Edge 144
  - Safari Technical Preview 232
- Does not work in the following browsers:
  - Firefox 145
  - Chrome Beta 143
  - Edge Beta 143
  - Safari 26.1
  - Opera 124

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/42003)
- [Firefox release PR](https://github.com/mdn/content/pull/42004)
- [Data PR](https://github.com/mdn/data/pull/1025)