### PR TITLE
Updates for Firefox 149 beta

### DIFF
--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "149"
           },
           "firefox_android": {
             "version_added": false
@@ -31,7 +31,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "firefox_android": {
               "version_added": false
@@ -68,7 +68,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -89,7 +89,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "firefox_android": {
               "version_added": false
@@ -106,7 +106,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -126,7 +126,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "firefox_android": {
               "version_added": false
@@ -143,7 +143,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -164,7 +164,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "firefox_android": {
               "version_added": false
@@ -181,7 +181,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -201,7 +201,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "firefox_android": {
               "version_added": false
@@ -218,7 +218,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -238,7 +238,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "firefox_android": {
               "version_added": false
@@ -255,7 +255,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -439,8 +439,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1919718"
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -455,7 +454,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -489,10 +489,15 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "prefix": "moz",
-              "version_added": "15"
-            },
+            "firefox": [
+              {
+                "version_added": "149"
+              },
+              {
+                "prefix": "moz",
+                "version_added": "15"
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -95,7 +95,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/ReportingObserver.json
+++ b/api/ReportingObserver.json
@@ -14,14 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "65",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.reporting.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "149"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -56,14 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.reporting.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -97,14 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "77",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.reporting.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "nodejs": {
@@ -124,7 +103,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -144,14 +123,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.reporting.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -186,14 +158,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.reporting.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -228,14 +193,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.reporting.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -281,7 +281,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/properties/alignment-baseline.json
+++ b/css/properties/alignment-baseline.json
@@ -18,7 +18,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "149"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -215,7 +215,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "149"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -297,6 +297,68 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "text-bottom": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-text-bottom",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "text-top": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-text-top",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/baseline-shift.json
+++ b/css/properties/baseline-shift.json
@@ -18,7 +18,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "149"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -72,6 +72,68 @@
             }
           }
         },
+        "bottom": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-shift-bottom",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "center": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-shift-center",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "sub": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub",
@@ -85,7 +147,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "149"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -119,7 +181,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "149"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -135,6 +197,37 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "top": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-shift-top",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/dominant-baseline.json
+++ b/css/properties/dominant-baseline.json
@@ -275,6 +275,68 @@
               "deprecated": false
             }
           }
+        },
+        "text-bottom": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-text-bottom",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "text-top": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-text-top",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -120,6 +120,99 @@
             }
           }
         },
+        "center": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-shift-center",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "first": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-source-first",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "last": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-source-last",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "middle": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-inline/#valdef-alignment-baseline-middle",


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.17.4) found new features shipping in Firefox 149 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 36 features as shipping in Firefox 149:

- api.CloseWatcher
- api.CloseWatcher.CloseWatcher
- api.CloseWatcher.cancel_event
- api.CloseWatcher.close
- api.CloseWatcher.close_event
- api.CloseWatcher.destroy
- api.CloseWatcher.requestClose
- api.HTMLInputElement.colorSpace
- api.HTMLMediaElement.captureStream
- api.PopStateEvent.hasUAVisualTransition
- api.ReportingObserver
- api.ReportingObserver.ReportingObserver
- api.ReportingObserver.worker_support
- api.ReportingObserver.disconnect
- api.ReportingObserver.observe
- api.ReportingObserver.takeRecords
- api.ShadowRoot.referenceTarget
- api.createImageBitmap.options_resizeQuality_parameter
- css.properties.alignment-baseline
- css.properties.alignment-baseline.baseline
- css.properties.alignment-baseline.middle
- css.properties.alignment-baseline.text-bottom
- css.properties.alignment-baseline.text-top
- css.properties.baseline-shift
- css.properties.baseline-shift.bottom
- css.properties.baseline-shift.center
- css.properties.baseline-shift.sub
- css.properties.baseline-shift.super
- css.properties.baseline-shift.top
- css.properties.dominant-baseline.text-bottom
- css.properties.dominant-baseline.text-top
- css.properties.vertical-align.center
- css.properties.vertical-align.first
- css.properties.vertical-align.last
- html.elements.template.shadowrootreferencetarget (added in a different PR)
- webdriver.bidi.browser.setDownloadBehavior (added in a different PR)

See also https://github.com/mdn/mdn/issues/810 and https://www.mozilla.org/en-US/firefox/149.0beta/releasenotes/

cc @pepelsbey 