### PR TITLE
Add `HTMLTemplateElement.shadowrootslotassignment` attribute

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -303,6 +303,47 @@
             "deprecated": false
           }
         }
+      },
+      "shadowRootSlotAssignment": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootslotassignment",
+          "tags": [
+            "web-features:declarative-shadow-dom"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.shadowdom.shadowRootSlotAssignment.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -312,7 +312,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/493315747"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -331,7 +332,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -278,6 +278,47 @@
               "deprecated": false
             }
           }
+        },
+        "shadowrootslotassignment": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootslotassignment",
+            "tags": [
+              "web-features:declarative-shadow-dom"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.shadowdom.shadowRootSlotAssignment.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
This adds relevant BCD for the `shadowrootslotassignment` attribute.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
[groups.google.com/a/mozilla.org/g/dev-platform/c/8qxAHE9-Xdo](https://groups.google.com/a/mozilla.org/g/dev-platform/c/8qxAHE9-Xdo) is my intent to ship this in Firefox. It is currently in Nightly behind a flag.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Refs https://github.com/mdn/content/pull/43753, https://github.com/whatwg/html/pull/12267

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
