### PR TITLE
Chrome 145 clipboardchange event permission

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -44,7 +44,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "144"
+              "version_added": "144",
+              "notes": "From version 145, firing `clipboardchange` events requires sticky activation or the `clipboard-read` permission to be granted."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

From Chrome 145, firing `clipboardchange` events requires sticky user activation or `clipboard-read` permission, to prevent unauthorized clipboard monitoring. See https://chromestatus.com/feature/5163741220044800.

This PR adds a note to make this clear. I thought a note would make the most sense, as it isn't a new feature; it's a change in the behavior of an existing feature.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
