### PR TITLE
Safari Tech Preview 238 supports `:open`

### DIFF
--- a/css/selectors/open.json
+++ b/css/selectors/open.json
@@ -34,7 +34,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Safari Tech Preview 238 supports `:open`

#### Test results and supporting details

https://webkit.org/blog/17848/release-notes-for-safari-technology-preview-238/#:~:text=for%20the%20CSS-,%3Aopen,-pseudo%2Dclass%2C%20which

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
