### PR TITLE
fix(update-browser-releases/edge): support full month names

### DIFF
--- a/scripts/update-browser-releases/edge.test.ts
+++ b/scripts/update-browser-releases/edge.test.ts
@@ -12,4 +12,11 @@ describe('parseReleaseDate', () => {
     assert.equal(result.getUTCMonth(), 2); // March is 0-indexed as 2
     assert.equal(result.getUTCDate(), 12);
   });
+
+  it('should parse date with full month correctly', () => {
+    const result = parseReleaseDate('09-April-2026');
+    assert.equal(result.getUTCFullYear(), 2026);
+    assert.equal(result.getUTCMonth(), 3); // April is 0-indexed as 3
+    assert.equal(result.getUTCDate(), 9);
+  });
 });

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -331,9 +331,8 @@ export const parseReleaseDate = (dateText: string) => {
     'Nov',
     'Dec',
   ];
-  const year = dateText.substring(7, 11);
-  const month = months.indexOf(dateText.substring(3, 6)) + 1;
-  const day = dateText.substring(0, 2);
+  const [day, monthText, year] = dateText.split('-');
+  const month = months.findIndex((m) => monthText.startsWith(m)) + 1;
 
   return new Date(`${year}-${month}-${day}Z`);
 };


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates `script/update-browser-releases/edge.ts` to support release dates with full month names (e.g. `09-April-2026`).

#### Test results and supporting details

##### Before

```console
% npm run update-browser-releases -- --edge

> @mdn/browser-compat-data@7.2.4 update-browser-releases
> tsx scripts/update-browser-releases/index.ts --edge

### Updates for Edge for Desktop

- New release date for edge 144: 2026-01-21, previously 2026-01-16.
- New status for edge 145: nightly, previously beta.
- New status for edge 145: beta, previously nightly.RangeError: Invalid time value
```

##### After

```console
% npm run update-browser-releases -- --edge                                         

> @mdn/browser-compat-data@7.2.4 update-browser-releases
> tsx scripts/update-browser-releases/index.ts --edge

### Updates for Edge for Desktop

- New release date for edge 144: 2026-01-21, previously 2026-01-16.
- New status for edge 145: nightly, previously beta.
- New status for edge 145: beta, previously nightly.
- New release date for edge 147: 2026-04-09, previously undefined.
```

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28885.
