### PR TITLE
Add shadowrootcustomelementregistry template attribute

### DIFF
--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -72,6 +72,41 @@
             }
           }
         },
+        "shadowrootcustomelementregistry": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/template#shadowrootcustomelementregistry",
+            "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootcustomelementregistry",
+            "tags": [
+              "web-features:scoped-custom-element-registries"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "146"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "shadowrootdelegatesfocus": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/template#shadowrootdelegatesfocus",


### PR DESCRIPTION
#### Summary

Adds support info for the `shadowrootcustomelementregistry` attribute for `<template>`.

#### Test results and supporting details

Tested in Chrome 146 and Safari 26, see beta PRs for `api.CustomElementRegistry`:

- https://github.com/mdn/browser-compat-data/pull/29033
- https://github.com/mdn/browser-compat-data/pull/27087