### PR TITLE
FF148 respects CSS `overflow` for replaced elements

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -196,6 +196,40 @@
             }
           }
         },
+        "replaced_elements": {
+          "__compat": {
+            "description": "`overflow-x` applies to replaced elements.",
+            "spec_url": "https://drafts.csswg.org/css-overflow-4/#overflow-control",
+            "support": {
+              "chrome": {
+                "version_added": "108"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "148"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scroll": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overflow/#valdef-overflow-scroll",

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -196,6 +196,40 @@
             }
           }
         },
+        "replaced_elements": {
+          "__compat": {
+            "description": "`overflow-y` applies to replaced elements.",
+            "spec_url": "https://drafts.csswg.org/css-overflow-4/#overflow-control",
+            "support": {
+              "chrome": {
+                "version_added": "108"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "148"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scroll": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overflow/#valdef-overflow-scroll",

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -220,6 +220,40 @@
             }
           }
         },
+        "replaced_elements": {
+          "__compat": {
+            "description": "`overflow` applies to replaced elements.",
+            "spec_url": "https://drafts.csswg.org/css-overflow-4/#overflow-control",
+            "support": {
+              "chrome": {
+                "version_added": "108"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "148"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scroll": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overflow/#valdef-overflow-scroll",


### PR DESCRIPTION
The `overflow` (and longhand variants) set how overflow is handled - such as by overflowing (visible), hiding or clipping to the bounding container, or clipping and adding scrollbars.

Prior to CSS Module 4 this was ignored for replaced elements (such as images) that overflow their container. In CSS Module 4 replaced elements should do as other elements: https://drafts.csswg.org/css-overflow-4/#overflow-control

Support was added for FF148 in https://bugzilla.mozilla.org/show_bug.cgi?id=1999100

Support was added for Crhome in 108 - https://chromestatus.com/feature/5137515594383360

Safari doesn't support this yet - ran this test code on latest browserstack hosted browser and you can see that the image is clipped to the circle https://codepen.io/therealpaulplay/pen/JoGQogd

This adds a subfeature to `overflow` and its longhands.

Related docs can be tracked in https://github.com/mdn/content/issues/42744