### PR TITLE
fix(lint/status): compute experimental status from core browser set

### DIFF
--- a/lint/linter/test-status.test.ts
+++ b/lint/linter/test-status.test.ts
@@ -65,6 +65,30 @@ describe('checkExperimental', () => {
 
     assert.equal(checkExperimental(data), false);
   });
+
+  it('should ignore non-relevant browsers when determining experimental status', () => {
+    const data: CompatStatement = {
+      status: {
+        experimental: true,
+        standard_track: true,
+        deprecated: false,
+      },
+      support: {
+        // Bun and Deno are not part of the Core browser set.
+        firefox: {
+          version_added: '1',
+        },
+        bun: {
+          version_added: '1.0',
+        },
+        deno: {
+          version_added: '1.0',
+        },
+      },
+    };
+
+    assert.equal(checkExperimental(data), true);
+  });
 });
 
 describe('checkStatus', () => {

--- a/lint/linter/test-status.ts
+++ b/lint/linter/test-status.ts
@@ -8,6 +8,17 @@ import { BrowserName, CompatStatement } from '../../types/types.js';
 import bcd from '../../index.js';
 const { browsers } = bcd;
 
+// See: https://github.com/web-platform-dx/web-features/blob/main/docs/baseline.md#core-browser-set
+const CORE_BROWSER_SET = new Set([
+  'chrome',
+  'chrome_android',
+  'edge',
+  'firefox',
+  'firefox_android',
+  'safari',
+  'safari_ios',
+]);
+
 /**
  * Check if experimental should be true or false
  * @param data The data to check
@@ -20,6 +31,9 @@ export const checkExperimental = (data: CompatStatement): boolean => {
     const browserSupport = new Set<BrowserName>();
 
     for (const [browser, support] of Object.entries(data.support)) {
+      if (!CORE_BROWSER_SET.has(browser)) {
+        continue;
+      }
       // Consider only the first part of an array statement.
       const statement = Array.isArray(support) ? support[0] : support;
       // Ignore anything behind flag, prefix or alternative name


### PR DESCRIPTION
#### Summary

Updates the status lint to compute the experimental status from the core browser set (as defined by Baseline).

#### Test results and supporting details

See: https://github.com/web-platform-dx/web-features/blob/main/docs/baseline.md#core-browser-set

#### Related issues

Unblocks https://github.com/mdn/browser-compat-data/pull/28592 (see [this review thread](https://github.com/mdn/browser-compat-data/pull/28592#discussion_r2606294957)).