### PR TITLE
Revert "chore(deps-dev): bump web-specs from 3.76.0 to 3.77.0"

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -851,7 +851,7 @@
         "fromAsync": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.fromasync",
+            "spec_url": "https://tc39.es/proposal-array-from-async/#sec-array.fromAsync",
             "tags": [
               "web-features:array-fromasync"
             ],

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -59,6 +59,7 @@
         "isRawJSON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/isRawJSON",
+            "spec_url": "https://tc39.es/proposal-json-parse-with-source/#sec-json.israwjson",
             "tags": [
               "web-features:json-raw"
             ],
@@ -94,7 +95,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -203,7 +204,7 @@
             "__compat": {
               "description": "Reviver has `context` parameter",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter",
-              "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-internalizejsonproperty",
+              "spec_url": "https://tc39.es/proposal-json-parse-with-source/#sec-internalizejsonproperty",
               "tags": [
                 "web-features:json-raw"
               ],
@@ -248,6 +249,7 @@
         "rawJSON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/rawJSON",
+            "spec_url": "https://tc39.es/proposal-json-parse-with-source/#sec-json.rawjson",
             "tags": [
               "web-features:json-raw"
             ],
@@ -283,7 +285,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -446,7 +446,7 @@
         "getOrInsert": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsert",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.getorinsert",
+            "spec_url": "https://tc39.es/proposal-upsert/#sec-map.prototype.getOrInsert",
             "support": {
               "bun": {
                 "version_added": "1.2.20"
@@ -481,7 +481,7 @@
         "getOrInsertComputed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsertComputed",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.getorinsertcomputed",
+            "spec_url": "https://tc39.es/proposal-upsert/#sec-map.prototype.getOrInsertComputed",
             "support": {
               "bun": {
                 "version_added": "1.2.20"

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -2158,7 +2158,7 @@
         "sumPrecise": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sumPrecise",
-            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sumprecise",
+            "spec_url": "https://tc39.es/proposal-math-sum/#sec-math.sumprecise",
             "tags": [
               "web-features:math-sum-precise"
             ],

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -219,7 +219,7 @@
         "fromBase64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-uint8array.frombase64",
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.frombase64",
             "tags": [
               "web-features:uint8array-base64-hex"
             ],
@@ -263,7 +263,7 @@
         "fromHex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromHex",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-uint8array.fromhex",
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.fromhex",
             "tags": [
               "web-features:uint8array-base64-hex"
             ],
@@ -307,7 +307,7 @@
         "setFromBase64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/setFromBase64",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-uint8array.prototype.setfrombase64",
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.setfrombase64",
             "tags": [
               "web-features:uint8array-base64-hex"
             ],
@@ -351,7 +351,7 @@
         "setFromHex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/setFromHex",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-uint8array.prototype.setfromhex",
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.setfromhex",
             "tags": [
               "web-features:uint8array-base64-hex"
             ],
@@ -395,7 +395,7 @@
         "toBase64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toBase64",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-uint8array.prototype.tobase64",
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.tobase64",
             "tags": [
               "web-features:uint8array-base64-hex"
             ],
@@ -439,7 +439,7 @@
         "toHex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toHex",
-            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-uint8array.prototype.tohex",
+            "spec_url": "https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.tohex",
             "tags": [
               "web-features:uint8array-base64-hex"
             ],

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -301,7 +301,7 @@
         "getOrInsert": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/getOrInsert",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.getorinsert",
+            "spec_url": "https://tc39.es/proposal-upsert/#sec-weakmap.prototype.getOrInsert",
             "support": {
               "bun": {
                 "version_added": "1.2.20"
@@ -336,7 +336,7 @@
         "getOrInsertComputed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/getOrInsertComputed",
-            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.getorinsertcomputed",
+            "spec_url": "https://tc39.es/proposal-upsert/#sec-weakmap.prototype.getOrInsertComputed",
             "support": {
               "bun": {
                 "version_added": "1.2.20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7554,9 +7554,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/web-specs": {
-      "version": "3.77.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.77.0.tgz",
-      "integrity": "sha512-VTUlkxkn1INBo7MJ7jBTUwXsAsLH+fNqMXwzM9/SzM1jTXa7EVCsy7UNyopEPq5By7IpICh8w/vVzGHvTR0Gwg==",
+      "version": "3.76.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.76.0.tgz",
+      "integrity": "sha512-mSoDvTlmIXbfi+DPwGJURJc4JQYNA/c4tWkxNkPZvernIVpQiRZdUqeX/iEb/nAbmxZ3aHAbwEJjqzSAwugYfw==",
       "dev": true,
       "license": "CC0-1.0"
     },


### PR DESCRIPTION
This change removed two spec ECMAScript proposal URLs where the features have not yet been included in the latest draft.

Until the next web-specs release appears, let's revert this change.

Reverts mdn/browser-compat-data#28926