### PR TITLE
Safari 26 added `Integrity-Policy` HTTP header

### DIFF
--- a/http/headers/Integrity-Policy-Report-Only.json
+++ b/http/headers/Integrity-Policy-Report-Only.json
@@ -21,7 +21,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -52,7 +52,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/http/headers/Integrity-Policy.json
+++ b/http/headers/Integrity-Policy.json
@@ -21,7 +21,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -52,7 +52,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Safari support for the `Integrity-Policy` HTTP header

#### Test results and supporting details

Implemented via https://github.com/WebKit/WebKit/commit/2745429641071660f77d69c64cd04727ee8e31c5 in WebKit [622.1.15](https://github.com/WebKit/WebKit/blob/2745429641071660f77d69c64cd04727ee8e31c5/Configurations/Version.xcconfig#L24-L26) before Safari 26 (WebKit [622.1.20](https://github.com/mdn/browser-compat-data/blob/ead83f9877ac9c8810d8854e4641e1699152730a/browsers/safari.json#L370-L376)).

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29433.