### PR TITLE
Safari has `CanvasRenderingContext2D.filter` behind flag

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1161,7 +1161,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18"
+              "version_added": "18",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Canvas Filters",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fixes the Safari support for `CanvasRenderingContext2D.filter`, which is actually behind a pref.

#### Test results and supporting details

See:

- https://github.com/WebKit/WebKit/blame/d45a59ea60e013f1c7a6b144f45b0f72d4a49478/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml#L1685
- https://github.com/search?q=repo%3AWebKit/WebKit%20CanvasFiltersEnabled&type=code

#### Related issues

Fixes #29193.