### PR TITLE
Add Firefox notes for `Selection.toString()`

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5053,17 +5053,13 @@
             },
             "firefox": [
               {
-                "version_added": "57",
-                "notes": "Before Firefox 139, `getSelection().toString()` returns an empty string on form elements. See [bug 85686](https://bugzil.la/85686)."
+                "version_added": "57"
               },
               {
                 "version_added": "1",
                 "version_removed": "57",
                 "partial_implementation": true,
-                "notes": [
-                  "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects.",
-                  "`getSelection().toString()` returns an empty string on form elements. See [bug 85686](https://bugzil.la/85686)."
-                ]
+                "notes": "Only supported for [`HTMLDocument`](https://developer.mozilla.org/docs/Web/API/HTMLDocument), not all `Document` objects."
               }
             ],
             "firefox_android": "mirror",

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -1308,7 +1308,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Before Firefox 139, `toString()` returns an empty string for selected texts in form elements. See [bug 85686](https://bugzil.la/85686)."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Firefox notes for `Document.getSelection()` mentioning a limitation before Firefox 139.

#### Test results and supporting details

See issue below.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21697.