### PR TITLE
Add sub features to CSS random()

### DIFF
--- a/css/types/random.json
+++ b/css/types/random.json
@@ -4,7 +4,7 @@
       "random": {
         "__compat": {
           "description": "`random()`",
-          "spec_url": "https://www.w3.org/TR/css-values-5/#random",
+          "spec_url": "https://drafts.csswg.org/css-values-5/#random",
           "tags": [
             "web-features:random-function"
           ],
@@ -33,6 +33,99 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "dashed-ident": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-values-5/#valdef-random-dashed-ident",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "element-shared": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-values-5/#valdef-random-element-shared",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "step": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-values-5/#ref-for-typedef-calc-sum①⑧",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
#### Summary

In https://github.com/openwebdocs/mdn-bcd-collector/pull/2992, @caugner contributed additional BCD collector tests for the CSS `random()` function. In the PR it was also noted that the spec reference is outdated. 

This PR adds the additional subfeature data as collected and corrects the spec URL to a more recent one.

#### Test results and supporting details

Collector results say this shipped in Safari 26.2.

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/28840
- https://github.com/openwebdocs/mdn-bcd-collector/pull/2992