### PR TITLE
webxtensions: `data_collection` support in `permissions.Permissions`

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -46,6 +46,27 @@
                 "version_added": "15"
               }
             }
+          },
+          "data_collection": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "140"
+                },
+                "firefox_android": {
+                  "version_added": "142"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "contains": {


### PR DESCRIPTION
#### Summary

Add information about the `data_collection` property added to `permissions.Permissions`as a result of the introduction of the Firefox built-in data collection experience.

#### Related issues

Related MDN content changes in TBC