### PR TITLE
FF147 supports importing ECMAScript  modules into serviceworkers

### DIFF
--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -51,8 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1360870"
+              "version_added": "147"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1858,8 +1858,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1360870"
+                "version_added": "147"
               },
               "firefox_android": "mirror",
               "nodejs": {


### PR DESCRIPTION
FF supports importing ECMAScript modules (rather than just classic scripts) into service workers in https://bugzilla.mozilla.org/show_bug.cgi?id=1360870

This updates the respective features.

Related docs work can be tracked in https://github.com/mdn/content/issues/42249