### PR TITLE
Chromium 145 supports Crash Reporting API

### DIFF
--- a/api/CrashReportContext.json
+++ b/api/CrashReportContext.json
@@ -1,0 +1,128 @@
+{
+  "api": {
+    "CrashReportContext": {
+      "__compat": {
+        "spec_url": "https://wicg.github.io/crash-reporting/#crashreportcontext",
+        "support": {
+          "chrome": {
+            "version_added": "145"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "delete": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/crash-reporting/#dom-crashreportcontext-delete",
+          "support": {
+            "chrome": {
+              "version_added": "145"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initialize": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/crash-reporting/#dom-crashreportcontext-initialize",
+          "support": {
+            "chrome": {
+              "version_added": "145"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "set": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/crash-reporting/#dom-crashreportcontext-set",
+          "support": {
+            "chrome": {
+              "version_added": "145"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Window.json
+++ b/api/Window.json
@@ -1059,6 +1059,37 @@
           }
         }
       },
+      "crashReport": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/crash-reporting/#dom-window-crashreport",
+          "support": {
+            "chrome": {
+              "version_added": "145"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "credentialless": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/credentialless",


### PR DESCRIPTION
#### Summary

Chromium browsers support the Crash Reporting API in version 145
Spec: https://wicg.github.io/crash-reporting/

#### Test results and supporting details

https://chromestatus.com/feature/6228675846209536
https://groups.google.com/a/chromium.org/g/blink-dev/c/UD2RcDSb270/m/lqU-bKuMAAAJ

#### Related issues

None, I think.
