### PR TITLE
fix(lint): report unnecessary `ie: false`

### DIFF
--- a/lint/linter/test-browsers-presence.js
+++ b/lint/linter/test-browsers-presence.js
@@ -71,6 +71,16 @@ const processData = (data, category, logger) => {
         `Missing the following browsers, which are required for ${styleText('bold', category)} compat data: ${styleText('bold', missingEntries.join(', '))}`,
       );
     }
+
+    if (
+      'ie' in support &&
+      JSON.stringify(support.ie) === '{"version_added":false}'
+    ) {
+      logger.error(
+        `Unnecessary ${styleText('bold', 'ie')} statement: ${styleText('bold', '"ie": {"version_added": false}')} is implicit and can be removed`,
+        { fixable: true },
+      );
+    }
   }
 };
 

--- a/lint/linter/test-browsers-presence.test.js
+++ b/lint/linter/test-browsers-presence.test.js
@@ -69,4 +69,25 @@ describe('test-browsers-presence', () => {
     });
     assert.equal(logger.messages.length, 1);
   });
+
+  it('should log an error for unnecessary ie: { version_added: false }', async () => {
+    data.support.ie = { version_added: false };
+
+    await test.check(logger, {
+      data,
+      path: { full: `${category}.Test`, category },
+    });
+    assert.equal(logger.messages.length, 1);
+    assert.ok(logger.messages[0].message.includes('ie'));
+  });
+
+  it('should not log an error for ie with actual support data', async () => {
+    data.support.ie = { version_added: '11' };
+
+    await test.check(logger, {
+      data,
+      path: { full: `${category}.Test`, category },
+    });
+    assert.equal(logger.messages.length, 0);
+  });
 });


### PR DESCRIPTION
#### Summary

Updates the `test-browsers-presence` lint to report unnecessary `ie: { version_added: false }` statements.

#### Test results and supporting details

`npm run lint` didn't report it, even though `npm run lint:fix` fixed it.

#### Related issues

Triggered by https://github.com/mdn/browser-compat-data/pull/29214#discussion_r2983045315.