### PR TITLE
Bug-2012727 action.isEnabled updated properties info

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -365,21 +365,19 @@
           },
           "details": {
             "__compat": {
+              "description": "`details` (object)",
               "support": {
                 "chrome": {
-                  "version_added": "110",
-                  "notes": "Can only contain an integer value for the ID of a tab to check."
+                  "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "109",
-                  "notes": "Until Firefox 149 could only contain an object containing `tabId` or `windowId`. From Firefox 149 can also be an integer value for the ID of a tab to check."
+                  "version_added": "109"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "15.4",
-                  "notes": "Can only contain an object containing `tabId` or `windowId`."
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -401,6 +399,26 @@
                   },
                   "safari_ios": "mirror"
                 }
+              }
+            }
+          },
+          "details_integer": {
+            "__compat": {
+              "description": "`details` (integer, `tabId`)",
+              "support": {
+                "chrome": {
+                  "version_added": "110"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "149"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
               }
             }
           }

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -423,22 +423,25 @@
           },
           "details": {
             "__compat": {
+              "description": "`details` (object)",
               "support": {
                 "chrome": {
                   "version_added": false
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "109",
-                  "notes": "Until Firefox 149 could only contain an object containing `tabId` or `windowId`. From Firefox 149 can also be an integer value for the ID of a tab to check."
+                  "version_added": "59"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": "79"
+                },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "15.4",
-                  "notes": "Can only contain an object containing `tabId` or `windowId`."
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             },
             "windowId": {
@@ -449,15 +452,37 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "109"
+                    "version_added": "62"
                   },
-                  "firefox_android": "mirror",
+                  "firefox_android": {
+                    "version_added": "79"
+                  },
                   "opera": "mirror",
                   "safari": {
                     "version_added": "18"
                   },
                   "safari_ios": "mirror"
                 }
+              }
+            }
+          },
+          "details_integer": {
+            "__compat": {
+              "description": "`details` (integer, `tabId`)",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "149"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
               }
             }
           }


### PR DESCRIPTION
#### Summary

Address is the dev-doc-needed requirements of 
- [Bug 2012727](https://bugzilla.mozilla.org/show_bug.cgi?id=2012727) "action.isEnabled() throws instead of returning the global enabled state", and
- [Bug 2013477](https://bugzilla.mozilla.org/show_bug.cgi?id=2013477) Support action.isEnabled(tabId) next to action.isEnabled(details) 
by, under `isEnabled`:

- adding `details` and moving the information for `windowID` under it.
- adding note to `details`regarding support for either an integer (tab ID) or object.

#### Related issues

Related content changes in https://github.com/mdn/content/pull/42997