### PR TITLE
Firefox Android unshipped `X-Frame-Options` header `ALLOW-FROM` directive

### DIFF
--- a/http/headers/X-Frame-Options.json
+++ b/http/headers/X-Frame-Options.json
@@ -39,44 +39,6 @@
             "deprecated": false
           }
         },
-        "ALLOW-FROM": {
-          "__compat": {
-            "description": "ALLOW-FROM",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": "18",
-                "version_removed": "70"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "8"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "SAMEORIGIN": {
           "__compat": {
             "description": "SAMEORIGIN",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

1. Updates the Firefox Android support statement for the `X-Frame-Options` header `ALLOW-FROM` directive.
2. Removes the feature altogether, because all browsers unshipped it more than 2.5 years ago.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20676.