### PR TITLE
Add Samsung Internet 29

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -303,12 +303,13 @@
         },
         "28.0": {
           "release_date": "2025-04-02",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "130"
         },
         "29.0": {
-          "status": "beta",
+          "release_date": "2025-10-25",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "136"
         }


### PR DESCRIPTION
#### Summary

Samsung Internet 29 is released. Still no release notes are being published for this on https://developer.samsung.com/internet/release-note.html

#### Test results and supporting details

Earliest release date from https://www.apkmirror.com/apk/samsung-electronics-co-ltd/samsung-internet-for-android/samsung-internet-browser-29-0-0-59-release/. It's installed on my Android and https://chromiumchecker.com says 136.

#### Related issues

None