### PR TITLE
Extract subfeature for negative `HTMLMediaElement.playbackRate`

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2152,20 +2152,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "3",
-              "partial_implementation": true,
-              "notes": "Setting the `playbackRate` to a negative value will throw an error."
+              "version_added": "3"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Setting the `playbackRate` to a negative value will throw an error."
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "20",
-              "partial_implementation": true,
-              "notes": "Setting the `playbackRate` to a negative value will throw an error."
+              "version_added": "20"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2173,14 +2167,10 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤12.1",
-              "partial_implementation": true,
-              "notes": "Setting the `playbackRate` to a negative value will throw an error."
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1",
-              "partial_implementation": true,
-              "notes": "Setting the `playbackRate` to a negative value will throw an error."
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "3.1"
@@ -2196,6 +2186,47 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "negative_values": {
+          "__compat": {
+            "description": "Negative `playbackRate` (backwards playback)",
+            "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate-dev",
+            "tags": [
+              "web-features:video"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/40719652",
+                "notes": "Setting negative `playbackRate` throws an error."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1308438",
+                "notes": "Setting negative `playbackRate` throws an error."
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3.1"
+              },
+              "safari_ios": {
+                "version_added": "3"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
#### Summary

Extracts a `negative_values` subfeature from `api.HTMLMediaElement.playbackRate`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29198#issuecomment-4053637807.
