### PR TITLE
Safari 26.2 supports Animation.prototype.overallProgress

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -447,7 +447,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "26.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari added support for `Animation.prototype.overallProgress` in 26.2:

https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#Animations