### PR TITLE
Firefox/Safari don't expose `DeviceMotionEventAcceleration` interface

### DIFF
--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -31,7 +31,7 @@
           },
           "safari_ios": {
             "version_added": "4.2",
-            "notes": "The `DeviceMotionEventAcceleration` interface is supported, but not exposed."
+            "notes": "The `DeviceMotionEventAcceleration` interface is supported, but not exposed on the `Window` scope."
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds Firefox/Safari notes about missing exposure if `DeviceMotionEventAcceleration` interface.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20785.