### PR TITLE
Safari Tech Preview 238 supports most of customisable select

### DIFF
--- a/api/HTMLSelectedContentElement.json
+++ b/api/HTMLSelectedContentElement.json
@@ -21,8 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false,
-            "impl_url": "https://webkit.org/b/286642"
+            "version_added": "preview"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -30,7 +29,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -127,7 +127,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -135,7 +135,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/picker-icon.json
+++ b/css/selectors/picker-icon.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -31,7 +31,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/picker.json
+++ b/css/selectors/picker.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -31,7 +31,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Safari Tech Preview 238 supports most of customisable select

#### Test results and supporting details

https://webkit.org/blog/17848/release-notes-for-safari-technology-preview-238/#:~:text=appearance%3A%20base%2Dselect

`::checkmark` deliberately hasn't been marked as supported as there's a bug in the current tech preview where it doesn't actually work. It should be fixed in the next one but for now I'll leave it as false.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
