### PR TITLE
Opera Android accepts encoding `br`, but not `zstd`

### DIFF
--- a/http/headers/Accept-Encoding.json
+++ b/http/headers/Accept-Encoding.json
@@ -65,9 +65,7 @@
               "opera": {
                 "version_added": "36"
               },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "11",
                 "notes": "Unsupported before macOS 10.13 High Sierra."
@@ -178,7 +176,9 @@
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
               "safari": {
                 "version_added": "26.3",
                 "notes": "Before macOS 26.3 Tahoe, this header value is not sent."


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Opera Android statements for `Accept-Encoding`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29207.