### PR TITLE
added nightly support for alpha & colorspace

### DIFF
--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -148,7 +148,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1919718"
               },
               "firefox_android": "mirror",
@@ -355,7 +355,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1919718"
               },
               "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

- Added firefox support for the following `<input type="color">` attributes
  - `alpha`
  - `colorspace`

#### Test results and supporting details

- This [code pen](https://codepen.io/CodeRedDigital/pen/azvQGxm) passes in:
  - Firefox Nightly 150.0a1 (2026-03-09)
- And Fails in:
  - Firefox 148.0 (aarch64)
  - Firefox Beta 149.0b6
  - Firefox Developer Edition 149.0b6

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/43401)