### PR TITLE
Remove erroneous partial_implementation from Firefox accepts_css_colors on color input

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -58,14 +58,12 @@
               "support": {
                 "chrome": {
                   "version_added": false,
-                  "impl_url": "https://crbug.com/368059226"
+                  "impl_url": "https://crbug.com/416245392"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "143",
-                  "partial_implementation": true,
-                  "notes": "Value will always be converted to the hex format."
+                  "version_added": "143"
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Remove erroneous partial_implementation from Firefox accepts_css_colors on color input

The feature is about whether it accepts all CSS colors, which it does, the fact they're serialised to hex is irrelevant (and is in fact correct if there's no alpha or colorspace attribute present).

This also corrects the bug link for chromium to the more specific one.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
