### PR TITLE
html.global_attributes.autocapitalize: Mark Safari as supported

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -100,7 +100,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
               "version_added": "5"


### PR DESCRIPTION
Fixes #25569

Set Safari support for the HTML global attribute autocapitalize to “yes”. 

Evidence: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-SW1