### PR TITLE
Add deprecated CSS properties: buffered-/color-rendering

### DIFF
--- a/css/properties/buffered-rendering.json
+++ b/css/properties/buffered-rendering.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "28"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -17,7 +17,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -34,7 +34,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -46,7 +46,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -64,7 +64,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -76,7 +76,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "28"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -106,7 +106,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/color-rendering.json
+++ b/css/properties/color-rendering.json
@@ -5,7 +5,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -17,7 +17,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1",
+              "version_added": "4",
               "version_removed": "15.4"
             },
             "safari_ios": "mirror",
@@ -35,7 +35,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -47,7 +47,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1",
+                "version_added": "4",
                 "version_removed": "15.4"
               },
               "safari_ios": "mirror",
@@ -66,7 +66,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -78,7 +78,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1",
+                "version_added": "4",
                 "version_removed": "15.4"
               },
               "safari_ios": "mirror",
@@ -97,7 +97,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -109,7 +109,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1",
+                "version_added": "4",
                 "version_removed": "15.4"
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
This was added to the collector by @caugner in https://github.com/openwebdocs/mdn-bcd-collector/pull/2968.

15.4 removal version comes from https://github.com/WebKit/WebKit/commit/030fde6a1d719f273fa9d894f42761c0df96a960.

Other versions I don't know, so I kept the ranged versions from the collector.

Partly fixes https://github.com/mdn/browser-compat-data/issues/24053