### PR TITLE
Issue 28550 `webNavigation` events support `parentFrameId` in firefox

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -579,11 +579,9 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "45"
+                  "version_added": false
                 },
-                "firefox_android": {
-                  "version_added": "48"
-                },
+                "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
                   "version_added": "18.4"


### PR DESCRIPTION
#### Summary

Update details for each event documenting `parentFrameId` to indicate Firefox support as per https://github.com/mdn/browser-compat-data/issues/28550#issuecomment-3629057893

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28550