### PR TITLE
CloseWatcher API is supported on Firefox/Android like desktop

### DIFF
--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -16,9 +16,7 @@
           "firefox": {
             "version_added": "149"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -53,9 +51,7 @@
             "firefox": {
               "version_added": "149"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -91,9 +87,7 @@
             "firefox": {
               "version_added": "149"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -128,9 +122,7 @@
             "firefox": {
               "version_added": "149"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -166,9 +158,7 @@
             "firefox": {
               "version_added": "149"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -203,9 +193,7 @@
             "firefox": {
               "version_added": "149"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -240,9 +228,7 @@
             "firefox": {
               "version_added": "149"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Although https://github.com/mdn/browser-compat-data/pull/29135 updates BDC for Firefox 149, Close watcher API's defines are still incorrect for Firefox/Android.  This API is turned on by https://bugzilla.mozilla.org/show_bug.cgi?id=1966467 and https://bugzilla.mozilla.org/show_bug.cgi?id=1966073 even if Firefox Android.