### PR TITLE
ci(workflows): use latest compatible node version

### DIFF
--- a/.github/workflows/add-push-artifacts.yml
+++ b/.github/workflows/add-push-artifacts.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
           package-manager-cache: true
       - run: npm ci

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           package-manager-cache: false
 
       - name: Install

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           package-manager-cache: false
           registry-url: "https://registry.npmjs.org/"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           package-manager-cache: false
           registry-url: "https://registry.npmjs.org/"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
           package-manager-cache: true
 
@@ -47,6 +48,7 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
           package-manager-cache: true
 
@@ -65,6 +67,7 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
           package-manager-cache: true
 

--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           package-manager-cache: false
 
       - run: npm ci

--- a/.github/workflows/update-mdn-urls.yml
+++ b/.github/workflows/update-mdn-urls.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           package-manager-cache: false
 
       - name: "Setup git"

--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           package-manager-cache: false
 
       - name: "Setup git"

--- a/.github/workflows/update-webdriver-bidi-data.yml
+++ b/.github/workflows/update-webdriver-bidi-data.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           package-manager-cache: false
 
       - name: "Setup git"


### PR DESCRIPTION
### Description

Updates all workflow steps using `actions/setup-node`, setting `check-latest: true`.

### Motivation

Ensures the latest compatible Node version is used consistently, with the corresponding npm version.

### Additional details


### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1309.
