### PR TITLE
Mark `text-decoration-skip` as deprecated

### DIFF
--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -38,9 +38,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "auto": {
@@ -71,9 +71,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -105,9 +105,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The spec disavows this feature, which I've taken to be functionally a deprecation.

#### Test results and supporting details

The [spec](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skipping) disavows the feature:

> The CSSWG resolved to be split skipping functionality into individual properties along the lines of [text-decoration-skip-ink](https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip-ink), to improve its cascading behavior. See [discussion](https://github.com/w3c/csswg-drafts/issues/843) and [resolution](https://lists.w3.org/Archives/Public/www-style/2017Feb/0049.html). This section is a rough draft and has not yet been vetted by the CSSWG

An alternative here would be to mark it as non-standard. I don't love that, especially as it implies that we should remove the specification URL, which seems silly. I know the guidelines don't intend for us to do something silly, so deprecation seems to capture the spirit of the text better than the letter.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Suggested by @captainbrosset in https://github.com/web-platform-dx/web-features/pull/3841/changes#r2894674156. Merging this would trigger minting a new, discouraged feature in web-features.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
