### PR TITLE
Add Safari iOS note for accept attribute `audio/*` limitation

### DIFF
--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -79,7 +79,10 @@
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "1",
+                "notes": "Does not support `audio/*` MIME type. See [bug 242110](https://webkit.org/b/242110)."
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a note to the `safari_ios` entry for the `input.accept` attribute indicating that Safari iOS does not support the `audio/*` MIME type, requiring developers to specify individual audio file extensions instead.

#### Test results and supporting details

Tested on iPad (iOS 17.0) using Safari, where setting `accept="audio/*"` does not allow picking any audio files. This behavior is documented in [WebKit bug 242110](https://bugs.webkit.org/show_bug.cgi?id=242110), which describes that iOS Safari treats `accept="audio/*"` identically to `accept="video/*"`, showing the video recorder and photo library options instead of audio files.
#### Related issues

Fixes #28629