### PR TITLE
Safari 26.2 adds `position-visibility: anchors-valid`

### DIFF
--- a/css/properties/position-visibility.json
+++ b/css/properties/position-visibility.json
@@ -86,7 +86,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary

Safari 26.2 supports position-visibility: anchors-valid

#### Test results and supporting details

https://bugs.webkit.org/show_bug.cgi?id=297314

#### Related issues

Content issue: https://github.com/mdn/content/issues/43120