### PR TITLE
fix(marker): update counter_support description

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -75,7 +75,7 @@
         },
         "counter_support": {
           "__compat": {
-            "description": "[`counter-increment`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/counter-increment), [`counter-reset`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/counter-reset), and [`counter-set`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/counter-set) support",
+            "description": "Support for CSS counter properties (`counter-increment`, `counter-reset`, and `counter-set`) on `::marker`",
             "spec_url": [
               "https://drafts.csswg.org/css-lists/#propdef-counter-increment",
               "https://drafts.csswg.org/css-lists/#propdef-counter-reset",


### PR DESCRIPTION
#### Summary

Fix and clarify the `counter_support` description for `::marker` by aligning it with BCD style guidelines and removing inline MDN links.

#### Test results and supporting details

This change is non-functional and only affects metadata (`description` field).
Verified consistency with existing entries such as `quotes_support` and `animation_and_transition_support`.

Updated description now:

* avoids inline markdown links (not used in BCD)
* explicitly mentions `::marker` context
* follows concise and consistent phrasing

#### Related issues

N/A
