### PR TITLE
Firefox 146 adds MathML `math-shift` CSS property

### DIFF
--- a/css/properties/math-shift.json
+++ b/css/properties/math-shift.json
@@ -15,14 +15,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "146"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF146 adds support for the MathML CSS [`math-shift`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/math-shift) property in https://bugzilla.mozilla.org/show_bug.cgi?id=1994171

Related docs work can be tracked in https://github.com/mdn/content/issues/41877
