### PR TITLE
Mark `Range.detach()` as deprecated + reinstate Firefox support

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -636,7 +636,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox still has `Range.detach()`, even if it is no-op since Firefox 15 as specified.

#### Test results and supporting details

https://bugzil.la/702948

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20830.