### PR TITLE
Add CSS `@media` `scan` feature

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1850,6 +1850,42 @@
             }
           }
         },
+        "scan": {
+          "__compat": {
+            "description": "`scan` media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@media/scan",
+            "spec_url": "https://drafts.csswg.org/mediaqueries/#scan",
+            "tags": [
+              "web-features:media-queries"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "104"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scripting": {
           "__compat": {
             "description": "`scripting` media feature",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome, Firefox, and Safari support the CSS `@media` `scan` feature.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21990.

Collector test: https://github.com/openwebdocs/mdn-bcd-collector/pull/3024