### PR TITLE
Before Chrome 140, `FontFace.featureSettings` had no effect

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -258,9 +258,17 @@
             "web-features:font-loading"
           ],
           "support": {
-            "chrome": {
-              "version_added": "35"
-            },
+            "chrome": [
+              {
+                "version_added": "140"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "140",
+                "partial_implementation": true,
+                "notes": "The property can be set, but has no effect. See [bug 324519293](https://crbug.com/324519293)"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Chrome support for `FontFace.featureSettings`, which had no effect before Chrome 140 (which added the [`font-feature-settings` descriptor](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@font-face/font-feature-settings#browser_compatibility)).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24050.