### PR TITLE
Update HTML Sanitizer API version info for Fx147

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -10336,7 +10336,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "Available by default in Nightly"
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -14,7 +14,15 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "148"
+            "version_added": "138",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.security.sanitizer.enabled",
+                "value_to_set": "true"
+              }
+            ],
+            "notes": "Available by default in Nightly."
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +56,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +99,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -118,7 +142,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -153,7 +185,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -188,7 +228,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -223,7 +271,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -258,7 +314,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -293,7 +357,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -328,7 +400,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -363,7 +443,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "138",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.sanitizer.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Available by default in Nightly."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Reverting version and preference info.
- Adding note for default availability in Nightly.

#### Context

As discussed with @jakearchibald, this is an update to https://github.com/mdn/browser-compat-data/pull/28774.

#### Background

Some notes to capture what's happened in the last few months:
- The correct entry with the flag info was added to browser compat in 138 via https://github.com/mdn/browser-compat-data/pull/26659. 
- The flag info was removed and version replaced with Nightly in https://github.com/mdn/browser-compat-data/pull/28262 (following https://bugzilla.mozilla.org/show_bug.cgi?id=1954437).

#### Changes in this PR

- The feature has been available behind the flag since 138, so this PR restores that flag info. We can change 138 to 148 and remove the preference info once the feature is available in stable release in 148.
- Since it's available by default in Nightly, I've added a note for this. (Do we have other ways to indicate this type of situation?)

#### Related docs

Channel-wise details are documented on the [Experimental features](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features#html_sanitizer_api) page.
147 makes it available by default in Beta and Developer Edition; but we don't mention those channels in BCD, only the stable release and Nightly.

/cc @hamishwillee for awareness.