### PR TITLE
Add Firefox impl_url for text-spacing-trim

### DIFF
--- a/css/properties/text-spacing-trim.json
+++ b/css/properties/text-spacing-trim.json
@@ -15,7 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1951795"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -48,7 +49,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1951795"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -82,7 +84,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1951795"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -116,7 +119,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1951795"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -150,7 +154,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1951795"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add the Firefox Bugzilla bug URL (https://bugzilla.mozilla.org/show_bug.cgi?id=1951795 / https://bugzil.la/1951795) to the css/properties/text-spacing-trim.json file.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://github.com/mdn/browser-compat-data/blob/main/css/properties/text-spacing-trim.json

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
