### PR TITLE
Firefox 150 adds `customElementRegistry` property behind pref

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2809,7 +2809,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.scoped-custom-element-registries.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/2018900"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -4454,7 +4454,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.scoped-custom-element-registries.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/2018900"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -152,7 +152,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "150",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.scoped-custom-element-registries.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/2018900"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
FF150 added support for  [`Element.customElementRegistry`](https://developer.mozilla.org/en-US/docs/Web/API/Element/customElementRegistry), [`Document.customElementRegistry`](https://developer.mozilla.org/en-US/docs/Web/API/Document/customElementRegistry) [`ShadowRoot.customElementRegistry`](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/customElementRegistry) behind the preference `dom.scoped-custom-element-registries.enabled` in https://bugzil.la/2018900

This updates the features. 

Related docs work can be tracked in https://github.com/mdn/content/issues/43555