### PR TITLE
Firefox 148 ships CSS `shape()`

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -489,7 +489,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "148"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Updated the Firefox support for CSS `shape()`

#### Test results and supporting details

- Tested in the following browsers using the [`shape()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/basic-shape/shape#examples) page:
  - Firefox Beta 148.0b14 
  - Firefox Developer Edition 148.0b14 
  - Firefox Nightly 149.0a1 (2026-02-10)
  - Firefox Beta for Android 148.0b14  (Build #2016143279)

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/43106)
