### PR TITLE
Reconcile `Element` and `KeyframeEffect` `iterationComposite` data

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -413,7 +413,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -421,7 +421,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari supports `iterationComposite` in both ways you can set it. It wasn't updated in both places though, when it shipped.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Caught by @captainbrosset in [web-platform-dx/web-features#3907 (review)](https://github.com/web-platform-dx/web-features/pull/3907#discussion_r3021105956 "Add `iterationComposite` feature").

I think this was not caught in the review of https://github.com/mdn/browser-compat-data/pull/18963.

Test: https://wpt.fyi/results/web-animations/interfaces/KeyframeEffect/iterationComposite.html?label=master&label=stable&aligned&q=iterationComposite

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Prompted by https://github.com/web-platform-dx/web-features/pull/3907 
- https://github.com/mdn/browser-compat-data/pull/18963

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
