### PR TITLE
TT: AsyncFunction, AsyncGeneratorFunction, GeneratorFunction

### DIFF
--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -93,6 +93,38 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "enforces_trusted_types": {
+            "__compat": {
+              "description": "Requires arguments to be `TrustedScript` instance when trusted types are enforced",
+              "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trustedscript",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "26"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/javascript/builtins/AsyncGeneratorFunction.json
+++ b/javascript/builtins/AsyncGeneratorFunction.json
@@ -89,6 +89,38 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "enforces_trusted_types": {
+            "__compat": {
+              "description": "Requires arguments to be `TrustedScript` instance when trusted types are enforced",
+              "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trustedscript",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "26"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -111,7 +111,7 @@
           "enforces_trusted_types": {
             "__compat": {
               "description": "Requires arguments to be `TrustedScript` instance when trusted types are enforced",
-              "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext",
+              "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trustedscript",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -93,6 +93,38 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "enforces_trusted_types": {
+            "__compat": {
+              "description": "Requires arguments to be `TrustedScript` instance when trusted types are enforced",
+              "spec_url": "https://w3c.github.io/trusted-types/dist/spec/#trustedscript",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "26"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
The [`AsyncFunction()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction/AsyncFunction), [`GeneratorFunction()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction/GeneratorFunction), and [`AsyncGeneratorFunction()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction/AsyncGeneratorFunction) contructors can execute their arguments as JavaScript. These are subclassed from `Function()` so share its TT behaviour.

This duplicates the TT entry from Function (I have tested that they work in Firefox only). NOTE, the spec URL used for Function was wrong. I can't find a better one though, so I have them all linked to https://w3c.github.io/trusted-types/dist/spec/#trustedscript

Related docs work tracked in https://github.com/mdn/content/issues/41507
