### PR TITLE
Update Firefox support for HTML datalist element

### DIFF
--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -18,19 +18,16 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "110",
-                "partial_implementation": true,
-                "notes": "The `date`, `time`, and `color` input types are not supported."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "110",
-                "partial_implementation": true,
-                "notes": "The `<datalist>` element will only create a dropdown for textual types, such as `text`, `search`, `url`, `tel`, `email` and `number`. The `date`, `time`, `range` and `color` types are not supported."
-              }
-            ],
+            "firefox": {
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": [
+                "Text types, such as `text`, `search`, `url`, `tel`, `email` and `number`, are supported from Firefox 4.",
+                "The `range` type is supported from Firefox 110.",
+                "The `date` and `time` types are not supported. See [bug 1905313](https://bugzil.la/1905313).",
+                "The `color` type is not supported. See [bug 2007533](https://bugzil.la/2007533)."
+              ]
+            },
             "firefox_android": [
               {
                 "version_added": "79",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Refine Firefox support data for HTML datalist element:

- Mention that the color type is not supported (unlike what https://github.com/mdn/browser-compat-data/pull/24225 stated).
- Merge the partial statements, splitting up the note, mentioning versions and bugs.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22630.

Relevant for https://github.com/mdn/browser-compat-data/pull/28189, which I will need to update.