### PR TITLE
chore(deps-dev): bump core-js-compat from 3.46.0 to 3.48.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,13 +2694,13 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.46.0.tgz",
-      "integrity": "sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
+      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.26.3"
+        "browserslist": "^4.28.1"
       },
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Bumps `core-js-compat` from 3.46.0 to 3.48.0, including the following transitive dependencies:

- `baseline-browser-mapping` from 2.8.20 to 2.9.18.
- `browserslist` from 4.27.0 to 4.28.1

#### Test results and supporting details

Avoids this warning caused by `baseline-browser-mapping` when running `npx eslint.`:

```
[baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
```

According to https://github.com/web-platform-dx/baseline-browser-mapping/pull/114#discussion_r2721925567:

> browserlist now suppresses the warnings

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
