### PR TITLE
chore: safari 18.4 supports rawJSON

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -86,7 +86,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -276,7 +276,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
This PR registers safari support of `JSON.rawJSON` and `JSON.isRawJSON` in safari 18.4 (released in march 2025)

This will make those API baseline newly avaiable.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
I manually tested on safari 26.1

EDIT: tested on browserstack

<img width="735" height="356" alt="image" src="https://github.com/user-attachments/assets/36ca67cc-5b8e-4ee2-9390-ce41cccb737d" />


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes

> Updated JSON.parse to provide the reviver function access to the input source text and extended JSON.stringify behavior to support object placeholders. (131579181)

The "extended JSON.stringify behavior to support object placeholders" part mentions rawJSON related methods.

commit [e2c5cd5](https://github.com/WebKit/WebKit/commit/e2c5cd5d4c07dff63d3670741f6e559534eae2cb) ([288223@main](https://commits.webkit.org/288223@main)[288223@main](https://commits.webkit.org/288223@main)) mentions rdar://131579181

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
As far as I search, no issue is opened.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
