### PR TITLE
Safari 26.2 supports `Math.sumPrecise`

### DIFF
--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -2185,7 +2185,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "26.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Support for `Math.sumPrecise` was added in Safari 26.2:

https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#JavaScript