### PR TITLE
Firefox 148 adds `Iterator.zip()` and `Iterator.zipKeyed()`

### DIFF
--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -738,6 +738,7 @@
         },
         "zip": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/zip",
             "spec_url": "https://tc39.es/proposal-joint-iteration/#sec-IteratorZip",
             "tags": [
               "web-features:iterator-methods"
@@ -767,7 +768,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "impl_url": "https://webkit.org/b/303246",
+                "impl_url": "https://webkit.org/b/303246"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -783,6 +784,7 @@
         },
         "zipKeyed": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/zipKeyed",
             "spec_url": "https://tc39.es/proposal-joint-iteration/#sec-iterator.zipkeyed",
             "tags": [
               "web-features:iterator-methods"
@@ -812,7 +814,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "impl_url": "https://webkit.org/b/303246",
+                "impl_url": "https://webkit.org/b/303246"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
FF148 ships the TC39 [joint iteration](https://github.com/tc39/proposal-joint-iteration) proposal in https://bugzilla.mozilla.org/show_bug.cgi?id=2003333 - that adds two methods to Iterator - zip and zipKeyed.

This adds features for both. These don't show up in Chrome and Safari yet. Searching doesn't show evidence they are in Bun, Deno, NodeJS yet - I haven't tested though. Have set to false.

Related docs work can be tracked in https://github.com/mdn/content/issues/42743