### PR TITLE
Firefox Android 116 fully supports `display-mode` CSS media query

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -533,6 +533,7 @@
                 },
                 {
                   "version_added": "47",
+                  "version_removed": "116",
                   "partial_implementation": true,
                   "notes": "Only supports the `browser` value, which always reports `true`."
                 }


### PR DESCRIPTION
Fenix sets correct value for display-mode media query by https://bugzilla.mozilla.org/show_bug.cgi?id=1796434.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Update display-mode CSS media query data for Firefox Android.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
Firefox Android sets display-mode value even if PWA after Firefox 116.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
- https://bugzilla.mozilla.org/show_bug.cgi?id=1796434

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
