### PR TITLE
Add MDN urls: CSS statics/`Symbol.dispose`/`Viewport.segments`

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -113,6 +113,7 @@
       "cap_static": {
         "__compat": {
           "description": "`cap()` static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-cap",
           "tags": [
             "web-features:numeric-factory-functions"
@@ -1035,6 +1036,7 @@
       "ic_static": {
         "__compat": {
           "description": "`ic()` static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ic",
           "tags": [
             "web-features:numeric-factory-functions"
@@ -1145,6 +1147,7 @@
       "lh_static": {
         "__compat": {
           "description": "`lh()` static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lh",
           "tags": [
             "web-features:numeric-factory-functions"
@@ -1737,6 +1740,7 @@
       "rcap_static": {
         "__compat": {
           "description": "`rcap()` static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rcap",
           "tags": [
             "web-features:numeric-factory-functions"
@@ -1773,6 +1777,7 @@
       "rch_static": {
         "__compat": {
           "description": "`rch()` static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rch",
           "tags": [
             "web-features:numeric-factory-functions"
@@ -1882,6 +1887,7 @@
       "rex_static": {
         "__compat": {
           "description": "`rex()` static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rex",
           "tags": [
             "web-features:numeric-factory-functions"
@@ -1918,6 +1924,7 @@
       "ric_static": {
         "__compat": {
           "description": "`ric()` static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ric",
           "tags": [
             "web-features:numeric-factory-functions"
@@ -1954,6 +1961,7 @@
       "rlh_static": {
         "__compat": {
           "description": "`rlh()` static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rlh",
           "tags": [
             "web-features:numeric-factory-functions"

--- a/api/Viewport.json
+++ b/api/Viewport.json
@@ -36,6 +36,7 @@
       },
       "segments": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Viewport/segments",
           "spec_url": "https://drafts.csswg.org/css-viewport/#dom-viewport-segments",
           "tags": [
             "web-features:viewport-segments"

--- a/javascript/builtins/AsyncDisposableStack.json
+++ b/javascript/builtins/AsyncDisposableStack.json
@@ -354,6 +354,7 @@
         },
         "@@asyncDispose": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/Symbol.asyncDispose",
             "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype-@@asyncDispose",
             "tags": [
               "web-features:explicit-resource-management"

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -47,6 +47,7 @@
         },
         "@@asyncDispose": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator/Symbol.asyncDispose",
             "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-asyncdisposablestack.prototype-@@asyncDispose",
             "tags": [
               "web-features:explicit-resource-management"

--- a/javascript/builtins/DisposableStack.json
+++ b/javascript/builtins/DisposableStack.json
@@ -354,6 +354,7 @@
         },
         "@@dispose": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack/Symbol.dispose",
             "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-disposablestack.prototype-@@dispose",
             "tags": [
               "web-features:explicit-resource-management"

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -830,6 +830,7 @@
         },
         "@@dispose": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Symbol.dispose",
             "spec_url": "https://tc39.es/proposal-async-explicit-resource-management/#sec-%iteratorprototype%-@@dispose",
             "tags": [
               "web-features:explicit-resource-management"


### PR DESCRIPTION
#### Summary

Add missing `mdn_url` keys for:

- CSS static methods
  - https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static
- Symbol dispose
  - https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncDisposableStack/Symbol.asyncDispose
  - https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator/Symbol.asyncDispose
  - https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack/Symbol.dispose
  - https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Symbol.dispose
- Viewport segments
  - https://developer.mozilla.org/docs/Web/API/Viewport/segments
