### PR TITLE
SVGAnimationElement onbegin is now supported in Safari 26.2

### DIFF
--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -161,11 +161,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10",
-              "partial_implementation": true,
-              "notes": "The `onbegin` event handler property is not supported."
-            },
+            "safari": [
+              {
+                "version_added": "26.2"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "26.2",
+                "partial_implementation": true,
+                "notes": "The `onbegin` event handler property is not supported."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
https://webkit.org/blog/17640/webkit-features-for-safari-26-2/#:~:text=Safari%2026.2%20also%20supports%20the%20onbegin%20event%20handler%20property%20defined%20in%20the%20SVGAnimationElement%20IDL%20(Interface%20Definition%20Language)%20that%20fires%20when%20an%20SVG%20animation%20starts.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
