### PR TITLE
Chrome 144 / Firefox 146 mirror/stretch MathML operators in RTL

### DIFF
--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -38,9 +38,9 @@
             "deprecated": false
           }
         },
-        "mirroring_rtl_operators": {
+        "rtl_operator_mirroring": {
           "__compat": {
-            "description": "Mirroring MathML operators in RTL, and stretching operators and grouping symbols",
+            "description": "Mirrors MathML operators in [RTL](https://developer.mozilla.org/docs/Glossary/RTL), and stretches operators and grouping symbols",
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Reference/Global_attributes/dir",
             "spec_url": "https://w3c.github.io/mathml-core/#layout-of-operators",
             "support": {


### PR DESCRIPTION
FF146 adds support for mirroring MathML operators in RTL languages in https://bugzilla.mozilla.org/show_bug.cgi?id=1994172. It also adds support for stretching operators and grouping symbols (like braces) around expressions - does not have to be in RTL mode.

More correctly, it has supported operator mirroring for some time in normal text for some time but this hasn't worked properly with operators and stretching. Also previously the behaviour was non standard, and now it is part of the spec. From the developer:

>  "In the past mirroring worked for normal text and stretching/largeop worked for math operators ; now the these two features properly work when used in combination".

This adds a subfeature to the mathML `dir` global attribute, which I **think** is the best place to highlight this. Arguably you could add this subfeature to the `<mo>`, `<msqrt>`, `<mfenced>` since those are the specific affected elements. The relevant spec part is https://w3c.github.io/mathml-core/#layout-of-operators - if you need me to put it there instead I can.

Related docs work can be tracked in https://github.com/mdn/content/issues/41878