### PR TITLE
Safari 26.2 adds CSS `url()` modifiers

### DIFF
--- a/css/types/url.json
+++ b/css/types/url.json
@@ -75,6 +75,39 @@
               "deprecated": false
             }
           }
+        },
+        "referrer-policy": {
+          "__compat": {
+            "description": "`referrer-policy()` modifier",
+            "spec_url": "https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier-referrer-policy-modifier",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/435625756"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -42,6 +42,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "cross-origin": {
+          "__compat": {
+            "description": "`cross-origin()` modifier",
+            "spec_url": "https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier-cross-origin-modifier",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/435625756"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds the first two supported CSS `url(… <modifier>)` modifiers, to limit how subresources are loaded.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

- Spec: [Request URL Modifiers](https://drafts.csswg.org/css-values-5/#request-url-modifiers)
- [Safari 26.2 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes#:~:text=Added%20support%20for%20cross%2Dorigin%28%29%20and%20referrer%2Dpolicy%28%29%20CSS%20URL%20modifiers%2E%20%28155625162)
- WPT: https://wpt.fyi/results/css/css-values/urls?label=master&label=experimental&aligned&q=css%2Fcss-values%2Furls%2Furl-request-modifiers

No implementer has shipped `integrity()` yet, though I expect Chrome to do so. I can add that feature too, with `impl_url`, if desired.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/issues/3930
- [CSS URL request modifiers - Chrome Platform Status](https://chromestatus.com/feature/5111997147512832)
- [Chromium bug 435625756](https://issues.chromium.org/issues/435625756)
- https://github.com/mozilla/standards-positions/issues/1386

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
