### PR TITLE
`position-area`: add behavioral subfeature for auto margins

### DIFF
--- a/css/properties/position-area.json
+++ b/css/properties/position-area.json
@@ -226,6 +226,47 @@
             }
           }
         },
+        "disables_auto_margins_and_insets": {
+          "__compat": {
+            "description": "`position-area` resolves `margin: auto` and `inset: auto` to 0",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position/#:~:text=available%0Afor%20positioning.-,the%20used%20value%20of%20any%20auto%20inset%20properties%20and%20auto%20margin%20properties%20resolves%20to%200.,-The%20normal%20value",
+            "tags": [
+              "web-features:anchor-positioning"
+            ],
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "143"
+                },
+                {
+                  "version_added": "125",
+                  "version_removed": "130"
+                }
+              ],
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "148"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "end": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-anchor-position/#valdef-position-area-end",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

A specification change to anchor positioning now requires that if a non-`none` `position-area` applies to an element, then `margin: auto` and `inset: auto` to [resolve to 0](https://drafts.csswg.org/css-anchor-position/#:~:text=available%0Afor%20positioning.-,the%20used%20value%20of%20any%20auto%20inset%20properties%20and%20auto%20margin%20properties%20resolves%20to%200.,-The%20normal%20value). This PR captures support for this behavior in a behavior subfeature.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

##### Spec

The spec text is [this bullet point](https://drafts.csswg.org/css-anchor-position/#:~:text=available%0Afor%20positioning.-,the%20used%20value%20of%20any%20auto%20inset%20properties%20and%20auto%20margin%20properties%20resolves%20to%200.,-The%20normal%20value):

> The used value of any 'auto' inset properties and 'auto' margin properties resolves to '0'.

It followed https://github.com/w3c/csswg-drafts/issues/10258#issuecomment-3407160892.

##### Chrome

According to [bug 374574260 (comment #18)](https://issues.chromium.org/issues/374574260#comment18) Chrome appears to have supported this behavior—or something close it—in its initial anchor positioning implementation. Then the spec changed _twice_, bringing back this original behavior.

##### Firefox

The actual support for this comes out of [Firefox bug 1997481](https://bugzilla.mozilla.org/show_bug.cgi?id=1997481), though the changes to make the test pass came about in [Firefox bug 2006398](https://bugzilla.mozilla.org/show_bug.cgi?id=2006398).

##### Safari

[WebKit bug 300823](https://bugs.webkit.org/show_bug.cgi?id=300823) tracks this; it was fixed by https://github.com/WebKit/WebKit/pull/52419. I determined the version number where it ultimately shipped from the [Safari 26.2 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#:~:text=Fixed%20auto%20margins).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Via https://github.com/web-platform-dx/web-features/issues/3558
- Spec resolution: https://github.com/w3c/csswg-drafts/issues/10258#issuecomment-3407160892
- [Chromium bug 374574260 (comment #18)](https://issues.chromium.org/issues/374574260#comment18)
- [Firefox bug 1997481](https://bugzilla.mozilla.org/show_bug.cgi?id=1997481) and [bug 2006398](https://bugzilla.mozilla.org/show_bug.cgi?id=2006398)
- [WebKit bug 300823](https://bugs.webkit.org/show_bug.cgi?id=300823) and https://github.com/WebKit/WebKit/pull/52419.
- Loosely related to https://github.com/mdn/browser-compat-data/pull/29272

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
