### PR TITLE
Safari iOS doesn't fully support `background-attachment: fixed`

### DIFF
--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -89,7 +89,6 @@
               ],
               "safari_ios": {
                 "version_added": "5",
-                "version_removed": "15.4",
                 "partial_implementation": true,
                 "notes": "`fixed` is recognized but has no effect. See [bug 275247](https://webkit.org/b/275247)."
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Safari for iOS support for `background-attachment: fixed`, which appears to still be only recognized without any effect.

Also updates the note for Safari, which mentions `local` and references a bug that is only related (although the corresponding patch may have fixed it).

#### Test results and supporting details

From the issue:

> - [MDN page containing incorrect information about background-attachment: fixed compatibility for iOS](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/background-attachment)
> - [WebKit developer confirming lack of support for background-attachment: fixed on iOS](https://bugs.webkit.org/show_bug.cgi?id=275247#c3)
> - [Bug report suggesting to set @supports(background-attachment: fixed) to false on iOS](https://bugs.webkit.org/show_bug.cgi?id=196327)

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/28856.
