### PR TITLE
Add device bound session credentials headers

### DIFF
--- a/http/headers/Sec-Secure-Session-Id.json
+++ b/http/headers/Sec-Secure-Session-Id.json
@@ -1,0 +1,47 @@
+{
+  "http": {
+    "headers": {
+      "Sec-Secure-Session-Id": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-dbsc/#header-sec-secure-session-id",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows and macOS only."
+              },
+              {
+                "version_added": "145",
+                "version_removed": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows only."
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/Secure-Session-Challenge.json
+++ b/http/headers/Secure-Session-Challenge.json
@@ -1,0 +1,47 @@
+{
+  "http": {
+    "headers": {
+      "Secure-Session-Challenge": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-dbsc/#header-secure-session-challenge",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows and macOS only."
+              },
+              {
+                "version_added": "145",
+                "version_removed": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows only."
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/Secure-Session-Registration.json
+++ b/http/headers/Secure-Session-Registration.json
@@ -1,0 +1,47 @@
+{
+  "http": {
+    "headers": {
+      "Secure-Session-Registration": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-dbsc/#header-secure-session-registration",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows and macOS only."
+              },
+              {
+                "version_added": "145",
+                "version_removed": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows only."
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/Secure-Session-Response.json
+++ b/http/headers/Secure-Session-Response.json
@@ -1,0 +1,47 @@
+{
+  "http": {
+    "headers": {
+      "Secure-Session-Response": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-dbsc/#header-secure-session-registration",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows and macOS only."
+              },
+              {
+                "version_added": "145",
+                "version_removed": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows only."
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/Secure-Session-Skipped.json
+++ b/http/headers/Secure-Session-Skipped.json
@@ -1,0 +1,47 @@
+{
+  "http": {
+    "headers": {
+      "Secure-Session-Skipped": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-dbsc/#header-secure-session-skipped",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows and macOS only."
+              },
+              {
+                "version_added": "145",
+                "version_removed": "147",
+                "partial_implementation": true,
+                "notes": "Supported on Windows only."
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This adds features for the request and response headers from the [Device Bound Session Credentials](https://w3c.github.io/webappsec-dbsc/) (DBSC) spec.

#### Test results and supporting details

I took the version numbers from the rollout steps in the [Chrome Platform Status entry](https://chromestatus.com/feature/5140168270413824). Vendor [commentary](https://github.com/web-platform-dx/web-features/issues/3749) on this feature in web-features led me to believe this is accurate.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/issues/3749

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
