### PR TITLE
Firefox 148 added CSS `@custom-media` behind pref

### DIFF
--- a/css/at-rules/custom-media.json
+++ b/css/at-rules/custom-media.json
@@ -14,7 +14,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "146",
+              "version_added": "148",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
Follow up to https://github.com/mdn/browser-compat-data/pull/28438

Firefox 146 added the flag, but the implementation was broken until 148 when https://bugzilla.mozilla.org/show_bug.cgi?id=2004653 landed.

The incorrect number here just tripped me up. I verified with the following demo: https://developer.mozilla.org/en-US/play?id=U8cvGsg%2BDaBm2AFnvIIk%2ByYP1LeLiLE5PiRV%2FdPMAPqVXjdJQJQT4sKK4rGFsaaMrx7IrMR9kfaXdnns

It shows red (i.e. no `@custom-media` support) on Firefox 146 and 147, and shows blue in 148.