### PR TITLE
Safari 18 removed unused `History.pushState` parameter

### DIFF
--- a/api/History.json
+++ b/api/History.json
@@ -283,11 +283,11 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "5",
-                "notes": "This feature may be removed, see [bug 223190](https://webkit.org/b/223190)."
+                "version_removed": "18"
               },
               "safari_ios": {
                 "version_added": "4",
-                "notes": "This feature may be removed, see [bug 223190](https://webkit.org/b/223190)."
+                "version_removed": "18"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Safari statement for `api.History.pushState` subfeature.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/27606.