### PR TITLE
Add details for auto-open-on-find

### DIFF
--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -117,7 +117,7 @@
               "firefox": {
                 "version_added": "139",
                 "partial_implementation": true,
-                "notes": "The browser does not correctly scroll to the matching text. See https://bugzil.la/2006040."
+                "notes": "The browser does not correctly scroll to the matching text. See [bug 2006040](https://bugzil.la/2006040)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -126,7 +126,7 @@
               "safari": {
                 "version_added": "26.2",
                 "partial_implementation": true,
-                "notes": "The browser does not correctly scroll to the matching text. See https://webkit.org/b/304174."
+                "notes": "The browser does not correctly scroll to the matching text. See [bug 304174](https://webkit.org/b/304174)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -604,7 +604,7 @@
               "firefox": {
                 "version_added": "139",
                 "partial_implementation": true,
-                "notes": "The browser does not correctly scroll to the matching text. See https://bugzil.la/2006040."
+                "notes": "The browser does not correctly scroll to the matching text. See [bug 2006040](https://bugzil.la/2006040)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -613,7 +613,7 @@
               "safari": {
                 "version_added": "26.2",
                 "partial_implementation": true,
-                "notes": "The browser does not correctly scroll to the matching text. See https://webkit.org/b/304174."
+                "notes": "The browser does not correctly scroll to the matching text. See [bug 304174](https://webkit.org/b/304174)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
`<div hidden="until-found">` and `<details>` auto-open when things are found within them. This landed later than `<details>`.

However, the implementation in Firefox and Safari is buggy.

It feels like the warrants "partial_implementation", because it results in the user often not seeing the content they're searching for.