### PR TITLE
refactor: migrate to styleText from chalk

### DIFF
--- a/lint/common/overlap.js
+++ b/lint/common/overlap.js
@@ -1,7 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import { compareVersions } from 'compare-versions';
 
 import { createStatementGroupKey } from '../utils.js';
@@ -93,7 +94,7 @@ export const checkOverlap = (data, browser, { logger, fix = false }) => {
 
       if (!fixed && logger) {
         logger.error(
-          chalk`{bold ${browser}} statements overlap for {bold ${groupKey}}: ` +
+          `${styleText('bold', browser)} statements overlap for ${styleText('bold', groupKey)}: ` +
             `[${formatRange(next)}, ${formatRange(current)}]`,
         );
       }

--- a/lint/fix.js
+++ b/lint/fix.js
@@ -4,11 +4,11 @@
 import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { styleText } from 'node:util';
 
 import esMain from 'es-main';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import chalk from 'chalk-template';
 
 import dataFolders from '../scripts/lib/data-folders.js';
 
@@ -69,7 +69,9 @@ const load = async (options, ...files) => {
     try {
       fsStats = await stat(file);
     } catch {
-      console.warn(chalk`{yellow File {bold ${file}} doesn't exist!}`);
+      console.warn(
+        styleText('yellow', `File ${styleText('bold', file)} doesn't exist!`),
+      );
       continue;
     }
 

--- a/lint/lint.js
+++ b/lint/lint.js
@@ -4,11 +4,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { styleText } from 'node:util';
 
 import esMain from 'es-main';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import chalk from 'chalk-template';
 
 import dataFolders from '../scripts/lib/data-folders.js';
 import extend from '../scripts/lib/extend.js';
@@ -67,7 +67,9 @@ const loadAndCheckFiles = async (...files) => {
     try {
       fsStats = await fs.stat(file);
     } catch {
-      console.warn(chalk`{yellow File {bold ${file}} doesn't exist!}`);
+      console.warn(
+        styleText('yellow', `File ${styleText('bold', file)} doesn't exist!`),
+      );
       continue;
     }
 
@@ -118,10 +120,10 @@ const main = async (files = dataFolders, options = {}) => {
 
   let hasErrors = false;
 
-  console.log(chalk`{cyan Loading and checking files...}`);
+  console.log(styleText('cyan', 'Loading and checking files...'));
   const data = await loadAndCheckFiles(...files);
 
-  console.log(chalk`{cyan Testing browser data...}`);
+  console.log(styleText('cyan', 'Testing browser data...'));
   for (const browser in data?.browsers) {
     await linters.runScope('browser', {
       data: data.browsers[browser],
@@ -134,7 +136,7 @@ const main = async (files = dataFolders, options = {}) => {
     });
   }
 
-  console.log(chalk`{cyan Testing feature data...}`);
+  console.log(styleText('cyan', 'Testing feature data...'));
   const walker = walk(undefined, data);
   for (const feature of walker) {
     await linters.runScope('feature', {
@@ -147,7 +149,7 @@ const main = async (files = dataFolders, options = {}) => {
     });
   }
 
-  console.log(chalk`{cyan Testing all features together...}`);
+  console.log(styleText('cyan', 'Testing all features together...'));
   await linters.runScope('tree', {
     data,
     rawdata: '',
@@ -186,30 +188,35 @@ const main = async (files = dataFolders, options = {}) => {
       .join(', ');
 
     console.error(
-      chalk`{${
-        messagesByLevel.error.length ? 'red' : 'yellow'
-      } ${linter} - {bold ${pluralize(
-        'problem',
-        messages.length,
-        true,
-      )}} (${errorCounts}):}`,
+      styleText(
+        messagesByLevel.error.length ? 'red' : 'yellow',
+        `${linter} - ${styleText('bold', pluralize('problem', messages.length, true))} (${errorCounts}):`,
+      ),
     );
 
     for (const message of messages) {
+      const levelColor =
+        message.level === 'error'
+          ? 'red'
+          : message.level === 'warning'
+            ? 'yellow'
+            : 'blue';
       console.error(
-        chalk`{${message.level === 'error' ? 'red' : message.level === 'warning' ? 'yellow' : 'blue'}  ✖ ${
-          message.path
-        } - ${message.level[0].toUpperCase() + message.level.substring(1)} → ${
-          message.message
-        }}`,
+        styleText(
+          levelColor,
+          `  ✖ ${message.path} - ${message.level[0].toUpperCase() + message.level.substring(1)} → ${message.message}`,
+        ),
       );
       if (message.fixable) {
         console.error(
-          chalk`{blue    ◆ Tip: Run {bold npm run fix} to fix this problem automatically}`,
+          styleText(
+            'blue',
+            `    ◆ Tip: Run ${styleText('bold', 'npm run fix')} to fix this problem automatically`,
+          ),
         );
       }
       if (message.tip) {
-        console.error(chalk`{blue    ◆ Tip: ${message.tip}}`);
+        console.error(styleText('blue', `    ◆ Tip: ${message.tip}`));
       }
     }
   }
@@ -222,7 +229,10 @@ const main = async (files = dataFolders, options = {}) => {
         if (missingExceptions[exception]) {
           hasErrors = true;
           console.error(
-            chalk`{red  ✖ ${linter.name} - Unnecessary exception → ${exception}}`,
+            styleText(
+              'red',
+              `  ✖ ${linter.name} - Unnecessary exception → ${exception}`,
+            ),
           );
         }
       }
@@ -230,22 +240,26 @@ const main = async (files = dataFolders, options = {}) => {
   }
 
   if (!hasErrors) {
-    console.log(chalk`{green All data {bold passed} linting!}`);
+    console.log(
+      styleText('green', `All data ${styleText('bold', 'passed')} linting!`),
+    );
     if (linters.linters.some((linter) => linter.exceptions)) {
       console.log(
-        chalk`{yellow Linters have some exceptions, please help us remove them!}`,
+        styleText(
+          'yellow',
+          'Linters have some exceptions, please help us remove them!',
+        ),
       );
       for (const linter of linters.linters) {
         if (linter.exceptions) {
           console.log(
-            chalk`{yellow  ${linter.name} has ${pluralize(
-              'exception',
-              linter.exceptions.length,
-              true,
-            )}}`,
+            styleText(
+              'yellow',
+              `  ${linter.name} has ${pluralize('exception', linter.exceptions.length, true)}`,
+            ),
           );
           for (const exception of linter.exceptions) {
-            console.log(chalk`{yellow   - ${exception}}`);
+            console.log(styleText('yellow', `   - ${exception}`));
           }
         }
       }

--- a/lint/linter/test-browsers-data.js
+++ b/lint/linter/test-browsers-data.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
@@ -25,9 +25,10 @@ const processData = (browser, data, logger) => {
 
     if (releasesForStatus.length > 1) {
       logger.error(
-        chalk`{red {bold ${browser}} has multiple {bold ${status}} releases (${releasesForStatus.join(
-          ', ',
-        )}), which is {bold not} allowed.}`,
+        styleText(
+          'red',
+          `${styleText('bold', browser)} has multiple ${styleText('bold', status)} releases (${releasesForStatus.join(', ')}), which is ${styleText('bold', 'not')} allowed.`,
+        ),
       );
     }
   }
@@ -36,15 +37,19 @@ const processData = (browser, data, logger) => {
   if (data.upstream) {
     if (data.upstream === browser) {
       logger.error(
-        chalk`{red The upstream for {bold ${browser}} is set to itself.}`,
+        styleText(
+          'red',
+          `The upstream for ${styleText('bold', browser)} is set to itself.`,
+        ),
       );
     }
 
     if (!Object.keys(browsers).includes(data.upstream)) {
       logger.error(
-        chalk`{red The upstream for {bold ${browser}} is an unknown browser (${
-          data.upstream
-        }) Valid options are: ${Object.keys(browsers).join(', ')}.}`,
+        styleText(
+          'red',
+          `The upstream for ${styleText('bold', browser)} is an unknown browser (${data.upstream}) Valid options are: ${Object.keys(browsers).join(', ')}.`,
+        ),
       );
     }
   }
@@ -64,9 +69,10 @@ const processData = (browser, data, logger) => {
 
     if (releasesWithoutDate.length > 0) {
       logger.error(
-        chalk`{red {bold ${browser}} has {bold ${status}} releases without release date (${releasesWithoutDate.join(
-          ', ',
-        )}), which is {bold not} allowed.}`,
+        styleText(
+          'red',
+          `${styleText('bold', browser)} has ${styleText('bold', status)} releases without release date (${releasesWithoutDate.join(', ')}), which is ${styleText('bold', 'not')} allowed.`,
+        ),
       );
     }
   }

--- a/lint/linter/test-browsers-presence.js
+++ b/lint/linter/test-browsers-presence.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
@@ -50,9 +50,7 @@ const processData = (data, category, logger) => {
     );
     if (undefEntries.length > 0) {
       logger.error(
-        chalk`Has the following browsers, which are not defined in BCD: {bold ${undefEntries.join(
-          ', ',
-        )}}`,
+        `Has the following browsers, which are not defined in BCD: ${styleText('bold', undefEntries.join(', '))}`,
       );
     }
 
@@ -61,9 +59,7 @@ const processData = (data, category, logger) => {
     ).filter((value) => !displayBrowsers.includes(value));
     if (invalidEntries.length > 0) {
       logger.error(
-        chalk`Has the following browsers, which are invalid for {bold ${category}} compat data: {bold ${invalidEntries.join(
-          ', ',
-        )}}`,
+        `Has the following browsers, which are invalid for ${styleText('bold', category)} compat data: ${styleText('bold', invalidEntries.join(', '))}`,
       );
     }
 
@@ -72,9 +68,7 @@ const processData = (data, category, logger) => {
     );
     if (missingEntries.length > 0) {
       logger.error(
-        chalk`Missing the following browsers, which are required for {bold ${category}} compat data: {bold ${missingEntries.join(
-          ', ',
-        )}}`,
+        `Missing the following browsers, which are required for ${styleText('bold', category)} compat data: ${styleText('bold', missingEntries.join(', '))}`,
       );
     }
   }

--- a/lint/linter/test-consistency.js
+++ b/lint/linter/test-consistency.js
@@ -1,8 +1,9 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
+import { styleText } from 'node:util';
+
 import { compare } from 'compare-versions';
-import chalk from 'chalk-template';
 
 import { query } from '../../utils/index.js';
 import mirrorSupport from '../../scripts/build/mirror.js';
@@ -426,15 +427,16 @@ export default {
       for (const { type, browser, parentValue, subfeatures } of errors) {
         let errorMessage = '';
         if (type == 'unsupported') {
-          errorMessage += chalk`No support in {bold ${browser}}, but support is declared in the following sub-feature(s):`;
+          errorMessage += `No support in ${styleText('bold', browser)}, but support is declared in the following sub-feature(s):`;
         } else if (type == 'subfeature_earlier_implementation') {
-          errorMessage += chalk`Basic support in {bold ${browser}} was declared implemented in a later version ({bold ${parentValue}}) than the following sub-feature(s):`;
+          errorMessage += `Basic support in ${styleText('bold', browser)} was declared implemented in a later version (${styleText('bold', String(parentValue))}) than the following sub-feature(s):`;
         }
 
         for (const subfeature of subfeatures) {
-          errorMessage += chalk`\n{red         → {bold ${path.join('.')}.${
-            subfeature[0]
-          }}: ${subfeature[1] === undefined ? '[Array]' : subfeature[1]}}`;
+          errorMessage += styleText(
+            'red',
+            `\n         → ${styleText('bold', `${path.join('.')}.${subfeature[0]}`)}: ${subfeature[1] === undefined ? '[Array]' : subfeature[1]}`,
+          );
         }
 
         logger.error(errorMessage, { path: path.join('.') });

--- a/lint/linter/test-descriptions.js
+++ b/lint/linter/test-descriptions.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import { validateHTML } from './test-notes.js';
 
@@ -142,12 +142,15 @@ export default {
 
     for (const error of errors) {
       if (typeof error === 'string') {
-        logger.error(chalk`{red ${error}}`);
+        logger.error(styleText('red', error));
       } else {
         logger.error(
-          chalk`{red Incorrect ${error.ruleName} description for {bold ${error.path}}
-      Actual: {yellow "${error.actual}"}
-      Expected: {green "${error.expected}"}}`,
+          styleText(
+            'red',
+            `Incorrect ${error.ruleName} description for ${styleText('bold', error.path)}
+      Actual: ${styleText('yellow', `"${error.actual}"`)}
+      Expected: ${styleText('green', `"${error.expected}"`)}`,
+          ),
           { fixable: true },
         );
       }

--- a/lint/linter/test-flags.js
+++ b/lint/linter/test-flags.js
@@ -1,7 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import { compare } from 'compare-versions';
 
 /** @import {Linter, LinterData} from '../types.js' */
@@ -133,11 +134,7 @@ export default {
 
     for (const error of errors) {
       logger.error(
-        chalk`Irrelevant flag data detected for {bold ${
-          error.browser
-        }}. Remove statement with {bold ${error.flagData
-          .map((flag) => flag.name)
-          .join(', ')}} flag`,
+        `Irrelevant flag data detected for ${styleText('bold', error.browser)}. Remove statement with ${styleText('bold', error.flagData.map((flag) => flag.name).join(', '))} flag`,
         { fixable: true },
       );
     }

--- a/lint/linter/test-links.js
+++ b/lint/linter/test-links.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import { IS_WINDOWS, indexToPos, indexToPosRaw } from '../utils.js';
 
@@ -299,7 +299,7 @@ export default {
 
     for (const error of errors) {
       logger.error(
-        chalk`${error.posString} – ${error.issue} ({yellow ${error.actual}} → {green ${error.expected}}).`,
+        `${error.posString} – ${error.issue} (${styleText('yellow', error.actual)} → ${styleText('green', error.expected ?? '')}).`,
         { fixable: true },
       );
     }

--- a/lint/linter/test-mdn-urls.js
+++ b/lint/linter/test-mdn-urls.js
@@ -1,7 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import mdnContentInventory from '@ddbeck/mdn-content-inventory';
 
 /** @import {Linter, LinterData} from '../types.js' */
@@ -155,21 +156,30 @@ export default {
     for (const issue of issues) {
       if (issue.expected === '') {
         logger.warning(
-          chalk`{red Current mdn_url is a 404:
-          {bold ${issue.actual}}}`,
+          styleText(
+            'red',
+            `Current mdn_url is a 404:
+          ${styleText('bold', issue.actual)}`,
+          ),
           { fixable: true },
         );
       } else if (issue.actual === '') {
         logger.warning(
-          chalk`{red New mdn_url to add:
-          {bold ${issue.expected}}}`,
+          styleText(
+            'red',
+            `New mdn_url to add:
+          ${styleText('bold', issue.expected)}`,
+          ),
           { fixable: true },
         );
       } else {
         logger.warning(
-          chalk`{red Issues with mdn_url found:
+          styleText(
+            'red',
+            `Issues with mdn_url found:
             Actual:   ${issue.actual}
-            Expected: ${issue.expected}}`,
+            Expected: ${issue.expected}`,
+          ),
           { fixable: true },
         );
       }

--- a/lint/linter/test-mirror.js
+++ b/lint/linter/test-mirror.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
@@ -34,7 +34,7 @@ const checkMirroring = (supportData, category, logger) => {
       isMirrorEquivalent(supportData, browser)
     ) {
       logger.error(
-        chalk`Data for {bold ${browser}} can be automatically mirrored, use {bold "${browser}": "mirror"} instead`,
+        `Data for ${styleText('bold', browser)} can be automatically mirrored, use ${styleText('bold', `"${browser}": "mirror"`)} instead`,
         { fixable: true },
       );
     }

--- a/lint/linter/test-multiple-statements.js
+++ b/lint/linter/test-multiple-statements.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import { createStatementGroupKey } from '../utils.js';
 
@@ -36,7 +36,7 @@ const processData = (data, browser, logger) => {
 
     if (statements.includes(statementKey)) {
       logger.error(
-        chalk`{bold ${browser}} has multiple statements for {bold ${statementKey}} exist without partial implementation! Please {bold merge} these statements and {bold combine} their notes, or set {bold partial_implementation} to {bold true} on applicable statements.`,
+        `${styleText('bold', browser)} has multiple statements for ${styleText('bold', statementKey)} exist without partial implementation! Please ${styleText('bold', 'merge')} these statements and ${styleText('bold', 'combine')} their notes, or set ${styleText('bold', 'partial_implementation')} to ${styleText('bold', 'true')} on applicable statements.`,
       );
     }
     statements.push(statementKey);

--- a/lint/linter/test-notes.js
+++ b/lint/linter/test-notes.js
@@ -1,7 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import HTMLParser from '@desertnet/html-parser';
 import { marked } from 'marked';
 
@@ -26,9 +27,7 @@ const testNode = (node) => {
     if (tag && !VALID_ELEMENTS.includes(tag)) {
       // Ensure we're only using select nodes
       errors.push(
-        chalk`HTML element {bold <${tag}>} is {bold not allowed}. Allowed HTML elements are: ${VALID_ELEMENTS.join(
-          ', ',
-        )}`,
+        `HTML element ${styleText('bold', `<${tag}>`)} is ${styleText('bold', 'not allowed')}. Allowed HTML elements are: ${VALID_ELEMENTS.join(', ')}`,
       );
     }
 
@@ -38,18 +37,14 @@ const testNode = (node) => {
       if (attrs.length !== 1 || !attrs.includes('href')) {
         // Ensure 'a' nodes only contain an 'href'
         errors.push(
-          chalk`HTML element {bold <${tag}>} has {bold invalid attributes}. {bold <${tag}>} elements may only have (and must have) an {bold href} attribute; found {bold ${
-            attrs.length ? attrs.join(', ') : 'no attributes'
-          }}.`,
+          `HTML element ${styleText('bold', `<${tag}>`)} has ${styleText('bold', 'invalid attributes')}. ${styleText('bold', `<${tag}>`)} elements may only have (and must have) an ${styleText('bold', 'href')} attribute; found ${styleText('bold', attrs.length ? attrs.join(', ') : 'no attributes')}.`,
         );
       }
     } else {
       if (attrs.length > 0) {
         // Ensure nodes (besides 'a') contain no attributes
         errors.push(
-          chalk`HTML element {bold <${tag}>} has {bold invalid attributes}. Elements other than {bold <a>} may {bold not} have any attributes; found {bold ${attrs.join(
-            ', ',
-          )}}.`,
+          `HTML element ${styleText('bold', `<${tag}>`)} has ${styleText('bold', 'invalid attributes')}. Elements other than ${styleText('bold', '<a>')} may ${styleText('bold', 'not')} have any attributes; found ${styleText('bold', attrs.join(', '))}.`,
         );
       }
     }
@@ -78,16 +73,16 @@ export const validateHTML = (string) => {
     errors.push(...testNode(parser.parse(html)));
   } else {
     errors.push(
-      chalk`Invalid HTML: ${htmlErrors.map((x) => x._message).join(', ')}`,
+      `Invalid HTML: ${htmlErrors.map((x) => x._message).join(', ')}`,
     );
   }
 
   if (string.includes('  ')) {
-    errors.push(chalk`Double-spaces are not allowed.`);
+    errors.push('Double-spaces are not allowed.');
   }
 
   if (string.includes('\n')) {
-    errors.push(chalk`Newlines are not allowed.`);
+    errors.push('Newlines are not allowed.');
   }
 
   return errors;
@@ -114,7 +109,7 @@ const checkNotes = (notes, browser, feature, logger) => {
 
   if (errors) {
     for (const error of errors) {
-      logger.error(chalk`Notes for {bold ${browser}} → ${error}`);
+      logger.error(`Notes for ${styleText('bold', browser)} → ${error}`);
     }
   }
 };

--- a/lint/linter/test-obsolete.js
+++ b/lint/linter/test-obsolete.js
@@ -1,8 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
-
 import bcd from '../../index.js';
 const { browsers } = bcd;
 
@@ -108,7 +106,7 @@ export const processData = (logger, data) => {
   if (data && data.support) {
     const rule1Fail = neverImplemented(data.support);
     if (rule1Fail) {
-      logger.error(chalk`feature was never implemented.`);
+      logger.error('feature was never implemented.');
 
       // No need to perform the next check if the first one fails
       return;
@@ -118,7 +116,7 @@ export const processData = (logger, data) => {
     const rule2Fail = implementedAndRemoved(data.support);
     if (rule2Fail) {
       logger[rule2Fail](
-        chalk`feature was implemented and has since been removed from all browsers dating back two or more years ago.`,
+        'feature was implemented and has since been removed from all browsers dating back two or more years ago.',
       );
     }
   }

--- a/lint/linter/test-prefix.js
+++ b/lint/linter/test-prefix.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 /** @import {Linter, LinterData} from '../types.js' */
 /** @import {Logger} from '../utils.js' */
@@ -56,7 +56,7 @@ const processData = (data, category, feature, logger) => {
       }
       if (statement.prefix && statement.alternative_name) {
         logger.error(
-          chalk`Both prefix and alternative name are defined, which is not allowed.`,
+          'Both prefix and alternative name are defined, which is not allowed.',
         );
       }
       if (
@@ -64,7 +64,7 @@ const processData = (data, category, feature, logger) => {
         !prefixes.some((p) => statement.prefix?.startsWith(p))
       ) {
         logger.error(
-          chalk`Prefix is set to {bold ${statement.prefix}}, which is invalid for ${category}`,
+          `Prefix is set to ${styleText('bold', statement.prefix)}, which is invalid for ${category}`,
         );
       }
       if (statement.alternative_name) {
@@ -79,7 +79,7 @@ const processData = (data, category, feature, logger) => {
         });
         if (altNameMatchesPrefix) {
           logger.error(
-            chalk`Use {bold "prefix": "${altNameMatchesPrefix}"} instead of {bold "alternative_name": "${statement.alternative_name}"}`,
+            `Use ${styleText('bold', `"prefix": "${altNameMatchesPrefix}"`)} instead of ${styleText('bold', `"alternative_name": "${statement.alternative_name}"`)}`,
           );
         }
       }

--- a/lint/linter/test-spec-urls.js
+++ b/lint/linter/test-spec-urls.js
@@ -1,7 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import specData from 'web-specs' with { type: 'json' };
 
 /** @import {Linter, LinterData} from '../types.js' */
@@ -94,7 +95,7 @@ const processData = (data, logger) => {
   for (const specURL of featureSpecURLs) {
     if (!allowedSpecURLs.some((prefix) => specURL.startsWith(prefix))) {
       logger.error(
-        chalk`Invalid specification URL found: {bold ${specURL}}. Check if:
+        `Invalid specification URL found: ${styleText('bold', specURL)}. Check if:
          - there is a more current specification URL
          - the specification is listed in https://github.com/w3c/browser-specs
          - the specification has a "good" standing`,

--- a/lint/linter/test-status-inheritance.js
+++ b/lint/linter/test-status-inheritance.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import walk from '../../utils/walk.js';
 
@@ -25,7 +25,10 @@ const checkStatusInheritance = (data, logger) => {
       )) {
         if (subfeature.compat.status?.deprecated === false) {
           logger.error(
-            chalk`{red Feature {italic ${feature.path}} is {bold deprecated}, but subfeature {italic ${subfeature.path}} is {bold not deprecated}.}`,
+            styleText(
+              'red',
+              `Feature ${styleText('italic', feature.path)} is ${styleText('bold', 'deprecated')}, but subfeature ${styleText('italic', subfeature.path)} is ${styleText('bold', 'not deprecated')}.`,
+            ),
             { fixable: true },
           );
         }
@@ -42,7 +45,10 @@ const checkStatusInheritance = (data, logger) => {
           subfeature.compat.status?.deprecated === false
         ) {
           logger.error(
-            chalk`{red Feature {italic ${feature.path}} is {bold experimental}, but subfeature {italic ${subfeature.path}} is {bold not experimental}.}`,
+            styleText(
+              'red',
+              `Feature ${styleText('italic', feature.path)} is ${styleText('bold', 'experimental')}, but subfeature ${styleText('italic', subfeature.path)} is ${styleText('bold', 'not experimental')}.`,
+            ),
             { fixable: true },
           );
         }
@@ -56,7 +62,10 @@ const checkStatusInheritance = (data, logger) => {
       )) {
         if (subfeature.compat.status?.standard_track === true) {
           logger.error(
-            chalk`{red Feature {italic ${feature.path}} is {bold not standardized}, but subfeature {italic ${subfeature.path}} is {bold standardized}.}`,
+            styleText(
+              'red',
+              `Feature ${styleText('italic', feature.path)} is ${styleText('bold', 'not standardized')}, but subfeature ${styleText('italic', subfeature.path)} is ${styleText('bold', 'standardized')}.`,
+            ),
             { fixable: true },
           );
         }

--- a/lint/linter/test-status.js
+++ b/lint/linter/test-status.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
@@ -93,26 +93,38 @@ const checkStatus = (data, logger, category) => {
     return;
   } else if (category === 'webextensions') {
     logger.error(
-      chalk`{red Has a {bold status object}, which is {bold not allowed} for web extensions.}`,
+      styleText(
+        'red',
+        `Has a ${styleText('bold', 'status object')}, which is ${styleText('bold', 'not allowed')} for web extensions.`,
+      ),
     );
   }
 
   if (status.experimental && status.deprecated) {
     logger.error(
-      chalk`{red Unexpected simultaneous {bold experimental} and {bold deprecated} status}`,
+      styleText(
+        'red',
+        `Unexpected simultaneous ${styleText('bold', 'experimental')} and ${styleText('bold', 'deprecated')} status`,
+      ),
       { fixable: true },
     );
   }
 
   if (data.spec_url && status.standard_track === false) {
     logger.error(
-      chalk`{red Marked as {bold non-standard}, but has a {bold spec_url}}`,
+      styleText(
+        'red',
+        `Marked as ${styleText('bold', 'non-standard')}, but has a ${styleText('bold', 'spec_url')}`,
+      ),
     );
   }
 
   if (!checkExperimental(data)) {
     logger.error(
-      chalk`{red {bold Experimental} should be set to {bold false} as the feature is {bold supported} in {bold multiple browser} engines.}`,
+      styleText(
+        'red',
+        `${styleText('bold', 'Experimental')} should be set to ${styleText('bold', 'false')} as the feature is ${styleText('bold', 'supported')} in ${styleText('bold', 'multiple browser')} engines.`,
+      ),
       { fixable: true },
     );
   }

--- a/lint/linter/test-style.js
+++ b/lint/linter/test-style.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import { IS_WINDOWS, jsonDiff } from '../utils.js';
 import { orderSupportBlock } from '../fixer//browser-order.js';
@@ -31,11 +31,10 @@ const processData = (rawData, logger, category) => {
 
   if (actual !== expectedPropertySorting) {
     logger.error(
-      chalk`Property sorting error on ${jsonDiff(
-        actual,
-        expectedPropertySorting,
-      )}`,
-      { tip: chalk`Run {bold npm run fix} to fix sorting automatically` },
+      `Property sorting error on ${jsonDiff(actual, expectedPropertySorting)}`,
+      {
+        tip: `Run ${styleText('bold', 'npm run fix')} to fix sorting automatically`,
+      },
     );
   }
 
@@ -59,35 +58,26 @@ const processData = (rawData, logger, category) => {
   }
 
   if (actual !== expected) {
-    logger.error(chalk`{red → Error on ${jsonDiff(actual, expected)}}`);
+    logger.error(styleText('red', `→ Error on ${jsonDiff(actual, expected)}`));
   }
 
   if (actual !== expectedBrowserSorting) {
     logger.error(
-      chalk`Browser sorting error on ${jsonDiff(
-        actual,
-        expectedBrowserSorting,
-      )}`,
+      `Browser sorting error on ${jsonDiff(actual, expectedBrowserSorting)}`,
       { fixable: true },
     );
   }
 
   if (actual !== expectedFeatureSorting) {
     logger.error(
-      chalk`Feature sorting error on ${jsonDiff(
-        actual,
-        expectedFeatureSorting,
-      )}`,
+      `Feature sorting error on ${jsonDiff(actual, expectedFeatureSorting)}`,
       { fixable: true },
     );
   }
 
   if (actual !== expectedStatementSorting) {
     logger.error(
-      chalk`Statement sorting error on ${jsonDiff(
-        actual,
-        expectedStatementSorting,
-      )}`,
+      `Statement sorting error on ${jsonDiff(actual, expectedStatementSorting)}`,
       { fixable: true },
     );
   }

--- a/lint/linter/test-tags.js
+++ b/lint/linter/test-tags.js
@@ -1,7 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import { features } from 'web-features';
 
 /** @import {Linter, LinterData} from '../types.js' */
@@ -27,9 +28,9 @@ const processData = (data, logger) => {
       !allowedNamespaces.some((namespace) => tag.startsWith(namespace + ':'))
     ) {
       logger.error(
-        chalk`Invalid tag found: {bold ${tag}}. Check if:
+        `Invalid tag found: ${styleText('bold', tag)}. Check if:
          - the tag has a namespace
-         - the tag uses one of the allowed namespaces: {bold ${allowedNamespaces}}`,
+         - the tag uses one of the allowed namespaces: ${styleText('bold', String(allowedNamespaces))}`,
       );
     }
 
@@ -41,7 +42,7 @@ const processData = (data, logger) => {
         !validFeatureIDs.includes(featureID)
       ) {
         logger.error(
-          chalk`Non-registered web-features ID found: {bold ${featureID}}.
+          `Non-registered web-features ID found: ${styleText('bold', featureID)}.
           - New web-feature IDs need to be present in https://github.com/web-platform-dx/web-features first.
           - Check for typos or remove tag. Tagging will be taken care of by web-features maintainers.`,
         );

--- a/lint/linter/test-versions.js
+++ b/lint/linter/test-versions.js
@@ -1,8 +1,9 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
+import { styleText } from 'node:util';
+
 import { compare, validate } from 'compare-versions';
-import chalk from 'chalk-template';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
@@ -110,7 +111,7 @@ const checkVersions = (supportData, category, logger) => {
         // If the data is to be mirrored, make sure it is mirrorable
         if (!browsers[browser].upstream) {
           logger.error(
-            chalk`{bold ${browser}} is set to mirror, however {bold ${browser}} does not have an upstream browser.`,
+            `${styleText('bold', browser)} is set to mirror, however ${styleText('bold', browser)} does not have an upstream browser.`,
           );
         }
         continue;
@@ -124,9 +125,7 @@ const checkVersions = (supportData, category, logger) => {
         }
         if (!isValidVersion(browser, category, version)) {
           logger.error(
-            chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${Object.keys(
-              browsers[browser].releases,
-            ).join(', ')}, false`,
+            `${styleText('bold', `${property}: "${version}"`)} is ${styleText('bold', 'NOT')} a valid version number for ${styleText('bold', browser)}\n    Valid ${styleText('bold', browser)} versions are: ${Object.keys(browsers[browser].releases).join(', ')}, false`,
             { tip: browserTips[browser] },
           );
         }
@@ -140,7 +139,7 @@ const checkVersions = (supportData, category, logger) => {
             releaseData.release_date > rangeCutoffDate
           ) {
             logger.error(
-              chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Ranged values are only allowed for browser versions released on or before ${rangeCutoffDate}. (Ranged values are also not allowed for browser versions without a known release date.)`,
+              `${styleText('bold', `${property}: "${version}"`)} is ${styleText('bold', 'NOT')} a valid version number for ${styleText('bold', browser)}\n    Ranged values are only allowed for browser versions released on or before ${rangeCutoffDate}. (Ranged values are also not allowed for browser versions without a known release date.)`,
             );
           }
         }
@@ -153,14 +152,14 @@ const checkVersions = (supportData, category, logger) => {
           addedBeforeRemoved(statement) === false
         ) {
           logger.error(
-            chalk`{bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}`,
+            `${styleText('bold', `version_removed: "${statement.version_removed}"`)} must be greater than ${styleText('bold', `version_added: "${statement.version_added}"`)}`,
           );
         }
       }
 
       if ('flags' in statement && !browsers[browser].accepts_flags) {
         logger.error(
-          chalk`This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.`,
+          `This browser (${styleText('bold', browser)}) does not support flags, so support cannot be behind a flag for this feature.`,
         );
       }
 
@@ -171,7 +170,7 @@ const checkVersions = (supportData, category, logger) => {
           )
         ) {
           logger.error(
-            chalk`The data for ({bold ${browser}}) says no support, but contains additional properties that suggest support.`,
+            `The data for (${styleText('bold', browser)}) says no support, but contains additional properties that suggest support.`,
           );
         }
       }
@@ -181,13 +180,13 @@ const checkVersions = (supportData, category, logger) => {
         statement.version_added === false
       ) {
         logger.error(
-          chalk`{bold ${browser}} cannot have a {bold version_added: false} in an array of statements.`,
+          `${styleText('bold', browser)} cannot have a ${styleText('bold', 'version_added: false')} in an array of statements.`,
         );
       }
 
       if ('version_last' in statement) {
         logger.error(
-          chalk`{bold version_last} is automatically generated and should not be defined manually.`,
+          `${styleText('bold', 'version_last')} is automatically generated and should not be defined manually.`,
         );
       }
     }

--- a/lint/utils.js
+++ b/lint/utils.js
@@ -2,8 +2,7 @@
  * See LICENSE file for more information. */
 
 import { platform } from 'node:os';
-
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 /** @import {SimpleSupportStatement} from '../types/types.js' */
 /** @import {Linter, LinterData, LinterMessage, LinterScope} from './types.js' */
@@ -106,16 +105,22 @@ export const jsonDiff = (actual, expected) => {
   const expectedLines = expected.split(/\n/);
 
   if (actualLines.length !== expectedLines.length) {
-    return chalk`{bold different number of lines:
-    {yellow → Actual:   {bold ${actualLines.length}}}
-    {green → Expected: {bold ${expectedLines.length}}}}`;
+    return styleText(
+      'bold',
+      `different number of lines:
+    ${styleText('yellow', `→ Actual:   ${styleText('bold', String(actualLines.length))}`)}
+    ${styleText('green', `→ Expected: ${styleText('bold', String(expectedLines.length))}`)}`,
+    );
   }
 
   for (let i = 0; i < actualLines.length; i++) {
     if (actualLines[i] !== expectedLines[i]) {
-      return chalk`{bold line #${i + 1}}:
-      {yellow → Actual:   {bold ${escapeInvisibles(actualLines[i])}}}
-      {green → Expected: {bold ${escapeInvisibles(expectedLines[i])}}}`;
+      return styleText(
+        'bold',
+        `line #${i + 1}:
+      ${styleText('yellow', `→ Actual:   ${styleText('bold', escapeInvisibles(actualLines[i]))}`)}
+      ${styleText('green', `→ Expected: ${styleText('bold', escapeInvisibles(expectedLines[i]))}`)}`,
+      );
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,6 @@
         "ajv-formats": "~3.0.1",
         "better-ajv-errors": "~2.0.2",
         "c8": "~10.1.1",
-        "chalk": "~5.6.0",
-        "chalk-template": "~1.1.0",
         "cli-progress": "^3.12.0",
         "compare-versions": "~6.1.0",
         "deep-diff": "~1.0.2",
@@ -1631,22 +1629,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk-template": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
-      "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/change-case": {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,6 @@
     "ajv-formats": "~3.0.1",
     "better-ajv-errors": "~2.0.2",
     "c8": "~10.1.1",
-    "chalk": "~5.6.0",
-    "chalk-template": "~1.1.0",
     "cli-progress": "^3.12.0",
     "compare-versions": "~6.1.0",
     "deep-diff": "~1.0.2",

--- a/scripts/bulk-editor/utils.js
+++ b/scripts/bulk-editor/utils.js
@@ -4,8 +4,8 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
+import { styleText } from 'node:util';
 
-import chalk from 'chalk-template';
 import { fdir } from 'fdir';
 
 import dataFolders from '../../scripts/lib/data-folders.js';
@@ -78,7 +78,7 @@ export const updateFeatures = (featureIDs, updater) => {
             2,
           );
           if (before != after) {
-            console.log(chalk`{yellow Updated ${featureID}}`);
+            console.log(styleText('yellow', `Updated ${featureID}`));
             changed = true;
           }
         }

--- a/scripts/check-mdn-url-anchors.js
+++ b/scripts/check-mdn-url-anchors.js
@@ -1,8 +1,9 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
+import { styleText } from 'node:util';
+
 import esMain from 'es-main';
-import chalk from 'chalk-template';
 
 import { lowLevelWalk } from '../utils/walk.js';
 
@@ -51,7 +52,10 @@ const checkAnchors = async () => {
       for (const { path, hash } of items) {
         if (!text.includes(`id="${hash.slice(1)}"`)) {
           console.warn(
-            chalk`{yellow Invalid mdn_url anchor https://developer.mozilla.org${slug}{bold ${hash}}} in {italic ${path}}`,
+            styleText(
+              'yellow',
+              `Invalid mdn_url anchor https://developer.mozilla.org${slug}${styleText('bold', hash)} in ${styleText('italic', path)}`,
+            ),
           );
         }
       }

--- a/scripts/diff-flat.js
+++ b/scripts/diff-flat.js
@@ -7,7 +7,8 @@
  * @typedef {'html' | 'plain'} Format
  */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import { diffArrays } from 'diff';
 import esMain from 'es-main';
 import stripAnsi from 'strip-ansi';
@@ -217,7 +218,7 @@ const diffKeys = (key, lastKey, options) => {
         return (
           (options.format === 'html'
             ? `<strong>${key}</strong>`
-            : chalk`{blue ${key}}`) + space
+            : styleText('blue', key)) + space
         );
       }
 
@@ -395,11 +396,11 @@ const printDiffs = (base, head, options) => {
         if (part.removed) {
           return options.format == 'html'
             ? `<ins style="color: green">${value}</ins>`
-            : chalk`{green ${value}}`;
+            : styleText('green', value);
         } else if (part.added) {
           return options.format == 'html'
             ? `<del style="color: red">${value}</del>`
-            : chalk`{red ${value}}`;
+            : styleText('red', value);
         }
 
         return value;
@@ -419,7 +420,7 @@ const printDiffs = (base, head, options) => {
         BROWSER_NAMES.includes(part),
       );
       const field = reverseKeyParts.find((part) => !/^\d+$/.test(part));
-      const groupKey = `${!browser ? '' : options.format == 'html' ? `<strong>${browser}</strong>.` : chalk`{cyan ${browser}}.`}${field} = ${value}`;
+      const groupKey = `${!browser ? '' : options.format == 'html' ? `<strong>${browser}</strong>.` : `${styleText('cyan', browser)}.`}${field} = ${value}`;
       const groupValue = key
         .split('.')
         .map((part) => (part !== browser && part !== field ? part : '{}'))
@@ -431,17 +432,14 @@ const printDiffs = (base, head, options) => {
             ? value
             : options.format == 'html'
               ? '<small>{}</small>'
-              : chalk`{dim \{\}}`,
+              : styleText('dim', '{}'),
         )
         .join('.');
       const group = groups.get(groupKey) ?? new Set();
       group.add(groupValue);
       groups.set(groupKey, group);
     } else {
-      const change =
-        options.format == 'html'
-          ? `${keyDiff} = ${value}`
-          : chalk`${keyDiff} = ${value}`;
+      const change = `${keyDiff} = ${value}`;
       const group = groups.get(commonName) ?? new Set();
       group.add(change);
       groups.set(commonName, group);
@@ -528,7 +526,7 @@ const printDiffs = (base, head, options) => {
         console.log(
           options.format == 'html'
             ? `<em>${line}</em>`
-            : chalk`{italic ${line}}`,
+            : styleText('italic', line),
         ),
       );
     }

--- a/scripts/diff.js
+++ b/scripts/diff.js
@@ -3,7 +3,8 @@
 
 /** @import {SupportStatement, Identifier, BrowserName} from '../types/types.js' */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import deepDiff from 'deep-diff';
 import esMain from 'es-main';
 import yargs from 'yargs';
@@ -218,7 +219,7 @@ if (esMain(import.meta)) {
 
   const { base, head } = argv;
   for (const [key, values] of getDiffs(getMergeBase(base, head), head)) {
-    console.log(chalk`{bold ${key}}:`);
+    console.log(`${styleText('bold', key)}:`);
     for (const value of values) {
       console.log(` → ${value}`);
     }

--- a/scripts/lib/pluralize.js
+++ b/scripts/lib/pluralize.js
@@ -1,7 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 const formatter = new Intl.NumberFormat('en-US');
 
@@ -16,14 +16,14 @@ const formatNumber = (n) => formatter.format(n);
  * Pluralizes a string
  * @param {string} word Word in singular form
  * @param {number} quantifier The quantifier
- * @param {boolean} [useChalk] Use chalk formatting
+ * @param {boolean} [useStyleText] Use styleText formatting
  * @returns {string} The pluralized string
  */
-const pluralize = (word, quantifier, useChalk = false) => {
+const pluralize = (word, quantifier, useStyleText = false) => {
   const formattedQuantifier = formatNumber(quantifier);
   const formattedWord = `${word}${quantifier === 1 ? '' : 's'}`;
-  return useChalk
-    ? chalk`{bold ${formattedQuantifier}} ${formattedWord}`
+  return useStyleText
+    ? `${styleText('bold', formattedQuantifier)} ${formattedWord}`
     : `${formattedQuantifier} ${formattedWord}`;
 };
 

--- a/scripts/release/changes.js
+++ b/scripts/release/changes.js
@@ -15,7 +15,8 @@
  * @property {FeatureChange[]} removed
  */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import cliProgress from 'cli-progress';
 
 import diffFeatures from '../diff-features.js';
@@ -82,24 +83,26 @@ const getDiff = async (pull) => {
     diff = await diffFeatures({ ref1: pull.mergeCommit, quiet: true });
   } catch (e) {
     throw new Error(
-      chalk`{red ${e}}\n {yellow (Failed to diff features for #${pull.number}, skipping)}`,
+      `${styleText('red', String(e))}\n ${styleText('yellow', `(Failed to diff features for #${pull.number}, skipping)`)}`,
     );
   }
 
   if (diff.added.length && diff.removed.length) {
     console.log(
-      chalk` | #${pull.number} - {blue ({green ${diff.added.length} added}, {red ${diff.removed.length} removed})}`,
+      ` | #${pull.number} - ${styleText('blue', `(${styleText('green', `${diff.added.length} added`)}, ${styleText('red', `${diff.removed.length} removed`)})`)}`,
     );
   } else if (diff.added.length) {
     console.log(
-      chalk` | #${pull.number} - {blue ({green ${diff.added.length} added})}`,
+      ` | #${pull.number} - ${styleText('blue', `(${styleText('green', `${diff.added.length} added`)})`)}`,
     );
   } else if (diff.removed.length) {
     console.log(
-      chalk` | #${pull.number} - {blue ({red ${diff.removed.length} removed})}`,
+      ` | #${pull.number} - ${styleText('blue', `(${styleText('red', `${diff.removed.length} removed`)})`)}`,
     );
   } else {
-    console.log(chalk` | #${pull.number} - {blue (No feature count changes)}`);
+    console.log(
+      ` | #${pull.number} - ${styleText('blue', '(No feature count changes)')}`,
+    );
   }
 
   return diff;

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -1,7 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import esMain from 'es-main';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -35,14 +36,17 @@ const commitAndPR = async (message, wait, { branch, pr }) => {
   if (wait) {
     console.log('');
     console.log(
-      chalk`{yellow Please {bold modify RELEASE_NOTES.md} and fill out the {bold Notable changes} section. I'll wait for you.}`,
+      styleText(
+        'yellow',
+        `Please ${styleText('bold', 'modify RELEASE_NOTES.md')} and fill out the ${styleText('bold', 'Notable changes')} section. I'll wait for you.`,
+      ),
     );
-    console.log(chalk`{yellow Press any key to continue.}`);
+    console.log(styleText('yellow', 'Press any key to continue.'));
     await keypress();
     console.log('');
   }
 
-  console.log(chalk`{blue Preparing ${branch} branch...}`);
+  console.log(styleText('blue', `Preparing ${branch} branch...`));
   spawn('git', ['stash']);
   spawn('git', ['switch', '-C', branch, 'origin/main']);
   spawn('git', ['stash', 'pop']);
@@ -54,15 +58,15 @@ const commitAndPR = async (message, wait, { branch, pr }) => {
     'release_notes/',
   ]);
 
-  console.log(chalk`{blue Committing changes...}`);
+  console.log(styleText('blue', 'Committing changes...'));
   await temporaryWriteTask(message, (commitFile) =>
     spawn('git', ['commit', '--file', commitFile]),
   );
 
-  console.log(chalk`{blue Pushing ${branch} branch...}`);
+  console.log(styleText('blue', `Pushing ${branch} branch...`));
   spawn('git', ['push', '--force', '--set-upstream', 'origin', branch]);
 
-  console.log(chalk`{blue Creating/editing pull request...}`);
+  console.log(styleText('blue', 'Creating/editing pull request...'));
   await temporaryWriteTask(pr.body, (bodyFile) => {
     const commonArgs = ['--title', pr.title, '--body-file', bodyFile];
     try {
@@ -86,7 +90,7 @@ const commitAndPR = async (message, wait, { branch, pr }) => {
  */
 const main = async ({ dryRun }) => {
   if (dryRun) {
-    console.log(chalk`{green Simulating release...}`);
+    console.log(styleText('green', 'Simulating release...'));
   }
 
   requireGitHubCLI();
@@ -94,16 +98,16 @@ const main = async ({ dryRun }) => {
     requireWriteAccess();
   }
 
-  console.log(chalk`{blue Fetching main branch...}`);
+  console.log(styleText('blue', 'Fetching main branch...'));
   fetchMain();
 
-  console.log(chalk`{blue Getting last version...}`);
+  console.log(styleText('blue', 'Getting last version...'));
   const lastVersion = getLatestTag();
   const lastVersionDate = getRefDate(lastVersion);
 
   // Determine what semver part to bump
   console.log(
-    chalk`{blue Checking merged PRs to determine semver bump level...}`,
+    styleText('blue', 'Checking merged PRs to determine semver bump level...'),
   );
   const semverBumpPulls = getSemverBumpPulls(lastVersionDate);
   /** @type {'major' | 'minor' | 'patch'} */
@@ -120,16 +124,19 @@ const main = async ({ dryRun }) => {
     JSON.parse(spawn('npm', ['version', '--json']))['@mdn/browser-compat-data'];
 
   console.log(
-    chalk`{green Performed {bold ${versionBump}} bump from {bold ${lastVersion}} to {bold ${thisVersion}}}`,
+    styleText(
+      'green',
+      `Performed ${styleText('bold', versionBump)} bump from ${styleText('bold', lastVersion)} to ${styleText('bold', thisVersion)}`,
+    ),
   );
 
-  console.log(chalk`{blue Getting statistics...}`);
+  console.log(styleText('blue', 'Getting statistics...'));
   const stats = await getStats(lastVersion, thisVersion, lastVersionDate);
 
-  console.log(chalk`{blue Getting lists of added/removed features...}`);
+  console.log(styleText('blue', 'Getting lists of added/removed features...'));
   const changes = await getChanges(lastVersionDate);
 
-  console.log(chalk`{blue Updating release notes...}`);
+  console.log(styleText('blue', 'Updating release notes...'));
   const notes = getNotes(thisVersion, changes, stats, versionBump);
   await addNotes(notes, versionBump, lastVersion);
 
@@ -146,7 +153,7 @@ const main = async ({ dryRun }) => {
     );
   }
 
-  console.log(chalk`{blue {bold Done!}}`);
+  console.log(styleText('blue', styleText('bold', 'Done!')));
 };
 
 if (esMain(import.meta)) {

--- a/scripts/release/stats.js
+++ b/scripts/release/stats.js
@@ -19,7 +19,7 @@
  * @typedef {Pick<Stats, 'commits' | 'changed' | 'insertions' | 'deletions'>} ChangeStats
  */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import { spawn, walk } from '../../utils/index.js';
 import pluralize from '../lib/pluralize.js';
@@ -57,7 +57,9 @@ const stats = (start) => {
   // Get just the diff stats summary
   const diff = spawn('git', ['diff', '--shortstat', `${start}...origin/main`]);
   if (diff === '') {
-    console.error(chalk`{red No changes for which to generate statistics.}`);
+    console.error(
+      styleText('red', 'No changes for which to generate statistics.'),
+    );
     process.exit(1);
   }
 
@@ -67,7 +69,9 @@ const stats = (start) => {
     /(?<changed>\d+) files? changed(?:, (?<insertions>\d+) insertions?(\(\+\)))?(?:, (?<deletions>\d+) deletions?\(-\))?/,
   );
   if (!match) {
-    console.error(chalk`{red No changes for which to generate statistics.}`);
+    console.error(
+      styleText('red', 'No changes for which to generate statistics.'),
+    );
     process.exit(1);
   }
 

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -1,7 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import esMain from 'es-main';
 import { markdownTable } from 'markdown-table';
 import yargs from 'yargs';
@@ -140,7 +141,9 @@ const getStats = (folder, allBrowsers, bcd = bcdData) => {
       iterateData(bcd[folder], browsers, stats);
     } else {
       if (process.env.NODE_ENV !== 'test') {
-        console.error(chalk`{red.bold Folder "${folder}/" doesn't exist!}`);
+        console.error(
+          styleText(['red', 'bold'], `Folder "${folder}/" doesn't exist!`),
+        );
       }
       return null;
     }
@@ -190,11 +193,10 @@ const printStats = (stats, folder, counts) => {
   );
 
   console.log(
-    chalk`{bold Status as of version ${
-      process.env.npm_package_version
-    } (released on ${releaseDate}) for ${
-      folder ? `the \`${folder}/\` directory` : 'web platform features'
-    }}: \n`,
+    styleText(
+      'bold',
+      `Status as of version ${process.env.npm_package_version} (released on ${releaseDate}) for ${folder ? `the \`${folder}/\` directory` : 'web platform features'}:`,
+    ) + ' \n',
   );
 
   const header = ['browser', 'exact', 'ranged'];

--- a/scripts/update-browser-releases/bun.js
+++ b/scripts/update-browser-releases/bun.js
@@ -19,8 +19,8 @@
  */
 
 import fs from 'node:fs/promises';
+import { styleText } from 'node:util';
 
-import chalk from 'chalk-template';
 import { compareVersions } from 'compare-versions';
 
 import stringify from '../lib/stringify-and-order-properties.js';
@@ -95,7 +95,10 @@ const fetchWebKitVersion = async (commitHash) => {
       }
 
       console.log(
-        chalk`{yellow Rate limited for commit ${commitHash}. Waiting ${waitTime} seconds...}`,
+        styleText(
+          'yellow',
+          `Rate limited for commit ${commitHash}. Waiting ${waitTime} seconds...`,
+        ),
       );
 
       await new Promise((resolve) => setTimeout(resolve, waitTime * 1000));
@@ -104,7 +107,10 @@ const fetchWebKitVersion = async (commitHash) => {
 
       if (!retryRes.ok) {
         console.warn(
-          chalk`{yellow Warning: Failed to fetch WebKit Version.xcconfig for commit ${commitHash} after retry: HTTP ${retryRes.status}}`,
+          styleText(
+            'yellow',
+            `Warning: Failed to fetch WebKit Version.xcconfig for commit ${commitHash} after retry: HTTP ${retryRes.status}`,
+          ),
         );
         return undefined;
       }
@@ -122,7 +128,10 @@ const fetchWebKitVersion = async (commitHash) => {
       }
 
       console.warn(
-        chalk`{yellow Warning: Could not parse version numbers from Version.xcconfig for commit ${commitHash}}`,
+        styleText(
+          'yellow',
+          `Warning: Could not parse version numbers from Version.xcconfig for commit ${commitHash}`,
+        ),
       );
       webkitVersionCache.set(commitHash, undefined);
       return undefined;
@@ -130,7 +139,10 @@ const fetchWebKitVersion = async (commitHash) => {
 
     if (!res.ok) {
       console.warn(
-        chalk`{yellow Warning: Failed to fetch WebKit Version.xcconfig for commit ${commitHash}: HTTP ${res.status}}`,
+        styleText(
+          'yellow',
+          `Warning: Failed to fetch WebKit Version.xcconfig for commit ${commitHash}: HTTP ${res.status}`,
+        ),
       );
       return undefined;
     }
@@ -148,13 +160,19 @@ const fetchWebKitVersion = async (commitHash) => {
     }
 
     console.warn(
-      chalk`{yellow Warning: Could not parse version numbers from Version.xcconfig for commit ${commitHash}}`,
+      styleText(
+        'yellow',
+        `Warning: Could not parse version numbers from Version.xcconfig for commit ${commitHash}`,
+      ),
     );
     webkitVersionCache.set(commitHash, undefined);
     return undefined;
   } catch (error) {
     console.warn(
-      chalk`{yellow Warning: Error fetching WebKit version for commit ${commitHash}: ${error}}`,
+      styleText(
+        'yellow',
+        `Warning: Error fetching WebKit version for commit ${commitHash}: ${error}`,
+      ),
     );
     webkitVersionCache.set(commitHash, undefined);
     return undefined;

--- a/scripts/update-browser-releases/chrome.js
+++ b/scripts/update-browser-releases/chrome.js
@@ -2,8 +2,7 @@
  * See LICENSE file for more information. */
 
 import * as fs from 'node:fs';
-
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import stringify from '../lib/stringify-and-order-properties.js';
 
@@ -48,7 +47,7 @@ const getReleaseNotesURL = async (version, date, core, status) => {
     releaseNote = await fetch(url);
 
     if (releaseNote.status !== 200) {
-      throw chalk`{red \nRelease note not found for ${version}}.`;
+      throw styleText('red', `\nRelease note not found for ${version}.`);
     }
   }
 
@@ -65,7 +64,7 @@ const getReleaseNotesURL = async (version, date, core, status) => {
   const releaseNote = await fetch(url);
 
   if (releaseNote.status !== 200) {
-    throw chalk`{red \nRelease note not found for ${version}}.`;
+    throw styleText('red', `\nRelease note not found for ${version}.`);
   }
 
   return url;
@@ -193,7 +192,10 @@ export const updateChromiumReleases = async (options) => {
       } else {
         // There is a retired version missing. Chromestatus doesn't list them.
         // There is an oddity: the version is not skipped but not in chromestatus
-        result += chalk`{red \nChrome ${i} not found in Chromestatus! Add it manually or add an exception.}`;
+        result += styleText(
+          'red',
+          `\nChrome ${i} not found in Chromestatus! Add it manually or add an exception.`,
+        );
       }
     }
   }

--- a/scripts/update-browser-releases/edge.js
+++ b/scripts/update-browser-releases/edge.js
@@ -2,8 +2,7 @@
  * See LICENSE file for more information. */
 
 import * as fs from 'node:fs';
-
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import stringify from '../lib/stringify-and-order-properties.js';
 
@@ -25,7 +24,7 @@ const getFutureReleaseDate = async (release, releaseScheduleURL) => {
   const scheduleHTML = await fetch(releaseScheduleURL);
   const text = await scheduleHTML.text();
   if (!text) {
-    throw chalk`{red \nRelease file not found.}`;
+    throw styleText('red', '\nRelease file not found.');
   }
   /**
    * Find the table row:
@@ -47,7 +46,10 @@ const getFutureReleaseDate = async (release, releaseScheduleURL) => {
   );
   const result = text.match(regexp);
   if (!result) {
-    throw chalk`{yellow \nNo entry found for Edge ${release} on [this page](<${releaseScheduleURL}>).}`;
+    throw styleText(
+      'yellow',
+      `\nNo entry found for Edge ${release} on [this page](<${releaseScheduleURL}>).`,
+    );
   }
   const releaseDateText = result[1];
 
@@ -73,7 +75,10 @@ const getReleaseNotesURL = async (status, version) => {
       return '';
     }
 
-    throw chalk`{red \nFailed to fetch Edge ${version} release notes at ${url}!}`;
+    throw styleText(
+      'red',
+      `\nFailed to fetch Edge ${version} release notes at ${url}!`,
+    );
   }
 
   return url;
@@ -234,7 +239,10 @@ export const updateEdgeReleases = async (options) => {
       } else {
         // There is a retired version missing. Edgeupdates doesn't list them.
         // There is an oddity: the version is not skipped but not in edgeupdates
-        result += chalk`{yellow \nEdge ${i} not found in Edgeupdates! Add it manually or add an exception.}`;
+        result += styleText(
+          'yellow',
+          `\nEdge ${i} not found in Edgeupdates! Add it manually or add an exception.`,
+        );
       }
     }
   }

--- a/scripts/update-browser-releases/safari.js
+++ b/scripts/update-browser-releases/safari.js
@@ -2,8 +2,7 @@
  * See LICENSE file for more information. */
 
 import * as fs from 'node:fs';
-
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
 
 import stringify from '../lib/stringify-and-order-properties.js';
 
@@ -32,7 +31,10 @@ const extractReleaseData = (str) => {
     );
   if (!result) {
     console.warn(
-      chalk`{yellow A release string for Safari is not parsable (${str}'). Skipped.}`,
+      styleText(
+        'yellow',
+        `A release string for Safari is not parsable (${str}'). Skipped.`,
+      ),
     );
     return null;
   }
@@ -65,7 +67,10 @@ export const updateSafariReleases = async (options) => {
   const releaseNoteFile = await fetch(`${options.releaseNoteJSON}`);
   if (releaseNoteFile.status !== 200) {
     console.error(
-      chalk`{red \nRelease note file not found at Apple (${options.releaseNoteJSON}).}`,
+      styleText(
+        'red',
+        `\nRelease note file not found at Apple (${options.releaseNoteJSON}).`,
+      ),
     );
     return '';
   }
@@ -89,7 +94,10 @@ export const updateSafariReleases = async (options) => {
 
     if (!releaseDataEntry) {
       console.warn(
-        chalk`{yellow Release string from Apple not understandable (${releases[id].abstract[0].text})}`,
+        styleText(
+          'yellow',
+          `Release string from Apple not understandable (${releases[id].abstract[0].text})`,
+        ),
       );
       continue;
     } else if (/^\d+\.\d+\.\d+$/.test(releaseDataEntry.version)) {

--- a/scripts/update-browser-releases/utils.js
+++ b/scripts/update-browser-releases/utils.js
@@ -11,7 +11,8 @@
  * @property {string} link
  */
 
-import chalk from 'chalk-template';
+import { styleText } from 'node:util';
+
 import xml2js from 'xml2js';
 
 const USER_AGENT =
@@ -51,7 +52,10 @@ export const newBrowserEntry = (
   if (engineVersion) {
     release['engine_version'] = engineVersion.toString();
   }
-  return chalk`{yellow \n- New release detected for {bold ${browser}}: Version {bold ${version}} as a {bold ${status}} release.}`;
+  return styleText(
+    'yellow',
+    `\n- New release detected for ${styleText('bold', browser)}: Version ${styleText('bold', version)} as a ${styleText('bold', status)} release.`,
+  );
 };
 
 /**
@@ -77,20 +81,32 @@ export const updateBrowserEntry = (
   const entry = json.browsers[browser].releases[version];
   let result = '';
   if (entry['status'] !== status) {
-    result += chalk`{cyan \n- New status for {bold ${browser} ${version}}: {bold ${status}}, previously ${entry['status']}.}`;
+    result += styleText(
+      'cyan',
+      `\n- New status for ${styleText('bold', `${browser} ${version}`)}: ${styleText('bold', status)}, previously ${entry['status']}.`,
+    );
     entry['status'] = status;
   }
   if (releaseDate && entry['release_date'] !== releaseDate) {
-    result += chalk`{cyan \n- New release date for {bold ${browser} ${version}}: {bold ${releaseDate}}, previously ${entry['release_date']}.}`;
+    result += styleText(
+      'cyan',
+      `\n- New release date for ${styleText('bold', `${browser} ${version}`)}: ${styleText('bold', releaseDate)}, previously ${entry['release_date']}.`,
+    );
     entry['release_date'] = releaseDate;
   }
   if (releaseNotesURL && entry['release_notes'] !== releaseNotesURL) {
-    result += chalk`{cyan \n- New release notes for {bold ${browser} ${version}}: {bold ${releaseNotesURL}}, previously ${entry['release_notes']}.}`;
+    result += styleText(
+      'cyan',
+      `\n- New release notes for ${styleText('bold', `${browser} ${version}`)}: ${styleText('bold', releaseNotesURL)}, previously ${entry['release_notes']}.`,
+    );
     entry['release_notes'] = releaseNotesURL;
   }
 
   if (engineVersion && entry['engine_version'] != engineVersion) {
-    result += chalk`{cyan \n- New engine version for {bold ${browser} ${version}}: {bold ${engineVersion}}, previously ${entry['engine_version']}.}`;
+    result += styleText(
+      'cyan',
+      `\n- New engine version for ${styleText('bold', `${browser} ${version}`)}: ${styleText('bold', String(engineVersion))}, previously ${entry['engine_version']}.`,
+    );
     entry['engine_version'] = engineVersion.toString();
   }
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Migrates to Node-native `styleText` from chalk + chalk-template.

#### Test results and supporting details

Reduces our dependencies by two.

Note: ESLint v9 depends on chalk, but [ESLint v10.0.0](https://github.com/eslint/eslint/releases/tag/v10.0.0) just migrated to `styleText`.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
