### PR TITLE
Add `crash-reporting` reporting endpoint name

### DIFF
--- a/http/headers/Reporting-Endpoints.json
+++ b/http/headers/Reporting-Endpoints.json
@@ -19,12 +19,8 @@
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "16.4"
             },
@@ -54,12 +50,8 @@
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This adds the `crash-reporting` endpoint name to the `Reporting-Endpoints` header.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I'm trying to add more detail to BCD so I can generate a status in web-features for crash reporting. This came out of that (incomplete) effort.

Chrome shipped `crash-reporting` in 139 (Aug 2025):
- https://chromestatus.com/feature/5129218731802624
- https://chromiumdash.appspot.com/commit/1cdd84c07d7e9c3f8498e57efc35b2ac626c0e20

While I was trying to piece together the history of crash reporting, I found that Firefox shipped `Reporting-Endpoints` earlier than recorded, in Firefox 130: https://bugzilla.mozilla.org/show_bug.cgi?id=1860588.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- [Firefox bug 1860588](https://bugzilla.mozilla.org/show_bug.cgi?id=1860588)
- [Chrome Platform Status - Crash Reporting API: Specify crash-reporting to receive only crash reports](https://chromestatus.com/feature/5129218731802624)
- https://github.com/mdn/content/issues/43688


<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
