### PR TITLE
Refine Safari notes for `AccentColor`/`AccentColorText` keywords

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1686,7 +1686,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "16.5",
-                  "notes": "Only supports a fallback: The native color when accent colour (in macOS' appearance panel) is set to 'multicolour'. On iOS falls back to the blue accent colour"
+                  "notes": "Always uses the system default accent color, blue. This accidentally produces the correct result when the system accent color is Multicolor."
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I found the current wording very confusing:

> Only supports a fallback: The native color when accent colour (in macOS' appearance panel) is set to 'multicolour'. On iOS falls back to the blue accent colour

I'm replacing it with this wording which I hope is more clear and correct:

> Always uses the system default accent color, blue. This accidentally produces the correct result when the system accent color is Multicolor.