### PR TITLE
Deprecate the Topics API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -992,9 +992,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -269,9 +269,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Request.json
+++ b/api/Request.json
@@ -216,9 +216,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -234,9 +234,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -313,9 +313,9 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": false,
-                "deprecated": false
+                "deprecated": true
               }
             }
           },
@@ -1554,9 +1554,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/http/headers/Observe-Browsing-Topics.json
+++ b/http/headers/Observe-Browsing-Topics.json
@@ -26,9 +26,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -270,9 +270,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/http/headers/Sec-Browsing-Topics.json
+++ b/http/headers/Sec-Browsing-Topics.json
@@ -26,9 +26,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As of version 144, Chrome is deprecating the [Topics API](https://developer.mozilla.org/en-US/docs/Web/API/Topics_API#specifications); see https://chromestatus.com/feature/5135370673061888. This is part of the Privacy Sandbox deprecation/removal work.

This PR updates all associated features to deprecated.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
