### PR TITLE
Chrome 144 :current support

### DIFF
--- a/css/selectors/current.json
+++ b/css/selectors/current.json
@@ -1,0 +1,38 @@
+{
+  "css": {
+    "selectors": {
+      "current": {
+        "__compat": {
+          "description": "`:current`",
+          "spec_url": "https://drafts.csswg.org/selectors-5/#current-pseudo",
+          "support": {
+            "chrome": {
+              "version_added": "144"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 144 supports the `::search-text` pseudo-element, which allows custom styling to be applied to browser search results; see https://chromestatus.com/feature/5195073796177920.

We already have BCD for `::search-text`, however, you can combine `::search-text` with the `:current` pseudo-class to style the currently-highlighted search term on the page. This currently doesn't have any BCD, so I am using this PR to add `:current` BCD.

I'm assuming it makes sense to put Chrome 144 down for this as well, as previously, there was no context in which `:current` was supported. However, you might have other opinions on this.

I also thought about putting `"partial_implementation": "true"` for this, but then again, `:current` is fully supported in the context it is supported in. It just isn't supported in other contexts.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29543.
