### PR TITLE
Chrome 142 restricts `pointerrawupdate` events to secure contexts

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7923,7 +7923,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "77",
+              "notes": "Before version 142, `pointerrawupdate` events were exposed to non-secure contexts."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -7932,7 +7933,10 @@
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "64",
+              "notes": "Before version 126, `pointerrawupdate` events were exposed to non-secure contexts."
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

From version 142 onwards, Chrome restricts `pointerrawupdate` events (and associated event handlers) to secure contexts. See https://chromestatus.com/feature/5151468306956288.

It has been this way in other browsers and the spec, and has been reported this way on MDN, for a long time. It also isn't a distinct feature. As a result, I've not added a separate data point for this — I've just added a note to the existing Chrome data point for the event to cover it. 

I also stopped the equivalent Opera data from mirroring, and gave it a separate version number and equivalent note. I did this because I didn't want the note to be exactly the same under the Opera data.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
