### PR TITLE
Fx147 support for view transition types

### DIFF
--- a/api/ViewTransition.json
+++ b/api/ViewTransition.json
@@ -152,7 +152,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1860854"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/ViewTransitionTypeSet.json
+++ b/api/ViewTransitionTypeSet.json
@@ -13,7 +13,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "147"
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1860854"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -45,7 +46,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -78,7 +79,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -111,7 +112,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -144,7 +145,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -177,7 +178,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -210,7 +211,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -243,7 +244,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -276,7 +277,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -309,7 +310,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -343,7 +344,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 147 adds support for SPA view transition types (cross-document view transitions are not yet supported). See https://bugzilla.mozilla.org/show_bug.cgi?id=2001878. The relevant features are:

- `Document.startViewTransition()`, the `types` option object property.
- The `:active-view-transition-type()` pseudo
- The `:active-view-transition` pseudo
- The `ViewTransition.types` property
- The `ViewTransitionTypeSet` interface

This PR adds Firefox support for the SPA view transition types features that were currently set to support `false`, except for `Document.startViewTransition()`, as that is being dealt with in https://github.com/mdn/browser-compat-data/pull/28541.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
