### PR TITLE
ci(workflows): commit bot-authored changes as mdn-bot

### DIFF
--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -43,6 +43,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }} # need the rights to create and edit PRs
           commit-message: Update browser releases
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          committer: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           signoff: false
           branch: browser-releases
           delete-branch: true

--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -54,6 +54,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }} # need the rights to create and edit PRs
           commit-message: Update web-features tags
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          committer: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           signoff: false
           branch: web-features-tags
           delete-branch: true

--- a/.github/workflows/update-webdriver-bidi-data.yml
+++ b/.github/workflows/update-webdriver-bidi-data.yml
@@ -53,6 +53,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: Update WebDriver BiDi data
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          committer: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           signoff: false
           branch: webdriver-bidi
           delete-branch: true


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update workflows using [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) to also specify the committer.

#### Test results and supporting details

Resolves a small nit where such commits are currently authored by mdn-bot, but committed by github-actions, see: https://github.com/mdn/browser-compat-data/pull/28975#issue-3896426777

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
