### PR TITLE
FF148 Auto-open on find - fully supported

### DIFF
--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -114,11 +114,17 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "139",
-                "partial_implementation": true,
-                "notes": "The browser does not correctly scroll to the matching text. See [bug 2006040](https://bugzil.la/2006040)."
-              },
+              "firefox": [
+                {
+                  "version_added": "148"
+                },
+                {
+                  "version_added": "139",
+                  "version_removed": "148",
+                  "partial_implementation": true,
+                  "notes": "The browser does not correctly scroll to the matching text. See [bug 2006040](https://bugzil.la/2006040)."
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -601,11 +601,17 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "139",
-                "partial_implementation": true,
-                "notes": "The browser does not correctly scroll to the matching text. See [bug 2006040](https://bugzil.la/2006040)."
-              },
+              "firefox": [
+                {
+                  "version_added": "148"
+                },
+                {
+                  "version_added": "139",
+                  "version_removed": "148",
+                  "partial_implementation": true,
+                  "notes": "The browser does not correctly scroll to the matching text. See [bug 2006040](https://bugzil.la/2006040)."
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
FF148 fixes a bug where finding text in a page would not open a containing element in order to navigate to it on search in https://bugzilla.mozilla.org/show_bug.cgi?id=2006040. 

This feature was marked as a partial implemention in #28672. This fix adds this as a full feaure n the same places as that PR marked it as partial.

Related docs work can be tracked in https://github.com/mdn/content/issues/42751
