### PR TITLE
Safari 26.2 added CSS `random()`

### DIFF
--- a/css/types/random.json
+++ b/css/types/random.json
@@ -4,7 +4,6 @@
       "random": {
         "__compat": {
           "description": "`random()`",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/random",
           "spec_url": "https://www.w3.org/TR/css-values-5/#random",
           "support": {
             "chrome": {


### PR DESCRIPTION
#### Summary

Adds Safari 26.2 support for the CSS `random()` function. Safari 26.2 shipped on December 12, 2025.

#### Test results and supporting details

See the following:

- [Rolling the Dice with CSS random()](https://webkit.org/blog/17285/rolling-the-dice-with-css-random/)
- [Added support for the CSS random() function](https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#:~:text=Added%20support%20for%20the%20CSS%20random()%20function.%20(145696017))
