### PR TITLE
Remove obsolete Firefox note from CSS `<gradient>`

### DIFF
--- a/css/types/gradient.json
+++ b/css/types/gradient.json
@@ -24,8 +24,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.6",
-              "notes": "Gradients are limited to [`background-image`](https://developer.mozilla.org/docs/Web/CSS/background-image), [`border-image`](https://developer.mozilla.org/docs/Web/CSS/border-image), and [`mask-image`](https://developer.mozilla.org/docs/Web/CSS/mask-image)."
+              "version_added": "3.6"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removes a Firefox note from CSS `<gradient>` which is out of context, and no longer relevant.

#### Test results and supporting details

See [this comment](https://github.com/mdn/browser-compat-data/issues/18503#issuecomment-4171174737).

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/18503.