### PR TITLE
Add Firefox note about coordinates in `drag` event

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -905,7 +905,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "The `drag` event handler receives a `DragEvent` whose coordinate properties (`clientX`/`clientY`, `pageX`/`pageY`, `screenX`/`screenY`) are always `0`. See [bug 505521](https://bugzil.la/505521)."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Firefox note about `DragEvent` coordinate properties being `0` for `drag` events.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21784#issuecomment-3804475024.