### PR TITLE
Firefox 146 adds non-registered symbols as `WeakMap`/`WeakSet` keys

### DIFF
--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -483,8 +483,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1710433"
+                "version_added": "146"
               },
               "firefox_android": "mirror",
               "nodejs": {

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -345,8 +345,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1710433"
+                "version_added": "146"
               },
               "firefox_android": "mirror",
               "nodejs": {


### PR DESCRIPTION
FF146 adds support for using non-registered symbols as keys for WeakMap and values for WeakSet in https://bugzilla.mozilla.org/show_bug.cgi?id=1966745

The issue only talks about WeakMap, but I ran a test for WeakSet and that behaves the same way:
```js
const ws = new WeakSet();
const sym = Symbol('foo');
ws.add(sym); 
```

This updates the subfeature.

Related docs work can be tracked in https://github.com/mdn/content/issues/41868