### PR TITLE
Firefox 149 ships `font-family: math`

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -243,7 +243,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "145"
+                "version_added": "149"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF149 adds support for CSS [`font-family: math`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-family#math) property and applies it by default to the [`<math>`](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/math) SVG element in https://bugzilla.mozilla.org/show_bug.cgi?id=2014703 

The existing entry said 145 for `math` support, but if you test the example https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-family#some_common_font_families in 149 by turning the font on and off you can see that the font on the math line changes. If you do the same change on FF148 the font on the math does not change.
Looking at the original bug https://bugzilla.mozilla.org/show_bug.cgi?id=1788937 indicates that this was implemented in nighlty only.

NOTE, should I also add something like this to MATH? I think I should - the spec seems to require it.
But I can't verify this easily - i.e. looking at FF the internal font and the by-default font look the same. For Chrome I can acutally see the UA settings on a test element and that seems to show that this isn't having the font family set to math automaticaly but I could be wrong.
EITHER way, lets do separately!

```json
        "font_family_math_by_default": {
          "__compat": {
            "description": "`font-family: math` font applied by default", 
            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Reference/Element/math",
            "spec_url": "https://w3c.github.io/mathml-core/#the-top-level-math-element",
            "support": {
              "chrome": {
                "version_added": false
              },
              "chrome_android": "mirror",
              "edge": "mirror",
              "firefox": {
                "version_added": "149"
              },
              "firefox_android": "mirror",
              "oculus": "mirror",
              "opera": "mirror",
              "opera_android": "mirror",
              "safari": {
                "version_added": false
              },
              "safari_ios": "mirror",
              "samsunginternet_android": "mirror",
              "webview_android": "mirror",
              "webview_ios": "mirror"
            },
            "status": {
              "experimental": true,
              "standard_track": true,
              "deprecated": false
            }
          }
        }
```

Related docs work can be tracked in https://github.com/mdn/content/issues/43209