### PR TITLE
Remove irrelevant Window.sizeToContent() method

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6988,45 +6988,6 @@
           }
         }
       },
-      "sizeToContent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/sizeToContent",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "120"
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "120",
-              "notes": "This method has no effect as a page is always in a tab."
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "speechSynthesis": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/speechSynthesis",


### PR DESCRIPTION
This should be removed according to BCD irrelevance guideline.

Obsolete - 1 problem (0 errors, 0 warnings, 1 info):
 ✖ api.Window.sizeToContent - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.