### PR TITLE
Add Firefox notes for `CSSStyleSheet.replace()`

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -421,7 +421,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "101"
+              "version_added": "101",
+              "notes": "Before Firefox 121, when calling `replace()` repeatedly, the style is applied, but the change is not reflected in the CSS Object Model. See [bug 1864815](https://bugzil.la/1864815)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Firefox notes for `CSSStyleSheet.replace()`, mentioning a bug that affecting Firefox 120 and earlier.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21259.