### PR TITLE
Firefox 150 adds JavaScript multiple import maps behind pref

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -678,7 +678,14 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false,
+                    "version_added": "150",
+                    "flags": [
+                      {
+                        "name": "dom.multiple_import_maps.enabled",
+                        "type": "preference",
+                        "value_to_set": "true"
+                      }
+                    ],
                     "impl_url": "https://bugzil.la/1916277"
                   },
                   "firefox_android": "mirror",


### PR DESCRIPTION
FF150 adds support for [multiple import maps](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps) behind a pref (`dom.multiple_import_maps.enabled`) in https://bugzilla.mozilla.org/show_bug.cgi?id=1916277

This updates the feature.

Related docs work can be tracked in https://github.com/mdn/content/issues/43551