### PR TITLE
fix(api): mark RTCRtpSender transactionId as supported in Firefox 110

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -381,7 +381,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "110"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -1061,7 +1061,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "110"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
#### Summary

Mark `transactionId` as supported in Firefox 110 for both `RTCRtpSender.getParameters()` (returned object property) and `RTCRtpSender.setParameters()` (parameter), where it was previously marked as unsupported.

#### Test results and supporting details

`transactionId` was implemented as part of bringing `get/setParameters` up to spec in [Bug 1401592](https://bugzil.la/1401592), which landed on December 13, 2022. The version bump to Firefox 111 occurred in January 2023, placing this in Firefox 110.

- Bugzilla bug: https://bugzil.la/1401592
- Commit: https://hg.mozilla.org/mozilla-central/rev/016eb374b146

`getParameters()` generates a unique `transactionId` UUID on each call, and `setParameters()` validates that the provided `transactionId` matches the one from the most recent `getParameters()` call, rejecting with `InvalidModificationError` if it does not match.