### PR TITLE
Safari 26.2 fixed `style-src-elem` CSP directive

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1303,9 +1303,17 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": "15.4"
-              },
+              "safari": [
+                {
+                  "version_added": "26.2"
+                },
+                {
+                  "version_added": "15.4",
+                  "version_removed": "26.2",
+                  "partial_implementation": true,
+                  "notes": "The `style-src-elem` directive was parsed, but had no effect. See [bug 276931](https://webkit.org/b/276931)."
+                }
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Safari statement for the `style-src-elem` CSP directive:

- Before Safari 26.2, it was "ignored".

#### Test results and supporting details

- Bug: https://webkit.org/b/276931

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24299.