### PR TITLE
Restructure ranged style query data

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -210,40 +210,40 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "style_queries_range_syntax": {
-          "__compat": {
-            "description": "Range syntax for style queries",
-            "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-style-range",
-            "tags": [
-              "web-features:container-style-queries"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "142"
+          },
+          "range_syntax": {
+            "__compat": {
+              "description": "Range syntax",
+              "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-style-range",
+              "tags": [
+                "web-features:container-style-queries"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "142"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/css/types/if.json
+++ b/css/types/if.json
@@ -36,16 +36,15 @@
             "deprecated": false
           }
         },
-        "style_queries_range_syntax": {
+        "style": {
           "__compat": {
-            "description": "Range syntax for style queries",
-            "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-style-range",
+            "description": "`style()` queries",
             "tags": [
-              "web-features:container-style-queries"
+              "web-features:if"
             ],
             "support": {
               "chrome": {
-                "version_added": "142"
+                "version_added": "137"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -68,6 +67,38 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "range_syntax": {
+            "__compat": {
+              "description": "Range syntax for style queries",
+              "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-style-range",
+              "support": {
+                "chrome": {
+                  "version_added": "142"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Restructure the ranged style query data newly added by https://github.com/mdn/browser-compat-data/pull/28510.

#### Test results and supporting details

There's no new information here, but I've restructured the data to be less surprisingly flat. When I was authoring https://github.com/web-platform-dx/web-features/pull/3579, I predicted some keys that did not yet exist in BCD, but what I found was rather different and confusing. In particular, the ranged behavior is a _peer_ to style queries, not a subfeature.

Here's the before:

- css.at-rules.container
   - css.at-rules.container.style_queries_for_custom_properties
   - css.at-rules.container.style_queries_range_syntax
- css.types.if
   - css.types.if.style_queries_range_syntax

And here's my after (new in **bold**, removed in ~~strike~~):

- css.at-rules.container
   - css.at-rules.container.style_queries_for_custom_properties
   - **css.at-rules.container.style_queries_for_custom_properties.range_syntax**
   - ~~css.at-rules.container.style_queries_range_syntax~~
 - css.types.if
   - ~~css.types.if.style_queries_range_syntax~~
   - **css.types.if.style**
   - **css.types.if.style.range_syntax**

This implies that we'd add some other keys at some point, namely:

- css.types.if.media
- css.types.if.scroll-state
- css.types.if.supports

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

A follow up to:

- https://github.com/mdn/browser-compat-data/pull/28510
- https://github.com/web-platform-dx/web-features/issues/3566
- https://github.com/web-platform-dx/web-features/pull/3579

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
