### PR TITLE
Chrome 1 supports `<col span="…">`

### DIFF
--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -175,7 +175,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Partially reverts https://github.com/mdn/browser-compat-data/pull/28029, which marked Chrome as not supporting the `span` attribute on the `<col>` element.

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/issues/28753#issuecomment-3728957363

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28753.
