### PR TITLE
Firefox still has `NodeIterator.detach()`

### DIFF
--- a/api/NodeIterator.json
+++ b/api/NodeIterator.json
@@ -52,7 +52,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Since Chrome 45, this method does nothing. See [bug 40362826](https://crbug.com/40362826)."
+              "notes": "Since Chrome 45, this method does nothing, as specified. See [bug 40362826](https://crbug.com/40362826)."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -60,7 +60,7 @@
             },
             "firefox": {
               "version_added": "3.5",
-              "notes": "Since Firefox 22, this method does nothing. See [bug 823549](https://bugzil.la/823549)."
+              "notes": "Since Firefox 22, this method does nothing, as specified. See [bug 823549](https://bugzil.la/823549)."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -69,19 +69,19 @@
             "oculus": "mirror",
             "opera": {
               "version_added": "9",
-              "notes": "Since Opera 32, this method does nothing. See [bug 40362826](https://crbug.com/40362826)."
+              "notes": "Since Opera 32, this method does nothing, as specified. See [bug 40362826](https://crbug.com/40362826)."
             },
             "opera_android": {
               "version_added": "10.1",
-              "notes": "Since Opera Android 32, this method does nothing. See [bug 40362826](https://crbug.com/40362826)."
+              "notes": "Since Opera Android 32, this method does nothing, as specified. See [bug 40362826](https://crbug.com/40362826)."
             },
             "safari": {
               "version_added": "3",
-              "notes": "Since Safari 10, this method does nothing. See [bug 148454](https://webkit.org/b/148454)."
+              "notes": "Since Safari 10, this method does nothing, as specified. See [bug 148454](https://webkit.org/b/148454)."
             },
             "safari_ios": {
               "version_added": "3",
-              "notes": "Since Safari on iOS 10, this method does nothing. See [bug 148454](https://webkit.org/b/148454)."
+              "notes": "Since Safari on iOS 10, this method does nothing, as specified. See [bug 148454](https://webkit.org/b/148454)."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",

--- a/api/Range.json
+++ b/api/Range.json
@@ -601,7 +601,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Since Chrome 37, this method does nothing. See [bug 40362748](https://crbug.com/40362748)."
+              "notes": "Since Chrome 37, this method does nothing, as specified. See [bug 40362748](https://crbug.com/40362748)."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -609,7 +609,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Since Firefox 15, this method does nothing. See [bug 702948](https://bugzil.la/702948)."
+              "notes": "Since Firefox 15, this method does nothing, as specified. See [bug 702948](https://bugzil.la/702948)."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -618,11 +618,11 @@
             "oculus": "mirror",
             "opera": {
               "version_added": "9",
-              "notes": "Since Opera 24, this method does nothing. See [bug 40362748](https://crbug.com/40362748)."
+              "notes": "Since Opera 24, this method does nothing, as specified. See [bug 40362748](https://crbug.com/40362748)."
             },
             "opera_android": {
               "version_added": "10.1",
-              "notes": "Since Opera 24, this method does nothing. See [bug 40362748](https://crbug.com/40362748)."
+              "notes": "Since Opera 24, this method does nothing, as specified. See [bug 40362748](https://crbug.com/40362748)."
             },
             "safari": {
               "version_added": "1",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update the Firefox statement for `NodeIterator.detach()`, indicating that this is still supported.

#### Test results and supporting details

Verified with collector test, see [this comment](https://github.com/mdn/browser-compat-data/issues/20829#issuecomment-3811033154).

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20829.