### PR TITLE
`position-area`: note Chromium bug with absolutely positioned elements

### DIFF
--- a/css/properties/position-area.json
+++ b/css/properties/position-area.json
@@ -11,7 +11,8 @@
           "support": {
             "chrome": [
               {
-                "version_added": "129"
+                "version_added": "129",
+                "notes": "The `position-area` property changes the position of absolutely positioned elements that do not find an anchor. See [bug 388575663](https://crbug.com/388575663)."
               },
               {
                 "alternative_name": "inset-area",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chromium sometimes repositions elements with `position-area` even if no anchor is found.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I used the test case in https://issues.chromium.org/issues/388575663 to confirm that the bug is still present.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- [Chromium bug 388575663](https://issues.chromium.org/issues/388575663)
- Toward https://github.com/web-platform-dx/web-features/issues/3558#issuecomment-3647042903

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
