### PR TITLE
`Clear-Site-Data`: record Chromium bugs

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -9,21 +9,9 @@
             "web-features:clear-site-data"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "127",
-                "partial_implementation": true,
-                "notes": [
-                  "Some requests may still be taken from the cache unless the tab is reloaded or the page is requested in a new tab. See [bug 364634040](https://crbug.com/364634040).",
-                  "The header may cause seconds-long hangs. See [bug 40233601](https://crbug.com/40233601)."
-                ]
-              },
-              {
-                "version_added": "61",
-                "version_removed": "127",
-                "notes": "The header may cause seconds-long hangs. See [bug 40233601](https://crbug.com/40233601)."
-              }
-            ],
+            "chrome": {
+              "version_added": "61"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -92,13 +80,27 @@
             "support": {
               "chrome": [
                 {
+                  "version_added": "127",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Some requests may still be taken from the cache unless the tab is reloaded or the page is requested in a new tab. See [bug 364634040](https://crbug.com/364634040).",
+                    "Setting this value may cause seconds-long hangs. See [bug 40233601](https://crbug.com/40233601)."
+                  ]
+                },
+                {
                   "version_added": "65",
-                  "notes": "Setting this value may increase response duration (see [bug 40233601](https://crbug.com/40233601)."
+                  "version_removed": "127",
+                  "partial_implementation": true,
+                  "notes": "Setting this value may cause seconds-long hangs. See [bug 40233601](https://crbug.com/40233601)."
                 },
                 {
                   "version_added": "61",
                   "version_removed": "63",
-                  "notes": "Setting this value may prevent a page from fully load (see [bug 41343050](https://crbug.com/41343050)."
+                  "partial_implementation": true,
+                  "notes": [
+                    "Setting this value may prevent a page from fully loading. See [bug 41343050](https://crbug.com/41343050).",
+                    "Setting this value may cause seconds-long hangs. See [bug 40233601](https://crbug.com/40233601)."
+                  ]
                 }
               ],
               "chrome_android": "mirror",
@@ -359,9 +361,22 @@
               "web-features:clear-site-data"
             ],
             "support": {
-              "chrome": {
-                "version_added": "117"
-              },
+              "chrome": [
+                {
+                  "version_added": "127",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Some requests may still be taken from the cache unless the tab is reloaded or the page is requested in a new tab. See [bug 364634040](https://crbug.com/364634040).",
+                    "Setting this value may cause seconds-long hangs. See [bug 40233601](https://crbug.com/40233601)."
+                  ]
+                },
+                {
+                  "version_added": "117",
+                  "version_removed": "127",
+                  "partial_implementation": true,
+                  "notes": "Setting this value may cause seconds-long hangs. See [bug 40233601](https://crbug.com/40233601)."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome has a couple of nasty bugs, which this PR captures as notes, with one triggering a partial implementation.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

[Bug 364634040](https://crbug.com/364634040) reports that `Clear-Site-Data` doesn't really take effect until a hard refresh or in a new tab. I took the version numbers in the report as true, since it was confirmed in the issue. I marked it as partial since the behavior is not feature detectable and the mitigation isn't really something developers can work around with a high expectation of success (e.g., asking users to do hard refreshes).

[Bug 40233601](https://crbug.com/40233601) reports long hangs on using the `Clear-Site-Data` header. Large sites (GitHub and MDN) reported serious issues with this header; GitHub stopped using the header as a consequence. This one could be a partial, but I didn't set it because MDN kept using the header and the header _works_ (in this case), just very slowly.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- [Bug 364634040](https://crbug.com/364634040)
- [Bug 40233601](https://crbug.com/40233601)
- Fixes https://github.com/mdn/browser-compat-data/issues/12788

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
