### PR TITLE
Safari treats `font-family: initial` like `font-family: inherit`

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -38,7 +38,7 @@
             },
             "safari": {
               "version_added": "1",
-              "notes": "`font-family: initial` is `inherit`. See [bug 200709](https://bugs.webkit.org/show_bug.cgi?id=200709)."
+              "notes": "Setting `font-family: initial` behaves like `font-family: inherit`. See [bug 200709](https://webkit.org/b/200709)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=200709
https://github.com/w3c/csswg-drafts/issues/4192

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
