### PR TITLE
safari 26 supports Intl.Locale#variants

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -1171,7 +1171,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "26"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION

#### Summary

Safari supports [`Intl.Locale#variants`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/variants) as of https://github.com/WebKit/WebKit/pull/46992, which was released in [WebKit-622.1.21](https://github.com/WebKit/WebKit/releases/tag/WebKit-7622.1.21), which [corresponds to Safari 26](https://github.com/mdn/browser-compat-data/blob/d64716cdadd87e7d87abf8206cc733d8bfcb2813/browsers/safari.json#L375).


#### Test results and supporting details

Open Safari and paste this into the devtools: 
```ts
new Intl.Locale('en-GB-oxendict').variants 
// should return "oxendict"
```

