### PR TITLE
Ff149htmlinputelement showpicker datalist

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2350,7 +2350,10 @@
               "firefox": {
                 "version_added": "149"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1535985"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",


### PR DESCRIPTION
FF149 supports `HTMLInputElement.showPicker()` for a `<datalist>` in https://bugzilla.mozilla.org/show_bug.cgi?id=1998668 - but according to that link not on Android

This adds the feature. 

Related docs work can be tracked in https://github.com/mdn/content/issues/43201
