### PR TITLE
Chrome 17 / Edge 18 added WebP support

### DIFF
--- a/mediatypes/image/webp.json
+++ b/mediatypes/image/webp.json
@@ -11,19 +11,13 @@
             "https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#main-content"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "23"
-              },
-              {
-                "version_added": "17",
-                "version_removed": "23",
-                "partial_implementation": true,
-                "notes": "Lossless compression and alpha transparency are not supported."
-              }
-            ],
+            "chrome": {
+              "version_added": "17"
+            },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "18"
+            },
             "firefox": {
               "version_added": "65"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Reconcile WebP data with caniuse and subfeatures

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

In https://github.com/web-platform-dx/web-features/pull/3624/, I started to use the WebP (and some other format) data. I ran into a couple discrepancies with web-features, caniuse, and BCD's own conventions. I'll self review to call out the specifics.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/27168
- https://github.com/web-platform-dx/web-features/pull/3624/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
