### PR TITLE
Add spec URL for the IntersectionObserverEntry constructor

### DIFF
--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -39,6 +39,7 @@
       "IntersectionObserverEntry": {
         "__compat": {
           "description": "`IntersectionObserverEntry()` constructor",
+          "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-intersectionobserverentry",
           "tags": [
             "web-features:intersection-observer"
           ],


### PR DESCRIPTION
#### Summary

Adds missing spec URL