### PR TITLE
Firefox 147 ships Navigation events

### DIFF
--- a/api/Navigation.json
+++ b/api/Navigation.json
@@ -224,8 +224,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1777171"
+              "version_added": "147"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -367,8 +366,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1777171"
+              "version_added": "147"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -404,8 +402,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1777171"
+              "version_added": "147"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -441,8 +438,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1777171"
+              "version_added": "147"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
This is forgotten in https://github.com/mdn/browser-compat-data/pull/28624 due to a bug in the collector where event data wouldn't get updated.