### PR TITLE
Safari 18 no longer uses `History.replaceState()` title argument

### DIFF
--- a/api/History.json
+++ b/api/History.json
@@ -365,11 +365,13 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "5",
-                "notes": "This feature may be removed, see [bug 223190](https://webkit.org/b/223190)."
+                "version_removed": "18",
+                "notes": "See [bug 223190](https://webkit.org/b/223190)."
               },
               "safari_ios": {
                 "version_added": "4",
-                "notes": "This feature may be removed, see [bug 223190](https://webkit.org/b/223190)."
+                "version_removed": "18",
+                "notes": "See [bug 223190](https://webkit.org/b/223190)."
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari 18 no longer uses `History.replaceState()` title argument

#### Test results and supporting details

See issue below.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/23121.