### PR TITLE
Mark `:autofill` as partially implemented in Firefox

### DIFF
--- a/css/selectors/autofill.json
+++ b/css/selectors/autofill.json
@@ -26,11 +26,15 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "86"
+                "version_added": "86",
+                "partial_implementation": true,
+                "notes": "The `:autofill` pseudo-class matches autofilled username and password fields, but not other autocompleted fields. See [bug 1923525](https://bugzil.la/1923525)."
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "86"
+                "version_added": "86",
+                "partial_implementation": true,
+                "notes": "The `:-webkit-autofill` pseudo-class matches autofilled username and password fields, but not other autocompleted fields. See [bug 1923525](https://bugzil.la/1923525)."
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mark `:autofill` as partially implemented in Firefox because it doesn't match for autocompleted fields.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

The status of this feature came up on the WebDX call yesterday (see also https://github.com/web-platform-dx/web-features/issues/3226). After some discussion, I concluded that the regression would be correct to do and the partial should be reflected in BCD.

No one opposed this, though there was a suggestion to record this as a behavioral subfeature. After mulling this over a bit, I do not think that a behavioral subfeature is a good fit here (this is not evolution and the context, such as it is, is a rather fine distinction between autofill and autocomplete).

<details>

<summary>Checklist</summary>

You must set `"partial_implementation": true` when all of the following conditions are met:

- The browser's support does not implement mandatory specified behavior. **Yes**. The spec explicitly calls out `autocomplete` behavior.
- The browser's support is inconsistent with at least one other browser. **Yes**. Chrome and Safari both match autocompleted fields.
- The browser's support causes confusing feature detection results. **Yes**. There's no developer-facing way to detect this.
- The browser's support has a demonstrable negative impact on web developers. **Yes**. See discussion below.

</details>

The breadth of negative impact on developers is difficult to gauge but, we have some evidence that suggests this may affect a lot of developers and sites:

- A Chrome use counter shows `:autofill` being [used on >2% of page loads](https://chromestatus.com/metrics/webfeature/timeline/popularity/352)
- The bug [filed against Firefox](https://bugzil.la/1923525)
- The issue [filed against BCD](https://github.com/mdn/browser-compat-data/issues/26245) about the Firefox bug
- MDN uses the expected behavior in [an example](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:autofill#examples)



<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Fixes https://github.com/mdn/browser-compat-data/issues/26245
- https://github.com/web-platform-dx/web-features/issues/3226
- [bug 1923525](https://bugzil.la/1923525)

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
