### PR TITLE
Chrome 117 / Safari 9.1 partially implement `font-variant-position: {sub,super}`

### DIFF
--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -129,7 +129,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "9.1",
+                "partial_implementation": true,
+                "notes": "If the font does not have superscript glyphs, then substitute characters are not synthesized (see [bug 151471](https://webkit.org/b/151471))."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Mark Chrome and Safari's `font-variant-position: sub` and `font-variant-position: super` as partially implemented, due to lack of font synthesis.

#### Test results and supporting details

Most of the prior discussion is on https://github.com/mdn/browser-compat-data/issues/24136.

Vendor bugs:

- [Chromium 352218916](https://issues.chromium.org/issues/352218916)
- [WebKit 151471](https://bugs.webkit.org/show_bug.cgi?id=151471)

Firefox does the right thing; see [Gecko 1024804](https://bugzilla.mozilla.org/show_bug.cgi?id=1024804).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24136 and fixes https://github.com/mdn/browser-compat-data/issues/20638.

Completes work started in https://github.com/mdn/browser-compat-data/pull/24152.

See also:
- https://github.com/mdn/browser-compat-data/issues/24510
- https://github.com/web-platform-tests/interop/issues/748
- https://github.com/web-platform-tests/interop/issues/1038

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
