### PR TITLE
Chrome added `preferred-text-scale` env / `text-scale` meta

### DIFF
--- a/css/types/env.json
+++ b/css/types/env.json
@@ -253,6 +253,37 @@
             }
           }
         },
+        "preferred-text-scale": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-env-1/#text-zoom",
+            "support": {
+              "chrome": {
+                "version_added": "138"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "safe-area-inset-bottom": {
           "__compat": {
             "description": "Safe area inset variable `safe-area-inset-bottom`",

--- a/css/types/env.json
+++ b/css/types/env.json
@@ -255,6 +255,7 @@
         },
         "preferred-text-scale": {
           "__compat": {
+            "description": "Preferred text zoom variable `preferred-text-scale`",
             "spec_url": "https://drafts.csswg.org/css-env-1/#text-zoom",
             "support": {
               "chrome": {

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -496,6 +496,7 @@
           },
           "text-scale": {
             "__compat": {
+              "description": "`<meta name=\"text-scale\">`",
               "spec_url": "https://drafts.csswg.org/css-fonts-5/#text-scale-meta",
               "support": {
                 "chrome": {

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -494,6 +494,39 @@
               }
             }
           },
+          "text-scale": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-fonts-5/#text-scale-meta",
+              "support": {
+                "chrome": {
+                  "version_added": "146"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "theme-color": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/meta/name/theme-color",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome has added support for two features that allow sites to size fonts in proportion to the operating system/browser text scale settings:

- The `<meta name="text-scale" content="..." />` element, which was added in Chrome 146, and works across Desktop and Mobile platforms. See https://chromestatus.com/feature/5112244702674944. As far as I can tell, this has full support, but that support varies depending on the text sizing functionality available in OS/browser combination being used. I'm intending to document these in as much detail as possible in the content update.
- The `preferred-text-scale` `env()` variable, which was added in Chrome 138. This allegedly works only in Android, but it also seems to have somewhat of an effect in Chrome desktop, which I am still investigating, and wish to write up in the content. As a result, I've listed it as supported on desktop too.  

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
