### PR TITLE
Chrome 144 adds `scrolled` scroll-state descriptor

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -212,7 +212,7 @@
           },
           "scrolled": {
             "__compat": {
-              "spec_url": "https://drafts.csswg.org/css-conditional-5/#scrolled",
+              "spec_url": "https://drafts.csswg.org/css-conditional-5/#descdef-container-scrolled",
               "tags": [
                 "web-features:container-scroll-state-queries"
               ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 144 adds support for the `@container` at-rule scroll-state `scrolled` descriptor; see https://chromestatus.com/feature/5083137520173056.

This PR adds a data point for this new descriptor.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
