### PR TITLE
Chrome 144 uniform_buffer_standard_layout WGSL extension

### DIFF
--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -257,6 +257,43 @@
           }
         }
       },
+      "extension_uniform_buffer_standard_layout": {
+        "__compat": {
+          "description": "`uniform_buffer_standard_layout` extension",
+          "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-uniform_buffer_standard_layout",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "144",
+              "partial_implementation": true,
+              "notes": "Supported on ChromeOS, macOS, Windows, and Linux (Intel Gen12+ GPUs only)."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "extension_unrestricted_pointer_parameters": {
         "__compat": {
           "description": "`unrestricted_pointer_parameters` extension",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 144 adds support for the `uniform_buffer_standard_layout` WGSL language extension. See https://chromestatus.com/feature/6680245553987584; also see https://developer.chrome.com/blog/new-in-webgpu-144#wgsl_uniform_buffer_standard_layout_extension for more context.

This PR adds a data point for the new extension.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
