### PR TITLE
Safari partially supports `AuthenticatorAttestationResponse.getPublicKey()`

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -165,7 +165,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16"
+              "version_added": "16",
+              "partial_implementation": true,
+              "notes": "Only algorithm -7 (ES256) is supported."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -167,7 +167,7 @@
             "safari": {
               "version_added": "16",
               "partial_implementation": true,
-              "notes": "Only algorithm -7 (ES256) is supported."
+              "notes": "Only algorithm -7 (ES256) is supported. See [bug 312081](https://webkit.org/b/312081)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -167,7 +167,7 @@
             "safari": {
               "version_added": "16",
               "partial_implementation": true,
-              "notes": "Only algorithm -7 (ES256) is supported. See [bug 312081](https://webkit.org/b/312081)."
+              "notes": "Supports only algorithm -7 (ES256). Does not support algorithms -8 (Ed25519) and -257 (RS256). See [bug 312081](https://webkit.org/b/312081)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Sets Safari's support for `AuthenticatorAttestationResponse.getPublicKey()` to `partial`. The [Web Authentication API specification](https://www.w3.org/TR/webauthn-3/#sctn-public-key-easy) (since level 2 where it was first described in) states that user agents MUST support algorithm -7 (ES256), -8 (Ed25519), and -257 (RS256). However, WebKit only supports -7 (ES256) and returns `null` for the other 2 algorithms.

#### Test results and supporting details

- [WebKit source code](https://github.com/WebKit/WebKit/blob/52dbebe20b922cab89928085f9dcfa8082a813e4/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp#L162)
- Tested on Safari 18.6 on macOS.
