### PR TITLE
ShadowRoot.setHTML and Document.parseHTML are shipping in Firefox

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6021,7 +6021,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -814,7 +814,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "148"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Both of these methods are part of the Sanitizer API. This update was missed somewhere.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
