### PR TITLE
Bug-1773681 updated navigator.clipboard read and write notes

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -320,7 +320,7 @@
               "version_added": "63",
               "notes": [
                 "This method must be called within user gesture event handlers.",
-                "Web extensions with the `clipboardWrite` permission in thier manifest can write data without a user interaction."
+                "Web extensions with the `clipboardWrite` permission in their manifest can write data without a user gesture."
               ]
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

This change addresses the dev-docs-needed requirement of [Bug 1773681](https://bugzilla.mozilla.org/show_bug.cgi?id=1773681) Enable showing "Paste" button for `navigator.clipboard.readText()` when called from Addons which don't have `clipboardRead` permssion. 

In addition, it also corrects what appeared to be an erroneous copy paste of notes for the read methods to the write methods.

#### Related issues

Related content changes in https://github.com/mdn/content/pull/42263
