### PR TITLE
Point SVGTransform.matrix to SVG 1.1 spec

### DIFF
--- a/api/SVGTransform.json
+++ b/api/SVGTransform.json
@@ -90,7 +90,7 @@
       "matrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/matrix",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__matrix",
+          "spec_url": "https://www.w3.org/TR/SVG11/coords.html#__svg__SVGTransform__matrix",
           "tags": [
             "web-features:svg"
           ],


### PR DESCRIPTION
#### Summary

Updates the `SVGTransform.matrix` feature to point to the SVG 1.1 spec.

#### Test results and supporting details

Browsers did not implement the change introduced in SVG 2, which expects the property to return `DOMMatrix` instead of `SVGMatrix`, so the SVG 1.1 spec describes the de facto standard.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28757.