### PR TITLE
Chrome 143 supports side-relative values for `background-position-x/y`

### DIFF
--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -48,8 +48,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "143",
-                "impl_url": "https://crbug.com/40468636"
+                "version_added": "143"
               },
               "chrome_android": "mirror",
               "edge": {

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -48,8 +48,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "143",
-                "impl_url": "https://crbug.com/40468636"
+                "version_added": "143"
               },
               "chrome_android": "mirror",
               "edge": {


### PR DESCRIPTION
e.g.

```css
.test {
  background-position-x: left 25%;
  background-position-y: top 30px;
}
```

- https://chromestatus.com/feature/5073321259565056
- https://crbug.com/40468636

----

> This feature is applied also to the "-webkit-mask-position-x/y" to ensure webcompat levels are the same.

Let's add it in a separate PR.
