### PR TITLE
Edge mirrors nested `RTCRtpSender.setParameters()` subfeature

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -914,9 +914,7 @@
                   "version_added": "74"
                 },
                 "chrome_android": "mirror",
-                "edge": {
-                  "version_added": false
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "46"
                 },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Changes Edge statement to mirror for nested `RTCRtpSender.setParameters()` feature `scaleResolutionDownBy`.

#### Test results and supporting details

This is both plausible, and was also tested in https://github.com/mdn/browser-compat-data/issues/24742.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24742.