### PR TITLE
Bug-1799344 Enable `browserAction.openPopup` and `action.openPopup`  without user interaction

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -483,9 +483,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "109",
-                "notes": [
-                  "Before Firefox 149, a user gesture was required to call this API."
-                ]
+                "notes": "Before Firefox 149, a user gesture is required to call this API."
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -555,7 +555,7 @@
               "firefox": {
                 "version_added": "57",
                 "notes": [
-                  "Before Firefox 149, a user gesture was required to call this API.",
+                  "Before Firefox 149, a user gesture is required to call this API.",
                   "Support for the `windowId` parameter was added in Firefox 108."
                 ]
               },


### PR DESCRIPTION
#### Summary

Addresses the dev-docs-needed requirements of [Bug 1799344](https://bugzilla.mozilla.org/show_bug.cgi?id=1799344) Enable browserAction.openPopup without user interaction on all channels (Remove `extensions.openPopupWithoutUserGesture.enabled` preference) with notes added to the `browserAction.openPopup` & `action.openPopup` methods

#### Related issues

Related MDN content changes made in https://github.com/mdn/content/pull/43370.
