### PR TITLE
Firefox 147 support for activeViewTransition property

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -148,37 +148,6 @@
           }
         }
       },
-      "activeViewTransition": {
-        "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-view-transitions-2/#dom-element-activeviewtransition",
-          "support": {
-            "chrome": {
-              "version_added": "142"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "147"
-            },
-            "firefox_android": "mirror",
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "26.2"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "after": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/after",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 147 supports the `activeViewTransition` property on both the `Document` and `Element` interfaces. See https://bugzilla.mozilla.org/show_bug.cgi?id=2001836.

This PR:

- Updates the `Document.activeViewTransition` data point to add the support info for Firefox.
- <s>Adds a new data point for `Element.activeViewTransition` with the same data as the other one. (I documented `activeViewTransition` when Chrome supported it in version 142, but I forgot to add support data/docs for the `Element` version).</s> — update: after doing some testing, it seems like `Element.activeViewTransition` isn't supported in Chrome or Firefox, so I've removed that data.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
