### PR TITLE
Safari iOS mirrors for SVG `paint-order` attribute

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -2093,9 +2093,7 @@
             "safari": {
               "version_added": "≤12"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Changes Safari iOS to mirror for the SVG `paint-order` attribute.

#### Test results and supporting details

This was missed in https://github.com/mdn/browser-compat-data/pull/23444.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24367.