### PR TITLE
Firefox 146 supports `::highlight()` with `text-decoration`

### DIFF
--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -21,7 +21,10 @@
             "firefox": {
               "version_added": "140",
               "partial_implementation": true,
-              "notes": "Cannot yet be used with `text-decoration` and `text-shadow`."
+              "notes": [
+                "Cannot yet be used with `text-shadow`. See [bug 1845447](https://bugzil.la/1845447).",
+                "Before Firefox 146, cannot be used with `text-decoration`. See [bug 1845446](https://bugzil.la/1845446)."
+              ]
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Firefox notes for `::highlight()` CSS selector:

- `text-decoration` is now supported.
- References bugs.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28754.
