### PR TITLE
Update Firefox note for scroll-driven animation feature

### DIFF
--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -128,7 +128,7 @@
                   }
                 ],
                 "notes": [
-                  "Zero scroll range is treated as 100% but should be 0% (see [bug 1780865](https://bugzil.la/1780865)).",
+                  "Before Firefox 112, zero scroll ranges are treated as 100% instead of 0%. See [bug 1780865](https://bugzil.la/1780865).",
                   "Supports the deprecated `horizontal` and `vertical` axis values, and not the `x` and `y` values."
                 ]
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates a Firefox note for scroll-driven animation feature.

#### Test results and supporting details

We could have also removed it, but it would have been the same work. It doesn't really matter, as the support statement will be removed once this ships.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29205