### PR TITLE
Safari 26.5 now fully supports hanging-punctuation

### DIFF
--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -27,6 +27,7 @@
               },
               {
                 "version_added": "10",
+                "version_removed": "26.5",
                 "partial_implementation": true,
                 "notes": "The characters `U+0027` and `U+0022` are not supported by the `first` and `last` keywords. See [bug 309123](https://webkit.org/b/309123)."
               }


### PR DESCRIPTION
See https://developer.apple.com/documentation/safari-release-notes/safari-26_5-release-notes

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
