### PR TITLE
Mark WebP animation as supported in Edge 18

### DIFF
--- a/mediatypes/image/webp.json
+++ b/mediatypes/image/webp.json
@@ -80,7 +80,9 @@
                 "version_added": "32"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "18"
+              },
               "firefox": {
                 "version_added": "65"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Edge 18 supported animations in WebP.

#### Test results and supporting details

I missed a spot in [my previous PR](https://github.com/mdn/browser-compat-data/pull/28653).

Sources are:

- https://caniuse.com/webp
- https://developers.google.com/speed/webp/faq#why_should_i_use_animated_webp

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/28653

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
