### PR TITLE
Updates for Safari 26.5 beta

### DIFF
--- a/api/Origin.json
+++ b/api/Origin.json
@@ -20,7 +20,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "26.5"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -28,7 +28,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -62,7 +62,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -89,7 +89,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -97,7 +97,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -123,7 +123,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -131,7 +131,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -157,7 +157,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -165,7 +165,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -191,7 +191,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -199,7 +199,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ToggleEvent.json
+++ b/api/ToggleEvent.json
@@ -161,8 +161,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/293686"
+              "version_added": "26.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/open.json
+++ b/css/selectors/open.json
@@ -34,7 +34,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "26.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org project (v10.17.9) found new features shipping in Safari 26.5 beta (21624.2.1.11.1) on macOS 26.5 beta (25F5042g) which was released last night. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Safari TP only, it is not considered here.

This PR contains 8 feature updates or additions and they can be verified with the [release notes](https://developer.apple.com/documentation/safari-release-notes/safari-26_5-release-notes). Verified features are marked with (*).

- api.Origin (*)
- api.Origin.Origin (*)
- api.Origin.from_static (*)
- api.Origin.isSameOrigin (*)
- api.Origin.isSameSite (*)
- api.Origin.opaque (*)
- api.ToggleEvent.source (*)
- css.selectors.open (*)
