### PR TITLE
Safari does not fire `pageswap` event for cross-origin navigations

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4316,7 +4316,7 @@
             "safari": {
               "version_added": "18.2",
               "partial_implementation": true,
-              "notes": "Does not fire for cross-origin navigations. See [bug 306447](https://webkit.org/b/306447)."
+              "notes": "Cross-origin navigation does not fire `pageswap`. See [bug 306447](https://webkit.org/b/306447)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari does not fire `pageswap` event for cross-origin navigations

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #28973.