### PR TITLE
Opera Android also supports `Content-Encoding: br`

### DIFF
--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -42,6 +42,7 @@
         },
         "br": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Encoding#br",
             "spec_url": "https://www.rfc-editor.org/rfc/rfc7932#section-13",
             "tags": [
               "web-features:brotli"
@@ -64,9 +65,7 @@
               "opera": {
                 "version_added": "36"
               },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "11",
                 "notes": "Unsupported before macOS 10.13 High Sierra."
@@ -177,7 +176,9 @@
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
               "safari": {
                 "version_added": "26.3",
                 "notes": "Before macOS 26.3 Tahoe, Safari cannot decode Zstandard responses."


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Opera Android statements for `Content-Encoding`, like PR #29234

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #29207
