### PR TITLE
HTMLMediaElement.captureStream - add notes

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -495,12 +495,18 @@
               },
               {
                 "prefix": "moz",
+                "version_added": "149"
+              },
+              {
+                "prefix": "moz",
                 "version_added": "15",
+                "version_removed": "149",
+                "partial_implementation": true,
                 "notes": [
-                  "From version 51 to version 148, if the source changes from a `MediaStream` after capture starts, the captured stream data cannot be updated until you switch the source back to a `MediaStream`.",
-                  "From version 51 to version 148, if `mozCaptureMediaStream()` is called on a media element with a `MediaStream` source, the returned object only contains tracks while the element is playing a `MediaStream`.",
-                  "From version 51 to version 148, if `mozCaptureMediaStream()` is called on a media element with no source media, its compatibility mode is be based on the first source that's added; and the stream will only work with that kind of stream from then on.",
-                  "Prior to version 51, `mozCaptureMediaStream()` could not be used on a media element whose source is itself a `MediaStream` (such as a `<video>` element presenting a stream being received over an `RTCPeerConnection`)."
+                  "From Firefox 51, if the source changes from a `MediaStream` after capture starts, the captured stream data cannot be updated until you switch the source back to a `MediaStream`.",
+                  "From Firefox 51, if `mozCaptureMediaStream()` is called on a media element with a `MediaStream` source, the returned object only contains tracks while the element is playing a `MediaStream`.",
+                  "From Firefox 51, if `mozCaptureMediaStream()` is called on a media element with no source media, its compatibility mode is be based on the first source that's added; and the stream will only work with that kind of stream from then on.",
+                  "Before Firefox 51, `mozCaptureMediaStream()` could not be used on a media element whose source is itself a `MediaStream` (such as a `<video>` element presenting a stream being received over an `RTCPeerConnection`)."
                 ]
               }
             ],


### PR DESCRIPTION
FF149 adds support for `HTMLElement.captureStream()` in https://bugzilla.mozilla.org/show_bug.cgi?id=2017708 - and this was recoreded in #29135.

Previously only a non-standards-compliant version `mozCaptureSttream()` was defined. The docs contained notes about the compliance issues. This attempts to move those to BCD, where they belong.

Related work for this can be tracked in https://github.com/mdn/content/issues/43215