### PR TITLE
Add `overscroll-behavior` on non-scrollable scroll container

### DIFF
--- a/css/properties/overscroll-behavior.json
+++ b/css/properties/overscroll-behavior.json
@@ -105,6 +105,41 @@
             }
           }
         },
+        "non_scrollable_container": {
+          "__compat": {
+            "description": "`overscroll-behavior` applies even if scroll container is not scrollable",
+            "spec_url": "https://drafts.csswg.org/css-overscroll/#overscroll-behavior-properties",
+            "tags": [
+              "web-features:overscroll-behavior"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "150"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-none",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 139 and Firefox 150 apply `overscroll-behavior` to non-scrollable scroll container (sic!), which [has affected MDN](https://github.com/mdn/fred/issues/1451).

#### Test results and supporting details

- Chrome bug: https://issues.chromium.org/issues/41371072
- Chrome commit: https://github.com/chromium/chromium/commit/58b3245a17f6fca41439333f6a64a196b2c3cb0a
- Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1837436
- Firefox commit: https://github.com/mozilla-firefox/firefox/commit/03d810d70c8e5c8d58cab32004ca814715508b25
- Safari bug: https://bugs.webkit.org/show_bug.cgi?id=243452

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
