### PR TITLE
Firefox 145 ships WebAssembly resizable array buffers

### DIFF
--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -77,6 +77,70 @@
           }
         }
       },
+      "Memory": {
+        "toFixedLengthBuffer": {
+          "__compat": {
+            "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-tofixedlengthbuffer",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "145"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "toResizableBuffer": {
+          "__compat": {
+            "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-toresizablebuffer",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "145"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
       "compile_static": {
         "__compat": {
           "description": "`compile()` static method",


### PR DESCRIPTION
Found by the https://collector.openwebdocs.org/ project (v10.16.1).

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1983901