### PR TITLE
Firefox only partially supports `MIDIAccess` `statechange` event

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -128,7 +128,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "108"
+              "version_added": "108",
+              "partial_implementation": true,
+              "notes": "The `onstatechange` event handler is supported, but the event never fires. See [bug 1802149](https://bugzil.la/1802149)."
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Firefox support statement for `MIDIAccess.statechange_event`, marking the implementation as partial, because the event never fires.

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1802149

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22703.