### PR TITLE
Firefox 147 adds CSS module import assertion

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1756,15 +1756,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.module-scripts.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1720570"
+                  "version_added": "147"
                 },
                 "firefox_android": "mirror",
                 "nodejs": {


### PR DESCRIPTION
FF147 adds support for CSS module imports in https://bugzilla.mozilla.org/show_bug.cgi?id=1986681. This updates the subfeature.

Note, there is another feature that references the same implementation bug - https://bugzil.la/1720570. I think that is a bug - we're not likely to support this with the deprecated syntax. Checking in https://bugzilla.mozilla.org/show_bug.cgi?id=1986681#c18.

Related docs work can be tracked in https://github.com/mdn/content/issues/42255