### PR TITLE
Remove FF bug link for import_assertions with assert syntax

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1601,8 +1601,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1720570"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "nodejs": {


### PR DESCRIPTION
This removes a bug link to https://bugzil.la/1720570 for import assertions that use the `assert` syntax. The bug was supposed to indicate the issue that would "support" the feature, however the bug has completed without supporting the syntax because it is deprecated.

It may be that the feature was once supported - see https://bugzilla.mozilla.org/show_bug.cgi?id=1910686 - but either way it is not now, so this particular change is good.
This follows on from #28617

Related docs work tracked in https://github.com/mdn/content/issues/42255


