### PR TITLE
fix(lint): cache mirroring in consistency lint

### DIFF
--- a/lint/linter/test-consistency.js
+++ b/lint/linter/test-consistency.js
@@ -11,8 +11,8 @@ import bcd from '../../index.js';
 
 /** @import {Linter, LinterData} from '../types.js' */
 /** @import {Logger} from '../utils.js' */
-/** @import {BrowserName, CompatData, CompatStatement, Identifier, SimpleSupportStatement, VersionValue} from '../../types/types.js' */
-/** @import {DataType, InternalSupportBlock, InternalSupportStatement} from '../../types/index.js' */
+/** @import {BrowserName, CompatData, CompatStatement, Identifier, SimpleSupportStatement, SupportStatement, VersionValue} from '../../types/types.js' */
+/** @import {InternalSupportBlock, InternalSupportStatement} from '../../types/index.js' */
 
 /**
  * @typedef {'unsupported' | 'subfeature_earlier_implementation'} ErrorType
@@ -39,6 +39,29 @@ import bcd from '../../index.js';
  * by detecting inconsistent information.
  */
 export class ConsistencyChecker {
+  /** @type {WeakMap<object, Map<string, SupportStatement>>} */
+  #mirrorCache = new WeakMap();
+
+  /**
+   * Resolve a mirror support statement with caching.
+   * @param {BrowserName} browser The browser to resolve
+   * @param {InternalSupportBlock} supportBlock The support block containing the mirror
+   * @returns {SupportStatement} The resolved support statement
+   */
+  #resolveMirror(browser, supportBlock) {
+    let byBrowser = this.#mirrorCache.get(supportBlock);
+    if (!byBrowser) {
+      byBrowser = new Map();
+      this.#mirrorCache.set(supportBlock, byBrowser);
+    }
+    let resolved = byBrowser.get(browser);
+    if (resolved === undefined) {
+      resolved = mirrorSupport(browser, supportBlock);
+      byBrowser.set(browser, resolved);
+    }
+    return resolved;
+  }
+
   /**
    * Checks the data for any errors
    * @param {CompatData} data The data to test
@@ -284,7 +307,7 @@ export class ConsistencyChecker {
 
     if (supportStatement === 'mirror') {
       return this.getVersionAdded(
-        { [browser]: mirrorSupport(browser, supportBlock) },
+        { [browser]: this.#resolveMirror(browser, supportBlock) },
         browser,
       );
     }
@@ -395,7 +418,7 @@ export class ConsistencyChecker {
         if (
           /** @type {InternalSupportStatement} */ (browserData) === 'mirror'
         ) {
-          browserData = mirrorSupport(browser, compatData.support);
+          browserData = this.#resolveMirror(browser, compatData.support);
         }
 
         if (Array.isArray(browserData)) {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Speed up the `consistency` lint by caching mirroring.

#### Test results and supporting details

Reduces runtime of `npm run lint` from 28s to 12s (-57%).

##### Before

```
% time npm run lint

> @mdn/browser-compat-data@7.3.6 lint
> node lint/lint.js

Loading and checking files...
Testing browser data...
Testing feature data...
Testing all features together...
Obsolete - 1 problem (0 errors, 0 warnings, 1 info):
  ✖ api.SVGRenderingIntent - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
All data passed linting!
Linters have some exceptions, please help us remove them!
  Flag data has 2 exceptions
   - api.Notification.requireInteraction
   - api.Window.dump
  Obsolete has 1 exception
   - html.elements.track.kind.descriptions
npm run lint  28.09s user 0.60s system 101% cpu 28.209 total
```

##### After

```
% time npm run lint

> @mdn/browser-compat-data@7.3.6 lint
> node lint/lint.js

Loading and checking files...
Testing browser data...
Testing feature data...
Testing all features together...
Obsolete - 1 problem (0 errors, 0 warnings, 1 info):
  ✖ api.SVGRenderingIntent - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
All data passed linting!
Linters have some exceptions, please help us remove them!
  Flag data has 2 exceptions
   - api.Notification.requireInteraction
   - api.Window.dump
  Obsolete has 1 exception
   - html.elements.track.kind.descriptions
npm run lint  12.04s user 0.61s system 102% cpu 12.379 total
```

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
