### PR TITLE
Firefox 105 added `@font-face` src `format(keyword)`

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -941,7 +941,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "105"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds the Firefox version for `@font-face` src `format(keyword)`.

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=650372#c13

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28772.
