### PR TITLE
`onrepeat` event handler now supported in Safari 26.2

### DIFF
--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -474,11 +474,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10",
-              "partial_implementation": true,
-              "notes": "The `onrepeat` event handler property is not supported."
-            },
+            "safari": [
+              {
+                "version_added": "26.2"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "26.2",
+                "partial_implementation": true,
+                "notes": "The `onrepeat` event handler property is not supported."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
See:

https://commits.webkit.org/298715@main

and

https://webkit.org/blog/17640/webkit-features-for-safari-26-2/#:~:text=The%20repeatEvent%20in%20SVG%20animations%20is%20an%20event%20that%20fires%20each%20time%20an%20SVG%20animation%20element%20repeats%20its%20iteration%2C%20now%20supported%20to%20better%20align%20with%20the%20SMIL%20specification%20and%20match%20other%20browsers.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
