### PR TITLE
Bug-1993037 add `splitViewId` detailt to `tabs` API

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -589,7 +589,7 @@
               "firefox": {
                 "version_added": "149"
               },
-              "firefox_android": "mirror"
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -1155,7 +1155,7 @@
                   "version_added": "149"
                 },
                 "firefox_android": {
-                  "version_added": "149,
+                  "version_added": "149",
                   "notes": "Always -1 as split views are not supported in Firefox for Android"
                 },
                 "opera": "mirror",
@@ -3364,6 +3364,27 @@
                     "safari_ios": "mirror"
                   }
                 }
+              },
+              "splitViewId": {
+                "__compat": {
+                  "support": {
+                    "chrome": {
+                      "version_added": false
+                    },
+                    "edge": "mirror",
+                    "firefox": {
+                      "version_added": "149"
+                    },
+                    "firefox_android": {
+                      "version_added": false
+                    },
+                    "opera": "mirror",
+                    "safari": {
+                      "version_added": false
+                    },
+                    "safari_ios": "mirror"
+                  }
+                }
               }
             }
           }
@@ -3903,7 +3924,7 @@
                   "firefox": {
                     "version_added": "149"
                   },
-                  "firefox_android": "mirror"
+                  "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
                     "version_added": false


### PR DESCRIPTION
#### Summary

Adds the browser compatibility data for [Bug 1993037](https://bugzilla.mozilla.org/show_bug.cgi?id=1993037)  Expose splitViewId in tabs extension API comprising:

- the `SPLIT_VIEW_ID_NONE` property
- addition of `splitViewId` to `tabs.Tab`, `tabs.onUpdated`, and `tabs.query()`. 

#### Related issues

Related MDN content changes in https://github.com/mdn/content/pull/43284.
