### PR TITLE
Firefox Nightly adds `color-mix()` with 1+ color arguments

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -261,9 +261,6 @@
                   ]
                 },
                 "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",


### PR DESCRIPTION
#### Summary

- Added `color-mix()` more then 2 color arguments

#### Test results and supporting details

- This [code pen](https://codepen.io/CodeRedDigital/pen/ogzzwOe) passes in:
  - Firefox Nightly 150.0a1 (2026-03-09)
  - With Flag `layout.css.color-mix-multi-color.enabled`:
    - Firefox Developer Edition 149.0b6 (aarch64)
    - Firefox Beta 149.0b6 (aarch64)
- And Fails in:
  - Firefox 148.0 (aarch64)
  - Chrome Canary 147.0.7725.0
  - Edge Canary 147.0.3906.0
  - Safari Technical Preview Release 236 (WebKit 20625.1.1.19.1)
  - Opera 128.0.5807.52

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/43388)