### PR TITLE
Nav API precommit handler will launch in Firefox 147

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -376,8 +376,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1777171"
+                "version_added": "147"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -392,7 +391,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Other parts of this API were correctly marked as 147 (like `NavigationPrecommitController`), but this bit had been missed.

I removed the impl URL as it felt too broad.