### PR TITLE
Safari only partially supports `PermissionStatus` change event

### DIFF
--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -59,7 +59,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "The `onchange` event handler is supported, but the event never fires. See [bug 259432](https://webkit.org/b/259432)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Safari support for `PermissionStatus` change event, marking the implementation as partial, because the event never fires.

#### Test results and supporting details

Frequently reported: https://github.com/mdn/browser-compat-data/issues/21497#issuecomment-3737907999

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21497.