### PR TITLE
Add CSS `@container` subfeature for name-only queries

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -147,7 +147,7 @@
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
             "support": {
               "chrome": {
-                "version_added": "preview",
+                "version_added": "148",
                 "impl_url": "https://crbug.com/40287550"
               },
               "chrome_android": "mirror",


### PR DESCRIPTION
FF149 adds support for [`@container`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@container) selections where the [`<container-query>`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@container#container-query) part is optiona in https://bugzilla.mozilla.org/show_bug.cgi?id=2016474

This allows you to just select a container based on its name:

```css
@container --name {}
```

This adds the subfeature. You can test this using https://wpt.live/css/css-conditional/container-queries/query-container-name.html

Note that I have set Chrome and Safari as `false` but you can tell it is coming because they pass the test on the latest versions but NOT on current versions I can access: https://wpt.fyi/results/css/css-conditional/container-queries/query-container-name.html?label=master&label=experimental&aligned
- Webkit: in STP release 235 https://webkit.org/blog/17739/release-notes-for-safari-technology-preview-235/

Related docs work can be tracked in https://github.com/mdn/content/issues/43212