### PR TITLE
Safari 26.2 supports NavigationHistoryEntry.dispose_event

### DIFF
--- a/api/NavigationHistoryEntry.json
+++ b/api/NavigationHistoryEntry.json
@@ -56,7 +56,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This was an oversight due to a [bug](https://github.com/openwebdocs/mdn-bcd-collector/pull/2949) in the collector. Like the other "web-features:navigation" features, this event is supported in Safari 26.2.