### PR TITLE
Undeprecate `font-stretch`, exceptionally

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -539,7 +539,7 @@
         "font-stretch": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@font-face/font-stretch",
-            "spec_url": "https://drafts.csswg.org/css-fonts/#font-prop-desc",
+            "spec_url": "https://drafts.csswg.org/css-fonts/#font-stretch-desc",
             "tags": [
               "web-features:font-stretch"
             ],
@@ -573,7 +573,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -11,7 +11,7 @@
           "support": {
             "chrome": {
               "version_added": "60",
-              "notes": "A `font-stretch` definition must be added to the `@font-face` before this property will function."
+              "notes": "A `font-stretch` declaration must be added to the `@font-face` before this property will function."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -38,7 +38,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         },
         "condensed": {
@@ -70,7 +70,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -103,7 +103,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -136,7 +136,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -169,7 +169,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -202,7 +202,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -238,7 +238,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -271,7 +271,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -304,7 +304,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -337,7 +337,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -370,7 +370,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Allows `font-stretch` property and descriptor to appear as undeprecated, in the absence of a widely available alternative.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This change is an exception to our data guideline that requires us to treat "legacy" as meaning deprecated.

For background, the CSS Working Group decided to rename `font-stretch` to `font-width` (see resolution in https://github.com/w3c/csswg-drafts/issues/551#issuecomment-1885196273), declaring the former name a legacy alias. There's no underlying font behavior change associated with this specification change.

This case of legacy aliasing is somewhat unfortunate, however, as the existing name is well established. It's interoperable and [a Chrome use counter](https://chromestatus.com/metrics/css/timeline/popularity/80) reports >25% of page loads use `font-stretch`. Meanwhile, BCD reports that `font-width` is only implemented in Safari on macOS.

This creates a weird situation, where MDN, caniuse, and various tools warn developers against using a CSS feature that has worked across all major browsers for over 8 years and directs them to an alternative that is very unlikely to work.

We should make this exception because, to the best of my knowledge, this is only case where a CSS feature's proper name is almost unusable, while the legacy alias is completely interoperable. For example, this is the only case of [a web-features entry](https://web-platform-dx.github.io/web-features-explorer/features/font-stretch "The <code>font-stretch</code> CSS property selects a font face from a font family based on width, either by a keyword such as <code>condensed</code> or a percentage.") ([source](https://github.com/web-platform-dx/web-features/blob/main/features/font-stretch.yml), [dist](https://github.com/web-platform-dx/web-features/blob/main/features/font-stretch.yml.dist)) where the feature would be Baseline widely available, while all of the alternative features are non-Baseline.

I raised this issue at the most-recent BCD meeting. After some discussion, we agreed to this way forward as an exception. It would be nice to follow this up with a search for other legacy aliases, to see if a more general rule change ought to be made about CSS's [legacy name aliases](https://github.com/search?q=repo%3Aw3c%2Fcsswg-drafts+%22legacy+name+alias%22&type=code).

##### Consequences

This change requires some downstream changes:

- MDN ought to withdraw the deprecation banner on `font-stretch` (see also: https://github.com/mdn/content/issues/42409)
- web-features ought to undiscourage the `font-stretch` feature

Someday, when more browsers implement `font-width`, we should consider undoing this exception.

#### Related issues

- https://github.com/mdn/content/issues/42409
- https://github.com/w3c/csswg-drafts/issues/551

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
