### PR TITLE
Add Chrome/Safari notes about nested `<rt>` elements

### DIFF
--- a/html/elements/rt.json
+++ b/html/elements/rt.json
@@ -10,7 +10,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "5",
+              "notes": "Nested `<rt>` elements do not render correctly due to missing `display: ruby-text` styling. See [bug 347597919](https://crbug.com/347597919)."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -27,7 +28,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5"
+              "version_added": "5",
+              "notes": "Nested `<rt>` elements do not render correctly due to missing `display: ruby-text` styling. See [bug 265316](https://webkit.org/b/265316)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Chrome/Safari notes about nested `<rt>` elements, which are missing the UA style `display: text-ruby`, and therefore don't render as expected.

#### Test results and supporting details

See [this comment](https://github.com/mdn/browser-compat-data/issues/22049#issuecomment-3804966442).

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22049#issuecomment-3804853696.