### PR TITLE
Add Firefox note for CSS `zoom`

### DIFF
--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -18,7 +18,7 @@
             },
             "firefox": {
               "version_added": "126",
-              "notes": "Before Firefox 131, SVGs are not zoomed properly. See [bug 1905023](https://bugzil.la/1905023) and [bug 878346](https://bugzil.la/878346)."
+              "notes": "Before Firefox 131, SVG elements are not zoomed properly. See [bug 1905023](https://bugzil.la/1905023) and [bug 878346](https://bugzil.la/878346)."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds Firefox note for CSS `zoom` describing a limitation affecting SVGs before Firefox 131.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24560.