### PR TITLE
Remove generic font-family features

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -87,117 +87,9 @@
             }
           }
         },
-        "fangsong": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-fonts-4/#valdef-font-family-generic-fangsong",
-            "tags": [
-              "web-features:font-family"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "fantasy": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-fonts-4/#valdef-font-family-fantasy",
-            "tags": [
-              "web-features:font-family"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "kai": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-fonts-4/#valdef-font-family-generic-kai",
-            "tags": [
-              "web-features:font-family"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "khmer-mul": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-fonts-4/#valdef-font-family-generic-khmer-mul",
             "tags": [
               "web-features:font-family"
             ],
@@ -267,42 +159,6 @@
         "monospace": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-fonts-4/#valdef-font-family-monospace",
-            "tags": [
-              "web-features:font-family"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "nastaliq": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-fonts-4/#valdef-font-family-generic-nastaliq",
             "tags": [
               "web-features:font-family"
             ],


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removes the CSS `font-family` subfeatures for generic fonts, because no browser actually supports them.

#### Test results and supporting details

The collector tests at https://collector.openwebdocs.org/tests/css/properties/font-family fail in Chrome 146, Firefox 149, and Safari 26.4.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29246#issuecomment-4067872654.