### PR TITLE
Safari 26 supports `*-self` for absolutely-positioned boxes

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -525,7 +525,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -276,7 +276,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -158,7 +158,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari does support using `justify-self`, `align-self`, and `place-self` on absolutely positioned items. I suspect this was released along with anchor positioning in Safari 26, but don't have evidence of that.

#### Test results and supporting details

I confirmed via SauceLabs that this didn't work in Safari 17. 
I confirmed in Safari 26.3.1 that is does work.

Demo from https://github.com/mdn/browser-compat-data/pull/24789-
https://codepen.io/pepelsbey/pen/xxvLBYZ