### PR TITLE
Firefox 146 supports compressed ECC key point format

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -1203,7 +1203,7 @@
           },
           "compressed_elliptic_curve_points": {
             "__compat": {
-              "description": "Key data can contain compressed elliptic curve points.",
+              "description": "Key data can contain compressed elliptic curve points",
               "spec_url": "https://w3c.github.io/webcrypto/#ecdsa-operations-import-key",
               "support": {
                 "chrome": {
@@ -1285,7 +1285,7 @@
           },
           "compressed_elliptic_curve_points": {
             "__compat": {
-              "description": "Key data can contain compressed elliptic curve points.",
+              "description": "Key data can contain compressed elliptic curve points",
               "spec_url": "https://w3c.github.io/webcrypto/#ecdsa-operations-import-key",
               "support": {
                 "chrome": {


### PR DESCRIPTION
FF146 supports WebCrypto import of EC keys in compressed format in https://bugzilla.mozilla.org/show_bug.cgi?id=1971499

I've added as a subfeature of importKey

Related docs work can be tracked in https://github.com/mdn/content/issues/41870