### PR TITLE
Firefox 147 / Safari 26 support implicit anchor references

### DIFF
--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -200,6 +200,10 @@
         "implicit_anchor_reference": {
           "__compat": {
             "description": "Implicit anchor reference via `commandForElement`",
+            "spec_url": [
+              "https://drafts.csswg.org/css-anchor-position/#implicit-anchor-element",
+              "https://html.spec.whatwg.org/multipage/popover.html#:~:text=implicit%20anchor%20element"
+            ],
             "tags": [
               "web-features:anchor-positioning"
             ],
@@ -750,6 +754,10 @@
         "implicit_anchor_reference": {
           "__compat": {
             "description": "Implicit anchor reference via `popoverTargetElement`",
+            "spec_url": [
+              "https://drafts.csswg.org/css-anchor-position/#implicit-anchor-element",
+              "https://html.spec.whatwg.org/multipage/popover.html#:~:text=implicit%20anchor%20element"
+            ],
             "tags": [
               "web-features:anchor-positioning"
             ],

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2493,7 +2493,10 @@
           "implicit_anchor_reference": {
             "__compat": {
               "description": "Implicit anchor reference via `source`",
-              "spec_url": "https://html.spec.whatwg.org/multipage/popover.html#:~:text=Set%20element's%20implicit%20anchor%20element%20to%20invoker.",
+              "spec_url": [
+                "https://drafts.csswg.org/css-anchor-position/#implicit-anchor-element",
+                "https://html.spec.whatwg.org/multipage/popover.html#:~:text=implicit%20anchor%20element"
+              ],
               "tags": [
                 "web-features:anchor-positioning"
               ],
@@ -3062,7 +3065,10 @@
           "implicit_anchor_reference": {
             "__compat": {
               "description": "Implicit anchor reference via `source`",
-              "spec_url": "https://html.spec.whatwg.org/multipage/popover.html#:~:text=Set%20element's%20implicit%20anchor%20element%20to%20invoker.",
+              "spec_url": [
+                "https://drafts.csswg.org/css-anchor-position/#implicit-anchor-element",
+                "https://html.spec.whatwg.org/multipage/popover.html#:~:text=implicit%20anchor%20element"
+              ],
               "tags": [
                 "web-features:anchor-positioning"
               ],

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1643,6 +1643,10 @@
         "implicit_anchor_reference": {
           "__compat": {
             "description": "Implicit anchor reference via `popoverTargetElement`",
+            "spec_url": [
+              "https://drafts.csswg.org/css-anchor-position/#implicit-anchor-element",
+              "https://html.spec.whatwg.org/multipage/popover.html#:~:text=implicit%20anchor%20element"
+            ],
             "tags": [
               "web-features:anchor-positioning"
             ],

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -149,6 +149,10 @@
           "implicit_anchor_reference": {
             "__compat": {
               "description": "Implicit anchor reference via `commandfor`",
+              "spec_url": [
+                "https://drafts.csswg.org/css-anchor-position/#implicit-anchor-element",
+                "https://html.spec.whatwg.org/multipage/popover.html#:~:text=implicit%20anchor%20element"
+              ],
               "tags": [
                 "web-features:anchor-positioning"
               ],
@@ -565,6 +569,10 @@
           "implicit_anchor_reference": {
             "__compat": {
               "description": "Implicit anchor reference via `popovertarget`",
+              "spec_url": [
+                "https://drafts.csswg.org/css-anchor-position/#implicit-anchor-element",
+                "https://html.spec.whatwg.org/multipage/popover.html#:~:text=implicit%20anchor%20element"
+              ],
               "tags": [
                 "web-features:anchor-positioning"
               ],

--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -1122,6 +1122,10 @@
           "implicit_anchor_reference": {
             "__compat": {
               "description": "Implicit anchor reference via `popovertarget`",
+              "spec_url": [
+                "https://drafts.csswg.org/css-anchor-position/#implicit-anchor-element",
+                "https://html.spec.whatwg.org/multipage/popover.html#:~:text=implicit%20anchor%20element"
+              ],
               "tags": [
                 "web-features:anchor-positioning"
               ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Firefox/Safari support for implicit anchor references:

- This was missed, because there are no collector tests.
- In one case, Firefox 141 allegedly added support, but Anchor Positioning only landed in Firefox 147.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29082.
