### PR TITLE
Chrome 145 adds `VideoFrame.metadata()`

### DIFF
--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -115,7 +115,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1802053"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 145 adds support for the `VideoFrame.metadata()` method; see https://chromestatus.com/feature/5186046555586560.

The BCD for the method itself has already been added, but `metadata` is also available as an option on the `VideoFrame()` constructor, so I wanted to add a data point for that, too.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
