### PR TITLE
ci(issue-regex-labeler): fix escaped dots

### DIFF
--- a/.github/issue-regex-labeler.yml
+++ b/.github/issue-regex-labeler.yml
@@ -1,33 +1,36 @@
 data:api:
-  - 'api\.'
+  - 'api\\.'
   - '\/docs\/Web\/API'
 data:css:
-  - 'css\.'
+  - 'css\\.'
   - '\/docs\/Web\/CSS'
 data:html:
-  - 'html\.'
+  - 'html\\.'
   - '\/docs\/Web\/HTML'
 data:http:
-  - 'http\.'
+  - 'http\\.'
   - '\/docs\/Web\/HTTP'
 data:js:
-  - 'js\.'
+  - 'js\\.'
   - '\/docs\/Web\/JavaScript'
 data:manifests:
-  - 'manifests\.'
+  - 'manifests\\.'
   - '\/docs\/Web\/Progressive_web_apps\/Manifest'
 data:mathml:
-  - 'mathml\.'
+  - 'mathml\\.'
   - '\/docs\/Web\/MathML'
+data:mediatypes:
+  - 'mediatypes\\.'
+  - '\/docs\/Web\/Media'
 data:svg:
-  - 'svg\.'
+  - 'svg\\.'
   - '\/docs\/Web\/SVG'
 data:wasm:
-  - 'webassembly\.'
+  - 'webassembly\\.'
   - '\/docs\/WebAssembly'
 data:webdriver:
-  - 'webdriver\.'
+  - 'webdriver\\.'
   - '\/docs\/Web\/WebDriver'
 data:webext:
-  - 'webextensions\.'
+  - 'webextensions\\.'
   - '\/docs\/Mozilla\/Add-ons'


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fix the issue label patterns, escaping dots properly with `\\` instead of `\`.

Also: Configures the `data:mediatypes` label.

#### Test results and supporting details

I had noticed that issues don't always get labeled (if they don't include an MDN url), and this might be the culprit.

Cf. https://github.com/github/issue-labeler/issues/16#issuecomment-657998947

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
