### PR TITLE
Chrome 144 supports side-relative values for `background-position-{x,y}`

### DIFF
--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -48,13 +48,18 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "143"
+                "version_added": "144"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "144"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "49"
               },

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -48,13 +48,18 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "143"
+                "version_added": "144"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "144"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "49"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

It appears `css.properties.background-position-x.side-relative_values` and `css.properties.background-position-y.side-relative_values` shipped in Chrome 144, not Chrome 143.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I used [the test case](https://bug-157511-attachments.webkit.org/attachment.cgi?id=278575) found via [Chromium issue 40468636 comment #5](https://issues.chromium.org/issues/40468636#comment5).

The test failed in Chrome 143, but works in Chrome 144. [Comment #35](https://issues.chromium.org/issues/40468636#comment35) points toward this being a version 144 change.

I manually mirrored the data for Edge as well, since I can see no reason it would have been intentionally held back for Edge.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Supersedes https://github.com/mdn/browser-compat-data/pull/28494
- Discovered via https://github.com/web-platform-dx/web-features/pull/3607/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
