### PR TITLE
Updates for Firefox 148 beta

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -78,7 +78,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/NavigationPrecommitController.json
+++ b/api/NavigationPrecommitController.json
@@ -31,6 +31,37 @@
           "deprecated": false
         }
       },
+      "addHandler": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationprecommitcontroller-addhandler",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "148"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "redirect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPrecommitController/redirect",

--- a/api/TrustedHTML.json
+++ b/api/TrustedHTML.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "148"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedScript.json
+++ b/api/TrustedScript.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "148"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedScriptURL.json
+++ b/api/TrustedScriptURL.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "148"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedTypePolicy.json
+++ b/api/TrustedTypePolicy.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "148"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -118,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -153,7 +153,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/TrustedTypePolicyFactory.json
+++ b/api/TrustedTypePolicyFactory.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "148"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -118,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -153,7 +153,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -188,7 +188,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -223,7 +223,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -258,7 +258,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -293,7 +293,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -328,7 +328,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/_globals/trustedTypes.json
+++ b/api/_globals/trustedTypes.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "148"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",

--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -53,8 +53,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1661582"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -70,7 +69,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -89,8 +88,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1661582"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -106,7 +104,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -125,8 +123,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1661582"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -142,7 +139,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/position-try-order.json
+++ b/css/properties/position-try-order.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1838746"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -49,8 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1838746"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -84,8 +82,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1838746"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -119,8 +116,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1838746"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -154,8 +150,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1838746"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -189,8 +184,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1838746"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.17.1) found new features shipping in Firefox 148 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 79 features as shipping in Firefox 148:

Data updated in this PR:

- api.Location.ancestorOrigins
- api.NavigationPrecommitController.addHandler
- api.TrustedHTML
- api.TrustedHTML.toJSON
- api.TrustedHTML.toString
- api.TrustedScript
- api.TrustedScript.toJSON
- api.TrustedScript.toString
- api.TrustedScriptURL
- api.TrustedScriptURL.toJSON
- api.TrustedScriptURL.toString
- api.TrustedTypePolicy
- api.TrustedTypePolicy.createHTML
- api.TrustedTypePolicy.createScript
- api.TrustedTypePolicy.createScriptURL
- api.TrustedTypePolicy.name
- api.TrustedTypePolicyFactory
- api.TrustedTypePolicyFactory.createPolicy
- api.TrustedTypePolicyFactory.defaultPolicy
- api.TrustedTypePolicyFactory.emptyHTML
- api.TrustedTypePolicyFactory.emptyScript
- api.TrustedTypePolicyFactory.getAttributeType
- api.TrustedTypePolicyFactory.getPropertyType
- api.TrustedTypePolicyFactory.isHTML
- api.TrustedTypePolicyFactory.isScript
- api.TrustedTypePolicyFactory.isScriptURL
- api.trustedTypes
- css.properties.overflow-clip-margin.border-box
- css.properties.overflow-clip-margin.content-box
- css.properties.overflow-clip-margin.padding-box
- css.properties.position-try-order
- css.properties.position-try-order.most-block-size
- css.properties.position-try-order.most-height
- css.properties.position-try-order.most-inline-size
- css.properties.position-try-order.most-width
- css.properties.position-try-order.normal


Data updated in other PRs:
- api.Element.setHTML
- api.Sanitizer
- api.Sanitizer.Sanitizer
- api.Sanitizer.allowAttribute
- api.Sanitizer.allowElement
- api.Sanitizer.get
- api.Sanitizer.removeAttribute
- api.Sanitizer.removeElement
- api.Sanitizer.removeUnsafe
- api.Sanitizer.replaceElementWithChildren
- api.Sanitizer.setComments
- api.Sanitizer.setDataAttributes
- css.properties.position-area.block-end
- css.properties.position-area.block-start
- css.properties.position-area.bottom
- css.properties.position-area.end
- css.properties.position-area.inline-end
- css.properties.position-area.inline-start
- css.properties.position-area.left
- css.properties.position-area.right
- css.properties.position-area.self-block-end
- css.properties.position-area.self-block-start
- css.properties.position-area.self-end
- css.properties.position-area.self-inline-end
- css.properties.position-area.self-inline-start
- css.properties.position-area.self-start
- css.properties.position-area.self-x-end
- css.properties.position-area.self-x-start
- css.properties.position-area.self-y-end
- css.properties.position-area.self-y-start
- css.properties.position-area.top
- css.properties.position-area.x-end
- css.properties.position-area.x-start
- css.properties.position-area.y-end
- css.properties.position-area.y-start
- css.properties.position-try-fallbacks.self-x-end
- css.properties.position-try-fallbacks.self-x-start
- css.properties.position-try-fallbacks.self-y-end
- css.properties.position-try-fallbacks.self-y-start
- css.properties.position-try.self-x-end
- css.properties.position-try.self-x-start
- css.properties.position-try.self-y-end
- css.properties.position-try.self-y-start

See also https://github.com/mdn/mdn/issues/786 and https://www.mozilla.org/en-US/firefox/148.0beta/releasenotes/