### PR TITLE
chore(coverage): refine c8 config

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,10 +1,12 @@
 {
   "all": true,
-  "include": ["index.ts", "**/scripts/**", "**/test/**", "**/utils/**"],
   "exclude": [
-    "**/.nyc_output/**",
-    "**/coverage/**",
-    "**/node_modules/**",
-    "**/**.test.ts"
+    "eslint.config.js",
+    "build/**",
+    "coverage/**",
+    "node_modules/**",
+    "scripts/migrations/",
+    "types/**",
+    "**/**.test.js"
   ]
 }


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Refine the c8 config for test coverage:

- Avoid `include` in favor of refined `exclude`.
- Remove obsolete `exclude` entries.

#### Test results and supporting details

In particular, this includes `lint/*` which wasn't reported in the test coverage before.

#### Related issues

Noticed while working on https://github.com/mdn/browser-compat-data/pull/29242.
