### PR TITLE
Updates for Firefox 150 beta

### DIFF
--- a/api/CSSFontFaceDescriptors.json
+++ b/api/CSSFontFaceDescriptors.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "150"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -26,9 +26,133 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
+        }
+      },
+      "ascent-override": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-ascent-override",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ascentOverride": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-ascentoverride",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "descent-override": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-descent-override",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "descentOverride": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-descentoverride",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "font-display": {
@@ -41,7 +165,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -56,7 +180,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -72,7 +196,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -87,7 +211,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -103,7 +227,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -111,6 +235,37 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "26"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "font-language-override": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-font-language-override",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -134,7 +289,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -149,7 +304,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -165,7 +320,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -173,6 +328,37 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "26"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "font-variation-settings": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-font-variation-settings",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -196,7 +382,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -211,7 +397,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -258,7 +444,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -273,7 +459,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -289,7 +475,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -304,7 +490,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -320,7 +506,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -328,6 +514,37 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "26"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fontLanguageOverride": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-fontlanguageoverride",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -351,7 +568,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -366,7 +583,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -382,7 +599,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -390,6 +607,37 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "26"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fontVariationSettings": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-fontvariationsettings",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -413,7 +661,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -428,7 +676,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -468,6 +716,68 @@
           }
         }
       },
+      "line-gap-override": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-line-gap-override",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lineGapOverride": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacedescriptors-linegapoverride",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "150"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "size-adjust": {
         "__compat": {
           "spec_url": "https://drafts.csswg.org/css-fonts-5/#dom-cssfontfacedescriptors-size-adjust",
@@ -478,7 +788,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -493,7 +803,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -509,7 +819,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -524,7 +834,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -540,7 +850,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -555,7 +865,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -571,7 +881,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -586,7 +896,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -602,7 +912,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -617,7 +927,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Document.json
+++ b/api/Document.json
@@ -781,7 +781,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -796,7 +796,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1172,7 +1172,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -1981,7 +1981,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -1996,7 +1996,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -252,7 +252,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -267,7 +267,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCError.json
+++ b/api/RTCError.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "150"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -87,7 +87,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -155,7 +155,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -192,7 +192,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -229,7 +229,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -266,7 +266,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCErrorEvent.json
+++ b/api/RTCErrorEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "150"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -85,7 +85,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -314,7 +314,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1964,8 +1964,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1561441"
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "150"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -117,7 +117,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -151,7 +151,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -215,7 +215,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -249,7 +249,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -373,8 +373,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1801658"
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -34,6 +34,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "revert-rule": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "150"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.17.7) found new features shipping in Firefox 150 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following 65 features as shipping in Firefox 150:

- api.CSSFontFaceDescriptors ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=2019904) and applies to the following sub features)
- api.CSSFontFaceDescriptors.ascent-override
- api.CSSFontFaceDescriptors.ascentOverride
- api.CSSFontFaceDescriptors.descent-override
- api.CSSFontFaceDescriptors.descentOverride
- api.CSSFontFaceDescriptors.font-display
- api.CSSFontFaceDescriptors.font-family
- api.CSSFontFaceDescriptors.font-feature-settings
- api.CSSFontFaceDescriptors.font-language-override
- api.CSSFontFaceDescriptors.font-stretch
- api.CSSFontFaceDescriptors.font-style
- api.CSSFontFaceDescriptors.font-variation-settings
- api.CSSFontFaceDescriptors.font-weight
- api.CSSFontFaceDescriptors.fontDisplay
- api.CSSFontFaceDescriptors.fontFamily
- api.CSSFontFaceDescriptors.fontFeatureSettings
- api.CSSFontFaceDescriptors.fontLanguageOverride
- api.CSSFontFaceDescriptors.fontStretch
- api.CSSFontFaceDescriptors.fontStyle
- api.CSSFontFaceDescriptors.fontVariationSettings
- api.CSSFontFaceDescriptors.fontWeight
- api.CSSFontFaceDescriptors.line-gap-override
- api.CSSFontFaceDescriptors.lineGapOverride
- api.CSSFontFaceDescriptors.size-adjust
- api.CSSFontFaceDescriptors.sizeAdjust
- api.CSSFontFaceDescriptors.src
- api.CSSFontFaceDescriptors.unicode-range
- api.CSSFontFaceDescriptors.unicodeRange
- api.Document.ariaNotify ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=2018095))
- api.Document.caretRangeFromPoint ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1550635))
- api.Element.ariaNotify ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=2018095))
- api.HighlightRegistry.highlightsFromPoint ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1917991))
- api.RTCError ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCError.RTCError  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCError.errorDetail  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCError.receivedAlert  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCError.sctpCauseCode  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCError.sdpLineNumber  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCError.sentAlert  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCErrorEvent  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCErrorEvent.RTCErrorEvent  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCErrorEvent.error  ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1814459))
- api.RTCIceTransport.role ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=2018843))
- api.RTCPeerConnection.icecandidateerror_event ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1561441))
- api.RTCPeerConnectionIceErrorEvent ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1561441))
- api.RTCPeerConnectionIceErrorEvent.RTCPeerConnectionIceErrorEvent ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1561441))
- api.RTCPeerConnectionIceErrorEvent.address ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1561441))
- api.RTCPeerConnectionIceErrorEvent.errorCode ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1561441))
- api.RTCPeerConnectionIceErrorEvent.errorText ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1561441))
- api.RTCPeerConnectionIceErrorEvent.port ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1561441))
- api.RTCPeerConnectionIceErrorEvent.url ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1561441))
- api.VisualViewport.scrollend_event ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=1801658))
- css.properties.all.revert-rule ([ref](https://bugzilla.mozilla.org/show_bug.cgi?id=2017307))
- css.selectors.buffering (updated in a different PR)
- css.selectors.muted (updated in a different PR)
- css.selectors.paused (updated in a different PR)
- css.selectors.playing (updated in a different PR)
- css.selectors.seeking (updated in a different PR)
- css.selectors.stalled (updated in a different PR)
- css.selectors.volume-locked (updated in a different PR)
- webdriver.bidi.emulation.setNetworkConditions (updated in a different PR)
- webdriver.bidi.emulation.setNetworkConditions.contexts_parameter (updated in a different PR)
- webdriver.bidi.emulation.setNetworkConditions.networkConditions_parameter (updated in a different PR)
- webdriver.bidi.emulation.setNetworkConditions.networkConditions_parameter.offline (updated in a different PR)
- webdriver.bidi.emulation.setNetworkConditions.userContexts_parameter (updated in a different PR)