### PR TITLE
Firefox 150 ships `Document.caretPositionFromPoint()` options

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1133,7 +1133,7 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "150"
                 },
                 {
                   "version_added": "131",


### PR DESCRIPTION
FF150  added support for [`options.shadowRoots`](https://developer.mozilla.org/en-US/docs/Web/API/Document/caretPositionFromPoint#shadowroots) in `Document.caretPositionFromPoint()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1914596 (this just flips pref `dom.shadowdom.new_caretPositionFromPoint_behavior.enabled`)

This updates the feature.

Related docs work can be tracked in https://github.com/mdn/content/issues/43563



