### PR TITLE
Add Chrome notes for `keydown` events with autocomplete suggestions

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -983,7 +983,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "When selecting an autocomplete suggestion, a `keydown` event fires where `KeyboardEvent.keyCode` is `undefined`. See [bug 41425904](https://crbug.com/41425904)."
+              "notes": "When selecting an autocomplete suggestion, a `keydown` event fires where the event's `keyCode` property is `undefined`. See [bug 41425904](https://crbug.com/41425904)."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -241,7 +241,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "When selecting an autocomplete suggestion, a `keydown` event fires where `UIEvent.which` is `undefined`. See [bug 41425904](https://crbug.com/41425904)."
+              "notes": "When selecting an autocomplete suggestion, a `keydown` event fires where the event's `which` property is `undefined`. See [bug 41425904](https://crbug.com/41425904)."
             },
             "chrome_android": "mirror",
             "edge": [


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds Chrome notes for `keydown` events with autocomplete suggestions, affecting `KeyboardEvent.{key,keyCode}` and `UIEvent.which`.

#### Test results and supporting details

- Chromium bug: https://crbug.com/41425904

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24143.