### PR TITLE
Update CSS `progress()` status (Safari 26 support, Firefox `impl_url`)

### DIFF
--- a/css/types/progress.json
+++ b/css/types/progress.json
@@ -13,14 +13,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1975530"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -28,7 +29,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Safari 26 [added support](https://developer.apple.com/documentation/safari-release-notes/safari-26-release-notes#CSS) for [`progress()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/progress)! And Firefox has an open Bugzilla issue that should be linked here.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Web Platform Tests are passing in Safari https://wpt.fyi/results/css/css-values/progress-computed.html?label=master&label=experimental&aligned

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #28244
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
