### PR TITLE
Safari TP now supports hanging-punctuation fully

### DIFF
--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -28,7 +28,7 @@
               {
                 "version_added": "10",
                 "partial_implementation": true,
-                "notes": "The characters `U+0027` and `U+0022` are not supported by the `first` and `last` keywords."
+                "notes": "The characters `U+0027` and `U+0022` are not supported by the `first` and `last` keywords. See [bug 309123](https://webkit.org/b/309123)."
               }
             ],
             "safari_ios": "mirror",


### PR DESCRIPTION
See https://webkit.org/blog/17896/release-notes-for-safari-technology-preview-240/

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
