### PR TITLE
Firefox 150 adds `HTMLImageElement.sizes` `auto` value

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1110,7 +1110,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "150",
                 "impl_url": "https://bugzil.la/1819581"
               },
               "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

The `<img sizes="auto" />` feature has been implemented in Firefox 150 beta.

#### Test results and supporting details

- Test link: https://wpt.live/html/semantics/embedded-content/the-img-element/sizes/sizes-auto.html
- Bugzilla link: https://bugzil.la/1819581
- Interop link: https://github.com/web-platform-tests/interop/issues/1114


<img width="935" height="373" alt="image" src="https://github.com/user-attachments/assets/de2472fc-f2bd-4433-a220-16bb712f8608" />



#### Related issues

None
