### PR TITLE
Firefox Nightly adds Document Picture-in-Picture API

### DIFF
--- a/api/DocumentPictureInPicture.json
+++ b/api/DocumentPictureInPicture.json
@@ -16,7 +16,8 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "impl_url": "https://bugzil.la/1858562"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -53,7 +54,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1858562"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -90,7 +92,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1858562"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -163,7 +166,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1858562"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -201,7 +205,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1858562"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/DocumentPictureInPictureEvent.json
+++ b/api/DocumentPictureInPictureEvent.json
@@ -16,7 +16,8 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "impl_url": "https://bugzil.la/1858562"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -53,7 +54,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1858562"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -90,7 +92,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1858562"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1400,7 +1400,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/1858562"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -573,7 +573,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "impl_url": "https://bugzil.la/1858562"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 148 adds support for the [Document Picture-in-Picture API](https://developer.mozilla.org/en-US/docs/Web/API/Document_Picture-in-Picture_API): see https://bugzilla.mozilla.org/show_bug.cgi?id=1858562.

We support all features except for the [`DocumentPictureInPicture/requestWindow()` `disallowReturnToOpener` option](https://developer.mozilla.org/en-US/docs/Web/API/DocumentPictureInPicture/requestWindow#disallowreturntoopener); see https://bugzilla.mozilla.org/show_bug.cgi?id=1858562#c21.

The feature is available by default in Nightly only. In non-Nightly 148+ Firefox, you can enable it via the `dom.documentpip.enabled` pref. I wasn't sure if I should include the pref information in the BCD, or just include it in the Experimental features writeup...?

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
