### PR TITLE
Update Deno compatibility for SubtleCrypto.generateKey

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -944,7 +944,11 @@
             "chrome_android": "mirror",
             "deno": [
               {
+                "version_added": "1.40"
+              },
+              {
                 "version_added": "1.14",
+                "version_removed": "1.40",
                 "partial_implementation": true,
                 "notes": "Not supported: ECDSA P-521, ECDH P-521."
               },


### PR DESCRIPTION
#### Summary

While browsing https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey I noticed that Deno is still marked as "partial support". We shipped missing algorithms in https://github.com/denoland/deno/commit/6e017dbba794ca13b7185c768e0eda3260c0357a and https://github.com/denoland/deno/commit/bfdca5bc7 which were part of Deno v1.40 release (https://github.com/denoland/deno/releases/tag/v1.40.0).
