### PR TITLE
Undeprecate font-stretch SVG attribute

### DIFF
--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -1384,7 +1384,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
#### Summary

Apparently, `font-stretch` is not only a CSS property and CSS descriptor, but it’s also an SVG attribute.

Since we have [undeprecated the property and descriptor](https://github.com/mdn/browser-compat-data/pull/28809), the same applies to the attribute: the `font-width` SVG attribute is currently supported only by Safari 18.4 and it’s impractical for developers to start using it yet.

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/28809
- https://github.com/mdn/content/pull/43567