### PR TITLE
Chrome 140 ::view-transition-group-children()

### DIFF
--- a/css/selectors/view-transition-group-children.json
+++ b/css/selectors/view-transition-group-children.json
@@ -1,0 +1,38 @@
+{
+  "css": {
+    "selectors": {
+      "view-transition-group-children": {
+        "__compat": {
+          "description": "`::view-transition-group-children()`",
+          "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#view-transition-group-children-pseudo",
+          "support": {
+            "chrome": {
+              "version_added": "140"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 140 adds support for the `view-transition-group` property and the `::view-transition-group-children()` pseudo-element, added along with view transition groups. See https://chromestatus.com/feature/5162799714795520.

The `view-transition-group` property is already in BCD, but the `::view-transition-group-children()` pseudo-element is not. This PR therefore adds it in.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
