### PR TITLE
Refine Firefox notes for `AudioListener` properties

### DIFF
--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -53,7 +53,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setOrientation()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -89,7 +89,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setOrientation()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -125,7 +125,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setOrientation()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -161,7 +161,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setPosition()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -197,7 +197,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setPosition()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -233,7 +233,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setPosition()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -341,7 +341,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setOrientation()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -377,7 +377,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setOrientation()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -413,7 +413,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Supports a deprecated way of setting orientation - the `setOrientation()` method."
+              "notes": "Can be set using the `setOrientation()` method instead."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Refines the Firefox notes for the `AudioListener` properties:

- Make them shorter.
- Distinguish `setOrientation()` and `setPosition()`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24588.