### PR TITLE
Misc LargestContentfulPaint updates

### DIFF
--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -203,7 +203,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26.2",
+              "partial_implementation": true,
+              "notes": "This property is exposed, but always returns `null`."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Correct erroneous LargestContentfulPaint data I spotted:

- Safari and Firefox do not support `presentationTime`
- Safari DOES support cross-origin render times.
- Chrome does support `paintTime` and `presentationTime` but behind a flag (unflagging in Chrome 145!)

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Safari does support cross-origin lcp render time but not `presentationTime` (tested on https://www.tunetheweb.com/experiments/lcp-cross-origin/)
<img width="1583" height="810" alt="image" src="https://github.com/user-attachments/assets/e3e64c66-0f96-4be1-97ce-351922bddcdf" />

**Firefox gives null for `presentationTime`:**

<img width="1481" height="836" alt="image" src="https://github.com/user-attachments/assets/50acd617-cf85-4629-926a-607fbad2a6c9" />

**Chrome 134 supports `paintTime` and `presentationTime` when experimental web platform features are turned on:**

<img width="2386" height="1162" alt="image" src="https://github.com/user-attachments/assets/3a01c5c9-b8d3-4375-843c-1c8de9e90d9f" />


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
