### PR TITLE
Firefox 145 supports WebGPU on macOS 26

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -87,7 +87,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -149,7 +149,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -237,7 +237,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -144,7 +144,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -194,7 +194,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -256,7 +256,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -313,7 +313,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -375,7 +375,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -87,7 +87,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -143,7 +143,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -199,7 +199,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -239,7 +239,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -284,7 +284,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -329,7 +329,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -385,7 +385,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -161,7 +161,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -223,7 +223,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -285,7 +285,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -347,7 +347,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -409,7 +409,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -471,7 +471,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -533,7 +533,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -26,7 +26,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -75,7 +75,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -128,7 +128,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -216,7 +216,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -266,7 +266,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -316,7 +316,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -201,7 +201,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -421,7 +421,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -483,7 +483,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -584,7 +584,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -646,7 +646,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -708,7 +708,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -770,7 +770,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -832,7 +832,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -894,7 +894,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -956,7 +956,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1018,7 +1018,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1080,7 +1080,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1137,7 +1137,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -26,7 +26,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -75,7 +75,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -26,7 +26,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -75,7 +75,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -125,7 +125,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -175,7 +175,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -225,7 +225,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -275,7 +275,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -325,7 +325,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -161,7 +161,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -223,7 +223,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -285,7 +285,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -347,7 +347,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -409,7 +409,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -471,7 +471,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -533,7 +533,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -636,7 +636,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -161,7 +161,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -82,7 +82,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -144,7 +144,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -323,7 +323,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -470,7 +470,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -532,7 +532,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -594,7 +594,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -695,7 +695,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -796,7 +796,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -897,7 +897,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -999,7 +999,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1061,7 +1061,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1366,7 +1366,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1671,7 +1671,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1733,7 +1733,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1795,7 +1795,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1899,7 +1899,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1961,7 +1961,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -2011,7 +2011,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -2155,7 +2155,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -2217,7 +2217,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -2279,7 +2279,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -2341,7 +2341,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -2403,7 +2403,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -2465,7 +2465,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -2516,7 +2516,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -161,7 +161,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -26,7 +26,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -75,7 +75,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUInternalError.json
+++ b/api/GPUInternalError.json
@@ -26,7 +26,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -76,7 +76,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -100,7 +100,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -26,7 +26,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -76,7 +76,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -124,7 +124,7 @@
                 "notes": [
                   "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                   "Before Firefox 145, supported only on Windows.",
-                  "From Firefox 145, supported only on Windows, and macOS 26+."
+                  "From Firefox 145, supported only on Windows, and macOS."
                 ]
               },
               "firefox_android": {
@@ -175,7 +175,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -161,7 +161,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -223,7 +223,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -285,7 +285,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -255,7 +255,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -317,7 +317,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -379,7 +379,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -480,7 +480,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -542,7 +542,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPURenderBundle.json
+++ b/api/GPURenderBundle.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -161,7 +161,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -211,7 +211,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -273,7 +273,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -335,7 +335,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -397,7 +397,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -459,7 +459,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -521,7 +521,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -583,7 +583,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -645,7 +645,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -748,7 +748,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -810,7 +810,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -872,7 +872,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -161,7 +161,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -223,7 +223,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -285,7 +285,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -347,7 +347,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -409,7 +409,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -471,7 +471,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -533,7 +533,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -595,7 +595,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -657,7 +657,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -719,7 +719,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -781,7 +781,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -843,7 +843,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -946,7 +946,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1008,7 +1008,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1070,7 +1070,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1132,7 +1132,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1194,7 +1194,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1256,7 +1256,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1371,7 +1371,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -161,7 +161,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -87,7 +87,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -149,7 +149,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -98,7 +98,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -234,7 +234,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -736,7 +736,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -826,7 +826,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1049,7 +1049,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1110,7 +1110,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1171,7 +1171,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1232,7 +1232,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1293,7 +1293,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1355,7 +1355,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -147,7 +147,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -209,7 +209,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -271,7 +271,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -321,7 +321,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -371,7 +371,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -433,7 +433,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -495,7 +495,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -557,7 +557,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -619,7 +619,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -681,7 +681,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -743,7 +743,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -805,7 +805,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -867,7 +867,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -969,7 +969,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1031,7 +1031,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1093,7 +1093,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1155,7 +1155,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1217,7 +1217,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1279,7 +1279,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1341,7 +1341,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1403,7 +1403,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1465,7 +1465,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1527,7 +1527,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1589,7 +1589,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1651,7 +1651,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1713,7 +1713,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1775,7 +1775,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1837,7 +1837,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1899,7 +1899,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -1961,7 +1961,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -243,7 +243,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -305,7 +305,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -367,7 +367,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -429,7 +429,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -533,7 +533,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -595,7 +595,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -657,7 +657,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -719,7 +719,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -781,7 +781,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -843,7 +843,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -99,7 +99,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -26,7 +26,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -76,7 +76,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {
@@ -126,7 +126,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -38,7 +38,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": {
@@ -100,7 +100,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": {

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -758,7 +758,7 @@
                 "notes": [
                   "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                   "Before Firefox 145, supported only on Windows.",
-                  "From Firefox 145, supported only on Windows, and macOS 26+."
+                  "From Firefox 145, supported only on Windows, and macOS."
                 ]
               },
               "firefox_android": {

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -382,7 +382,7 @@
                 "notes": [
                   "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                   "Before Firefox 145, supported only on Windows.",
-                  "From Firefox 145, supported only on Windows, and macOS 26+."
+                  "From Firefox 145, supported only on Windows, and macOS."
                 ]
               },
               "firefox_android": {

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -23,7 +23,7 @@
             "notes": [
               "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
               "Before Firefox 145, supported only on Windows.",
-              "From Firefox 145, supported only on Windows, and macOS 26+."
+              "From Firefox 145, supported only on Windows, and macOS."
             ]
           },
           "firefox_android": "mirror",
@@ -66,7 +66,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": "mirror",
@@ -258,7 +258,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": "mirror",
@@ -302,7 +302,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": "mirror",
@@ -346,7 +346,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": "mirror",
@@ -390,7 +390,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": "mirror",
@@ -434,7 +434,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": "mirror",
@@ -479,7 +479,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": "mirror",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -334,7 +334,7 @@
               "notes": [
                 "Service workers are not supported. See [bug 1942431](https://bugzil.la/1942431).",
                 "Before Firefox 145, supported only on Windows.",
-                "From Firefox 145, supported only on Windows, and macOS 26+."
+                "From Firefox 145, supported only on Windows, and macOS."
               ]
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the notes for Firefox' partial implementation of WebGPU features to account for newly added macOS support.

#### Test results and supporting details

Source from issue: https://github.com/gpuweb/gpuweb/wiki/Implementation-Status#firefox

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28555.