### PR TITLE
MouseEvent is now in pointerevents

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -4,7 +4,7 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent",
         "spec_url": [
-          "https://w3c.github.io/uievents/#interface-mouseevent",
+          "https://w3c.github.io/pointerevents/#interface-mouseevent",
           "https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface",
           "https://w3c.github.io/pointerlock/#extensions-to-the-mouseevent-interface"
         ],
@@ -51,7 +51,7 @@
         "__compat": {
           "description": "`MouseEvent()` constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/MouseEvent",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-mouseevent",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-mouseevent",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -88,7 +88,7 @@
       "altKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/altKey",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-altkey",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-altkey",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -132,7 +132,7 @@
       "button": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/button",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-button",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-button",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -176,7 +176,7 @@
       "buttons": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/buttons",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-buttons",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-buttons",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -219,7 +219,7 @@
       "clientX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/clientX",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-clientx",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-clientx",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -263,7 +263,7 @@
       "clientY": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/clientY",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-clienty",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-clienty",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -307,7 +307,7 @@
       "ctrlKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/ctrlKey",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-ctrlkey",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-ctrlkey",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -351,7 +351,7 @@
       "getModifierState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/getModifierState",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-getmodifierstate",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-getmodifierstate",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -422,7 +422,7 @@
       "initMouseEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/initMouseEvent",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-initmouseevent",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-initmouseevent",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -535,7 +535,7 @@
       "metaKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/metaKey",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-metakey",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-metakey",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -905,7 +905,7 @@
       "relatedTarget": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/relatedTarget",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-relatedtarget",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-relatedtarget",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -985,7 +985,7 @@
       "screenX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/screenX",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-screenx",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-screenx",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -1029,7 +1029,7 @@
       "screenY": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/screenY",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-screeny",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-screeny",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -1073,7 +1073,7 @@
       "shiftKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/shiftKey",
-          "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-shiftkey",
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-mouseevent-shiftkey",
           "tags": [
             "web-features:mouse-events"
           ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

https://github.com/mdn/browser-compat-data/pull/28974 was incomplete and forgot to move MouseEvent as well.

#### Test results and supporting details

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- https://github.com/w3c/pointerevents/pull/564
- https://github.com/w3c/uievents/pull/411
- https://github.com/mdn/content/pull/43011
- https://github.com/web-platform-dx/web-features/pull/3690
- https://github.com/mdn/browser-compat-data/pull/28974

#### Related issues

https://github.com/mdn/browser-compat-data/pull/28974
