### PR TITLE
Firefox 110 adds list attribute for color on Windows/Linux

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -108,8 +108,9 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/2007533"
+                  "version_added": "110",
+                  "partial_implementation": true,
+                  "notes": "Not available on macOS and Android. See [bug 1805397](https://bugzil.la/1805397)."
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Firefox support statement for `list` attribute on `<input type="color">`, which is supported on Windows and Linux, but not on macOS and Android.

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1805397

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20455.