### PR TITLE
Chrome 102 added `FileSystemFileHandle.move()`

### DIFF
--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -114,9 +114,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "102",
+              "partial_implementation": true,
+              "notes": "Only available on `FileSystemFileHandle`. Not available on `FileSystemHandle` and `FileSystemDirectoryHandle`. See [bug 40198034](https://crbug.com/40198034)."
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "111"

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -116,7 +116,7 @@
             "chrome": {
               "version_added": "102",
               "partial_implementation": true,
-              "notes": "Only available on `FileSystemFileHandle`. Not available on `FileSystemHandle` and `FileSystemDirectoryHandle`. See [bug 40198034](https://crbug.com/40198034)."
+              "notes": "Directory moves are not supported. The method is only expopsed on `FileSystemFileHandle`, not on `FileSystemHandle` and `FileSystemDirectoryHandle`. See [bug 40198034](https://crbug.com/40198034)."
             },
             "chrome_android": {
               "version_added": "109"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Chrome support for `FileSystemHandle.move()`, which is partially supported (only on `FileSystemFileHandle`.

#### Test results and supporting details

See [this comment](https://github.com/mdn/browser-compat-data/issues/20341#issuecomment-4170225516) and below.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20341.
