### PR TITLE
Update CSSFontFaceDescriptors and CSSFontFaceRule

### DIFF
--- a/api/CSSFontFaceRule.json
+++ b/api/CSSFontFaceRule.json
@@ -85,6 +85,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "type_CSSFontFaceDescriptors": {
+          "__compat": {
+            "description": "Type changed to [`CSSFontFaceDescriptors`](https://developer.mozilla.org/docs/Web/API/CSSFontFaceDescriptors)",
+            "tags": [
+              "web-features:font-face"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
#### Summary

Adds `type_CSSFontFaceDescriptors` sub-feature under `CSSFontFaceRule.style` to record the return type change from `CSSStyleDeclaration`, matching the existing `CSSPageRule.style.type_CSSPageDescriptors` pattern.

#### Test results and supporting details

- mdn/content#43286