### PR TITLE
`anchor-name`: add `position_after_layout` behavioral subfeature

### DIFF
--- a/css/properties/anchor-name.json
+++ b/css/properties/anchor-name.json
@@ -68,6 +68,47 @@
               "deprecated": false
             }
           }
+        },
+        "position_after_layout": {
+          "__compat": {
+            "description": "Positioning applies after layout, such as zoom, position, and transform",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position/#anchor-position-size:~:text=The%20anchor%20box%E2%80%99s%20position%20and%20size%20is%20determined%20after%20layout%2E",
+            "tags": [
+              "web-features:anchor-positioning"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "144"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1993692"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": [
+                  "https://webkit.org/b/289743",
+                  "https://webkit.org/b/309921",
+                  "https://webkit.org/b/307660"
+                ]
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This captures the specification change, where anchor positioning happens after layout, such as zooms or transforms. Originally reported in https://github.com/mdn/browser-compat-data/issues/28499.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This spec change occurred in https://github.com/w3c/csswg-drafts/issues/8584#issuecomment-3109444615. The spec text can be found in [the paragraph beginning with](https://drafts.csswg.org/css-anchor-position/#anchor-position-size:~:text=The%20anchor%20box%E2%80%99s%20position%20and%20size%20is%20determined%20after%20layout%2E):

> The anchor box’s position and size is determined after layout.

Chromium appears to be the only engine implementing. See [Chromium bug 1993692 (comment #7)](https://issues.chromium.org/issues/382294252#comment7).

[Firefox bug 1993692](https://bugzilla.mozilla.org/show_bug.cgi?id=1993692) tracks this in Gecko.

I found three related bugs against WebKit, but none are confirmed or accepted. Since I don't know which one will ultimately be worked on, I used them all for `impl_url`. See related issues below for a complete list.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Fixes https://github.com/mdn/browser-compat-data/issues/28499
- Toward https://github.com/web-platform-dx/web-features/issues/3558#issuecomment-3647042903
- [Chromium bug 382294252](https://issues.chromium.org/issues/382294252#comment7)
- [Firefox bug 1993692](https://bugzilla.mozilla.org/show_bug.cgi?id=1993692)
- [WebKit bug 289743](https://bugs.webkit.org/show_bug.cgi?id=289743)
- [WebKit bug 309921](https://bugs.webkit.org/show_bug.cgi?id=309921)
- [WebKit bug 307660](https://bugs.webkit.org/show_bug.cgi?id=307660)

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
