### PR TITLE
Chrome 133 supports more attr functions

### DIFF
--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -231,6 +231,44 @@
               }
             }
           },
+          "ident": {
+            "__compat": {
+              "description": "`<ident>`",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/ident",
+              "spec_url": "https://drafts.csswg.org/css-values/#typedef-ident",
+              "tags": [
+                "web-features:attr"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "133"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1871815"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/26609"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "image": {
             "__compat": {
               "description": "`<image>`",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

These were added by @caugner in #26624 but testing shows Chrome does support this.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Go to: https://codepen.io/web-dot-dev/pen/emZRyaZ

Put in an invalid value and not the copepen tells you this:

<img width="963" height="479" alt="image" src="https://github.com/user-attachments/assets/710c076e-211c-4036-a085-ff5aa5164c8f" />

Put in a supported value and not message, showing this is supported:

<img width="804" height="396" alt="image" src="https://github.com/user-attachments/assets/1d3d3f32-864c-4962-a7d3-e95df786be26" />

Note for `<ident>` you should just use any custom value (e.g. `--test`) to show it is supported.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
