### PR TITLE
ci(test): add diff-build job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,12 +125,14 @@ jobs:
 
       - name: Install
         run: |
+          # sed command prefixes each line of output with [base] or [pr]
           cd base && npm ci | sed "s/^/[base] /" &
           cd pr && npm ci | sed "s/^/[pr] /" &
           wait
 
       - name: Format
         run: |
+          # sed command prefixes each line of output with [base] or [pr]
           cd base/build && npx prettier --write . | sed "s/^/[base] /" &
           cd pr/build && npx prettier --write . | sed "s/^/[pr] /" &
           wait


### PR DESCRIPTION
#### Summary

Updates the `test` workflow, adding a `diff-build` job that compares the `build/` output between the PR and its base.

(For release PRs, compares against the previous release.)

#### Test results and supporting details

See [job in this PR](https://github.com/mdn/browser-compat-data/actions/runs/21986676385/job/63522561944?pr=29042#step:8:7).

Inspired by https://github.com/mdn/rari/pull/384 and https://github.com/mdn/rari/pull/386.

#### Related issues

Related to https://github.com/mdn/browser-compat-data/pull/29041.