### PR TITLE
Chrome 143 / Firefox 149 allow more characters in DOM APIs

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -211,7 +211,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {
@@ -422,7 +422,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -1809,7 +1809,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {
@@ -1885,7 +1885,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {
@@ -2096,7 +2096,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {
@@ -2276,7 +2276,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -10228,7 +10228,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {
@@ -10350,7 +10350,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {
@@ -10873,7 +10873,7 @@
         },
         "html_name_validity": {
           "__compat": {
-            "description": "Emoji and more Unicode in namespace, element, and attribute names (valid names match HTML parser)",
+            "description": "Emoji and more Unicode in element and attribute names and namespace prefix (valid names match HTML parser)",
             "spec_url": "https://dom.spec.whatwg.org/#namespaces",
             "support": {
               "chrome": {


### PR DESCRIPTION
FF149 adds support for additional characters to be allowed in attribute and element names in https://bugzilla.mozilla.org/show_bug.cgi?id=1773312. 

Previously  you could only use the chars allowed in XML names - now the rules are less restrictive to allow the same chars as the HTML parser.

Spec update: https://github.com/whatwg/html/pull/7991

Chrome states support in 143:
- https://developer.chrome.com/blog/chrome-143-beta#allow_more_characters_in_javascript_dom_apis
- https://chromestatus.com/feature/6278918763708416

Webkit added support in https://bugs.webkit.org/show_bug.cgi?id=241419  but I don't think this made it to Safari yet.

Related docs work can be tracked in https://github.com/mdn/content/issues/43218
