### PR TITLE
Chrome/Firefox/Safari apply `font-family: math` to `<math>` element

### DIFF
--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -106,6 +106,39 @@
               "deprecated": false
             }
           }
+        },
+        "font_family_math_styles": {
+          "__compat": {
+            "description": "CSS `font-family: math` property applied by default",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-family#math",
+            "spec_url": "https://w3c.github.io/mathml-core/#the-top-level-math-element",
+            "support": {
+              "chrome": {
+                "version_added": "109"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
FF149 adds support for CSS [`font-family: math`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-family#math) property and applies it by default to the [`<math>`](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/math) SVG element in https://bugzilla.mozilla.org/show_bug.cgi?id=2014703 

This follows on from #29250 which added the note about the font-family. It adds info about versions that use the font family for math element.

Related docs work can be tracked in https://github.com/mdn/content/issues/43209