### PR TITLE
Safari 26 / Bun 1.2.3 added RegExp modifiers

### DIFF
--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -596,7 +596,7 @@
           ],
           "support": {
             "bun": {
-              "version_added": "1.0.0"
+              "version_added": "1.2.3"
             },
             "chrome": {
               "version_added": "125"
@@ -617,7 +617,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Safari/Bun support statement for Regular Expression modifiers.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28568.