### PR TITLE
Update `await using` node version

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -118,7 +118,7 @@
             },
             "firefox_android": "mirror",
             "nodejs": {
-              "version_added": false
+              "version_added": "24.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
#### Summary

Update `await using` node version from `false` to `"24.0.0"`.
Used the same version number as regular `using` declaration.

#### Test results and supporting details

Node 24 release notes:
https://nodejs.org/en/blog/release/v24.0.0#v8-136

- Updates to v8 13.6
- Implements Explicit Resource management:
  https://tc39.es/proposal-explicit-resource-management/
  including the `await using` declaration


#### Related issues
