### PR TITLE
Firefox 149 adds `CSSNumericValue.to()` behind pref

### DIFF
--- a/api/CSSNumericValue.json
+++ b/api/CSSNumericValue.json
@@ -339,7 +339,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "149",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.typed-om.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "impl_url": "https://bugzil.la/1278697"
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
FF149 adds support for [`CSSNumericValue.to()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSNumericValue/to) behind the pref `layout.css.typed-om.enabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=2013251

This updates the feature. NOTE, I left the `impl_url` as the meta bug rather than the specific fix bug. I assume that is correct, since that is what you'd track for shipping.

Related docs work can be tracked in https://github.com/mdn/content/issues/43211