### PR TITLE
Add HTML `link` element attribute values `as="{json,script,style}"` for `modulepreload`

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1028,7 +1028,7 @@
                   "webview_ios": "mirror"
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
                 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This change adds `as="style"`, `as="script"`, and `as="json"` to the `<link rel="modulepreload">` compat data. Chromium is shipping this in 147, so this adds that data as well (see https://chromestatus.com/feature/5202661416763392).

#### Test results and supporting details

`as="script"` is the default, and support for this goes back to when each browser originally supported `<link rel="modulepreload">`. Chrome 147 will begin supporting `as="style"` and `as="json"`, and Safari recently added support for `as="json"`, in version 26.2 (see "Fixed “text/json/json+json” to be considered an invalid JSON MIME type." note in https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes).

WPT tests reflecting these results:

For Chrome 147 supporting JSON and style modulepreloads, see Experimental results: https://wpt.fyi/results/preload/modulepreload-as.html?label=master&label=experimental&aligned&q=modulepreload-as.html

For Safari 26 supporting JSON modulepreloads, see https://wpt.fyi/results/preload/modulepreload-as.html?label=stable&label=master&aligned

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromestatus.com/feature/5202661416763392
https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
