### PR TITLE
Safari 17.4 adds HTML input attribute `switch`

### DIFF
--- a/html/elements/input/checkbox.json
+++ b/html/elements/input/checkbox.json
@@ -42,45 +42,6 @@
               "deprecated": false
             }
           }
-        },
-        "switch": {
-          "__compat": {
-            "description": "`switch` attribute for checkbox input elements",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/input/checkbox#switch",
-            "spec_url": "https://webkit.org/blog/15054/an-html-switch-control/",
-            "tags": [
-              "web-features:input-checkbox"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "17.4"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Adds checkbox `switch` attribute BCD.
#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://webkit.org/blog/15054/an-html-switch-control/
https://webkit.org/blog/15063/webkit-features-in-safari-17-4/
https://github.com/openwebdocs/mdn-bcd-collector/pull/3013
#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixed #28896
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
