### PR TITLE
Safari iOS does not support `interactive-widget` viewport feature

### DIFF
--- a/html/elements/meta/name/viewport/interactive-widget.json
+++ b/html/elements/meta/name/viewport/interactive-widget.json
@@ -29,9 +29,7 @@
                   "safari": {
                     "version_added": false
                   },
-                  "safari_ios": {
-                    "version_added": "3"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror",
                   "webview_ios": "mirror"


### PR DESCRIPTION
#### Summary

Updated/corrected compatibility data for `interactive-widget` for iOS, according to @caugner's instructions at https://github.com/mdn/browser-compat-data/issues/29011#issuecomment-3916609237

As discussed in the linked issue, Safari and WebView on iOS do not support this feature.

#### Test results and supporting details

Didn't run any tests tests.

#### Related issues

Fixes #29011