### PR TITLE
fix(scripts/update-browser-releases): improve Safari beta detection

### DIFF
--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -26,7 +26,7 @@ interface Release {
 const extractReleaseData = (str): Release | null => {
   // Note: \s is needed as some spaces in Apple source are non-breaking
   const result =
-    /Released\s+(.*)\s*—\s*(?:Version\s+)?(\d+(?:\.\d+)*)\s*(\s*beta)?\s*\((.*)\)/.exec(
+    /Released\s+(.*)\s*—\s*(?:Version\s+)?(\d+(?:\.\d+)*)\s*(?:\s*beta)?\s*\((.*)\)/.exec(
       str,
     );
   if (!result) {
@@ -35,11 +35,12 @@ const extractReleaseData = (str): Release | null => {
     );
     return null;
   }
+  const isBeta = /\bbeta\b/i.test(str);
   return {
     date: new Date(`${result[1]} UTC`).toISOString().substring(0, 10),
     version: result[2].replace(/\.0$/, ''),
-    channel: result[3] ? 'beta' : 'retired',
-    engineVersion: result[4].substring(2),
+    channel: isBeta ? 'beta' : 'retired',
+    engineVersion: result[3].substring(2),
     releaseNote: '',
   };
 };
@@ -79,7 +80,10 @@ export const updateSafariReleases = async (options) => {
     if (releases[id].kind !== 'article') {
       continue;
     }
-    const releaseDataEntry = extractReleaseData(releases[id].abstract[0].text);
+
+    const releaseDataEntry = extractReleaseData(
+      releases[id].title + '\n' + releases[id].abstract[0].text,
+    );
 
     if (!releaseDataEntry) {
       console.warn(


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the `update-browser-releases` script for Safari, improving the beta detection by taking into consideration the release notes title.

#### Test results and supporting details

Before, we were expecting the "beta" keyword in the subtitle.

Now, we look for the word "beta" anywhere in the title or abstract.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28867.