### PR TITLE
text-decoration shorthand is fully supported in Safari 26.2

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -321,7 +321,7 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "26.2"
                 },
                 {
                   "prefix": "-webkit-",


### PR DESCRIPTION
https://webkit.org/blog/17640/webkit-features-for-safari-26-2/#:~:text=In%20Safari%2026.2%2C%20the%20text%2Ddecoration%20property%20is%20a%20proper%20shorthand%20for%20all%20four%20of%20the%20longhand%20properties:%20text%2Ddecoration%2Dline%2C%20text%2Ddecoration%2Dcolor%2C%20text%2Ddecoration%2Dstyle%20and%20text%2Ddecoration%2Dthickness.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
