### PR TITLE
font-family: math is supported in Safari 26.2

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -234,7 +234,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
https://webkit.org/blog/17640/webkit-features-for-safari-26-2/#:~:text=A%20new%20value%20forfont%2Dfamily%20is%20now%20available%20in%20Safari%2026.2%2C%20named%20math.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
