### PR TITLE
Safari 9 added CSS `filter()` function

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -105,47 +105,6 @@
             }
           }
         },
-        "filter": {
-          "__compat": {
-            "description": "`filter()`",
-            "spec_url": "https://drafts.csswg.org/filter-effects-1/#FilterCSSImageValue",
-            "support": {
-              "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/41208242"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1191043"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "9.1"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "9",
-                  "version_removed": "9.1"
-                }
-              ],
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "element": {
           "__compat": {
             "description": "`element()`",
@@ -213,6 +172,47 @@
             },
             "status": {
               "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "filter": {
+          "__compat": {
+            "description": "`filter()`",
+            "spec_url": "https://drafts.csswg.org/filter-effects-1/#FilterCSSImageValue",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/41208242"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1191043"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": [
+                {
+                  "version_added": "9.1"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "9",
+                  "version_removed": "9.1"
+                }
+              ],
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This has been supported since Safari 9, see https://caniuse.com/css-filter-function.

https://github.com/mdn/mdn/issues/726

