### PR TITLE
Chrome 140 counters in content property alt text

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -76,6 +76,47 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "counters": {
+            "__compat": {
+              "description": "`counter()` and `counters()` in alternative text",
+              "tags": [
+                "web-features:alt-text-generated-content"
+              ],
+              "support": {
+                "chrome": [
+                  {
+                    "version_added": "preview"
+                  },
+                  {
+                    "version_added": "140",
+                    "partial_implementation": true,
+                    "notes": "Counters are recognised, but the spoken values do not increment"
+                  }
+                ],
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "close-quote": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 140 adds support for `counter()` and `counters()` functions in `content` property alt text. See https://chromestatus.com/feature/5185442420621312.

In testing, I found that the counters were recognized, but they didn't increment. For example, every counter value gets read out as `0` in [my test](https://codepen.io/Chris-Mills/full/GgqZjpd). I informed the engineering team about this, and they have fixed it, but the fix is only available in Canary at present.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
