### PR TITLE
Safari 26.2 supports api.HTMLElement.command_event

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -697,7 +697,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "26.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This was an oversight due to a bug in the collector. Like the other "web-features:invoker-commands" features, this is supported in Safari 26.2.