### PR TITLE
Firefox supports Web Share API behind flag, Firefox for Android without flag

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -5140,7 +5140,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "71"
+                "version_added": "79"
               },
               "nodejs": {
                 "version_added": false


### PR DESCRIPTION
#### Summary

This PR corrects the compatibility data for `navigator.share()` and `navigator.canShare()` (specifically `data_text_parameter`) in Firefox and Firefox for Android.

**Changes applied:**

1. **Firefox (Desktop):**
   - **Restored version:** Restored `version_added: "96"` which appears to have been inadvertently removed in PR #23687.
   - **Added flag:** Added the `dom.webshare.enabled` flag configuration to accurately reflect that this feature requires a preference setting.

2. **Firefox for Android:**
   - **Mirror removal:** Switched from `"mirror"` to explicit version numbers (`"79"` for `share` and `"96"` for `canShare`) to bypass the flag requirement issue.

**Context and Verification:**

* **Mirroring Issue:** Currently, the desktop `firefox` entry requires the `dom.webshare.enabled` preference. However, `firefox_android` is defined with `"accepts_flags": false`. Consequently, the build script incorrectly resolves the mirrored support status to `false`.
* **Android `canShare` status:** There appear to have been historical bugs regarding `data_text_parameter` support in `canShare` on Android. Although I was unable to trace the specific details or issue tracks myself, I have confirmed on a physical device (latest Firefox for Android) that it currently works as expected.

#### Related issues

- #23687
- #13810