### PR TITLE
Custom select - add `impl_url` for Firefox and Safari

### DIFF
--- a/html/elements/selectedcontent.json
+++ b/html/elements/selectedcontent.json
@@ -15,14 +15,16 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1974276"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/301929"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

The HTML `<selectedcontent>` is currently supported only by Chromium.

This PR adds `impl_url` for Firefox and Safari
