### PR TITLE
FF149 Intl.DateTimeFormat supports islamic-umalqura calendar

### DIFF
--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -329,7 +329,7 @@
                     "description": "`options.calendar` parameter accepts `islamic-umalqura`",
                     "support": {
                       "bun": {
-                        "version_added": "1.0.0"
+                        "version_added": false
                       },
                       "chrome": {
                         "version_added": "80"


### PR DESCRIPTION
FF140 adds support for  `islamic-umalqura` calendar in https://bugzilla.mozilla.org/show_bug.cgi?id=2011505. That means the option will appear in [`Intl.supportedValuesOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf) for the calendar option (`console.log(Intl.supportedValuesOf("calendar"));`) and can be used in the `DataTimeFormat` constructor like this:

```js
const date = new Date();

const umAlQuraFormatter = new Intl.DateTimeFormat('en-u-ca-islamic-umalqura', {
  calendar: 'islamic-umalqura',
  dateStyle: 'full'
});

console.log(umAlQuraFormatter.format(date));
```

This PR is created to **test** whether BCD team wants to track support for languages and the other options - if you don't we can close this.
It updates the `DataTimeFormat` constructor to indicate the value is supported. Note that I didn't update `supportedValuesOf()` because it is not a compatibility break to not support the value there. 

I tested on chrome and Safari for the other versions in browserstack.

Related docs work can be tracked in https://github.com/mdn/content/issues/43203

