### PR TITLE
Add Safari note for unprefixed CSS `line-clamp` in Safari 18.2

### DIFF
--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -34,7 +34,8 @@
               },
               {
                 "version_added": "18.2",
-                "version_removed": "18.4"
+                "version_removed": "18.4",
+                "notes": "Accidental exposure."
               }
             ],
             "safari_ios": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Safari note for unprefixed CSS `line-clamp` in Safari 18.2, mentioning that it was an accidental exposure.

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/pull/26771#issuecomment-3046159494

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
