### PR TITLE
Firefox 147 adds support for Iterator.concat()

### DIFF
--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -92,6 +92,49 @@
             }
           }
         },
+        "concat": {
+          "__compat": {
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-iterator.concat",
+            "tags": [
+              "web-features:iterator-methods"
+            ],
+            "support": {
+              "bun": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "147"
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "drop": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/drop",


### PR DESCRIPTION
#### Summary

Adds new Iterator.concat() method.

#### Test results and supporting details

- [Firefox’s Bugzilla](https://bugzil.la/1986672)
- [Firefox’s intent to ship](https://groups.google.com/a/mozilla.org/g/dev-platform/c/mTL4C0f_oT0)
- [Chromium issue (not started)](https://issues.chromium.org/issues/434977727)
- [Mentioned in Safari 18.4 release notes](https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#:~:text=Iterator%2Econcat), buuuut I can’t seem to make it work:

```js
typeof Iterator.concat === "function"
// true in Firefox, false in Safari and Chrome
typeof Iterator.from === "function"
// true in Firefox, Safari, and Chrome
```

[TC39’s presentation](https://docs.google.com/presentation/d/1rOgJ2LY5IF4M6zXo_Cbn0HkTFlFceBrmEkvwKw-u3go/edit?slide=id.g398766346cd_0_45#slide=id.g398766346cd_0_45) says it’s behind the flag in Safari 18.4, but I couldn’t find any flag in the UI (both stable 26.2 and Safari TP), and it’s also listed as a stable feature in the 18.4 release notes. Go figure.

So, Safari gets `false` for now.

⚠️ I haven’t tested implementations in Node.js or Bun

### Related issues and pull requests

- Issue tracker: https://github.com/mdn/content/issues/42248
- Content PR: https://github.com/mdn/content/pull/42671
- Release notes PR: https://github.com/mdn/content/pull/42713