### PR TITLE
FF148 `Document.execCommand` with `paste` supported in content

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3595,6 +3595,41 @@
               }
             }
           }
+        },
+        "paste": {
+          "__compat": {
+            "description": "`paste` command",
+            "tags": [
+              "web-features:execcommand"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "42"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "148",
+                "notes": "Supported in content scripts (not just extensions) via the [Clipboard API](https://developer.mozilla.org/docs/Web/API/Clipboard_API)"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
         }
       },
       "exitFullscreen": {
@@ -3704,41 +3739,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "paste": {
-          "__compat": {
-            "description": "`paste` command",
-            "tags": [
-              "web-features:execcommand"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "42"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "148",
-                "notes": "Supported in content scripts (not just extensions) via the [Clipboard API](https://developer.mozilla.org/docs/Web/API/Clipboard_API)"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
           }
         },
         "returns_promise": {


### PR DESCRIPTION
FF148 Supports using Document.execCommand with option "paste" in web content in https://bugzilla.mozilla.org/show_bug.cgi?id=1998195#c18

Previously this would only work on extensions. The change is a reimplementation of the feature using the Clipboard API, so shares the same behaviour as added in #28587. 

The feature is non-standard but in its "kind of" standard, paste is only supported in extensions. So what we're doing is adding non-standard behaviour to some browsers. What I have done is added an entry for paste that matches `copy` and similar in versions, then added version notes for this additional "non-standard" implementation.

Related docs work can be tracked in https://github.com/mdn/content/issues/42747