### PR TITLE
Move `html.elements.video.{autoplay.loading => loading}`

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1503,7 +1503,6 @@
       },
       "loading": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/loading",
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#attr-media-loading",
           "tags": [
             "web-features:loading-lazy-media"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

In #29256 I added the `loading` attribute, but it seems I incorretly added it to the wrong place in the JSON for one of them as can be seen from the [MDN compat data table](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video#browser_compatibility)

<img width="838" height="204" alt="loading attribute incorrectly nested under autoplay" src="https://github.com/user-attachments/assets/d3cbfd9e-4318-41a3-933b-37d85f139889" />

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

N/A covered in #29256

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fix incorrect data added in #29256

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
