### PR TITLE
ci(release): remove obsolete npm upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,6 @@ jobs:
           package-manager-cache: false
           registry-url: "https://registry.npmjs.org/"
 
-      # Ensure npm 11.5.1 or later for trusted publishing
-      - run: npm install -g npm@latest
-
       - run: npm ci
 
       - run: npm test


### PR DESCRIPTION
#### Summary

Updates the `release` workflow, removing the now-obsolete npm upgrade.

#### Test results and supporting details

See environment in [last release run](https://github.com/mdn/browser-compat-data/actions/runs/21755716837/job/62765289444#step:3:16):

```
Environment details
  node: v24.13.0
  npm: 11.6.2
  yarn: 1.22.22
```

#### Related issues

Part of https://github.com/mdn/fred/issues/1300.