### PR TITLE
Firefox 147 doesn't yet ship Trusted Types

### DIFF
--- a/api/TrustedHTML.json
+++ b/api/TrustedHTML.json
@@ -14,7 +14,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "147"
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1994690"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedHTML.json
+++ b/api/TrustedHTML.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1994690"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -49,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -84,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedScript.json
+++ b/api/TrustedScript.json
@@ -14,7 +14,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "147"
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1994690"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedScript.json
+++ b/api/TrustedScript.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1994690"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -49,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -84,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedScriptURL.json
+++ b/api/TrustedScriptURL.json
@@ -14,7 +14,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "147"
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1994690"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedScriptURL.json
+++ b/api/TrustedScriptURL.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1994690"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -49,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -84,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedTypePolicy.json
+++ b/api/TrustedTypePolicy.json
@@ -14,7 +14,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "147"
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1994690"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -118,7 +119,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -153,7 +154,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedTypePolicy.json
+++ b/api/TrustedTypePolicy.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1994690"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -49,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -84,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -119,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -154,7 +153,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedTypePolicyFactory.json
+++ b/api/TrustedTypePolicyFactory.json
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -118,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -153,7 +153,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -258,7 +258,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -293,7 +293,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -328,7 +328,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedTypePolicyFactory.json
+++ b/api/TrustedTypePolicyFactory.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "147"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -118,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -153,7 +153,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -188,7 +188,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -223,7 +223,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -258,7 +258,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -293,7 +293,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -328,7 +328,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/_globals/trustedTypes.json
+++ b/api/_globals/trustedTypes.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "147"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/28624#issuecomment-3634393982 ff.

I reverted this back to what it was before the collector PR and updated the bugzilla URL to https://bugzil.la/1994690.
TT might ship in Firefox 148 but it might be too early to say that. 

It would be great if Firefox had a command line option to make the beta behave like a stable browser. Not sure where to request this, probably someone could file a bugzilla bug about it. It would help to prevent BCD from releasing wrong data.