### PR TITLE
docs(publishing): update release cadence

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,6 +1,6 @@
 # Publishing a new version of `@mdn/browser-compat-data`
 
-New releases of the [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data) NPM package are published 1-2 times per week, usually on Tuesday and/or Friday, except during year-end holidays.
+New releases of the [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data) NPM package are usually published once per week or more often around browser releases.
 
 The release process is mostly automated using two GitHub workflows:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Documents the new release cadence: 1-2 releases per week, usually on Tuesday and/or Friday.

#### Test results and supporting details

Discussed in the BCD meeting on 2025-12-02.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
