### PR TITLE
Edge probably supports `IDBRecord` as well

### DIFF
--- a/api/IDBRecord.json
+++ b/api/IDBRecord.json
@@ -8,9 +8,7 @@
             "version_added": "141"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": false
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },
@@ -40,9 +38,7 @@
               "version_added": "141"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -73,9 +69,7 @@
               "version_added": "141"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -106,9 +100,7 @@
               "version_added": "141"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
getAllRecords were fixed in https://github.com/mdn/browser-compat-data/pull/28097 but not IDBRecord.

Originally, this was probably an oversight when I ran the collector for Chrome 141 in https://github.com/mdn/browser-compat-data/pull/27757