### PR TITLE
Chrome 148 ships `PerformanceResourceTiming.contentType`

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -265,7 +265,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "148"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -291,7 +291,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

`contentType` property of Resouce timing has been in Chrome for a while behind a file but wasn't not marked as such in BCD. It's going to be enabled by default from Chrome 148.

#### Test results and supporting details

https://chromestatus.com/feature/5156068351541248

https://wpt.fyi/results/resource-timing/content-type.html?label=experimental&label=master&aligned

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
