### PR TITLE
Firefox never shipped `GPUAdapter.isFallbackAdapter`

### DIFF
--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -207,20 +207,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "141",
-              "partial_implementation": true,
-              "notes": [
-                "Supports all contexts except service workers. See [bug 1942431](https://bugzil.la/1942431).",
-                "Supports Windows since Firefox 141. See [bug 1972486](https://bugzil.la/1972486).",
-                "Supports macOS Tahoe on Apple silicon since Firefox 145. See [bug 1992212](https://bugzil.la/1992212).",
-                "Supports older macOS versions on Apple silicon since Firefox 147. See [bug 1993341](https://bugzil.la/1993341).",
-                "Does not support macOS on Intel CPUs. See [bug 2004105](https://bugzil.la/2004105).",
-                "Does not support Linux. See [bug 2006676](https://bugzil.la/2006676)."
-              ]
-            },
-            "firefox_android": {
               "version_added": false
             },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Firefox support for the `GPUAdapter.isFallbackAdapter` property, which was only available in Nightly, and moved to `GPUAdapterInfo` before it shipped.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29039.