### PR TITLE
Deno 2.2 adds `createImageBitmap` option `colorSpaceConversion`

### DIFF
--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -50,7 +50,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "2.2"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The option was supported in [v2.2](https://github.com/denoland/deno/releases/tag/v2.2.0), but it was not added here.

- https://github.com/mdn/browser-compat-data/pull/25905

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
