### PR TITLE
Fractional pointer event coordinates are now in Safari 26.2

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -569,8 +569,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "26.2",
-                "impl_url": "https://webkit.org/b/279540"
+                "version_added": "26.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
See https://webkit.org/blog/17640/webkit-features-for-safari-26-2/#:~:text=Safari%2026.2%20adds%20support%20for%20fractional%20coordinates%20in%20PointerEvent%20and%20TouchEvent%20properties%20like%20clientX%2C%20clientY%2C%20pageX%2C%20pageY%2C%20offsetX%2C%20offsetY%2C%20and%20screenX/screenY.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
