### PR TITLE
Chrome 141/Firefox 140 storage access activation per origin

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7295,9 +7295,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "11.1",
-              "notes": [
-                "Client-side storage access is granted per-page ([see explanation](https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works:~:text=In%20older%20spec%20versions%2C%20the%20access%20was%20per%2Dpage))."
-              ]
+              "notes": "Client-side storage access is granted per-page ([see explanation](https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works:~:text=In%20older%20spec%20versions%2C%20the%20access%20was%20per%2Dpage))."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

While using the [Storage Access API](https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API), when embedded content activates a previously-granted `storage-access` permission via the `requestStorageAccess()` method, 3rd party cookies are now only sent with requests to the calling embed's exact origin.

Previously, 3rd party cookies were sent with requests to the calling embed's site.

This behavioral change has occurred in:

- Chrome 141: See https://chromestatus.com/feature/5169937372676096.
- Firefox 140: See https://wpt.fyi/results/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window.html?run_id=5176618970775552

This PR adds notes in relevant places to document this change.

cc @cfredric / @hamishwillee — I'd appreciate your input on this one, folks.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
