### PR TITLE
Firefox 148 fully supports `pointerrawupdate` event on `Element`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7915,7 +7915,7 @@
                 "version_added": "140",
                 "version_removed": "148",
                 "partial_implementation": true,
-                "notes": "Inherited `movementX` and `movementY` properties are set to zero."
+                "notes": "The `pointerrawupdate` event handler receives a `MouseEvent` whose movement properties (`movementX`, `movementY`) are always `0`. See [bug 1987671](https://bugzil.la/1987671)."
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
`MouseEvent.movementX` and `MouseEvent.movementY` are set on the `mousemove` and `pointermove` event in all browsers per the spec https://w3c.github.io/pointerlock/#extensions-to-the-mouseevent-interface.

Chrome interpretted the spec to mean that `pointerrawupdate` should also cause those properties to be updated on movement (it came after the spec was written) while FF140 (first version) did not. There are PRs to clarify the spec in this respect.

FF148 now updates  `pointerrawupdate` to also populate those values on movement in https://bugzilla.mozilla.org/show_bug.cgi?id=1987671

Anyway, what I have done is treated the original FF implementation of `pointerrawupdate`  as a partial implementation that will be fixed in FF148. That is the cleanest way of capturing a compatibiliy difference that only exists for 8 releases (I could have put this on the `movementX`/`Y` in some way, but that would probably be more complicated.

Related docs work can be tracked in https://github.com/mdn/content/issues/42752
