### PR TITLE
ci(system-file-changes): ignore standard-track exceptions

### DIFF
--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -13,6 +13,7 @@ on:
       - "!html/**.json"
       - "!http/**.json"
       - "!javascript/**.json"
+      - "!lint/common/standard-track-exceptions.txt"
       - "!manifests/**.json"
       - "!mathml/**.json"
       - "!mediatypes/**.json"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the `system-file-changes` workflow, declassifying the new standard-track exceptions list.

#### Test results and supporting details

In other words: Allow everyone to change the file.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Noticed in https://github.com/mdn/browser-compat-data/pull/29216 that changes by non-admins non-owners to the standard-track exceptions list causes the system-file-changes workflow to fail.