### PR TITLE
Updates for Firefox 146 beta

### DIFF
--- a/api/CSSScopeRule.json
+++ b/api/CSSScopeRule.json
@@ -14,15 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "128",
-            "flags": [
-              {
-                "name": "layout.css.at-scope.enabled",
-                "type": "preference",
-                "value_to_set": "true"
-              }
-            ],
-            "impl_url": "https://bugzil.la/1886441"
+            "version_added": "146"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -56,15 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "128",
-              "flags": [
-                {
-                  "name": "layout.css.at-scope.enabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1886441"
+              "version_added": "146"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -99,15 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "128",
-              "flags": [
-                {
-                  "name": "layout.css.at-scope.enabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1886441"
+              "version_added": "146"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/properties/math-shift.json
+++ b/css/properties/math-shift.json
@@ -45,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "146"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -60,7 +60,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -76,7 +76,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "146"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -91,7 +91,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -155,8 +155,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1863140"
+                  "version_added": "146"
                 },
                 "firefox_android": "mirror",
                 "nodejs": {

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -110,8 +110,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1863140"
+                  "version_added": "146"
                 },
                 "firefox_android": "mirror",
                 "nodejs": {

--- a/webassembly/relaxed-SIMD.json
+++ b/webassembly/relaxed-SIMD.json
@@ -13,7 +13,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "146"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -28,7 +28,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.16.1) found new features shipping in Firefox 146 beta which was released a couple of weeks ago. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 26 features as shipping in Firefox 145:

- api.CSSScopeRule
- api.CSSScopeRule.end
- api.CSSScopeRule.start
- css.properties.math-shift.compact
- css.properties.math-shift.normal
- javascript.builtins.FinalizationRegistry.register.symbol_as_target
- javascript.builtins.WeakRef.WeakRef.symbol_as_target
- javascript.builtins.WeakSet.symbol_as_keys
- webassembly.relaxed-SIMD

Updated in other PRs:

- api.CSSCustomMediaRule
- css.at-rules.custom-media
- css.at-rules.scope
- css.properties.height.stretch (as -webkit-fill-available)
- css.properties.math-shift
- css.properties.text-decoration-inset
- css.properties.text-decoration-inset.auto
- css.properties.width.stretch (as -webkit-fill-available)
- css.types.color.contrast-color
- javascript.builtins.WeakMap.symbol_as_keys
- webdriver.bidi.emulation.setLocaleOverride.locale_parameter.sets_navigator_language
- webdriver.bidi.network.getData.data_url
- webdriver.bidi.network.getData.dataType_parameter.request
- webdriver.bidi.network.setExtraHeaders
- webdriver.bidi.network.setExtraHeaders.contexts_parameter
- webdriver.bidi.network.setExtraHeaders.headers_parameter
- webdriver.bidi.network.setExtraHeaders.userContexts_parameter

See also https://github.com/mdn/mdn/issues/763 and https://www.mozilla.org/en-US/firefox/146.0beta/releasenotes/
