### PR TITLE
Add Chrome notes for EyeDropper API

### DIFF
--- a/api/EyeDropper.json
+++ b/api/EyeDropper.json
@@ -9,7 +9,11 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "95"
+            "version_added": "95",
+            "notes": [
+              "Before Chrome 120, the EyeDropper API is not available on ChromeOS. See [bug 40720753](https://crbug.com/40720753).",
+              "Available on Linux X11, but not available on Linux Wayland. See [bug 40720753](https://crbug.com/40720753)."
+            ]
           },
           "chrome_android": {
             "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Chrome statement for the `EyeDropper` interface, because it is not available in Linux Wayland, and wasn't available in ChromeOS before Chrome 120.

#### Test results and supporting details

- Bug: https://issues.chromium.org/issues/40720753
- Commit for ChromeOS support: https://github.com/chromium/chromium/commit/10f8be246e6bffa08fd4cb2b91d22ee5e0e90cca
-  
#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20515.