### PR TITLE
Firefox 149 adds CSS `text-box{,-edge,-trim}` behind pref

### DIFF
--- a/css/properties/text-box-edge.json
+++ b/css/properties/text-box-edge.json
@@ -22,7 +22,10 @@
                   "name": "layout.css.text-box.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1977183",
+              "partial_implementation": true,
+              "notes": "Rendering not implemented (only parsing and serialization)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -62,7 +65,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -100,7 +106,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -138,7 +147,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -176,7 +188,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -214,7 +229,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -252,7 +270,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/text-box-trim.json
+++ b/css/properties/text-box-trim.json
@@ -13,6 +13,7 @@
               "version_added": "133"
             },
             "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": "149",
               "flags": [
@@ -21,7 +22,10 @@
                   "name": "layout.css.text-box.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1977183",
+              "partial_implementation": true,
+              "notes": "Rendering not implemented (only parsing and serialization)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -61,7 +65,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -102,7 +109,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -143,7 +153,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -184,7 +197,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/text-box.json
+++ b/css/properties/text-box.json
@@ -22,7 +22,10 @@
                   "name": "layout.css.text-box.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1977183",
+              "partial_implementation": true,
+              "notes": "Rendering not implemented (only parsing and serialization)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -59,7 +62,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -97,7 +103,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -135,7 +144,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -235,7 +247,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -276,7 +291,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -314,7 +332,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -352,7 +373,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -390,7 +414,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -428,7 +455,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/types/text-edge.json
+++ b/css/types/text-edge.json
@@ -23,7 +23,10 @@
                   "name": "layout.css.text-box.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/1977183",
+              "partial_implementation": true,
+              "notes": "Rendering not implemented (only parsing and serialization)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -63,7 +66,10 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "impl_url": "https://bugzil.la/1977183",
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -104,7 +110,9 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -145,7 +153,9 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -186,7 +196,9 @@
                     "name": "layout.css.text-box.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "partial_implementation": true,
+                "notes": "Rendering not implemented (only parsing and serialization)."
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF149 adds support parsing and serialization support, but not rendering, for the shorthand CSS property [`text-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-box) , corresponding longhand properties [`text-box-trim`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-box-trim) and [`text-box-edge`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-box-edge), and the value [`text-edge`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/text-edge) behind the preference `layout.css.text-box.enabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=2013458.

This updates the features indicating partial support and the implementation URL that will give full support. Obviously that will disappear when this releases.

 Collector tests appear to pass when the pref is enabled:
- https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-box-trim
- https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-box-edge
- https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-box

Related docs work can be tracked in https://github.com/mdn/content/issues/43208

