### PR TITLE
Chrome 145 listbox <select> base styling

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -139,6 +139,108 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "listbox": {
+            "__compat": {
+              "description": "Base styling for listbox: `<select multiple>` or `<select size=\"3\">`",
+              "tags": [
+                "web-features:customizable-select"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "145"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "multiple_dropdown": {
+            "__compat": {
+              "description": "Base styling for multiple dropdown: `<select multiple size=\"1\">`",
+              "tags": [
+                "web-features:customizable-select"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "135"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "single_dropdown": {
+            "__compat": {
+              "description": "Base styling for single dropdown: `<select>`",
+              "tags": [
+                "web-features:customizable-select"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "135"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "button": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome has supported [Customizable `<select>` elements](https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select) (via [`appearance: base-select`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/appearance#base-select)) for single dropdown selects since version 135, and since 145, now supports it for listbox selects, e.g. `<select size="3">` or `<select multiple>`.

See https://chromestatus.com/feature/6222145025867776.

This PR adds sub-data points below `appearance: base-select` for the different select types. Note that I've included a data point for multiple dropdown selects, even though they are not supported yet, as I think people will definitely ask that question. If you'd like me to record that differently, just let me know.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29183

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
