### PR TITLE
Firefox 148 / Safari 15.6 support Legacy RegExp features

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -164,7 +164,7 @@
           },
           "rexexp_legacy_features": {
             "__compat": {
-              "description": "`TypeError` when used in `RegExp` subclass or with cross-realm mismatch.",
+              "description": "Throws `TypeError` when used in `RegExp` subclass or with cross-realm mismatch.",
               "support": {
                 "bun": {
                   "version_added": false


### PR DESCRIPTION
FF implements the [TC39 Legacy RegExp features in JavaScript](https://github.com/tc39/proposal-regexp-legacy-features) in https://bugzilla.mozilla.org/show_bug.cgi?id=1306461. 

This makes `RegExp.prototyp.compile()` throw if called on a `RegExp` subclass or cross realm. It also normalizes the static properties that get populated when a regexp is evaluated. There is an excellent overview of the specific implementation in https://blogs.igalia.com/compilers/2026/01/20/legacy-regexp-features-in-javascript/

I used this test script in console on browserstack to get Safari version. Chrome not supported. Did not test Bun/NodeJS - have set to False.

```js
// 1. Create a "new global" using an iframe
const iframe = document.createElement('iframe');
document.body.appendChild(iframe);

// 2. Get the RegExp constructor from the iframe's realm
const foreignRegExp = iframe.contentWindow.RegExp;

// 3. Create a regex object inside that iframe
const re = new foreignRegExp("x");

try {
  // 4. Try to use the PARENT's compile method on the IFRAME's object
  RegExp.prototype.compile.call(re, "y");
} catch (e) {
  console.error(e); // TypeError: RegExp operation not permitted on object from different realm
```

Related docs work can be tracked in https://github.com/mdn/content/issues/42746
