### PR TITLE
Add `color-gamut` media query value subfeatures

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -296,8 +296,8 @@
           "p3": {
             "__compat": {
               "description": "`p3` value",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@media/color-gamut#p3",
               "spec_url": "https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-p3",
-              "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/color-gamut#p3",
               "support": {
                 "chrome": {
                   "version_added": "58"
@@ -330,8 +330,8 @@
           "rec2020": {
             "__compat": {
               "description": "`rec2020` value",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@media/color-gamut#rec2020",
               "spec_url": "https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-rec2020",
-              "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/color-gamut#rec2020",
               "support": {
                 "chrome": {
                   "version_added": "58"
@@ -364,8 +364,8 @@
           "srgb": {
             "__compat": {
               "description": "`srgb` value",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@media/color-gamut#srgb",
               "spec_url": "https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-srgb",
-              "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/color-gamut#srgb",
               "support": {
                 "chrome": {
                   "version_added": "58"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This adds data on the individual values of the `color-gamut` media query.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

All browsers parse the media query and all its values; see [the web platform tests for feature color-gamut](https://wpt.fyi/results/css/mediaqueries?label=master&label=experimental&aligned&q=feature%3Acolor-gamut).

However, Firefox does not support displays with a wider gamut (or, strictly speaking, it works only in sRGB and hands off color management to the OS), so the values other than `srgb` are always false. This does not mean the media query is unsupported (as suggested by https://github.com/mdn/browser-compat-data/issues/21422). This is the correct behavior given by the spec (emphasis added):

> the approximate range of colors that are supported by the UA **and** output device

This might be slightly surprising if you have a P3 display connected. I've added notes to capture this nuance, similar to what I've done in https://github.com/mdn/browser-compat-data/pull/28868.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21422

This came up in resolving https://github.com/web-platform-dx/web-features/issues/3227.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
