### PR TITLE
Edge 18 fully implemented WebP

### DIFF
--- a/mediatypes/image/webp.json
+++ b/mediatypes/image/webp.json
@@ -48,7 +48,9 @@
                 "version_added": "23"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "18"
+              },
               "firefox": {
                 "version_added": "65"
               },
@@ -112,7 +114,9 @@
                 "version_added": "23"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "18"
+              },
               "firefox": {
                 "version_added": "65"
               },
@@ -144,7 +148,9 @@
                 "version_added": "17"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "18"
+              },
               "firefox": {
                 "version_added": "65"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Edge 18 supported _everything_ in WebP, from the start.

#### Test results and supporting details

I missed this in two previous PRs 🤦:

- https://github.com/mdn/browser-compat-data/pull/28769
- https://github.com/mdn/browser-compat-data/pull/28653

Sources are:

- https://caniuse.com/webp
- https://developers.google.com/speed/webp/faq#why_should_i_use_animated_webp

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/28653
- https://github.com/web-platform-dx/web-features/pull/3624

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
