### PR TITLE
Chrome 144 adds `RTCDegradationPreference` `maintain-framerate-and-resolution`

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -252,38 +252,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "maintain-framerate-and-resolution_value": {
-            "__compat": {
-              "description": "`maintain-framerate-and-resolution` value",
-              "spec_url": "https://w3c.github.io/mst-content-hint/#dom-rtcdegradationpreference-maintain-framerate-and-resolution",
-              "support": {
-                "chrome": {
-                  "version_added": "144"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror",
-                "webview_ios": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         },
         "return_object_property_encodings": {


### PR DESCRIPTION
… value

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 144 adds support for the `maintain-framerate-and-resolution` value of the [`RTCDegradationPreference`](https://w3c.github.io/mst-content-hint/#dom-rtcdegradationpreference) dictionary, which is used in the options object of the [`RTCRtpSender.setParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters) method, and available in the return value of the [`RTCRtpSender.getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/getParameters) method.

See https://chromestatus.com/feature/5156290162720768 for the release details.

This PR adds a sub-data point to each method's data structure for this new value.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
