### PR TITLE
FF147 CompressionStream/DecompressionStream brotli - plus zstd

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -114,7 +114,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "147"
               },
               "firefox_android": "mirror",
               "nodejs": [
@@ -294,7 +294,15 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "138",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.compression_streams.zstd.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1947431"
               },
               "firefox_android": "mirror",
               "nodejs": {

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -114,7 +114,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "147"
               },
               "firefox_android": "mirror",
               "nodejs": [
@@ -294,7 +294,15 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "138",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.compression_streams.zstd.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1947431"
               },
               "firefox_android": "mirror",
               "nodejs": {


### PR DESCRIPTION
FF147 supports brotli compression in [`CompressionStream` constructor](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream/CompressionStream) and [`DecompressionStream()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream/DecompressionStream) in https://bugzilla.mozilla.org/show_bug.cgi?id=1921583

While looking at the code I also see that FF138 also supports `zstd` behind a pref in https://bugzilla.mozilla.org/show_bug.cgi?id=1947431.

Added version info for both features.

Related docs work: https://github.com/mdn/content/issues/42251