### PR TITLE
Fx147 supports -webkit-perspective with unitless values

### DIFF
--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -34,7 +34,8 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "49"
+                "version_added": "49",
+                "notes": "From version 147, Firefox supports `-webkit-perspective` with unitless values for increased compatibility."
               },
               {
                 "prefix": "-moz-",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 147 adds support for unitless `-webkit-perspective` values, for increased compatibility. See https://bugzilla.mozilla.org/show_bug.cgi?id=1362499.

This PR adds a note to the Firefox `-webkit-perspective` support data point to express this. I thought a brief note would make sense, and that it doesn't need its own data point.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
