### PR TITLE
Correct data for `Intl.NumberFormat` options

### DIFF
--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -388,7 +388,9 @@
                     "firefox": {
                       "version_added": "42"
                     },
-                    "firefox_android": "mirror",
+                    "firefox_android": {
+                      "version_added": "56"
+                    },
                     "nodejs": {
                       "version_added": "12.11.0"
                     },


### PR DESCRIPTION
#### Summary

The collector proposes the following corrections to NumberFormat data.

- currencyDisplay option: Firefox 78 -> Firefox 42
- numberingSystem: Firefox 29 -> Firefox 76
- numberingSystem Safari 10 -> Safari 14.1

#### Test results and supporting details

- currencyDisplay Firefox 42 can probably be confirmed with https://bugzilla.mozilla.org/show_bug.cgi?id=1093421 and https://bugzilla.mozilla.org/show_bug.cgi?id=1075758.
- numberingSystem Firefox 76 can be confirmed with https://bugzilla.mozilla.org/show_bug.cgi?id=1625975#c5
- numberingSystem Safari can be confirmed with https://github.com/WebKit/WebKit/commit/8fd0feda7d6d8cc9f34246ef9d1b807847bee09c

#### Related issues

None that are open, it seems.