### PR TITLE
Chrome 140 adds PerformanceResourceTiming worker timing getters

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -1342,6 +1342,68 @@
           }
         }
       },
+      "workerCacheLookupStart": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-workercachelookupstart",
+          "support": {
+            "chrome": {
+              "version_added": "140"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "workerRouterEvaluationStart": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-workerrouterevaluationstart",
+          "support": {
+            "chrome": {
+              "version_added": "140"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "workerStart": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/workerStart",


### PR DESCRIPTION
This shipped in Microsoft Edge in Chromium 140: https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/140#service-worker-static-routing-api-timings

See also: https://chromestatus.com/feature/6309742380318720