### PR TITLE
Add Firefox bug for CSS `::cue(<selector>)`

### DIFF
--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -52,7 +52,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1321489"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a `impl_url` for Firefox's `::cue(<selector>)` support.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I wanted to know why this was unsupported (and to confirm that it was in fact unsupported), so I searched for the bug and found this.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://bugzilla.mozilla.org/show_bug.cgi?id=1321489
- https://github.com/mdn/browser-compat-data/issues/4892
- https://github.com/mdn/browser-compat-data/pull/5860

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
