### PR TITLE
fix: Safari 26.2 is current

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -384,14 +384,14 @@
         "26.2": {
           "release_date": "2025-12-12",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes",
-          "status": "retired",
+          "status": "current",
           "engine": "WebKit",
           "engine_version": "623.1.14"
         },
         "26.3": {
           "release_date": "2025-12-15",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-26_3-release-notes",
-          "status": "current",
+          "status": "beta",
           "engine": "WebKit",
           "engine_version": "623.2.2"
         }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -356,14 +356,14 @@
         "26.2": {
           "release_date": "2025-12-12",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes",
-          "status": "retired",
+          "status": "current",
           "engine": "WebKit",
           "engine_version": "623.1.14"
         },
         "26.3": {
           "release_date": "2025-12-15",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-26_3-release-notes",
-          "status": "current",
+          "status": "beta",
           "engine": "WebKit",
           "engine_version": "623.2.2"
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari 26.2 (released 2025-12-12) is marked as "retired" but AFAIK it's still current. The 26.3 (released 2025-12-15) is beta, not current. I've fixed this for both `safari` and `safari_ios` jsons.

https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes

https://developer.apple.com/documentation/safari-release-notes/safari-26_3-release-notes

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
