### PR TITLE
Update compatibility data for `api.AudioParam.cancelScheduledValues`

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -123,7 +123,7 @@
                 "version_added": "14",
                 "version_removed": "83",
                 "partial_implementation": true,
-                "notes": "Before Chrome 83, `cancelScheduledValues()` does not cancel in-progress curve events created by `setValueCurveAtTime()`. See [bug 1063502](https://crbug.com/1063502)."
+                "notes": "Before Chrome 83, `cancelScheduledValues()` does not cancel in-progress curve events created by `setValueCurveAtTime()`. See [bug 40123334](https://crbug.com/40123334)."
               }
             ],
             "chrome_android": "mirror",


### PR DESCRIPTION
#### Summary

Updates `api.AudioParam.cancelScheduledValues` to mark partial support for older Chrome/Safari versions and Firefox.

#### Test results and supporting details

Per the March 2020 spec update (WebAudio/web-audio-api#2071), `cancelScheduledValues` should cancel in-progress curve events created by `setValueCurveAtTime`. Chrome and Safari have implemented this behavior, but Firefox has not.

Supported by the following implementation evidence and release notes:

**Chrome**:
- Chromium bug: [Bug 1063502](https://crbug.com/1063502)
- Implementation: [Commit 7a87148a](https://chromium.googlesource.com/chromium/src/+/7a87148abe74349f55729acfbd54ebb02418aac6)
- Release: [Chrome 83](https://chromiumdash.appspot.com/commits?commit=7a87148abe74349f55729acfbd54ebb02418aac6&platform=Windows)

**Safari**:
- WebKit bug: [Bug 216132](https://bugs.webkit.org/show_bug.cgi?id=216132)
- Implementation: [Changeset r266558](https://trac.webkit.org/changeset/266558)
- Release: [Safari TP 114](https://webkit.org/blog/11300/release-notes-for-safari-technology-preview-114/), [Safari 14.1](https://webkit.org/blog/11648/new-webkit-features-in-safari-14-1/)

**Firefox**:
- Not implemented ([Bug 1752775](https://bugzilla.mozilla.org/show_bug.cgi?id=1752775))

#### Related issues

Fixes #29029